### PR TITLE
Fix some games not functioning unless launched from the container

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -862,7 +862,7 @@ private fun setupXEnvironment(
         val wow64Mode = container.isWoW64Mode
         //            String guestExecutable = wineInfo.getExecutable(this, wow64Mode)+" explorer /desktop=shell,"+xServer.screenInfo+" "+getWineStartCommand();
         val guestExecutable = "wine explorer /desktop=shell," + xServer.screenInfo + " " +
-            getWineStartCommand(appId, container, bootToContainer, appLaunchInfo, envVars) +
+            getWineStartCommand(appId, container, bootToContainer, appLaunchInfo, envVars, guestProgramLauncherComponent) +
             (if (container.execArgs.isNotEmpty()) " " + container.execArgs else "")
         guestProgramLauncherComponent.isWoW64Mode = wow64Mode
         guestProgramLauncherComponent.guestExecutable = guestExecutable
@@ -997,6 +997,7 @@ private fun getWineStartCommand(
     bootToContainer: Boolean,
     appLaunchInfo: LaunchInfo?,
     envVars: EnvVars,
+    guestProgramLauncherComponent: GuestProgramLauncherComponent
 ): String {
     val tempDir = File(container.getRootDir(), ".wine/drive_c/windows/temp")
     FileUtils.clear(tempDir)
@@ -1014,6 +1015,9 @@ private fun getWineStartCommand(
             container.executablePath = executablePath
             container.saveData()
         }
+        val executableDir = appDirPath + "/" + executablePath.substringBeforeLast("/", "")
+        guestProgramLauncherComponent.workingDir = File(executableDir);
+        Timber.i("Working directory is ${executableDir}")
 
         Timber.i("Final exe path is " + executablePath)
         val drives = container.drives

--- a/app/src/main/java/com/winlator/xenvironment/components/GlibcProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/GlibcProgramLauncherComponent.java
@@ -42,6 +42,7 @@ public class GlibcProgramLauncherComponent extends GuestProgramLauncherComponent
     private boolean wow64Mode = true;
     private final ContentsManager contentsManager;
     private final ContentProfile wineProfile;
+    private File workingDir;
 
     public GlibcProgramLauncherComponent(ContentsManager contentsManager, ContentProfile wineProfile) {
         this.contentsManager = contentsManager;
@@ -164,6 +165,14 @@ public class GlibcProgramLauncherComponent extends GuestProgramLauncherComponent
         this.box64Preset = box64Preset;
     }
 
+    public File getWorkingDir() {
+        return workingDir;
+    }
+
+    public void setWorkingDir(File workingDir) {
+        this.workingDir = workingDir;
+    }
+
     private int execGuestProgram() {
         Context context = environment.getContext();
         ImageFs imageFs = ImageFs.find(context);
@@ -207,7 +216,7 @@ public class GlibcProgramLauncherComponent extends GuestProgramLauncherComponent
         String command = box64Path + " " + guestExecutable;
         Log.d("GlibcProgramLauncherComponent", "Final command: " + command);
 
-        return ProcessHelper.exec(command, envVars.toStringArray(), rootDir, (status) -> {
+        return ProcessHelper.exec(command, envVars.toStringArray(), workingDir != null ? workingDir : rootDir, (status) -> {
             Log.d("GlibcProgramLauncherComponent", "Process terminated " + pid + " with status " + status);
             synchronized (lock) {
                 pid = -1;
@@ -334,7 +343,7 @@ public class GlibcProgramLauncherComponent extends GuestProgramLauncherComponent
         // Execute the command and capture its output
         try {
             Log.d("GlibcProgramLauncherComponent", "Shell command is " + finalCommand);
-            java.lang.Process process = Runtime.getRuntime().exec(finalCommand, envVars.toStringArray(), imageFs.getRootDir());
+            java.lang.Process process = Runtime.getRuntime().exec(finalCommand, envVars.toStringArray(), workingDir != null ? workingDir : imageFs.getRootDir());
             BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
             BufferedReader errorReader = new BufferedReader(new InputStreamReader(process.getErrorStream()));
 


### PR DESCRIPTION
Allows overriding the working directory of programs launched by the ProgramLauncherComponents and sets it to the directory of the executable defined by the executable path.
For example, if the executable path is `SomeFolder/Game.exe`, the working directory will be inside `SomeFolder` to match the behaviour of launching from the file explorer. if the executable path is `Game.exe`, the working directory will be in the folder that corresponds with the `A` drive.

If you have any issues with how I implemented it please let me know so I can fix them :)

Before changes:

https://github.com/user-attachments/assets/2ac56974-3ee3-421c-9aba-033a92105b0b

After changes:

https://github.com/user-attachments/assets/2969a0af-dae3-46d8-9edd-1c975615035b

