### PR TITLE
Pagination and optimisation for big libraries

### DIFF
--- a/app/src/main/java/app/gamenative/service/DownloadService.kt
+++ b/app/src/main/java/app/gamenative/service/DownloadService.kt
@@ -1,0 +1,40 @@
+package app.gamenative.service
+
+import java.io.File
+
+object DownloadService {
+    init {
+        getDownloadDirectoryApps()
+    }
+
+    private var lastUpdateTime: Long = 0
+    private lateinit var downloadDirectoryApps: MutableList<String>
+
+    fun getDownloadDirectoryApps (): MutableList<String> {
+        // What apps have folders in the download area?
+        // Isn't checking for "complete" marker - incomplete is accepted
+
+        // Only update if cache is over 30 seconds old
+        val time = System.currentTimeMillis()
+        if (lastUpdateTime < (time - 30000) || lastUpdateTime > time) {
+            lastUpdateTime = time
+
+            // For now, grab parent directories from SteamService
+            val subDir = getSubdirectories(SteamService.internalAppInstallPath)
+            subDir += getSubdirectories(SteamService.externalAppInstallPath)
+
+            downloadDirectoryApps = subDir
+        }
+
+        return downloadDirectoryApps
+    }
+
+    private fun getSubdirectories (path: String): MutableList<String> {
+        // Names of immediate subdirectories
+        val subDir = File(path).list() { dir, name -> File(dir, name).isDirectory}
+        if (subDir == null) {
+            return emptyList<String>().toMutableList()
+        }
+        return subDir.toMutableList()
+    }
+}

--- a/app/src/main/java/app/gamenative/service/DownloadService.kt
+++ b/app/src/main/java/app/gamenative/service/DownloadService.kt
@@ -14,9 +14,9 @@ object DownloadService {
         // What apps have folders in the download area?
         // Isn't checking for "complete" marker - incomplete is accepted
 
-        // Only update if cache is over 30 seconds old
+        // Only update if cache is over N milliseconds old
         val time = System.currentTimeMillis()
-        if (lastUpdateTime < (time - 30000) || lastUpdateTime > time) {
+        if (lastUpdateTime < (time - 5 * 1000) || lastUpdateTime > time) {
             lastUpdateTime = time
 
             // For now, grab parent directories from SteamService

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1740,16 +1740,14 @@ class SteamService : Service(), IChallengeUrlChanged {
                     }
                 }
 
+                // continuously check for pics changes
+                continuousPICSChangesChecker()
+
+                // request app pics data when needed
+                continuousPICSGetProductInfo()
+
                 if (false) {
-                    // Noticeable performance hit to do this at present
-                    // and no social features are implemented at present
-
-                    // continuously check for pics changes
-                    continuousPICSChangesChecker()
-
-                    // request app pics data when needed
-                    continuousPICSGetProductInfo()
-
+                    // No social features are implemented at present
                     // continuously check for game names that friends are playing.
                     continuousFriendChecker()
                 }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -278,14 +278,14 @@ class SteamService : Service(), IChallengeUrlChanged {
         private val depotManifestsPath: String
             get() = Paths.get(instance!!.dataDir.path, "Steam", "depot_manifests.zip").pathString
 
-        private val internalAppInstallPath: String
+        val internalAppInstallPath: String
             get() {
                 if (instance != null) {
                     return Paths.get(instance!!.dataDir.path, "Steam", "steamapps", "common").pathString
                 }
                 return ""
             }
-        private val externalAppInstallPath: String
+        val externalAppInstallPath: String
             get() {
                 return Paths.get(PrefManager.externalStoragePath, "Steam", "steamapps", "common").pathString
             }
@@ -446,11 +446,19 @@ class SteamService : Service(), IChallengeUrlChanged {
                 .associate { it.toPair() }
         }
 
-        fun getAppDirPath(appId: Int): String {
-            var appName = getAppInfoOf(appId)?.config?.installDir.orEmpty()
+        fun getAppDirName(app: SteamApp?): String {
+            // The folder name, if it got made
+            var appName = app?.config?.installDir.orEmpty()
             if (appName.isEmpty()) {
-                appName = getAppInfoOf(appId)?.name.orEmpty()
+                appName = app?.name.orEmpty()
             }
+            return appName
+        }
+
+        fun getAppDirPath(appId: Int): String {
+
+            val appName = getAppDirName(getAppInfoOf(appId))
+
             // Internal first (legacy installs), external second
             val internalPath = Paths.get(internalAppInstallPath, appName)
             if (Files.exists(internalPath)) return internalPath.pathString
@@ -459,7 +467,10 @@ class SteamService : Service(), IChallengeUrlChanged {
             if (Files.exists(externalPath)) return externalPath.pathString
 
             // Nothing on disk yet – default to whatever location you want new installs to use
-            return internalPath.pathString      // or externalPath.pathString
+            if (PrefManager.useExternalStorage) {
+                return externalPath.pathString
+            }
+            return internalPath.pathString
         }
 
         private fun isExecutable(flags: Any): Boolean = when (flags) {

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -280,7 +280,10 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         private val internalAppInstallPath: String
             get() {
-                return Paths.get(instance!!.dataDir.path, "Steam", "steamapps", "common").pathString
+                if (instance != null) {
+                    return Paths.get(instance!!.dataDir.path, "Steam", "steamapps", "common").pathString
+                }
+                return ""
             }
         private val externalAppInstallPath: String
             get() {

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1740,14 +1740,19 @@ class SteamService : Service(), IChallengeUrlChanged {
                     }
                 }
 
-                // continuously check for pics changes
-                continuousPICSChangesChecker()
+                if (false) {
+                    // Noticeable performance hit to do this at present
+                    // and no social features are implemented at present
 
-                // request app pics data when needed
-                continuousPICSGetProductInfo()
+                    // continuously check for pics changes
+                    continuousPICSChangesChecker()
 
-                // continuously check for game names that friends are playing.
-                continuousFriendChecker()
+                    // request app pics data when needed
+                    continuousPICSGetProductInfo()
+
+                    // continuously check for game names that friends are playing.
+                    continuousFriendChecker()
+                }
 
                 // Tell steam we're online, this allows friends to update.
                 _steamFriends?.setPersonaState(PrefManager.personaState)

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -301,7 +301,8 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         val defaultAppInstallPath: String
             get() {
-                return if (PrefManager.useExternalStorage && File(externalAppInstallPath).exists()) {
+                return if (PrefManager.useExternalStorage && File(PrefManager.externalStoragePath).exists()) {
+                    // We still have an SD card file structure as expected
                     Timber.i("Using external storage")
                     Timber.i("install path for external storage is " + externalAppInstallPath)
                     externalAppInstallPath

--- a/app/src/main/java/app/gamenative/ui/data/LibraryState.kt
+++ b/app/src/main/java/app/gamenative/ui/data/LibraryState.kt
@@ -8,6 +8,8 @@ import java.util.EnumSet
 data class LibraryState(
     val appInfoSortType: EnumSet<AppFilter> = PrefManager.libraryFilter,
     val appInfoList: List<LibraryItem> = emptyList(),
+    val currentPaginationPage: Int = 1,
+    val lastPaginationPage: Int = 1,
     val modalBottomSheet: Boolean = false,
 
     val isSearching: Boolean = false,

--- a/app/src/main/java/app/gamenative/ui/data/LibraryState.kt
+++ b/app/src/main/java/app/gamenative/ui/data/LibraryState.kt
@@ -8,6 +8,9 @@ import java.util.EnumSet
 data class LibraryState(
     val appInfoSortType: EnumSet<AppFilter> = PrefManager.libraryFilter,
     val appInfoList: List<LibraryItem> = emptyList(),
+
+    // For display
+    val totalAppsInFilter: Int = 0,
     val currentPaginationPage: Int = 1,
     val lastPaginationPage: Int = 1,
     val modalBottomSheet: Boolean = false,

--- a/app/src/main/java/app/gamenative/ui/data/LibraryState.kt
+++ b/app/src/main/java/app/gamenative/ui/data/LibraryState.kt
@@ -9,10 +9,11 @@ data class LibraryState(
     val appInfoSortType: EnumSet<AppFilter> = PrefManager.libraryFilter,
     val appInfoList: List<LibraryItem> = emptyList(),
 
-    // For display
+    // Human readable, not 0-indexed
     val totalAppsInFilter: Int = 0,
     val currentPaginationPage: Int = 1,
     val lastPaginationPage: Int = 1,
+
     val modalBottomSheet: Boolean = false,
 
     val isSearching: Boolean = false,

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -145,10 +145,11 @@ class LibraryViewModel @Inject constructor(
                         true
                     }
                 }
-                .sortedWith(
-                    compareByDescending<SteamApp> { SteamService.isAppInstalled(it.id) }
-                        .thenBy { it.name.lowercase() }
-                );
+                // Can sort by downloaded status later. Performance hit currently is massive.
+//                .sortedWith(
+//                    compareByDescending<SteamApp> { SteamService.isAppInstalled(it.id) }
+//                        .thenBy { it.name.lowercase() }
+//                );
 
             // Split here to get a count of the amount of games the filter includes
             val totalFound = filteredList.count()

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -38,7 +38,7 @@ class LibraryViewModel @Inject constructor(
     var listState: LazyListState by mutableStateOf(LazyListState(0, 0))
 
     // How many items loaded on one page of results
-    private val paginationSize: Int = 20;
+    private val paginationSize: Int = 25;
     private var paginationCurrentPage: Int = 0;
     private var lastPageInCurrentFilter: Int = 0;
 
@@ -52,9 +52,12 @@ class LibraryViewModel @Inject constructor(
             ).collect { apps ->
                 Timber.tag("LibraryViewModel").d("Collecting ${apps.size} apps")
 
-                appList = apps
+                if (appList.size != apps.size) {
+                    // Don't filter if it's no change
+                    appList = apps
 
-                onFilterApps()
+                    onFilterApps(paginationCurrentPage)
+                }
             }
         }
     }
@@ -175,8 +178,9 @@ class LibraryViewModel @Inject constructor(
             _state.update {
                 it.copy(
                     appInfoList = filteredListPage,
-                    currentPaginationPage = paginationPage + 1,
+                    currentPaginationPage = paginationPage + 1, // visual display is not 0 indexed
                     lastPaginationPage = lastPageInCurrentFilter + 1,
+                    totalAppsInFilter = totalFound,
                     )
             }
         }

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -35,6 +35,10 @@ class LibraryViewModel @Inject constructor(
     // Keep the library scroll state. This will last longer as the VM will stay alive.
     var listState: LazyListState by mutableStateOf(LazyListState(0, 0))
 
+    // How many items loaded on one page of results
+    private val paginationSize = 20;
+    private var paginationCurrentPage = 0;
+
     // Complete and unfiltered app list
     private var appList: List<SteamApp> = emptyList()
 
@@ -87,11 +91,21 @@ class LibraryViewModel @Inject constructor(
         onFilterApps()
     }
 
-    private fun onFilterApps() {
+    fun onPageChange(pageIncrement: Int) {
+        // Amount to change by
+        onFilterApps(paginationCurrentPage + pageIncrement)
+    }
+
+    private fun onFilterApps(paginationPage: Int = 0) {
+        // May be filtering 1000+ apps - in future should paginate at the point of DAO request
         Timber.tag("LibraryViewModel").d("onFilterApps")
         viewModelScope.launch {
             val currentState = _state.value
             val currentFilter = AppFilter.getAppType(currentState.appInfoSortType)
+
+            val firstItem = paginationPage * paginationSize;
+            val lastItem = firstItem + paginationSize;
+            paginationCurrentPage = paginationPage;
 
             val filteredList = appList
                 .asSequence()
@@ -130,6 +144,10 @@ class LibraryViewModel @Inject constructor(
                     compareByDescending<SteamApp> { SteamService.isAppInstalled(it.id) }
                         .thenBy { it.name.lowercase() }
                 )
+                .filterIndexed { index, steamApp ->
+                    // Paginate to only show one page of games
+                    index in firstItem..lastItem
+                }
                 .mapIndexed { idx, item ->
                     LibraryItem(
                         index = idx,

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -10,6 +10,7 @@ import app.gamenative.PrefManager
 import app.gamenative.data.LibraryItem
 import app.gamenative.data.SteamApp
 import app.gamenative.db.dao.SteamAppDao
+import app.gamenative.service.DownloadService
 import app.gamenative.service.SteamService
 import app.gamenative.ui.data.LibraryState
 import app.gamenative.ui.enums.AppFilter
@@ -111,6 +112,8 @@ class LibraryViewModel @Inject constructor(
             val currentState = _state.value
             val currentFilter = AppFilter.getAppType(currentState.appInfoSortType)
 
+            val downloadDirectoryApps = DownloadService.getDownloadDirectoryApps()
+
             val firstItem = paginationPage * paginationSize;
             val lastItem = firstItem + paginationSize - 1;
             paginationCurrentPage = paginationPage;
@@ -143,16 +146,15 @@ class LibraryViewModel @Inject constructor(
                 }
                 .filter { item ->
                     if (currentState.appInfoSortType.contains(AppFilter.INSTALLED)) {
-                        SteamService.isAppInstalled(item.id)
+                        downloadDirectoryApps.contains(SteamService.getAppDirName(item))
                     } else {
                         true
                     }
                 }
-                // Can sort by downloaded status later. Performance hit currently is massive.
-//                .sortedWith(
-//                    compareByDescending<SteamApp> { SteamService.isAppInstalled(it.id) }
-//                        .thenBy { it.name.lowercase() }
-//                );
+                .sortedWith(
+                    // Comes from DAO in alphabetical order
+                    compareByDescending<SteamApp> { downloadDirectoryApps.contains(SteamService.getAppDirName(it)) }
+                );
 
             // Split here to get a count of the amount of games the filter includes
             val totalFound = filteredList.count()

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import kotlin.math.max
+import kotlin.math.min
 
 @HiltViewModel
 class LibraryViewModel @Inject constructor(
@@ -36,8 +38,9 @@ class LibraryViewModel @Inject constructor(
     var listState: LazyListState by mutableStateOf(LazyListState(0, 0))
 
     // How many items loaded on one page of results
-    private val paginationSize = 20;
-    private var paginationCurrentPage = 0;
+    private val paginationSize: Int = 20;
+    private var paginationCurrentPage: Int = 0;
+    private var lastPageInCurrentFilter: Int = 0;
 
     // Complete and unfiltered app list
     private var appList: List<SteamApp> = emptyList()
@@ -93,7 +96,9 @@ class LibraryViewModel @Inject constructor(
 
     fun onPageChange(pageIncrement: Int) {
         // Amount to change by
-        onFilterApps(paginationCurrentPage + pageIncrement)
+        var toPage = max(0, paginationCurrentPage + pageIncrement)
+        toPage = min(toPage, lastPageInCurrentFilter)
+        onFilterApps(toPage)
     }
 
     private fun onFilterApps(paginationPage: Int = 0) {
@@ -104,7 +109,7 @@ class LibraryViewModel @Inject constructor(
             val currentFilter = AppFilter.getAppType(currentState.appInfoSortType)
 
             val firstItem = paginationPage * paginationSize;
-            val lastItem = firstItem + paginationSize;
+            val lastItem = firstItem + paginationSize - 1;
             paginationCurrentPage = paginationPage;
 
             val filteredList = appList
@@ -143,7 +148,13 @@ class LibraryViewModel @Inject constructor(
                 .sortedWith(
                     compareByDescending<SteamApp> { SteamService.isAppInstalled(it.id) }
                         .thenBy { it.name.lowercase() }
-                )
+                );
+
+            // Split here to get a count of the amount of games the filter includes
+            val totalFound = filteredList.count()
+            lastPageInCurrentFilter =  totalFound / paginationSize // Rounds down, correctly
+
+            val filteredListPage = filteredList
                 .filterIndexed { index, steamApp ->
                     // Paginate to only show one page of games
                     index in firstItem..lastItem
@@ -159,8 +170,14 @@ class LibraryViewModel @Inject constructor(
                 }
                 .toList()
 
-            Timber.tag("LibraryViewModel").d("Filtered list size: ${filteredList.size}")
-            _state.update { it.copy(appInfoList = filteredList) }
+            Timber.tag("LibraryViewModel").d("Filtered list size: ${totalFound}")
+            _state.update {
+                it.copy(
+                    appInfoList = filteredListPage,
+                    currentPaginationPage = paginationPage + 1,
+                    lastPaginationPage = lastPageInCurrentFilter + 1,
+                    )
+            }
         }
     }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -1271,6 +1271,7 @@ internal fun GameMigrationDialog(
 @Composable
 private fun Preview_AppScreen() {
     val context = LocalContext.current
+    PrefManager.init(context)
     val intent = Intent(context, SteamService::class.java)
     context.startForegroundService(intent)
     var isDownloading by remember { mutableStateOf(false) }

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -62,6 +62,7 @@ fun HomeLibraryScreen(
         listState = viewModel.listState,
         sheetState = sheetState,
         onFilterChanged = viewModel::onFilterChanged,
+        onPageChange = viewModel::onPageChange,
         onModalBottomSheet = viewModel::onModalBottomSheet,
         onIsSearching = viewModel::onIsSearching,
         onSearchQuery = viewModel::onSearchQuery,
@@ -78,6 +79,7 @@ private fun LibraryScreenContent(
     listState: LazyListState,
     sheetState: SheetState,
     onFilterChanged: (AppFilter) -> Unit,
+    onPageChange: (Int) -> Unit,
     onModalBottomSheet: (Boolean) -> Unit,
     onIsSearching: (Boolean) -> Unit,
     onSearchQuery: (String) -> Unit,
@@ -103,6 +105,7 @@ private fun LibraryScreenContent(
                 listState = listState,
                 sheetState = sheetState,
                 onFilterChanged = onFilterChanged,
+                onPageChange = onPageChange,
                 onModalBottomSheet = onModalBottomSheet,
                 onIsSearching = onIsSearching,
                 onSearchQuery = onSearchQuery,
@@ -162,6 +165,7 @@ private fun Preview_LibraryScreenContent() {
             onIsSearching = {},
             onSearchQuery = {},
             onFilterChanged = { },
+            onPageChange = { },
             onModalBottomSheet = {
                 val currentState = state.modalBottomSheet
                 println("State: $currentState")

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -48,7 +49,9 @@ internal fun LibraryBottomBar(
     onPageChange: (Int) -> Unit,
 ) {
     Column(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.background)
     ) {
         // Colored top border
         Box(
@@ -68,7 +71,6 @@ internal fun LibraryBottomBar(
             horizontalArrangement = Arrangement.spacedBy((-1).dp),
             modifier = Modifier
                 .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.background)
                 .padding(4.dp)
         ) {
 
@@ -137,6 +139,12 @@ internal fun LibraryBottomBar(
                     .clipToBounds()
             )
         }
+
+        // Don't slip behind device navigation
+        Box (
+            modifier = Modifier
+                .navigationBarsPadding()
+        )
     }
 
 }

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
@@ -1,27 +1,34 @@
 package app.gamenative.ui.screen.library.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
-import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.sharp.ArrowForward
 import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -51,34 +58,56 @@ internal fun LibraryBottomBar(
                 )
         )
         FlowRow (
+            horizontalArrangement = Arrangement.spacedBy((-1).dp),
             modifier = Modifier
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.background)
                 .padding(4.dp)
         ) {
 
-            ExtendedFloatingActionButton(
-                text = { Text("Prev") },
-                icon = { Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBackIos, contentDescription = null) },
+            // Prev page
+            OutlinedButton(
+                content = { Icon(imageVector = Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null) },
                 onClick = { onPageChange(-1) },
-                expanded = false,
-                contentColor = MaterialTheme.colorScheme.onPrimary,
+                contentPadding = PaddingValues(6.dp),
+                shape = RoundedCornerShape(7.dp, 0.dp, 0.dp, 7.dp),
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.primary
+                ),
                 modifier = Modifier
                     .height(35.dp)
-                    .border(1.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(7.dp, 0.dp, 0.dp, 7.dp))
-                    .clipToBounds()
+                    .width(40.dp)
             )
 
-            ExtendedFloatingActionButton(
-                text = { Text("Next") },
-                icon = { Icon(imageVector = Icons.AutoMirrored.Default.ArrowForwardIos, contentDescription = null) },
-                onClick = { onPageChange(1) },
-                expanded = false,
-                contentColor = MaterialTheme.colorScheme.onPrimary,
+            // Number
+            OutlinedButton(
+                content = { Text("5/28") },
+                onClick = { },
+                contentPadding = PaddingValues(4.dp),
+                shape = RectangleShape,
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.primary
+                ),
                 modifier = Modifier
                     .height(35.dp)
-                    .border(1.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(0.dp, 7.dp, 7.dp, 0.dp))
-                    .clipToBounds()
+                    .width(55.dp)
+            )
+
+            // Next page
+            OutlinedButton(
+                content = { Icon(imageVector = Icons.AutoMirrored.Sharp.ArrowForward, contentDescription = null) },
+                onClick = { onPageChange(1) },
+                contentPadding = PaddingValues(6.dp),
+                shape = RoundedCornerShape(0.dp, 7.dp, 7.dp, 0.dp),
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.primary
+                ),
+                modifier = Modifier
+                    .height(35.dp)
+                    .width(40.dp)
             )
 
             // Fills space
@@ -90,8 +119,8 @@ internal fun LibraryBottomBar(
                 text = { Text(text = "Filters") },
                 icon = { Icon(imageVector = Icons.Default.FilterList, contentDescription = null) },
                 onClick = { onModalBottomSheet(true) },
-//                containerColor = MaterialTheme.colorScheme.primary,
-                contentColor = MaterialTheme.colorScheme.onPrimary,
+                containerColor = MaterialTheme.colorScheme.background,
+                contentColor = MaterialTheme.colorScheme.primary,
                 shape = RoundedCornerShape(7.dp),
                 modifier = Modifier
                     .height(35.dp)

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
@@ -25,6 +25,9 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Brush
@@ -33,10 +36,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.gamenative.PrefManager
+import app.gamenative.data.LibraryItem
+import app.gamenative.ui.data.LibraryState
+import app.gamenative.ui.internal.fakeAppInfo
 import app.gamenative.ui.theme.PluviaTheme
 
 @Composable
 internal fun LibraryBottomBar(
+    state: LibraryState,
     onModalBottomSheet: (Boolean) -> Unit,
     onPageChange: (Int) -> Unit,
 ) {
@@ -82,7 +89,7 @@ internal fun LibraryBottomBar(
 
             // Number
             OutlinedButton(
-                content = { Text("5/28") },
+                content = { Text("${state.currentPaginationPage}/${state.lastPaginationPage}") },
                 onClick = { },
                 contentPadding = PaddingValues(4.dp),
                 shape = RectangleShape,
@@ -137,9 +144,25 @@ internal fun LibraryBottomBar(
 private fun Preview_LibrarySearchBar() {
     val context = LocalContext.current
     PrefManager.init(context)
+    val state by remember {
+        mutableStateOf(
+            LibraryState(
+                appInfoList = List(155) { idx ->
+                    val item = fakeAppInfo(idx)
+                    LibraryItem(
+                        index = idx,
+                        appId = item.id,
+                        name = item.name,
+                        iconHash = item.iconHash,
+                    )
+                }
+            )
+        )
+    }
     PluviaTheme {
         Surface {
             LibraryBottomBar(
+                state = state,
                 onModalBottomSheet = {},
                 onPageChange = {},
             )

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
@@ -1,0 +1,115 @@
+package app.gamenative.ui.screen.library.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
+import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import app.gamenative.PrefManager
+import app.gamenative.ui.theme.PluviaTheme
+
+@Composable
+internal fun LibraryBottomBar() {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        // Colored top border
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(3.dp)
+                .background(
+                    brush = Brush.horizontalGradient(
+                        colors = listOf(
+                            MaterialTheme.colorScheme.primary,
+                            MaterialTheme.colorScheme.tertiary
+                        )
+                    )
+                )
+        )
+        FlowRow (
+//            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(4.dp)
+        ) {
+
+            ExtendedFloatingActionButton(
+                text = { Text("Prev") },
+                icon = { Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBackIos, contentDescription = null) },
+                onClick = { },
+                expanded = false,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier
+                    .height(35.dp)
+                    .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(7.dp, 0.dp, 0.dp, 7.dp))
+                    .clipToBounds()
+            )
+
+            ExtendedFloatingActionButton(
+                text = { Text("Next") },
+                icon = { Icon(imageVector = Icons.AutoMirrored.Default.ArrowForwardIos, contentDescription = null) },
+                onClick = { },
+                expanded = false,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier
+                    .height(35.dp)
+                    .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(0.dp, 7.dp, 7.dp, 0.dp))
+                    .clipToBounds()
+            )
+
+            // Fills space
+            Box (
+                modifier = Modifier.weight(1f)
+            )
+
+            ExtendedFloatingActionButton(
+                text = { Text(text = "Filters") },
+                icon = { Icon(imageVector = Icons.Default.FilterList, contentDescription = null) },
+                onClick = { },
+//                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+                shape = RoundedCornerShape(7.dp),
+                modifier = Modifier
+                    .height(35.dp)
+                    .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(7.dp))
+                    .clipToBounds()
+            )
+        }
+    }
+
+}
+
+@Preview(uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES or android.content.res.Configuration.UI_MODE_TYPE_NORMAL)
+@Composable
+private fun Preview_LibrarySearchBar() {
+    val context = LocalContext.current
+    PrefManager.init(context)
+    PluviaTheme {
+        Surface {
+            LibraryBottomBar(
+            )
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
@@ -29,7 +29,10 @@ import app.gamenative.PrefManager
 import app.gamenative.ui.theme.PluviaTheme
 
 @Composable
-internal fun LibraryBottomBar() {
+internal fun LibraryBottomBar(
+    onModalBottomSheet: (Boolean) -> Unit,
+    onPageChange: (Int) -> Unit,
+) {
     Column(
         modifier = Modifier.fillMaxWidth(),
     ) {
@@ -37,7 +40,7 @@ internal fun LibraryBottomBar() {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(3.dp)
+                .height(2.dp)
                 .background(
                     brush = Brush.horizontalGradient(
                         colors = listOf(
@@ -48,7 +51,6 @@ internal fun LibraryBottomBar() {
                 )
         )
         FlowRow (
-//            horizontalArrangement = Arrangement.spacedBy(4.dp),
             modifier = Modifier
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.background)
@@ -58,24 +60,24 @@ internal fun LibraryBottomBar() {
             ExtendedFloatingActionButton(
                 text = { Text("Prev") },
                 icon = { Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBackIos, contentDescription = null) },
-                onClick = { },
+                onClick = { onPageChange(-1) },
                 expanded = false,
                 contentColor = MaterialTheme.colorScheme.onPrimary,
                 modifier = Modifier
                     .height(35.dp)
-                    .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(7.dp, 0.dp, 0.dp, 7.dp))
+                    .border(1.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(7.dp, 0.dp, 0.dp, 7.dp))
                     .clipToBounds()
             )
 
             ExtendedFloatingActionButton(
                 text = { Text("Next") },
                 icon = { Icon(imageVector = Icons.AutoMirrored.Default.ArrowForwardIos, contentDescription = null) },
-                onClick = { },
+                onClick = { onPageChange(1) },
                 expanded = false,
                 contentColor = MaterialTheme.colorScheme.onPrimary,
                 modifier = Modifier
                     .height(35.dp)
-                    .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(0.dp, 7.dp, 7.dp, 0.dp))
+                    .border(1.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(0.dp, 7.dp, 7.dp, 0.dp))
                     .clipToBounds()
             )
 
@@ -87,13 +89,13 @@ internal fun LibraryBottomBar() {
             ExtendedFloatingActionButton(
                 text = { Text(text = "Filters") },
                 icon = { Icon(imageVector = Icons.Default.FilterList, contentDescription = null) },
-                onClick = { },
+                onClick = { onModalBottomSheet(true) },
 //                containerColor = MaterialTheme.colorScheme.primary,
                 contentColor = MaterialTheme.colorScheme.onPrimary,
                 shape = RoundedCornerShape(7.dp),
                 modifier = Modifier
                     .height(35.dp)
-                    .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(7.dp))
+                    .border(1.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(7.dp))
                     .clipToBounds()
             )
         }
@@ -109,6 +111,8 @@ private fun Preview_LibrarySearchBar() {
     PluviaTheme {
         Surface {
             LibraryBottomBar(
+                onModalBottomSheet = {},
+                onPageChange = {},
             )
         }
     }

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
@@ -67,13 +67,13 @@ internal fun LibraryBottomBar(
                     )
                 )
         )
-        FlowRow (
+        FlowRow(
             horizontalArrangement = Arrangement.spacedBy((-1).dp),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(4.dp)
         ) {
-
+            // Hide buttons when only a single page
             if (state.lastPaginationPage > 1) {
                 // Prev page
                 OutlinedButton(
@@ -165,7 +165,9 @@ private fun Preview_LibrarySearchBar() {
                         name = item.name,
                         iconHash = item.iconHash,
                     )
-                }
+                },
+                currentPaginationPage = 14,
+                lastPaginationPage = 20,
             )
         )
     }

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryBottomBar.kt
@@ -72,50 +72,52 @@ internal fun LibraryBottomBar(
                 .padding(4.dp)
         ) {
 
-            // Prev page
-            OutlinedButton(
-                content = { Icon(imageVector = Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null) },
-                onClick = { onPageChange(-1) },
-                contentPadding = PaddingValues(6.dp),
-                shape = RoundedCornerShape(7.dp, 0.dp, 0.dp, 7.dp),
-                border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
-                colors = ButtonDefaults.outlinedButtonColors(
-                    contentColor = MaterialTheme.colorScheme.primary
-                ),
-                modifier = Modifier
-                    .height(35.dp)
-                    .width(40.dp)
-            )
+            if (state.lastPaginationPage > 1) {
+                // Prev page
+                OutlinedButton(
+                    content = { Icon(imageVector = Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null) },
+                    onClick = { onPageChange(-1) },
+                    contentPadding = PaddingValues(6.dp),
+                    shape = RoundedCornerShape(7.dp, 0.dp, 0.dp, 7.dp),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.primary
+                    ),
+                    modifier = Modifier
+                        .height(35.dp)
+                        .width(40.dp)
+                )
 
-            // Number
-            OutlinedButton(
-                content = { Text("${state.currentPaginationPage}/${state.lastPaginationPage}") },
-                onClick = { },
-                contentPadding = PaddingValues(4.dp),
-                shape = RectangleShape,
-                border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
-                colors = ButtonDefaults.outlinedButtonColors(
-                    contentColor = MaterialTheme.colorScheme.primary
-                ),
-                modifier = Modifier
-                    .height(35.dp)
-                    .width(55.dp)
-            )
+                // Number
+                OutlinedButton(
+                    content = { Text("${state.currentPaginationPage}/${state.lastPaginationPage}") },
+                    onClick = { },
+                    contentPadding = PaddingValues(4.dp),
+                    shape = RectangleShape,
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.primary
+                    ),
+                    modifier = Modifier
+                        .height(35.dp)
+                        .width(55.dp)
+                )
 
-            // Next page
-            OutlinedButton(
-                content = { Icon(imageVector = Icons.AutoMirrored.Sharp.ArrowForward, contentDescription = null) },
-                onClick = { onPageChange(1) },
-                contentPadding = PaddingValues(6.dp),
-                shape = RoundedCornerShape(0.dp, 7.dp, 7.dp, 0.dp),
-                border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
-                colors = ButtonDefaults.outlinedButtonColors(
-                    contentColor = MaterialTheme.colorScheme.primary
-                ),
-                modifier = Modifier
-                    .height(35.dp)
-                    .width(40.dp)
-            )
+                // Next page
+                OutlinedButton(
+                    content = { Icon(imageVector = Icons.AutoMirrored.Sharp.ArrowForward, contentDescription = null) },
+                    onClick = { onPageChange(1) },
+                    contentPadding = PaddingValues(6.dp),
+                    shape = RoundedCornerShape(0.dp, 7.dp, 7.dp, 0.dp),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.primary
+                    ),
+                    modifier = Modifier
+                        .height(35.dp)
+                        .width(40.dp)
+                )
+            }
 
             // Fills space
             Box (

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
@@ -6,7 +6,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import app.gamenative.PrefManager
 import app.gamenative.service.SteamService
 import app.gamenative.ui.data.LibraryState
 import app.gamenative.ui.enums.AppFilter
@@ -61,9 +63,10 @@ internal fun LibraryDetailPane(
  ***********/
 
 @Preview(uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES or android.content.res.Configuration.UI_MODE_TYPE_NORMAL)
-@Preview
+@Preview(device = "spec:width=1920px,height=1080px,dpi=440") // Odin2 Mini
 @Composable
 private fun Preview_LibraryDetailPane() {
+    PrefManager.init(LocalContext.current)
     PluviaTheme {
         LibraryDetailPane(
             appId = Int.MAX_VALUE,

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
@@ -41,6 +41,7 @@ internal fun LibraryDetailPane(
                 listState = listState,
                 sheetState = sheetState,
                 onFilterChanged = {},
+                onPageChange = {},
                 onModalBottomSheet = {},
                 onIsSearching = {},
                 onLogout = {},

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryList.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryList.kt
@@ -3,6 +3,7 @@ package app.gamenative.ui.screen.library.components
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -45,7 +46,9 @@ internal fun LibraryList(
         }
     } else {
         LazyColumn(
-            modifier = modifier.fillMaxSize(),
+            modifier = modifier
+                .fillMaxSize()
+                .navigationBarsPadding(),
             state = listState,
             contentPadding = contentPaddingValues,
         ) {

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -112,7 +112,7 @@ internal fun LibraryListPane(
                             )
                         )
                         Text(
-                            text = "${state.appInfoList.size} games • $installedCount installed",
+                            text = "${state.totalAppsInFilter} games • $installedCount installed",
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -47,6 +47,7 @@ import app.gamenative.ui.data.LibraryState
 import app.gamenative.ui.enums.AppFilter
 import app.gamenative.ui.internal.fakeAppInfo
 import app.gamenative.PrefManager
+import app.gamenative.service.DownloadService
 import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.ui.component.topbar.AccountButton
 
@@ -67,9 +68,7 @@ internal fun LibraryListPane(
 ) {
     val expandedFab by remember { derivedStateOf { listState.firstVisibleItemIndex == 0 } }
     val snackBarHost = remember { SnackbarHostState() }
-    val installedCount = remember(state.appInfoList) {
-        state.appInfoList.count { SteamService.isAppInstalled(it.appId) }
-    }
+    val installedCount = remember { DownloadService.getDownloadDirectoryApps().count() }
 
     // Determine the orientation to add additional scaffold padding.
     val configuration = LocalConfiguration.current

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -164,21 +164,6 @@ internal fun LibraryListPane(
                     onItemClick = onNavigate,
                 )
 
-                // Filter FAB - Moved outside of Column scope
-                if (!state.isSearching) {
-                    ExtendedFloatingActionButton(
-                        text = { Text(text = "Filters") },
-                        expanded = expandedFab,
-                        icon = { Icon(imageVector = Icons.Default.FilterList, contentDescription = null) },
-                        onClick = { onModalBottomSheet(true) },
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary,
-                        modifier = Modifier
-                            .align(Alignment.BottomEnd)
-                            .padding(24.dp)
-                    )
-                }
-
                 if (state.modalBottomSheet) {
                     ModalBottomSheet(
                         onDismissRequest = { onModalBottomSheet(false) },

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -80,7 +80,7 @@ internal fun LibraryListPane(
     Scaffold(
         modifier = if (isPortrait) Modifier else Modifier.statusBarsPadding(),
         snackbarHost = { SnackbarHost(snackBarHost) },
-        bottomBar = { LibraryBottomBar(onModalBottomSheet = onModalBottomSheet, onPageChange = onPageChange) }
+        bottomBar = { LibraryBottomBar(state = state, onModalBottomSheet = onModalBottomSheet, onPageChange = onPageChange) }
     ) { paddingValues ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -58,6 +58,7 @@ internal fun LibraryListPane(
     sheetState: SheetState,
     onFilterChanged: (AppFilter) -> Unit,
     onModalBottomSheet: (Boolean) -> Unit,
+    onPageChange: (Int) -> Unit,
     onIsSearching: (Boolean) -> Unit,
     onLogout: () -> Unit,
     onNavigate: (Int) -> Unit,
@@ -79,6 +80,7 @@ internal fun LibraryListPane(
     Scaffold(
         modifier = if (isPortrait) Modifier else Modifier.statusBarsPadding(),
         snackbarHost = { SnackbarHost(snackBarHost) },
+        bottomBar = { LibraryBottomBar(onModalBottomSheet = onModalBottomSheet, onPageChange = onPageChange) }
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -228,6 +230,7 @@ private fun Preview_LibraryListPane() {
                 state = state,
                 sheetState = sheetState,
                 onFilterChanged = { },
+                onPageChange = { },
                 onModalBottomSheet = {
                     val currentState = state.modalBottomSheet
                     println("State: $currentState")

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -45,6 +46,7 @@ import app.gamenative.service.SteamService
 import app.gamenative.ui.data.LibraryState
 import app.gamenative.ui.enums.AppFilter
 import app.gamenative.ui.internal.fakeAppInfo
+import app.gamenative.PrefManager
 import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.ui.component.topbar.AccountButton
 
@@ -199,9 +201,10 @@ internal fun LibraryListPane(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
-@Preview
+@Preview(device = "spec:width=1920px,height=1080px,dpi=440") // Odin2 Mini
 @Composable
 private fun Preview_LibraryListPane() {
+    PrefManager.init(LocalContext.current)
     val sheetState = rememberModalBottomSheetState()
     var state by remember {
         mutableStateOf(

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibrarySearchBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibrarySearchBar.kt
@@ -38,6 +38,8 @@ import kotlinx.coroutines.flow.debounce
 import timber.log.Timber
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.ui.platform.LocalContext
+import app.gamenative.PrefManager
 
 @OptIn(ExperimentalMaterial3Api::class, FlowPreview::class)
 @Composable
@@ -125,9 +127,10 @@ internal fun LibrarySearchBar(
  ***********/
 
 @Preview(uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES or android.content.res.Configuration.UI_MODE_TYPE_NORMAL)
-@Preview
 @Composable
 private fun Preview_LibrarySearchBar() {
+    val context = LocalContext.current
+    PrefManager.init(context)
     PluviaTheme {
         Surface {
             LibrarySearchBar(


### PR DESCRIPTION
For my 1300 game library (with family share), reduces filter time from 12 seconds to <1
- Filter data after DAO request but before it reaches UI, reducing the amount of image requests etc
- Download status is determined by getting the installed folder names, and comparing items to that rather than making 1300 individual folder exist checks (plus 1300 more for sorting)
- Limit pages to 25 items, UI at bottom to navigate
- Moved filter button to be inline with these

Misc:
- Switch off the "continuousFriendChecker" while it's not relevant or visible
- Enabled the "external storage" preference to return the external folder location for a new install (!)
- Stopped the PICS request re-filtering if the number of apps hasn't changed