### PR TITLE
Small fixes and tweaks

### DIFF
--- a/app/src/main/java/app/gamenative/service/DownloadService.kt
+++ b/app/src/main/java/app/gamenative/service/DownloadService.kt
@@ -44,14 +44,22 @@ object DownloadService {
         return subDir.toMutableList()
     }
 
+    fun getSizeFromStoreDisplay (appId: Int): String {
+        // How big is the game? The store should know. Human readable.
+        val depots = SteamService.getDownloadableDepots(appId)
+        val installBytes = depots.values.sumOf { it.manifests["public"]?.size ?: 0L }
+        return StorageUtils.formatBinarySize(installBytes)
+    }
+
     fun getSizeOnDiskDisplay (appId: Int, setResult: (String) -> Unit) {
         // Outputs "3.76GiB" etc to the result lambda without locking up the main thread
         if (SteamService.isAppInstalled(appId)) {
-            // Slow operation, so done asynchronously with a placeholder
+            // Slow operation, so done asynchronously with a placeholder first
             var appSizeText = "..."
             setResult(appSizeText)
+
             CoroutineScope(Dispatchers.IO).launch {
-                val job = CoroutineScope(Dispatchers.IO).async {
+                CoroutineScope(Dispatchers.IO).async {
                     appSizeText = StorageUtils.formatBinarySize(
                         StorageUtils.getFolderSize(SteamService.getAppDirPath(appId))
                     )

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -118,6 +118,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.foundation.border
 import app.gamenative.PrefManager
+import app.gamenative.service.DownloadService
 import java.nio.file.Paths
 import kotlin.io.path.pathString
 import kotlin.math.roundToInt
@@ -1149,16 +1150,7 @@ private fun AppScreenContent(
                                     )
                                     Spacer(modifier = Modifier.height(4.dp))
                                     Text(
-                                        text = if (isInstalled) {
-                                            StorageUtils.formatBinarySize(
-                                                StorageUtils.getFolderSize(SteamService.getAppDirPath(appInfo.id))
-                                            )
-                                        } else {
-                                            val depots = SteamService.getDownloadableDepots(appInfo.id)
-                                            val downloadBytes = depots.values.sumOf { it.manifests["public"]?.download ?: 0L }
-                                            val installBytes = depots.values.sumOf { it.manifests["public"]?.size ?: 0L }
-                                            "${StorageUtils.formatBinarySize(installBytes)}"
-                                        },
+                                        text = DownloadService.getSizeFromStoreDisplay(appInfo.id),
                                         style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold)
                                     )
                                 }

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -626,15 +626,12 @@ fun AppScreen(
                             AppMenuOption(
                                 AppOptionMenuType.Uninstall,
                                 onClick = {
-                                    val sizeOnDisk = StorageUtils.formatBinarySize(
-                                        StorageUtils.getFolderSize(SteamService.getAppDirPath(appInfo.id)),
-                                    )
                                     // TODO: show loading screen of delete progress
                                     msgDialogState = MessageDialogState(
                                         visible = true,
                                         type = DialogType.DELETE_APP,
                                         title = context.getString(R.string.delete_prompt_title),
-                                        message = "Are you sure you want to delete this app?\n\n\tSize on Disk: $sizeOnDisk",
+                                        message = "Are you sure you want to delete this app?",
                                         confirmBtnText = context.getString(R.string.delete_app),
                                         dismissBtnText = context.getString(R.string.cancel),
                                     )

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryAppItem.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryAppItem.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -114,9 +115,9 @@ internal fun AppItem(
                     color = MaterialTheme.colorScheme.onSurface
                 )
 
-                Row(
+                FlowRow(
                     modifier = Modifier.padding(top = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     // Status indicator: Installing / Installed / Not installed
                     val statusText = when {
@@ -157,12 +158,7 @@ internal fun AppItem(
                     // Only show game size for installed games
                     if (isInstalled) {
                         Text(
-                            text = " • ",
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-
-                        Text(
-                            text = appSizeOnDisk,
+                            text = "• $appSizeOnDisk",
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -170,11 +166,13 @@ internal fun AppItem(
 
                     // Family share indicator if needed
                     if (appInfo.isShared) {
-                        Text(
-                            text = " • Family Shared",
-                            style = MaterialTheme.typography.bodyMedium.copy(fontStyle = FontStyle.Italic),
-                            color = MaterialTheme.colorScheme.tertiary
-                        )
+                        Box(modifier = Modifier.align(Alignment.CenterVertically)) {
+                            Text(
+                                text = "• Family Shared",
+                                style = MaterialTheme.typography.bodyMedium.copy(fontStyle = FontStyle.Italic),
+                                color = MaterialTheme.colorScheme.tertiary
+                            )
+                        }
                     }
                 }
             }
@@ -204,7 +202,7 @@ internal fun AppItem(
  ***********/
 
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
-@Preview
+@Preview(device = "spec:width=1920px,height=1080px,dpi=440") // Odin2 Mini
 @Composable
 private fun Preview_AppItem() {
     PluviaTheme {

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryAppItem.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryAppItem.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -56,10 +57,13 @@ internal fun AppItem(
         SteamService.isAppInstalled(appInfo.appId)
     }
 
-    var appSize by remember { mutableStateOf("") }
+    var appSizeOnDisk by remember { mutableStateOf("") }
 
     LaunchedEffect(Unit) {
-        DownloadService.getSizeOnDiskDisplay(appInfo.appId) {  appSize = it }
+        if (isInstalled) {
+            appSizeOnDisk = "..."
+            DownloadService.getSizeOnDiskDisplay(appInfo.appId) {  appSizeOnDisk = it }
+        }
     }
 
     // Modern card-style item with gradient hover effect
@@ -158,7 +162,7 @@ internal fun AppItem(
                         )
 
                         Text(
-                            text = appSize,
+                            text = appSizeOnDisk,
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryAppItem.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryAppItem.kt
@@ -23,7 +23,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,11 +36,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.gamenative.data.LibraryItem
+import app.gamenative.service.DownloadService
 import app.gamenative.service.SteamService
 import app.gamenative.ui.internal.fakeAppInfo
 import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.ui.util.ListItemImage
-import app.gamenative.utils.StorageUtils
 
 @Composable
 internal fun AppItem(
@@ -52,12 +56,10 @@ internal fun AppItem(
         SteamService.isAppInstalled(appInfo.appId)
     }
 
-    val gameSize = remember(appInfo.appId) {
-        if (isInstalled) {
-            StorageUtils.formatBinarySize(
-                StorageUtils.getFolderSize(SteamService.getAppDirPath(appInfo.appId))
-            )
-        } else ""
+    var appSize by remember { mutableStateOf("") }
+
+    LaunchedEffect(Unit) {
+        DownloadService.getSizeOnDiskDisplay(appInfo.appId) {  appSize = it }
     }
 
     // Modern card-style item with gradient hover effect
@@ -156,7 +158,7 @@ internal fun AppItem(
                         )
 
                         Text(
-                            text = gameSize,
+                            text = appSize,
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -275,6 +275,7 @@ private fun Preview_LibraryListPane() {
                         appId = item.id,
                         name = item.name,
                         iconHash = item.iconHash,
+                        isShared = idx % 2 == 0,
                     )
                 },
             ),

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -55,6 +55,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
+import app.gamenative.PrefManager
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.distinctUntilChanged
 
@@ -136,6 +137,24 @@ internal fun LibraryListPane(
                         )
                     }
 
+                    if (! isPortrait) {
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 30.dp, vertical = 18.dp)
+                        ) {
+                            LibrarySearchBar(
+                                state = state,
+                                listState = listState,
+                                onIsSearching = onIsSearching,
+                                onSearchQuery = onSearchQuery,
+                                onSettings = onSettings,
+                                onLogout = onLogout,
+                                onItemClick = onNavigate,
+                            )
+                        }
+                    }
+
                     // User profile button
                     Box(
                         modifier = Modifier
@@ -151,21 +170,23 @@ internal fun LibraryListPane(
                 }
             }
 
-            // Search bar
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp, vertical = 12.dp)
-            ) {
-                LibrarySearchBar(
-                    state = state,
-                    listState = listState,
-                    onIsSearching = onIsSearching,
-                    onSearchQuery = onSearchQuery,
-                    onSettings = onSettings,
-                    onLogout = onLogout,
-                    onItemClick = onNavigate,
-                )
+            if (isPortrait) {
+                // Search bar
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp, vertical = 12.dp)
+                ) {
+                    LibrarySearchBar(
+                        state = state,
+                        listState = listState,
+                        onIsSearching = onIsSearching,
+                        onSearchQuery = onSearchQuery,
+                        onSettings = onSettings,
+                        onLogout = onLogout,
+                        onItemClick = onNavigate,
+                    )
+                }
             }
 
             // Game list
@@ -246,6 +267,8 @@ internal fun LibraryListPane(
 @Preview(device = "spec:width=1920px,height=1080px,dpi=440") // Odin2 Mini
 @Composable
 private fun Preview_LibraryListPane() {
+    val context = LocalContext.current
+    PrefManager.init(context)
     val sheetState = rememberModalBottomSheetState()
     var state by remember {
         mutableStateOf(

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -36,13 +35,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.gamenative.data.LibraryItem
-import app.gamenative.service.SteamService
 import app.gamenative.ui.data.LibraryState
 import app.gamenative.ui.enums.AppFilter
 import app.gamenative.ui.internal.fakeAppInfo
@@ -53,9 +50,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
 import app.gamenative.PrefManager
+import app.gamenative.utils.DeviceUtils
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.distinctUntilChanged
 
@@ -78,11 +77,8 @@ internal fun LibraryListPane(
     val snackBarHost = remember { SnackbarHostState() }
     val installedCount = remember { DownloadService.getDownloadDirectoryApps().count() }
 
-    // Determine the orientation to add additional scaffold padding.
-    val configuration = LocalConfiguration.current
-    val isPortrait = remember(configuration) {
-        configuration.orientation == Configuration.ORIENTATION_PORTRAIT
-    }
+    // Responsive width for better layouts
+    val isViewWide = DeviceUtils.isViewWide(currentWindowAdaptiveInfo())
 
     // Infinite scroll: load next page when scrolled to bottom
     LaunchedEffect(listState, state.appInfoList.size) {
@@ -98,7 +94,6 @@ internal fun LibraryListPane(
     }
 
     Scaffold(
-        modifier = if (isPortrait) Modifier else Modifier.statusBarsPadding(),
         snackbarHost = { SnackbarHost(snackBarHost) }
     ) { paddingValues ->
         Column(
@@ -137,11 +132,11 @@ internal fun LibraryListPane(
                         )
                     }
 
-                    if (! isPortrait) {
+                    if (isViewWide) {
                         Box(
                             modifier = Modifier
                                 .weight(1f)
-                                .padding(horizontal = 30.dp, vertical = 18.dp)
+                                .padding(horizontal = 30.dp)
                         ) {
                             LibrarySearchBar(
                                 state = state,
@@ -170,7 +165,7 @@ internal fun LibraryListPane(
                 }
             }
 
-            if (isPortrait) {
+            if (! isViewWide) {
                 // Search bar
                 Box(
                     modifier = Modifier

--- a/app/src/main/java/app/gamenative/utils/DeviceUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/DeviceUtils.kt
@@ -1,0 +1,17 @@
+package app.gamenative.utils
+
+import androidx.compose.material3.adaptive.WindowAdaptiveInfo
+import androidx.window.core.layout.WindowWidthSizeClass
+
+object DeviceUtils {
+    // Functions related to the device and view
+
+    fun isViewWide (windowSizeClass: WindowAdaptiveInfo): Boolean {
+        if (windowSizeClass.windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.MEDIUM
+            || windowSizeClass.windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.EXPANDED
+        ) {
+            return true
+        }
+        return false
+    }
+}


### PR DESCRIPTION
- Getting the size on disk was seriously slow for some games on external storage - 15+ seconds. Rewritten the function to ~8 seconds, and set it in coroutines that are halted when the UI is unloaded or when "Play" is pressed
- Search bar is moved into the header row when device is wide enough
- Search does not scroll to top 500ms after viewing library. Instead scrolls to top when search value changes or is removed