### PR TITLE
Convert Settings nav function to generic, so others can use the same callback

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -460,8 +460,8 @@ fun PluviaMain(
                     onChat = {
                         navController.navigate(PluviaScreen.Chat.route(it))
                     },
-                    onSettings = {
-                        navController.navigate(PluviaScreen.Settings.route)
+                    onNavigateRoute = {
+                        navController.navigate(it)
                     },
                     onLogout = {
                         SteamService.logOut()

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ProfileDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ProfileDialog.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.gamenative.R
+import app.gamenative.ui.screen.PluviaScreen
 import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.ui.util.SteamIconImage
 import app.gamenative.utils.getAvatarURL
@@ -44,7 +45,7 @@ fun ProfileDialog(
     avatarHash: String,
     state: EPersonaState,
     onStatusChange: (EPersonaState) -> Unit,
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
     onLogout: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -102,7 +103,7 @@ fun ProfileDialog(
 
                 /* Action Buttons */
                 Spacer(modifier = Modifier.height(16.dp))
-                FilledTonalButton(modifier = Modifier.fillMaxWidth(), onClick = onSettings) {
+                FilledTonalButton(modifier = Modifier.fillMaxWidth(), onClick = { onNavigateRoute(PluviaScreen.Settings.route) }) {
                     Icon(imageVector = Icons.Default.Settings, contentDescription = null)
                     Spacer(modifier = Modifier.size(ButtonDefaults.IconSize))
                     Text(text = "Settings")
@@ -133,7 +134,7 @@ private fun Preview_ProfileDialog() {
             avatarHash = "",
             state = EPersonaState.Online,
             onStatusChange = {},
-            onSettings = {},
+            onNavigateRoute = {},
             onLogout = {},
             onDismiss = {},
         )

--- a/app/src/main/java/app/gamenative/ui/component/topbar/AccountButton.kt
+++ b/app/src/main/java/app/gamenative/ui/component/topbar/AccountButton.kt
@@ -28,7 +28,7 @@ import timber.log.Timber
 
 @Composable
 fun AccountButton(
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
     onLogout: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
@@ -64,8 +64,8 @@ fun AccountButton(
                 SteamService.setPersonaState(it)
             }
         },
-        onSettings = {
-            onSettings()
+        onNavigateRoute = {
+            onNavigateRoute(it)
             showDialog = false
         },
         onLogout = {
@@ -97,7 +97,7 @@ private fun Preview_AccountButton() {
             title = { Text("Top App Bar") },
             actions = {
                 AccountButton(
-                    onSettings = {},
+                    onNavigateRoute = {},
                     onLogout = {},
                 )
             },

--- a/app/src/main/java/app/gamenative/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/HomeScreen.kt
@@ -22,7 +22,7 @@ fun HomeScreen(
     onClickExit: () -> Unit,
     onClickPlay: (Int, Boolean) -> Unit,
     onLogout: () -> Unit,
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
 ) {
     val homeState by viewModel.homeState.collectAsStateWithLifecycle()
 
@@ -34,7 +34,7 @@ fun HomeScreen(
     // Always show the Library screen
     HomeLibraryScreen(
         onClickPlay = onClickPlay,
-        onSettings = onSettings,
+        onNavigateRoute = onNavigateRoute,
         onLogout = onLogout,
     )
 }
@@ -54,7 +54,7 @@ private fun Preview_HomeScreenContent() {
             onChat = {},
             onClickPlay = { _, _ -> },
             onLogout = {},
-            onSettings = {},
+            onNavigateRoute = {},
             onClickExit = {}
         )
     }

--- a/app/src/main/java/app/gamenative/ui/screen/downloads/HomeDownloadsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/downloads/HomeDownloadsScreen.kt
@@ -39,14 +39,14 @@ import app.gamenative.ui.theme.PluviaTheme
 
 @Composable
 fun HomeDownloadsScreen(
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
     onLogout: () -> Unit,
 ) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
 
     DownloadsScreenContent(
         onBack = { onBackPressedDispatcher?.onBackPressed() },
-        onSettings = onSettings,
+        onNavigateRoute = onNavigateRoute,
         onLogout = onLogout,
     )
 }
@@ -55,7 +55,7 @@ fun HomeDownloadsScreen(
 @Composable
 private fun DownloadsScreenContent(
     onBack: () -> Unit,
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
     onLogout: () -> Unit,
 ) {
     val snackbarHost = remember { SnackbarHostState() }
@@ -78,7 +78,7 @@ private fun DownloadsScreenContent(
                         navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, 1L)
                     },
                     onBack = onBack,
-                    onSettings = onSettings,
+                    onNavigateRoute = onNavigateRoute,
                     onLogout = onLogout,
                 )
             }
@@ -102,7 +102,7 @@ private fun DownloadsScreenPane(
     snackbarHost: SnackbarHostState,
     onClick: () -> Unit,
     onBack: () -> Unit,
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
     onLogout: () -> Unit,
 ) {
     Scaffold(
@@ -112,7 +112,7 @@ private fun DownloadsScreenPane(
                 title = { Text(text = "Downloads") },
                 actions = {
                     AccountButton(
-                        onSettings = onSettings,
+                        onNavigateRoute = onNavigateRoute,
                         onLogout = onLogout,
                     )
                 },
@@ -197,7 +197,7 @@ private fun Preview_DownloadsScreenContent() {
         Surface {
             DownloadsScreenContent(
                 onBack = {},
-                onSettings = {},
+                onNavigateRoute = {},
                 onLogout = {},
             )
         }

--- a/app/src/main/java/app/gamenative/ui/screen/friends/FriendsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/friends/FriendsScreen.kt
@@ -128,7 +128,7 @@ fun FriendsScreen(
     viewModel: FriendsViewModel = hiltViewModel(),
     onChat: (Long) -> Unit,
     onLogout: () -> Unit,
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
 ) {
     val navigator = rememberListDetailPaneScaffoldNavigator<Unit>()
     val state by viewModel.friendsState.collectAsStateWithLifecycle()
@@ -146,7 +146,7 @@ fun FriendsScreen(
         onHeaderAction = viewModel::onHeaderAction,
         onLogout = onLogout,
         onNickName = viewModel::onNickName,
-        onSettings = onSettings,
+        onNavigateRoute = onNavigateRoute,
         onAlias = viewModel::onAlias,
     )
 }
@@ -164,7 +164,7 @@ private fun FriendsScreenContent(
     onHeaderAction: (String) -> Unit,
     onLogout: () -> Unit,
     onNickName: (String) -> Unit,
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
     onAlias: () -> Unit,
 ) {
     val listState = rememberLazyListState() // Hoisted high to preserve state
@@ -203,7 +203,7 @@ private fun FriendsScreenContent(
                     },
                     onHeaderAction = onHeaderAction,
                     onLogout = onLogout,
-                    onSettings = onSettings,
+                    onNavigateRoute = onNavigateRoute,
                 )
             }
         },
@@ -237,7 +237,7 @@ private fun FriendsListPane(
     onFriendClick: (SteamFriend) -> Unit,
     onHeaderAction: (String) -> Unit,
     onLogout: () -> Unit,
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
 ) {
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHost) },
@@ -246,7 +246,7 @@ private fun FriendsListPane(
                 title = { Text(text = "Friends") },
                 actions = {
                     AccountButton(
-                        onSettings = onSettings,
+                        onNavigateRoute = onNavigateRoute,
                         onLogout = onLogout,
                     )
                 },
@@ -807,7 +807,7 @@ private fun Preview_FriendsScreenContent(
                 onFriendClick = { },
                 onHeaderAction = { },
                 onBack = { },
-                onSettings = { },
+                onNavigateRoute = { },
                 onLogout = { },
                 onChat = { },
                 onBlock = { },

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -51,7 +51,7 @@ import java.util.EnumSet
 fun HomeLibraryScreen(
     viewModel: LibraryViewModel = hiltViewModel(),
     onClickPlay: (Int, Boolean) -> Unit,
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
     onLogout: () -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -67,7 +67,7 @@ fun HomeLibraryScreen(
         onIsSearching = viewModel::onIsSearching,
         onSearchQuery = viewModel::onSearchQuery,
         onClickPlay = onClickPlay,
-        onSettings = onSettings,
+        onNavigateRoute = onNavigateRoute,
         onLogout = onLogout,
     )
 }
@@ -84,7 +84,7 @@ private fun LibraryScreenContent(
     onIsSearching: (Boolean) -> Unit,
     onSearchQuery: (String) -> Unit,
     onClickPlay: (Int, Boolean) -> Unit,
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
     onLogout: () -> Unit,
 ) {
     var selectedAppId by remember { mutableStateOf<Int?>(null) }
@@ -109,7 +109,7 @@ private fun LibraryScreenContent(
                 onModalBottomSheet = onModalBottomSheet,
                 onIsSearching = onIsSearching,
                 onSearchQuery = onSearchQuery,
-                onSettings = onSettings,
+                onNavigateRoute = onNavigateRoute,
                 onLogout = onLogout,
                 onNavigate = { appId -> selectedAppId = appId }
             )
@@ -172,7 +172,7 @@ private fun Preview_LibraryScreenContent() {
                 state = state.copy(modalBottomSheet = !currentState)
             },
             onClickPlay = { _, _ -> },
-            onSettings = {},
+            onNavigateRoute = {},
             onLogout = {},
         )
     }

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
@@ -47,7 +47,7 @@ internal fun LibraryDetailPane(
                 onLogout = {},
                 onNavigate = {},
                 onSearchQuery = {},
-                onSettings = {},
+                onNavigateRoute = {},
             )
         } else {
             AppScreen(

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -71,7 +71,7 @@ internal fun LibraryListPane(
     onLogout: () -> Unit,
     onNavigate: (Int) -> Unit,
     onSearchQuery: (String) -> Unit,
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
 ) {
     val expandedFab by remember { derivedStateOf { listState.firstVisibleItemIndex == 0 } }
     val snackBarHost = remember { SnackbarHostState() }
@@ -144,7 +144,7 @@ internal fun LibraryListPane(
                             .padding(8.dp)
                     ) {
                         AccountButton(
-                            onSettings = onSettings,
+                            onNavigateRoute = onNavigateRoute,
                             onLogout = onLogout
                         )
                     }
@@ -162,7 +162,7 @@ internal fun LibraryListPane(
                     listState = listState,
                     onIsSearching = onIsSearching,
                     onSearchQuery = onSearchQuery,
-                    onSettings = onSettings,
+                    onNavigateRoute = onNavigateRoute,
                     onLogout = onLogout,
                     onItemClick = onNavigate,
                 )
@@ -277,7 +277,7 @@ private fun Preview_LibraryListPane() {
                 },
                 onIsSearching = { },
                 onSearchQuery = { },
-                onSettings = { },
+                onNavigateRoute = { },
                 onLogout = { },
                 onNavigate = { },
             )

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibrarySearchBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibrarySearchBar.kt
@@ -48,7 +48,7 @@ internal fun LibrarySearchBar(
     listState: LazyListState,
     onIsSearching: (Boolean) -> Unit,
     onSearchQuery: (String) -> Unit,
-    onSettings: () -> Unit,
+    onNavigateRoute: (String) -> Unit,
     onLogout: () -> Unit,
     onItemClick: (Int) -> Unit,
 ) {
@@ -149,7 +149,7 @@ private fun Preview_LibrarySearchBar() {
                 listState = rememberLazyListState(),
                 onIsSearching = { },
                 onSearchQuery = { },
-                onSettings = { },
+                onNavigateRoute = { },
                 onLogout = { },
                 onItemClick = { },
             )


### PR DESCRIPTION
…(and get the same protections)

Means other top level routes can be button destinations with calls equivalent to;

```
FilledTonalButton(modifier = Modifier.fillMaxWidth(), onClick = { onNavigateRoute(PluviaScreen.Home.route) }) {
    Text(text = "Library")
}
```