### PR TITLE
Stabilise pics requests

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -15,9 +15,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -192,15 +194,17 @@ fun PluviaMain(
         }
     }
 
-    LaunchedEffect(lifecycleOwner) {
-        if (!state.isSteamConnected && !isConnecting) {
-            isConnecting = true
-            val intent = Intent(context, SteamService::class.java)
-            context.startForegroundService(intent)
-        }
-        // Go to the Home screen if we're already logged in.
-        if (SteamService.isLoggedIn && state.currentScreen == PluviaScreen.LoginUser) {
-            navController.navigate(PluviaScreen.Home.route)
+    LaunchedEffect(Unit) {
+        //
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            if (!state.isSteamConnected && !isConnecting) {
+                Timber.d("Steam not connected - attempt")
+                isConnecting = true
+                context.startForegroundService(Intent(context, SteamService::class.java))
+            }
+            if (SteamService.isLoggedIn && state.currentScreen == PluviaScreen.LoginUser) {
+                navController.navigate(PluviaScreen.Home.route)
+            }
         }
     }
 


### PR DESCRIPTION
If the Steam service is disconnected and kills itself, the app will crash from ongoing PICS requests. This change gives more exit points, and also forces termination at critical moments of the Steam service isn't instantiated

Also change to when the Steam service is requested so it restarts when the app resumes