### PR TITLE
Show storage directory on app page if installed

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -124,6 +124,7 @@ import androidx.compose.runtime.setValue
 import app.gamenative.enums.Marker
 import app.gamenative.enums.SaveLocation
 import androidx.compose.animation.core.*
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.ui.graphics.compositeOver
 import app.gamenative.utils.MarkerUtils
 
@@ -1319,6 +1320,33 @@ private fun AppScreenContent(
                                             Text(
                                                 text = appSizeOnDisk,
                                                 style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold)
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Location item
+                            if (isInstalled) {
+                                item (span = { GridItemSpan(maxLineSpan) }) {
+
+                                    Column {
+                                        Text(
+                                            text = "Location",
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                        Spacer(modifier = Modifier.height(4.dp))
+                                        Surface(
+                                            shape = RoundedCornerShape(20.dp),
+                                            color = MaterialTheme.colorScheme.secondary.copy(alpha = 0.3f),
+                                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.secondary.copy(alpha = 0.5f)),
+                                        ) {
+                                            Text(
+                                                text = getAppDirPath(appInfo.id),
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                                             )
                                         }
                                     }


### PR DESCRIPTION
Nice-to-have view of where a game is located. There's not otherwise a good way to see if something is internal or external, so this is a start on that too.

Not installed:
<img width="1920" height="1080" alt="Screenshot_20250729-132519" src="https://github.com/user-attachments/assets/1ce478ae-2dcf-4ae8-9122-855d0a5911a5" />
Internal storage:
<img width="1920" height="1080" alt="Screenshot_20250729-132207" src="https://github.com/user-attachments/assets/da58cb11-02d1-445b-9252-915a9c5108bb" />
External storage:
<img width="1920" height="1080" alt="Screenshot_20250729-132239" src="https://github.com/user-attachments/assets/8357bb1f-b364-46de-8657-d905960b4233" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Location" section to the game information screen, displaying the app's installation directory when the app is installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->