### PR TITLE
Message dialog is accurate to the intended destination of the game

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -326,7 +326,7 @@ fun AppScreen(
                 val depots = SteamService.getDownloadableDepots(appId)
                 Timber.i("There are ${depots.size} depots belonging to $appId")
                 // TODO: get space available based on where user wants to install
-                val availableBytes = StorageUtils.getAvailableSpace(context.filesDir.absolutePath)
+                val availableBytes = StorageUtils.getAvailableSpace(SteamService.defaultAppInstallPath)
                 val availableSpace = StorageUtils.formatBinarySize(availableBytes)
                 // TODO: un-hardcode "public" branch
                 val downloadSize = StorageUtils.formatBinarySize(


### PR DESCRIPTION
This is now accurate to my SD card, and lets install proceed:

<img width="1920" height="1080" alt="Screenshot_20250729-133831" src="https://github.com/user-attachments/assets/6890b5d8-4837-4f95-9ae6-a382a2ee6f7c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of available storage space checks before installing Steam apps by referencing the default installation location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->