### PR TITLE
feat: add intent-based game launching with temporary container config

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,6 +54,10 @@
                     android:host="pluvia"
                     android:scheme="home" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="app.gamenative.LAUNCH_GAME" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
         <service
             android:name=".service.SteamService"

--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -3,6 +3,7 @@ package app.gamenative
 import android.os.StrictMode
 import androidx.navigation.NavController
 import app.gamenative.events.EventDispatcher
+import app.gamenative.utils.IntentLaunchManager
 import com.google.android.play.core.splitcompat.SplitCompatApplication
 import com.winlator.inputcontrols.InputControlsManager
 import com.winlator.widget.InputControlsView
@@ -44,6 +45,14 @@ class PluviaApp : SplitCompatApplication() {
         // Init our datastore preferences.
         PrefManager.init(this)
 
+        // Clear any stale temporary config overrides from previous app sessions
+        try {
+            IntentLaunchManager.clearAllTemporaryOverrides()
+            Timber.d("[PluviaApp]: Cleared temporary config overrides from previous session")
+        } catch (e: Exception) {
+            Timber.e(e, "[PluviaApp]: Failed to clear temporary config overrides")
+        }
+
         // Initialize PostHog Analytics
         val postHogConfig = PostHogAndroidConfig(
             apiKey = BuildConfig.POSTHOG_API_KEY,
@@ -56,7 +65,7 @@ class PluviaApp : SplitCompatApplication() {
         internal val events: EventDispatcher = EventDispatcher()
         internal var onDestinationChangedListener: NavChangedListener? = null
 
-        // TODO: find a way to make this saveable, this is terrible
+        // TODO: find a way to make this saveable, this is terrible (leak that memory baby)
         internal var xEnvironment: XEnvironment? = null
         internal var xServerView: XServerView? = null
         var inputControlsView: InputControlsView? = null

--- a/app/src/main/java/app/gamenative/events/AndroidEvent.kt
+++ b/app/src/main/java/app/gamenative/events/AndroidEvent.kt
@@ -13,5 +13,7 @@ interface AndroidEvent<T> : Event<T> {
     data class KeyEvent(val event: android.view.KeyEvent) : AndroidEvent<Boolean>
     data class MotionEvent(val event: android.view.MotionEvent?) : AndroidEvent<Boolean>
     data object EndProcess : AndroidEvent<Unit>
+    data class ExternalGameLaunch(val appId: Int) : AndroidEvent<Unit>
+    data class PromptSaveContainerConfig(val appId: Int) : AndroidEvent<Unit>
     // data class SetAppBarVisibility(val visible: Boolean) : AndroidEvent<Unit>
 }

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -30,6 +31,7 @@ import androidx.navigation.navArgument
 import androidx.navigation.navDeepLink
 import app.gamenative.BuildConfig
 import app.gamenative.Constants
+import app.gamenative.MainActivity
 import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
 import app.gamenative.enums.AppTheme
@@ -55,6 +57,8 @@ import app.gamenative.ui.screen.settings.SettingsScreen
 import app.gamenative.ui.screen.xserver.XServerScreen
 import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.utils.ContainerUtils
+import app.gamenative.utils.IntentLaunchManager
+import app.gamenative.R
 import com.google.android.play.core.splitcompat.SplitCompat
 import com.winlator.container.ContainerManager
 import com.winlator.xenvironment.ImageFsInstaller
@@ -88,11 +92,82 @@ fun PluviaMain(
 
     var isConnecting by rememberSaveable { mutableStateOf(false) }
 
+    // Process any pending launch request from MainActivity after login
+    LaunchedEffect(SteamService.isLoggedIn) {
+        if (SteamService.isLoggedIn) {
+            MainActivity.pendingLaunchRequest?.let { launchRequest ->
+                Timber.i("[PluviaMain]: Processing pending launch request for app ${launchRequest.appId} (user is now logged in)")
+
+                // Check if the game is installed
+                if (!SteamService.isAppInstalled(launchRequest.appId)) {
+                    val appName = SteamService.getAppInfoOf(launchRequest.appId)?.name ?: "App ${launchRequest.appId}"
+                    Timber.w("[PluviaMain]: Game not installed: $appName (${launchRequest.appId})")
+
+                    // Show error message
+                    msgDialogState = MessageDialogState(
+                        visible = true,
+                        type = DialogType.SYNC_FAIL,
+                        title = context.getString(R.string.game_not_installed_title),
+                        message = context.getString(R.string.game_not_installed_message, appName),
+                        dismissBtnText = context.getString(R.string.ok)
+                    )
+                    MainActivity.pendingLaunchRequest = null
+                    return@let
+                }
+
+                if (launchRequest.containerConfig != null) {
+                    IntentLaunchManager.applyTemporaryConfigOverride(
+                        context,
+                        launchRequest.appId,
+                        launchRequest.containerConfig
+                    )
+                    Timber.i("[PluviaMain]: Applied container config override for app ${launchRequest.appId}")
+                }
+
+                if (navController.currentDestination?.route != PluviaScreen.Home.route) {
+                    navController.navigate(PluviaScreen.Home.route) {
+                        popUpTo(navController.graph.startDestinationId) {
+                            saveState = false
+                        }
+                    }
+                }
+
+                viewModel.setLaunchedAppId(launchRequest.appId)
+                viewModel.setBootToContainer(false)
+                preLaunchApp(
+                    context = context,
+                    appId = launchRequest.appId,
+                    useTemporaryOverride = true,
+                    setLoadingDialogVisible = viewModel::setLoadingDialogVisible,
+                    setLoadingProgress = viewModel::setLoadingDialogProgress,
+                    setMessageDialogState = setMessageDialogState,
+                    onSuccess = viewModel::launchApp,
+                )
+                MainActivity.pendingLaunchRequest = null
+            }
+        }
+    }
+
     LaunchedEffect(Unit) {
         viewModel.uiEvent.collect { event ->
             when (event) {
                 MainViewModel.MainUiEvent.LaunchApp -> {
                     navController.navigate(PluviaScreen.XServer.route)
+                }
+
+                is MainViewModel.MainUiEvent.ExternalGameLaunch -> {
+                    Timber.i("[PluviaMain]: Received ExternalGameLaunch UI event for app ${event.appId}")
+                    viewModel.setLaunchedAppId(event.appId)
+                    viewModel.setBootToContainer(false)
+                    preLaunchApp(
+                        context = context,
+                        appId = event.appId,
+                        useTemporaryOverride = true,
+                        setLoadingDialogVisible = viewModel::setLoadingDialogVisible,
+                        setLoadingProgress = viewModel::setLoadingDialogProgress,
+                        setMessageDialogState = setMessageDialogState,
+                        onSuccess = viewModel::launchApp,
+                    )
                 }
 
                 MainViewModel.MainUiEvent.OnBackPressed -> {
@@ -132,7 +207,7 @@ fun PluviaMain(
                                         "You can view and export the most recent crash log in the app's settings " +
                                         "and attach it as a Github issue in the project's repository.\n" +
                                         "Link to the Github repo is also in settings!",
-                                    confirmBtnText = "OK",
+                                    confirmBtnText = context.getString(R.string.ok),
                                 )
                             } else if (!(PrefManager.tipped || BuildConfig.GOLD) && !state.annoyingDialogShown) {
                                 viewModel.setAnnoyingDialogShown(true)
@@ -195,10 +270,9 @@ fun PluviaMain(
     }
 
     LaunchedEffect(Unit) {
-        //
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             if (!state.isSteamConnected && !isConnecting) {
-                Timber.d("Steam not connected - attempt")
+                Timber.d("[PluviaMain]: Steam not connected - attempt")
                 isConnecting = true
                 context.startForegroundService(Intent(context, SteamService::class.java))
             }
@@ -215,11 +289,35 @@ fun PluviaMain(
         }
     }
 
+    // Listen for save container config prompt
+    var pendingSaveAppId by rememberSaveable { mutableStateOf<Int?>(null) }
+    val onPromptSaveConfig: (AndroidEvent.PromptSaveContainerConfig) -> Unit = { event ->
+        pendingSaveAppId = event.appId
+        msgDialogState = MessageDialogState(
+            visible = true,
+            type = DialogType.SAVE_CONTAINER_CONFIG,
+            title = context.getString(R.string.save_container_settings_title),
+            message = context.getString(R.string.save_container_settings_message),
+            confirmBtnText = context.getString(R.string.save),
+            dismissBtnText = context.getString(R.string.discard)
+        )
+    }
+
+    LaunchedEffect(Unit) {
+        PluviaApp.events.on<AndroidEvent.PromptSaveContainerConfig, Unit>(onPromptSaveConfig)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            PluviaApp.events.off<AndroidEvent.PromptSaveContainerConfig, Unit>(onPromptSaveConfig)
+        }
+    }
+
     // Timeout if stuck in connecting state for 10 seconds so that its not in loading state forever
     LaunchedEffect(isConnecting) {
         if (isConnecting) {
             Timber.d("Started connecting, will timeout in 10s")
-            kotlinx.coroutines.delay(10000)
+            delay(10000)
             Timber.d("Timeout reached, isSteamConnected=${state.isSteamConnected}")
             if (!state.isSteamConnected) {
                 isConnecting = false
@@ -387,6 +485,41 @@ fun PluviaMain(
             }
         }
 
+        DialogType.SAVE_CONTAINER_CONFIG -> {
+            onConfirmClick = {
+                // Save the container config permanently
+                pendingSaveAppId?.let { appId ->
+                    IntentLaunchManager.getEffectiveContainerConfig(context, appId)?.let { config ->
+                        ContainerUtils.applyToContainer(context, appId, config)
+                        Timber.i("[PluviaMain]: Saved container configuration for app $appId")
+                    }
+                    // Clear the temporary override after saving
+                    IntentLaunchManager.clearTemporaryOverride(appId)
+                }
+                pendingSaveAppId = null
+                setMessageDialogState(MessageDialogState(false))
+            }
+            onDismissClick = {
+                // Discard the temporary config and restore original
+                pendingSaveAppId?.let { appId ->
+                    IntentLaunchManager.restoreOriginalConfiguration(context, appId)
+                    IntentLaunchManager.clearTemporaryOverride(appId)
+                    Timber.i("[PluviaMain]: Discarded temporary config and restored original for app $appId")
+                }
+                pendingSaveAppId = null
+                setMessageDialogState(MessageDialogState(false))
+            }
+            onDismissRequest = {
+                // Treat closing dialog as discard
+                pendingSaveAppId?.let { appId ->
+                    IntentLaunchManager.restoreOriginalConfiguration(context, appId)
+                    IntentLaunchManager.clearTemporaryOverride(appId)
+                }
+                pendingSaveAppId = null
+                setMessageDialogState(MessageDialogState(false))
+            }
+        }
+
         else -> {
             onDismissRequest = null
             onDismissClick = null
@@ -540,10 +673,12 @@ fun preLaunchApp(
     appId: Int,
     ignorePendingOperations: Boolean = false,
     preferredSave: SaveLocation = SaveLocation.None,
+    useTemporaryOverride: Boolean = false,
     setLoadingDialogVisible: (Boolean) -> Unit,
     setLoadingProgress: (Float) -> Unit,
     setMessageDialogState: (MessageDialogState) -> Unit,
     onSuccess: KFunction2<Context, Int, Unit>,
+    retryCount: Int = 0,
 ) {
     setLoadingDialogVisible(true)
     // TODO: add a way to cancel
@@ -561,7 +696,11 @@ fun preLaunchApp(
         // create container if it does not already exist
         // TODO: combine somehow with container creation in HomeLibraryAppScreen
         val containerManager = ContainerManager(context)
-        val container = ContainerUtils.getOrCreateContainer(context, appId)
+        val container = if (useTemporaryOverride) {
+            ContainerUtils.getOrCreateContainerWithOverride(context, appId)
+        } else {
+            ContainerUtils.getOrCreateContainer(context, appId)
+        }
         // must activate container before downloading save files
         containerManager.activateContainer(container)
 
@@ -595,7 +734,41 @@ fun preLaunchApp(
                 )
             }
 
-            SyncResult.InProgress,
+            SyncResult.InProgress -> {
+                if (useTemporaryOverride && retryCount < 5) {
+                    // For intent launches, retry after a short delay (max 5 retries = ~10 seconds)
+                    Timber.i("Sync in progress for intent launch, retrying in 2 seconds... (attempt ${retryCount + 1}/5)")
+                    delay(2000)
+                    preLaunchApp(
+                        context = context,
+                        appId = appId,
+                        ignorePendingOperations = ignorePendingOperations,
+                        preferredSave = preferredSave,
+                        useTemporaryOverride = useTemporaryOverride,
+                        setLoadingDialogVisible = setLoadingDialogVisible,
+                        setLoadingProgress = setLoadingProgress,
+                        setMessageDialogState = setMessageDialogState,
+                        onSuccess = onSuccess,
+                        retryCount = retryCount + 1
+                    )
+                } else {
+                    val message = if (useTemporaryOverride) {
+                        "Sync operation is taking too long. Please try launching the game again in a moment."
+                    } else {
+                        "Sync is currently in progress. Please try again in a moment."
+                    }
+                    setMessageDialogState(
+                        MessageDialogState(
+                            visible = true,
+                            type = DialogType.SYNC_FAIL,
+                            title = context.getString(R.string.sync_error_title),
+                            message = message,
+                            dismissBtnText = context.getString(R.string.ok),
+                        ),
+                    )
+                }
+            }
+
             SyncResult.UnknownFail,
             SyncResult.DownloadFail,
             SyncResult.UpdateFail,
@@ -604,9 +777,9 @@ fun preLaunchApp(
                     MessageDialogState(
                         visible = true,
                         type = DialogType.SYNC_FAIL,
-                        title = "Sync Error",
+                        title = context.getString(R.string.sync_error_title),
                         message = "Failed to sync save files: ${postSyncInfo.syncResult}. Please restart app.",
-                        dismissBtnText = "Ok",
+                        dismissBtnText = context.getString(R.string.ok),
                     ),
                 )
             }
@@ -636,7 +809,7 @@ fun preLaunchApp(
                                         "on the device ${pro.machineName} " +
                                         "(${Date(pro.timeLastUpdated * 1000L)}) and the save of " +
                                         "that session is still uploading.\nTry again later.",
-                                    dismissBtnText = "Ok",
+                                    dismissBtnText = context.getString(R.string.ok),
                                 ),
                             )
                         }
@@ -687,9 +860,9 @@ fun preLaunchApp(
                                 MessageDialogState(
                                     visible = true,
                                     type = DialogType.APP_SESSION_SUSPENDED,
-                                    title = "Sync Error",
+                                    title = context.getString(R.string.sync_error_title),
                                     message = "App session suspended. Please restart app.",
-                                    dismissBtnText = "Ok",
+                                    dismissBtnText = context.getString(R.string.ok),
                                 ),
                             )
                         }
@@ -700,9 +873,9 @@ fun preLaunchApp(
                                 MessageDialogState(
                                     visible = true,
                                     type = DialogType.PENDING_OPERATION_NONE,
-                                    title = "Sync Error",
+                                    title = context.getString(R.string.sync_error_title),
                                     message = "Received pending remote operations whose operation was 'none'. Please restart app.",
-                                    dismissBtnText = "Ok",
+                                    dismissBtnText = context.getString(R.string.ok),
                                 ),
                             )
                         }
@@ -713,9 +886,9 @@ fun preLaunchApp(
                         MessageDialogState(
                             visible = true,
                             type = DialogType.MULTIPLE_PENDING_OPERATIONS,
-                            title = "Sync Error",
+                            title = context.getString(R.string.sync_error_title),
                             message = "Multiple pending remote operations, try again later. Please restart app.",
-                            dismissBtnText = "Ok",
+                            dismissBtnText = context.getString(R.string.ok),
                         ),
                     )
                 }

--- a/app/src/main/java/app/gamenative/ui/enums/DialogType.kt
+++ b/app/src/main/java/app/gamenative/ui/enums/DialogType.kt
@@ -23,6 +23,8 @@ enum class DialogType(val icon: ImageVector? = null) {
     CANCEL_APP_DOWNLOAD,
     DELETE_APP,
     INSTALL_IMAGEFS,
+    
+    SAVE_CONTAINER_CONFIG,
 
     NONE,
 

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -15,6 +15,7 @@ import app.gamenative.events.AndroidEvent
 import app.gamenative.events.SteamEvent
 import app.gamenative.service.SteamService
 import app.gamenative.ui.data.MainState
+import app.gamenative.utils.IntentLaunchManager
 import app.gamenative.ui.screen.PluviaScreen
 import app.gamenative.utils.SteamUtils
 import com.materialkolor.PaletteStyle
@@ -47,6 +48,7 @@ class MainViewModel @Inject constructor(
         data object OnBackPressed : MainUiEvent()
         data object OnLoggedOut : MainUiEvent()
         data object LaunchApp : MainUiEvent()
+        data class ExternalGameLaunch(val appId: Int) : MainUiEvent()
         data class OnLogonEnded(val result: LoginResult) : MainUiEvent()
     }
 
@@ -90,10 +92,19 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    private val onExternalGameLaunch: (AndroidEvent.ExternalGameLaunch) -> Unit = {
+        Timber.i("[MainViewModel]: Received external game launch event for app ${it.appId}")
+        viewModelScope.launch {
+            Timber.i("[MainViewModel]: Sending ExternalGameLaunch UI event for app ${it.appId}")
+            _uiEvent.send(MainUiEvent.ExternalGameLaunch(it.appId))
+        }
+    }
+
     private var bootingSplashTimeoutJob: Job? = null
 
     init {
         PluviaApp.events.on<AndroidEvent.BackPressed, Unit>(onBackPressed)
+        PluviaApp.events.on<AndroidEvent.ExternalGameLaunch, Unit>(onExternalGameLaunch)
         PluviaApp.events.on<SteamEvent.Connected, Unit>(onSteamConnected)
         PluviaApp.events.on<SteamEvent.Disconnected, Unit>(onSteamDisconnected)
         PluviaApp.events.on<SteamEvent.LogonStarted, Unit>(onLoggingIn)
@@ -196,15 +207,13 @@ class MainViewModel @Inject constructor(
     }
 
     fun launchApp(context: Context, appId: Int) {
-        // Check if we should use real Steam or replace Steam API
-        val container = ContainerUtils.getContainer(context, appId)
-
         // Show booting splash before launching the app
         viewModelScope.launch {
             setShowBootingSplash(true)
             PluviaApp.events.emit(AndroidEvent.SetAllowedOrientation(PrefManager.allowedOrientation))
 
             val apiJob = viewModelScope.async(Dispatchers.IO) {
+                val container = ContainerUtils.getOrCreateContainer(context, appId)
                 if (container.isLaunchRealSteam()) {
                     SteamUtils.restoreSteamApi(context, appId)
                 } else {
@@ -223,10 +232,19 @@ class MainViewModel @Inject constructor(
 
     fun exitSteamApp(context: Context, appId: Int) {
         viewModelScope.launch {
+            // Check if we have a temporary override before doing anything
+            val hadTemporaryOverride = IntentLaunchManager.hasTemporaryOverride(appId)
+            
             SteamService.notifyRunningProcesses()
             SteamService.closeApp(appId) { prefix ->
                 PathType.from(prefix).toAbsPath(context, appId)
             }.await()
+
+            // Prompt user to save temporary container configuration if one was applied
+            if (hadTemporaryOverride) {
+                PluviaApp.events.emit(AndroidEvent.PromptSaveContainerConfig(appId))
+                // Dialog handler in PluviaMain manages the save/discard logic
+            }
         }
     }
 
@@ -268,8 +286,15 @@ class MainViewModel @Inject constructor(
                     GameProcessInfo(appId = appId, processes = processes).let {
                         // Only notify Steam if we're not using real Steam
                         // When launchRealSteam is true, let the real Steam client handle the "game is running" notification
-                        val container = ContainerUtils.getContainer(context, appId)
-                        if (!container.isLaunchRealSteam()) {
+                        val shouldLaunchRealSteam = try {
+                            val container = ContainerUtils.getContainer(context, appId)
+                            container.isLaunchRealSteam()
+                        } catch (e: Exception) {
+                            // Container might not exist, default to notifying Steam
+                            false
+                        }
+
+                        if (!shouldLaunchRealSteam) {
                             SteamService.notifyRunningProcesses(it)
                         } else {
                             Timber.i("Skipping Steam process notification - real Steam will handle this")

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -60,6 +60,7 @@ object ContainerUtils {
             box64Version = PrefManager.box64Version,
             box86Preset = PrefManager.box86Preset,
             box64Preset = PrefManager.box64Preset,
+            desktopTheme = WineThemeManager.DEFAULT_DESKTOP_THEME,
 
             csmt = PrefManager.csmt,
             videoPciDeviceID = PrefManager.videoPciDeviceID,
@@ -188,8 +189,12 @@ object ContainerUtils {
         }
     }
 
-    private fun applyToContainer(context: Context, container: Container, containerData: ContainerData) {
-        Timber.d("Applying containerData to container. execArgs: '${containerData.execArgs}'")
+    fun applyToContainer(context: Context, container: Container, containerData: ContainerData) {
+        applyToContainer(context, container, containerData, saveToDisk = true)
+    }
+    
+    fun applyToContainer(context: Context, container: Container, containerData: ContainerData, saveToDisk: Boolean) {
+        Timber.d("Applying containerData to container. execArgs: '${containerData.execArgs}', saveToDisk: $saveToDisk")
         val userRegFile = File(container.rootDir, ".wine/user.reg")
         WineRegistryEditor(userRegFile).use { registryEditor ->
             registryEditor.setDwordValue("Software\\Wine\\Direct3D", "csmt", if (containerData.csmt) 3 else 0)
@@ -235,7 +240,6 @@ object ContainerUtils {
         container.desktopTheme = containerData.desktopTheme
         container.graphicsDriverVersion = containerData.graphicsDriverVersion
         container.setDisableMouseInput(containerData.disableMouseInput)
-        container.saveData()
 
         // Apply controller settings to container
         val api = when {
@@ -247,7 +251,10 @@ object ContainerUtils {
         container.setInputType(api.ordinal)
         container.setDinputMapperType(containerData.dinputMapperType)
         Timber.d("Container set: preferredInputApi=%s, dinputMapperType=0x%02x", api, containerData.dinputMapperType)
-        container.saveData()
+        
+        if (saveToDisk) {
+            container.saveData()
+        }
         Timber.d("Set container.execArgs to '${containerData.execArgs}'")
     }
 
@@ -273,25 +280,34 @@ object ContainerUtils {
         }
     }
 
-    fun getOrCreateContainer(context: Context, appId: Int): Container {
-        val containerId = getContainerId(appId)
+    private fun createNewContainer(
+        context: Context,
+        appId: Int,
+        containerId: Int,
+        containerManager: ContainerManager,
+        customConfig: ContainerData? = null
+    ): Container {
+        // set up container drives to include app
+        val defaultDrives = PrefManager.drives
+        val appDirPath = SteamService.getAppDirPath(appId)
+        val drive: Char = Container.getNextAvailableDriveLetter(defaultDrives)
+        val drives = "$defaultDrives$drive:$appDirPath"
+        Timber.d("Prepared container drives: $drives")
 
-        val containerManager = ContainerManager(context)
-        return if (containerManager.hasContainer(containerId)) {
-            containerManager.getContainerById(containerId)
+        val data = JSONObject()
+        data.put("name", "container_$containerId")
+        val container = containerManager.createContainerFuture(containerId, data).get()
+
+        val containerData = if (customConfig != null) {
+            // Use custom config, but ensure drives are set if not specified
+            if (customConfig.drives == Container.DEFAULT_DRIVES) {
+                customConfig.copy(drives = drives)
+            } else {
+                customConfig
+            }
         } else {
-            // set up container drives to include app
-            val defaultDrives = PrefManager.drives
-            val appDirPath = SteamService.getAppDirPath(appId)
-            val drive: Char = Container.getNextAvailableDriveLetter(defaultDrives)
-            val drives = "$defaultDrives$drive:$appDirPath"
-            Timber.d("Prepared container drives: $drives")
-
-            val data = JSONObject()
-            data.put("name", "container_$containerId")
-            val container = containerManager.createContainerFuture(containerId, data).get()
-
-            val containerData = ContainerData(
+            // Use default config with drives
+            ContainerData(
                 screenSize = PrefManager.screenSize,
                 envVars = PrefManager.envVars,
                 cpuList = PrefManager.cpuList,
@@ -322,9 +338,59 @@ object ContainerUtils {
                 mouseWarpOverride = PrefManager.mouseWarpOverride,
                 disableMouseInput = PrefManager.disableMouseInput,
             )
-            applyToContainer(context, container, containerData)
+        }
+        
+        applyToContainer(context, container, containerData)
+        return container
+    }
 
+    fun getOrCreateContainer(context: Context, appId: Int): Container {
+        val containerId = getContainerId(appId)
+        val containerManager = ContainerManager(context)
+        
+        return if (containerManager.hasContainer(containerId)) {
+            containerManager.getContainerById(containerId)
+        } else {
+            createNewContainer(context, appId, containerId, containerManager)
+        }
+    }
+    
+    fun getOrCreateContainerWithOverride(context: Context, appId: Int): Container {
+        val containerId = getContainerId(appId)
+        val containerManager = ContainerManager(context)
+        
+        return if (containerManager.hasContainer(containerId)) {
+            val container = containerManager.getContainerById(containerId)
+            
+            // Apply temporary override if present (without saving to disk)
+            if (IntentLaunchManager.hasTemporaryOverride(appId)) {
+                val overrideConfig = IntentLaunchManager.getTemporaryOverride(appId)
+                if (overrideConfig != null) {
+                    // Backup original config before applying override (if not already backed up)
+                    if (IntentLaunchManager.getOriginalConfig(appId) == null) {
+                        val originalConfig = toContainerData(container)
+                        IntentLaunchManager.setOriginalConfig(appId, originalConfig)
+                    }
+                    
+                    // Get the effective config (merge base with override)
+                    val effectiveConfig = IntentLaunchManager.getEffectiveContainerConfig(context, appId)
+                    if (effectiveConfig != null) {
+                        applyToContainer(context, container, effectiveConfig, saveToDisk = false)
+                        Timber.i("Applied temporary config override to existing container for app $appId (in-memory only)")
+                    }
+                }
+            }
+            
             container
+        } else {
+            // Create new container with override config if present
+            val overrideConfig = if (IntentLaunchManager.hasTemporaryOverride(appId)) {
+                IntentLaunchManager.getTemporaryOverride(appId)
+            } else {
+                null
+            }
+            
+            createNewContainer(context, appId, containerId, containerManager, overrideConfig)
         }
     }
 

--- a/app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt
+++ b/app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt
@@ -1,0 +1,301 @@
+package app.gamenative.utils
+
+import android.content.Context
+import android.content.Intent
+import com.winlator.container.Container
+import com.winlator.container.ContainerData
+import org.json.JSONObject
+import timber.log.Timber
+
+/**
+ * Handles external game launch intents with container configuration overrides.
+ */
+object IntentLaunchManager {
+
+    private const val EXTRA_APP_ID = "app_id"
+    private const val EXTRA_CONTAINER_CONFIG = "container_config"
+    private const val ACTION_LAUNCH_GAME = "app.gamenative.LAUNCH_GAME"
+    private const val MAX_CONFIG_JSON_SIZE = 50000 // 50KB limit to prevent memory exhaustion
+
+    data class LaunchRequest(
+        val appId: Int,
+        val containerConfig: ContainerData? = null
+    )
+
+    fun parseLaunchIntent(intent: Intent): LaunchRequest? {
+        Timber.d("[IntentLaunchManager]: Parsing intent: action=${intent.action}, extras=${intent.extras}")
+
+        if (intent.action != ACTION_LAUNCH_GAME) {
+            Timber.d("[IntentLaunchManager]: Intent action '${intent.action}' doesn't match expected action '$ACTION_LAUNCH_GAME'")
+            return null
+        }
+
+        val appId = intent.getIntExtra(EXTRA_APP_ID, -1)
+        Timber.d("[IntentLaunchManager]: Extracted app_id: $appId from intent extras")
+
+        if (appId <= 0) {
+            Timber.w("[IntentLaunchManager]: Invalid or missing app_id in launch intent: $appId")
+            return null
+        }
+
+        val containerConfigJson = intent.getStringExtra(EXTRA_CONTAINER_CONFIG)
+        val containerConfig = if (containerConfigJson != null) {
+            try {
+                parseContainerConfig(containerConfigJson)
+            } catch (e: Exception) {
+                Timber.e(e, "[IntentLaunchManager]: Failed to parse container configuration JSON")
+                null
+            }
+        } else {
+            null
+        }
+
+        return LaunchRequest(appId, containerConfig)
+    }
+
+    fun applyTemporaryConfigOverride(context: Context, appId: Int, configOverride: ContainerData) {
+        try {
+            TemporaryConfigStore.setOverride(appId, configOverride)
+
+            if (ContainerUtils.hasContainer(context, appId)) {
+                val container = ContainerUtils.getContainer(context, appId)
+
+                // Backup original config before applying override
+                val originalConfig = ContainerUtils.toContainerData(container)
+                TemporaryConfigStore.setOriginalConfig(appId, originalConfig)
+
+                // Get the effective config (merge base with override)
+                val effectiveConfig = getEffectiveContainerConfig(context, appId)
+                if (effectiveConfig != null) {
+                    ContainerUtils.applyToContainer(context, container, effectiveConfig, saveToDisk = false)
+                    Timber.i("[IntentLaunchManager]: Applied temporary config override for app $appId (in-memory only)")
+                }
+            } else {
+                Timber.i("[IntentLaunchManager]: Stored temporary config override for app $appId (container will be created on launch)")
+            }
+
+        } catch (e: Exception) {
+            Timber.e(e, "[IntentLaunchManager]: Failed to apply temporary config override for app $appId")
+            throw e
+        }
+    }
+
+    fun getEffectiveContainerConfig(context: Context, appId: Int): ContainerData? {
+        return try {
+            val baseConfig = if (ContainerUtils.hasContainer(context, appId)) {
+                val container = ContainerUtils.getContainer(context, appId)
+                ContainerUtils.toContainerData(container)
+            } else {
+                null
+            }
+
+            val override = TemporaryConfigStore.getOverride(appId)
+
+            when {
+                override != null && baseConfig != null -> mergeConfigurations(baseConfig, override)
+                override != null -> override
+                else -> baseConfig
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "[IntentLaunchManager]: Failed to get effective container config for app $appId")
+            null
+        }
+    }
+
+    fun clearTemporaryOverride(appId: Int) {
+        TemporaryConfigStore.clearOverride(appId)
+        Timber.d("[IntentLaunchManager]: Cleared temporary config override for app $appId")
+    }
+
+    fun clearAllTemporaryOverrides() {
+        TemporaryConfigStore.clearAll()
+        Timber.d("[IntentLaunchManager]: Cleared all temporary config overrides")
+    }
+
+    fun restoreOriginalConfiguration(context: Context, appId: Int) {
+        try {
+            val originalConfig = TemporaryConfigStore.getOriginalConfig(appId)
+            if (originalConfig != null && ContainerUtils.hasContainer(context, appId)) {
+                val container = ContainerUtils.getContainer(context, appId)
+                ContainerUtils.applyToContainer(context, container, originalConfig, saveToDisk = false)
+                Timber.i("[IntentLaunchManager]: Restored original configuration for app $appId")
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "[IntentLaunchManager]: Failed to restore original configuration for app $appId")
+        }
+    }
+
+    fun hasTemporaryOverride(appId: Int): Boolean {
+        return TemporaryConfigStore.hasOverride(appId)
+    }
+
+    fun getTemporaryOverride(appId: Int): ContainerData? {
+        return TemporaryConfigStore.getOverride(appId)
+    }
+
+    fun getOriginalConfig(appId: Int): ContainerData? {
+        return TemporaryConfigStore.getOriginalConfig(appId)
+    }
+
+    fun setOriginalConfig(appId: Int, config: ContainerData) {
+        TemporaryConfigStore.setOriginalConfig(appId, config)
+    }
+
+    private fun validateContainerConfig(config: ContainerData): List<String> {
+        val issues = mutableListOf<String>()
+
+        if (!config.screenSize.matches(Regex("\\d+x\\d+"))) {
+            issues.add("Invalid screen size format: ${config.screenSize}. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)")
+        }
+
+        if (config.cpuList.isNotEmpty() && !config.cpuList.matches(Regex("\\d+(,\\d+)*"))) {
+            issues.add("Invalid CPU list format: ${config.cpuList}. Expected comma-separated numbers (e.g., 0,1,2,3)")
+        }
+
+        if (!config.videoMemorySize.matches(Regex("\\d+"))) {
+            issues.add("Invalid video memory size: ${config.videoMemorySize}. Expected numeric value in MB")
+        }
+
+        if (config.drives.isNotEmpty() && !config.drives.matches(Regex("([A-Z]:([^:]+))*"))) {
+            issues.add("Invalid drives format: ${config.drives}. Expected format: LETTER:PATH (e.g., C:/path/to/drive)")
+        }
+
+        return issues
+    }
+
+    private fun parseContainerConfig(jsonString: String): ContainerData {
+        if (jsonString.length > MAX_CONFIG_JSON_SIZE) {
+            throw IllegalArgumentException("Container configuration JSON too large (max ${MAX_CONFIG_JSON_SIZE / 1000}KB)")
+        }
+
+        val json = JSONObject(jsonString)
+
+        // Only include non-default values to avoid overriding existing container settings
+        val config = ContainerData(
+            name = if (json.has("name")) json.getString("name") else "",
+            screenSize = if (json.has("screenSize")) json.getString("screenSize") else Container.DEFAULT_SCREEN_SIZE,
+            envVars = if (json.has("envVars")) json.getString("envVars") else Container.DEFAULT_ENV_VARS,
+            graphicsDriver = if (json.has("graphicsDriver")) json.getString("graphicsDriver") else Container.DEFAULT_GRAPHICS_DRIVER,
+            graphicsDriverVersion = if (json.has("graphicsDriverVersion")) json.getString("graphicsDriverVersion") else "",
+            dxwrapper = if (json.has("dxwrapper")) json.getString("dxwrapper") else Container.DEFAULT_DXWRAPPER,
+            dxwrapperConfig = if (json.has("dxwrapperConfig")) json.getString("dxwrapperConfig") else "",
+            audioDriver = if (json.has("audioDriver")) json.getString("audioDriver") else Container.DEFAULT_AUDIO_DRIVER,
+            wincomponents = if (json.has("wincomponents")) json.getString("wincomponents") else Container.DEFAULT_WINCOMPONENTS,
+            drives = if (json.has("drives")) json.getString("drives") else Container.DEFAULT_DRIVES,
+            execArgs = if (json.has("execArgs")) json.getString("execArgs") else "",
+            executablePath = if (json.has("executablePath")) json.getString("executablePath") else "",
+            installPath = if (json.has("installPath")) json.getString("installPath") else "",
+            showFPS = if (json.has("showFPS")) json.getBoolean("showFPS") else false,
+            launchRealSteam = if (json.has("launchRealSteam")) json.getBoolean("launchRealSteam") else false,
+            cpuList = if (json.has("cpuList")) json.getString("cpuList") else Container.getFallbackCPUList(),
+            cpuListWoW64 = if (json.has("cpuListWoW64")) json.getString("cpuListWoW64") else Container.getFallbackCPUListWoW64(),
+            wow64Mode = if (json.has("wow64Mode")) json.getBoolean("wow64Mode") else true,
+            startupSelection = if (json.has("startupSelection")) json.getInt("startupSelection").toByte() else Container.STARTUP_SELECTION_ESSENTIAL.toInt().toByte(),
+            box86Version = if (json.has("box86Version")) json.getString("box86Version") else "",
+            box64Version = if (json.has("box64Version")) json.getString("box64Version") else "",
+            box86Preset = if (json.has("box86Preset")) json.getString("box86Preset") else "",
+            box64Preset = if (json.has("box64Preset")) json.getString("box64Preset") else "",
+            desktopTheme = if (json.has("desktopTheme")) json.getString("desktopTheme") else "",
+            csmt = if (json.has("csmt")) json.getBoolean("csmt") else true,
+            videoPciDeviceID = if (json.has("videoPciDeviceID")) json.getInt("videoPciDeviceID") else 1728,
+            offScreenRenderingMode = if (json.has("offScreenRenderingMode")) json.getString("offScreenRenderingMode") else "fbo",
+            strictShaderMath = if (json.has("strictShaderMath")) json.getBoolean("strictShaderMath") else true,
+            videoMemorySize = if (json.has("videoMemorySize")) json.getString("videoMemorySize") else "2048",
+            mouseWarpOverride = if (json.has("mouseWarpOverride")) json.getString("mouseWarpOverride") else "disable",
+            sdlControllerAPI = if (json.has("sdlControllerAPI")) json.getBoolean("sdlControllerAPI") else true,
+            enableXInput = if (json.has("enableXInput")) json.getBoolean("enableXInput") else true,
+            enableDInput = if (json.has("enableDInput")) json.getBoolean("enableDInput") else true,
+            dinputMapperType = if (json.has("dinputMapperType")) json.getInt("dinputMapperType").toByte() else 1.toByte(),
+            disableMouseInput = if (json.has("disableMouseInput")) json.getBoolean("disableMouseInput") else false,
+            shaderBackend = if (json.has("shaderBackend")) json.getString("shaderBackend") else "glsl",
+            useGLSL = if (json.has("useGLSL")) json.getString("useGLSL") else "enabled"
+        )
+
+        val validationIssues = validateContainerConfig(config)
+        if (validationIssues.isNotEmpty()) {
+            Timber.w("[IntentLaunchManager]: Container configuration validation issues: ${validationIssues.joinToString("; ")}")
+        }
+
+        return config
+    }
+
+    private fun mergeConfigurations(base: ContainerData, override: ContainerData): ContainerData {
+        // Quick return if no actual overrides
+        if (override == base) return base
+
+        return ContainerData(
+            name = override.name.ifEmpty { base.name },
+            screenSize = if (override.screenSize != Container.DEFAULT_SCREEN_SIZE) override.screenSize else base.screenSize,
+            envVars = if (override.envVars != Container.DEFAULT_ENV_VARS) override.envVars else base.envVars,
+            graphicsDriver = if (override.graphicsDriver != Container.DEFAULT_GRAPHICS_DRIVER) override.graphicsDriver else base.graphicsDriver,
+            graphicsDriverVersion = override.graphicsDriverVersion.ifEmpty { base.graphicsDriverVersion },
+            dxwrapper = if (override.dxwrapper != Container.DEFAULT_DXWRAPPER) override.dxwrapper else base.dxwrapper,
+            dxwrapperConfig = override.dxwrapperConfig.ifEmpty { base.dxwrapperConfig },
+            audioDriver = if (override.audioDriver != Container.DEFAULT_AUDIO_DRIVER) override.audioDriver else base.audioDriver,
+            wincomponents = if (override.wincomponents != Container.DEFAULT_WINCOMPONENTS) override.wincomponents else base.wincomponents,
+            drives = if (override.drives != Container.DEFAULT_DRIVES) override.drives else base.drives,
+            execArgs = override.execArgs.ifEmpty { base.execArgs },
+            executablePath = override.executablePath.ifEmpty { base.executablePath },
+            installPath = override.installPath.ifEmpty { base.installPath },
+            showFPS = override.showFPS,
+            launchRealSteam = override.launchRealSteam,
+            cpuList = if (override.cpuList != Container.getFallbackCPUList()) override.cpuList else base.cpuList,
+            cpuListWoW64 = if (override.cpuListWoW64 != Container.getFallbackCPUListWoW64()) override.cpuListWoW64 else base.cpuListWoW64,
+            wow64Mode = override.wow64Mode,
+            startupSelection = override.startupSelection,
+            box86Version = override.box86Version.ifEmpty { base.box86Version },
+            box64Version = override.box64Version.ifEmpty { base.box64Version },
+            box86Preset = override.box86Preset.ifEmpty { base.box86Preset },
+            box64Preset = override.box64Preset.ifEmpty { base.box64Preset },
+            desktopTheme = override.desktopTheme.ifEmpty { base.desktopTheme },
+            csmt = override.csmt,
+            videoPciDeviceID = override.videoPciDeviceID,
+            offScreenRenderingMode = override.offScreenRenderingMode,
+            strictShaderMath = override.strictShaderMath,
+            videoMemorySize = override.videoMemorySize,
+            mouseWarpOverride = override.mouseWarpOverride,
+            sdlControllerAPI = override.sdlControllerAPI,
+            enableXInput = override.enableXInput,
+            enableDInput = override.enableDInput,
+            dinputMapperType = override.dinputMapperType,
+            disableMouseInput = override.disableMouseInput,
+            shaderBackend = override.shaderBackend,
+            useGLSL = override.useGLSL
+        )
+    }
+}
+
+private object TemporaryConfigStore {
+    private val overrides = mutableMapOf<Int, ContainerData>()
+    private val originalConfigs = mutableMapOf<Int, ContainerData>()
+
+    fun setOverride(appId: Int, config: ContainerData) {
+        overrides[appId] = config
+    }
+
+    fun getOverride(appId: Int): ContainerData? {
+        return overrides[appId]
+    }
+
+    fun clearOverride(appId: Int) {
+        overrides.remove(appId)
+        originalConfigs.remove(appId)
+    }
+
+    fun hasOverride(appId: Int): Boolean {
+        return overrides.containsKey(appId)
+    }
+
+    fun setOriginalConfig(appId: Int, config: ContainerData) {
+        originalConfigs[appId] = config
+    }
+
+    fun getOriginalConfig(appId: Int): ContainerData? {
+        return originalConfigs[appId]
+    }
+
+    fun clearAll() {
+        overrides.clear()
+        originalConfigs.clear()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,13 @@
     <string name="duplicate">Duplicate</string>
     <string name="reconfigure">Reconfigure</string>
     <string name="content_info">Content Info</string>
+    <string name="game_not_installed_title">Game Not Installed</string>
+    <string name="game_not_installed_message">%s is not installed. Please install the game first before launching.</string>
+    <string name="save_container_settings_title">Save Container Settings?</string>
+    <string name="save_container_settings_message">The container configuration has been modified. Do you want to save these changes?</string>
+    <string name="sync_error_title">Sync Error</string>
+    <string name="save">Save</string>
+    <string name="discard">Discard</string>
     <string name="shortcuts">Shortcuts</string>
     <string name="containers">Containers</string>
     <string name="box64_rc_file">Box64 RCFile</string>


### PR DESCRIPTION
Implements support for launching games via Android intents from external applications (like EmuReady). This allows third-party apps to launch specific Steam games with custom container configurations without permanently modifying the user's settings.

**Key Features**

  - Accept app.gamenative.LAUNCH_GAME intents with game ID and optional container config
  - Apply temporary container configuration overrides that don't persist to disk
  - Prompt users to save or discard config changes when exiting games launched via intent
  - Automatic cleanup of temporary configs on app restart

**Technical Changes**

  - Added IntentLaunchManager to handle intent parsing and temporary config management
  - Refactored ContainerUtils to reduce code duplication and support temporary overrides
  - Added resource strings for all user-facing messages
  - Implemented proper error handling for missing containers and invalid configurations

**Testing**

  Tested with EmuReady app for launching games with custom Wine/Proton configurations. Verified that:
  - Games launch correctly with temporary configs
  - Save/discard dialog appears on game exit
  - Normal game launches remain unaffected
  - App handles missing games gracefully