### PR TITLE
Updated appId to be String and platform prefixed

### DIFF
--- a/app/src/main/java/app/gamenative/data/LibraryItem.kt
+++ b/app/src/main/java/app/gamenative/data/LibraryItem.kt
@@ -2,16 +2,29 @@ package app.gamenative.data
 
 import app.gamenative.Constants
 
+enum class GameSource {
+    STEAM,
+    // Add other platforms here..
+}
+
 /**
  * Data class for the Library list
  */
 data class LibraryItem(
     val index: Int = 0,
-    val appId: Int = 0,
+    val appId: String = "",
     val name: String = "",
     val iconHash: String = "",
     val isShared: Boolean = false,
+    val gameSource: GameSource = GameSource.STEAM,
 ) {
     val clientIconUrl: String
-        get() = Constants.Library.ICON_URL + "$appId/$iconHash.ico"
+        get() = Constants.Library.ICON_URL + "${gameId}/$iconHash.ico"
+    
+    /**
+     * Helper property to get the game ID as an integer
+     * Extracts the numeric part by removing the gameSource prefix
+     */
+    val gameId: Int
+        get() = appId.removePrefix("${gameSource.name}_").toInt()
 }

--- a/app/src/main/java/app/gamenative/events/AndroidEvent.kt
+++ b/app/src/main/java/app/gamenative/events/AndroidEvent.kt
@@ -13,8 +13,8 @@ interface AndroidEvent<T> : Event<T> {
     data class KeyEvent(val event: android.view.KeyEvent) : AndroidEvent<Boolean>
     data class MotionEvent(val event: android.view.MotionEvent?) : AndroidEvent<Boolean>
     data object EndProcess : AndroidEvent<Unit>
-    data class ExternalGameLaunch(val appId: Int) : AndroidEvent<Unit>
-    data class PromptSaveContainerConfig(val appId: Int) : AndroidEvent<Unit>
-    data class ShowGameFeedback(val appId: Int) : AndroidEvent<Unit>
+    data class ExternalGameLaunch(val appId: String) : AndroidEvent<Unit>
+    data class PromptSaveContainerConfig(val appId: String) : AndroidEvent<Unit>
+    data class ShowGameFeedback(val appId: String) : AndroidEvent<Unit>
     // data class SetAppBarVisibility(val visible: Boolean) : AndroidEvent<Unit>
 }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -426,9 +426,9 @@ class SteamService : Service(), IChallengeUrlChanged {
             return appName
         }
 
-        fun getAppDirPath(appId: Int): String {
+        fun getAppDirPath(gameId: Int): String {
 
-            val appName = getAppDirName(getAppInfoOf(appId))
+            val appName = getAppDirName(getAppInfoOf(gameId))
 
             // Internal first (legacy installs), external second
             val internalPath = Paths.get(internalAppInstallPath, appName)

--- a/app/src/main/java/app/gamenative/ui/component/dialog/state/GameFeedbackDialogState.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/state/GameFeedbackDialogState.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.saveable.mapSaver
 
 data class GameFeedbackDialogState(
     val visible: Boolean,
-    val appId: Int = -1,
+    val appId: String = "",
     val rating: Int = 0, // 0-5 stars, 0 means no selection
     val selectedTags: Set<String> = emptySet(),
     val feedbackText: String = "",
@@ -22,7 +22,7 @@ data class GameFeedbackDialogState(
             "does_not_open",
             "directx_error"
         )
-        
+
         val Saver = mapSaver(
             save = { state ->
                 mapOf(
@@ -38,7 +38,7 @@ data class GameFeedbackDialogState(
             restore = { savedMap ->
                 GameFeedbackDialogState(
                     visible = savedMap["visible"] as Boolean,
-                    appId = savedMap["appId"] as Int,
+                    appId = savedMap["appId"] as String,
                     rating = savedMap["rating"] as Int,
                     selectedTags = (savedMap["selectedTags"] as List<String>).toSet(),
                     feedbackText = savedMap["feedbackText"] as String,

--- a/app/src/main/java/app/gamenative/ui/data/MainState.kt
+++ b/app/src/main/java/app/gamenative/ui/data/MainState.kt
@@ -15,7 +15,7 @@ data class MainState(
     val annoyingDialogShown: Boolean = false,
     val hasCrashedLastStart: Boolean = false,
     val isSteamConnected: Boolean = false,
-    val launchedAppId: Int = 0,
+    val launchedAppId: String = "",
     val bootToContainer: Boolean = false,
     val showBootingSplash: Boolean = false,
 )

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import app.gamenative.PrefManager
 import app.gamenative.data.LibraryItem
 import app.gamenative.data.SteamApp
+import app.gamenative.data.GameSource
 import app.gamenative.db.dao.SteamAppDao
 import app.gamenative.service.DownloadService
 import app.gamenative.service.SteamService
@@ -174,7 +175,7 @@ class LibraryViewModel @Inject constructor(
                 .mapIndexed { idx, item ->
                     LibraryItem(
                         index = idx,
-                        appId = "STEAM_${item.id}",
+                        appId = "${GameSource.STEAM.name}_${item.id}",
                         name = item.name,
                         iconHash = item.clientIconHash,
                         isShared = (PrefManager.steamUserAccountId != 0 && !item.ownerAccountId.contains(PrefManager.steamUserAccountId)),

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -174,7 +174,7 @@ class LibraryViewModel @Inject constructor(
                 .mapIndexed { idx, item ->
                     LibraryItem(
                         index = idx,
-                        appId = item.id,
+                        appId = "STEAM_${item.id}",
                         name = item.name,
                         iconHash = item.clientIconHash,
                         isShared = (PrefManager.steamUserAccountId != 0 && !item.ownerAccountId.contains(PrefManager.steamUserAccountId)),

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
 import app.gamenative.data.GameProcessInfo
+import app.gamenative.data.LibraryItem
 import app.gamenative.di.IAppTheme
 import app.gamenative.enums.AppTheme
 import app.gamenative.enums.LoginResult
@@ -48,10 +49,10 @@ class MainViewModel @Inject constructor(
         data object OnBackPressed : MainUiEvent()
         data object OnLoggedOut : MainUiEvent()
         data object LaunchApp : MainUiEvent()
-        data class ExternalGameLaunch(val appId: Int) : MainUiEvent()
+        data class ExternalGameLaunch(val appId: String) : MainUiEvent()
         data class OnLogonEnded(val result: LoginResult) : MainUiEvent()
         data object ShowDiscordSupportDialog : MainUiEvent()
-        data class ShowGameFeedbackDialog(val appId: Int) : MainUiEvent()
+        data class ShowGameFeedbackDialog(val appId: String) : MainUiEvent()
         data class ShowToast(val message: String) : MainUiEvent()
     }
 
@@ -146,7 +147,7 @@ class MainViewModel @Inject constructor(
             it.copy(
                 isSteamConnected = SteamService.isConnected,
                 hasCrashedLastStart = PrefManager.recentlyCrashed,
-                launchedAppId = SteamService.INVALID_APP_ID,
+                launchedAppId = "",
             )
         }
     }
@@ -207,7 +208,7 @@ class MainViewModel @Inject constructor(
         _state.update { it.copy(resettedScreen = it.currentScreen) }
     }
 
-    fun setLaunchedAppId(value: Int) {
+    fun setLaunchedAppId(value: String) {
         _state.update { it.copy(launchedAppId = value) }
     }
 
@@ -215,18 +216,18 @@ class MainViewModel @Inject constructor(
         _state.update { it.copy(bootToContainer = value) }
     }
 
-    fun launchApp(context: Context, appId: Int) {
+    fun launchApp(context: Context, libraryItem: LibraryItem) {
         // Show booting splash before launching the app
         viewModelScope.launch {
             setShowBootingSplash(true)
             PluviaApp.events.emit(AndroidEvent.SetAllowedOrientation(PrefManager.allowedOrientation))
 
             val apiJob = viewModelScope.async(Dispatchers.IO) {
-                val container = ContainerUtils.getOrCreateContainer(context, appId)
+                val container = ContainerUtils.getOrCreateContainer(context, libraryItem.appId)
                 if (container.isLaunchRealSteam()) {
-                    SteamUtils.restoreSteamApi(context, appId)
+                    SteamUtils.restoreSteamApi(context, libraryItem)
                 } else {
-                    SteamUtils.replaceSteamApi(context, appId)
+                    SteamUtils.replaceSteamApi(context, libraryItem)
                 }
             }
 
@@ -239,31 +240,33 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun exitSteamApp(context: Context, appId: Int) {
+    fun exitSteamApp(context: Context, libraryItem: LibraryItem) {
         viewModelScope.launch {
             // Check if we have a temporary override before doing anything
-            val hadTemporaryOverride = IntentLaunchManager.hasTemporaryOverride(appId)
+            val hadTemporaryOverride = IntentLaunchManager.hasTemporaryOverride(libraryItem.appId)
+
+            val gameId = libraryItem.gameId
 
             SteamService.notifyRunningProcesses()
-            SteamService.closeApp(appId, isOffline.value) { prefix ->
-                PathType.from(prefix).toAbsPath(context, appId, SteamService.userSteamId!!.accountID)
+            SteamService.closeApp(gameId, isOffline.value) { prefix ->
+                PathType.from(prefix).toAbsPath(context, gameId, SteamService.userSteamId!!.accountID)
             }.await()
 
             // Prompt user to save temporary container configuration if one was applied
             if (hadTemporaryOverride) {
-                PluviaApp.events.emit(AndroidEvent.PromptSaveContainerConfig(appId))
+                PluviaApp.events.emit(AndroidEvent.PromptSaveContainerConfig(libraryItem.appId))
                 // Dialog handler in PluviaMain manages the save/discard logic
             }
 
             // After app closes, check if we need to show the feedback dialog
             try {
-                val container = ContainerUtils.getContainer(context, appId)
+                val container = ContainerUtils.getContainer(context, libraryItem.appId)
                 val shown = container.getExtra("discord_support_prompt_shown", "false") == "true"
                 val configChanged = container.getExtra("config_changed", "false") == "true"
                 if (!shown) {
                     container.putExtra("discord_support_prompt_shown", "true")
                     container.saveData()
-                    _uiEvent.send(MainUiEvent.ShowGameFeedbackDialog(appId))
+                    _uiEvent.send(MainUiEvent.ShowGameFeedbackDialog(libraryItem.appId))
                 }
 
                 // Only show feedback if container config was changed before this game run
@@ -272,7 +275,7 @@ class MainViewModel @Inject constructor(
                     container.putExtra("config_changed", "false")
                     container.saveData()
                     // Show the feedback dialog
-                    _uiEvent.send(MainUiEvent.ShowGameFeedbackDialog(appId))
+                    _uiEvent.send(MainUiEvent.ShowGameFeedbackDialog(libraryItem.appId))
                 }
             } catch (_: Exception) {
                 // ignore container errors
@@ -280,16 +283,18 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun onWindowMapped(context: Context, window: Window, appId: Int) {
+    fun onWindowMapped(context: Context, window: Window, libraryItem: LibraryItem) {
         viewModelScope.launch {
             // Hide the booting splash when a window is mapped
             bootingSplashTimeoutJob?.cancel()
             bootingSplashTimeoutJob = null
             setShowBootingSplash(false)
 
-            SteamService.getAppInfoOf(appId)?.let { appInfo ->
+            val gameId = libraryItem.gameId
+
+            SteamService.getAppInfoOf(gameId)?.let { appInfo ->
                 // TODO: this should not be a search, the app should have been launched with a specific launch config that we then use to compare
-                val launchConfig = SteamService.getWindowsLaunchInfos(appId).firstOrNull {
+                val launchConfig = SteamService.getWindowsLaunchInfos(gameId).firstOrNull {
                     val gameExe = Paths.get(it.executable.replace('\\', '/')).name.lowercase()
                     val windowExe = window.className.lowercase()
                     gameExe == windowExe
@@ -315,11 +320,11 @@ class MainViewModel @Inject constructor(
                         processes.add(process)
                     } while (parentWindow != null)
 
-                    GameProcessInfo(appId = appId, processes = processes).let {
+                    GameProcessInfo(appId = libraryItem.gameId, processes = processes).let {
                         // Only notify Steam if we're not using real Steam
                         // When launchRealSteam is true, let the real Steam client handle the "game is running" notification
                         val shouldLaunchRealSteam = try {
-                            val container = ContainerUtils.getContainer(context, appId)
+                            val container = ContainerUtils.getContainer(context, libraryItem.appId)
                             container.isLaunchRealSteam()
                         } catch (e: Exception) {
                             // Container might not exist, default to notifying Steam

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -71,6 +71,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import app.gamenative.Constants
 import app.gamenative.R
+import app.gamenative.data.LibraryItem
 import app.gamenative.data.SteamApp
 import app.gamenative.service.SteamService
 import app.gamenative.ui.component.LoadingScreen
@@ -170,25 +171,28 @@ private fun SkeletonText(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppScreen(
-    appId: Int,
+    libraryItem: LibraryItem,
     onClickPlay: (Boolean) -> Unit,
     onBack: () -> Unit,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
+    val gameId = libraryItem.gameId
+    val appId = libraryItem.appId
+
     val appInfo by remember(appId) {
-        mutableStateOf(SteamService.getAppInfoOf(appId)!!)
+        mutableStateOf(SteamService.getAppInfoOf(gameId)!!)
     }
 
     var downloadInfo by remember(appId) {
-        mutableStateOf(SteamService.getAppDownloadInfo(appId))
+        mutableStateOf(SteamService.getAppDownloadInfo(gameId))
     }
     var downloadProgress by remember(appId) {
         mutableFloatStateOf(downloadInfo?.getProgress() ?: 0f)
     }
     var isInstalled by remember(appId) {
-        mutableStateOf(SteamService.isAppInstalled(appId))
+        mutableStateOf(SteamService.isAppInstalled(gameId))
     }
 
     val isValidToDownload by remember(appId) {
@@ -219,10 +223,10 @@ fun AppScreen(
     DisposableEffect(downloadInfo) {
         val onDownloadProgress: (Float) -> Unit = {
             if (it >= 1f) {
-                isInstalled = SteamService.isAppInstalled(appId)
+                isInstalled = SteamService.isAppInstalled(gameId)
                 downloadInfo = null
                 isInstalled = true
-                MarkerUtils.addMarker(getAppDirPath(appId), Marker.DOWNLOAD_COMPLETE_MARKER)
+                MarkerUtils.addMarker(getAppDirPath(gameId), Marker.DOWNLOAD_COMPLETE_MARKER)
             }
             downloadProgress = it
         }
@@ -324,7 +328,7 @@ fun AppScreen(
             if (writePermissionGranted && readPermissionGranted) {
                 hasStoragePermission = true
 
-                val depots = SteamService.getDownloadableDepots(appId)
+                val depots = SteamService.getDownloadableDepots(gameId)
                 Timber.i("There are ${depots.size} depots belonging to $appId")
                 // How much free space is on disk
                 val availableBytes = StorageUtils.getAvailableSpace(SteamService.defaultStoragePath)
@@ -378,10 +382,10 @@ fun AppScreen(
                         "game_name" to appInfo.name
                     ))
                 downloadInfo?.cancel()
-                SteamService.deleteApp(appId)
+                SteamService.deleteApp(gameId)
                 downloadInfo = null
                 downloadProgress = 0f
-                isInstalled = SteamService.isAppInstalled(appId)
+                isInstalled = SteamService.isAppInstalled(gameId)
                 msgDialogState = MessageDialogState(false)
             }
             onDismissRequest = { msgDialogState = MessageDialogState(false) }
@@ -403,7 +407,7 @@ fun AppScreen(
                     ))
                 CoroutineScope(Dispatchers.IO).launch {
                     downloadProgress = 0f
-                    downloadInfo = SteamService.downloadApp(appId)
+                    downloadInfo = SteamService.downloadApp(gameId)
                     msgDialogState = MessageDialogState(false)
                 }
             }
@@ -413,12 +417,12 @@ fun AppScreen(
         DialogType.DELETE_APP -> {
             onConfirmClick = {
                 // Delete the Steam app data
-                SteamService.deleteApp(appId)
+                SteamService.deleteApp(gameId)
                 // Also delete the associated container so it will be recreated on next launch
                 ContainerUtils.deleteContainer(context, appId)
                 msgDialogState = MessageDialogState(false)
 
-                isInstalled = SteamService.isAppInstalled(appId)
+                isInstalled = SteamService.isAppInstalled(gameId)
             }
             onDismissRequest = { msgDialogState = MessageDialogState(false) }
             onDismissClick = { msgDialogState = MessageDialogState(false) }
@@ -504,10 +508,10 @@ fun AppScreen(
                         confirmBtnText = context.getString(R.string.yes),
                         dismissBtnText = context.getString(R.string.no),
                     )
-                } else if (SteamService.hasPartialDownload(appId)) {
+                } else if (SteamService.hasPartialDownload(gameId)) {
                     // Resume incomplete download
                     CoroutineScope(Dispatchers.IO).launch {
-                        downloadInfo = SteamService.downloadApp(appId)
+                        downloadInfo = SteamService.downloadApp(gameId)
                     }
                 } else if (!isInstalled) {
                     permissionLauncher.launch(
@@ -530,7 +534,7 @@ fun AppScreen(
                     downloadInfo?.cancel()
                     downloadInfo = null
                 } else {
-                    downloadInfo = SteamService.downloadApp(appId)
+                    downloadInfo = SteamService.downloadApp(gameId)
                 }
             },
             onDeleteDownloadClick = {
@@ -543,7 +547,7 @@ fun AppScreen(
                     dismissBtnText = context.getString(R.string.no)
                 )
             },
-            onUpdateClick = { CoroutineScope(Dispatchers.IO).launch { downloadInfo = SteamService.downloadApp(appId) } },
+            onUpdateClick = { CoroutineScope(Dispatchers.IO).launch { downloadInfo = SteamService.downloadApp(gameId) } },
             onBack = onBack,
             optionsMenu = arrayOf(
                 AppMenuOption(
@@ -607,7 +611,7 @@ fun AppScreen(
                                 AppOptionMenuType.ResetDrm,
                                 onClick = {
                                     val container = ContainerUtils.getOrCreateContainer(context, appId)
-                                    MarkerUtils.removeMarker(getAppDirPath(appId), Marker.STEAM_DLL_RESTORED)
+                                    MarkerUtils.removeMarker(getAppDirPath(gameId), Marker.STEAM_DLL_RESTORED)
                                     container.isNeedsUnpacking = true
                                     container.saveData()
                                 },
@@ -616,7 +620,7 @@ fun AppScreen(
                                 AppOptionMenuType.VerifyFiles,
                                 onClick = {
                                     CoroutineScope(Dispatchers.IO).launch {
-                                        downloadInfo = SteamService.downloadApp(appId)
+                                        downloadInfo = SteamService.downloadApp(gameId)
                                     }
                                 },
                             ),
@@ -624,7 +628,7 @@ fun AppScreen(
                                 AppOptionMenuType.Update,
                                 onClick = {
                                     CoroutineScope(Dispatchers.IO).launch {
-                                        downloadInfo = SteamService.downloadApp(appId)
+                                        downloadInfo = SteamService.downloadApp(gameId)
                                     }
                                 },
                             ),
@@ -687,10 +691,10 @@ fun AppScreen(
                                         containerManager.activateContainer(container)
 
                                         val prefixToPath: (String) -> String = { prefix ->
-                                            PathType.from(prefix).toAbsPath(context, appId, SteamService.userSteamId!!.accountID)
+                                            PathType.from(prefix).toAbsPath(context, gameId, SteamService.userSteamId!!.accountID)
                                         }
                                         val syncResult = SteamService.forceSyncUserFiles(
-                                            appId = appId,
+                                            appId = gameId,
                                             prefixToPath = prefixToPath
                                         ).await()
 
@@ -724,10 +728,10 @@ fun AppScreen(
                                         containerManager.activateContainer(container)
 
                                         val prefixToPath: (String) -> String = { prefix ->
-                                            PathType.from(prefix).toAbsPath(context, appId, SteamService.userSteamId!!.accountID)
+                                            PathType.from(prefix).toAbsPath(context, gameId, SteamService.userSteamId!!.accountID)
                                         }
                                         val syncResult = SteamService.forceSyncUserFiles(
-                                            appId = appId,
+                                            appId = gameId,
                                             prefixToPath = prefixToPath,
                                             preferredSave = SaveLocation.Remote,
                                             overrideLocalChangeNumber = -1L
@@ -759,10 +763,10 @@ fun AppScreen(
                                         containerManager.activateContainer(container)
 
                                         val prefixToPath: (String) -> String = { prefix ->
-                                            PathType.from(prefix).toAbsPath(context, appId, SteamService.userSteamId!!.accountID)
+                                            PathType.from(prefix).toAbsPath(context, gameId, SteamService.userSteamId!!.accountID)
                                         }
                                         val syncResult = SteamService.forceSyncUserFiles(
-                                            appId = appId,
+                                            appId = gameId,
                                             prefixToPath = prefixToPath,
                                             preferredSave = SaveLocation.Local
                                         ).await()

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -33,6 +33,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.gamenative.PrefManager
 import app.gamenative.data.LibraryItem
+import app.gamenative.data.GameSource
 import app.gamenative.service.SteamService
 import app.gamenative.ui.data.LibraryState
 import app.gamenative.ui.enums.AppFilter
@@ -126,13 +127,13 @@ private fun LibraryScreenContent(
             val selectedLibraryItem = selectedAppId?.let { appId ->
                 state.appInfoList.find { it.appId == appId }
             }
-            
+
             LibraryDetailPane(
                 libraryItem = selectedLibraryItem,
                 onBack = { selectedAppId = null },
-                onClickPlay = { 
+                onClickPlay = {
                     selectedLibraryItem?.let { libraryItem ->
-                        onClickPlay(libraryItem.gameId, it) 
+                        onClickPlay(libraryItem.gameId, it)
                     }
                 },
             )
@@ -166,7 +167,7 @@ private fun Preview_LibraryScreenContent() {
                     val item = fakeAppInfo(idx)
                     LibraryItem(
                         index = idx,
-                        appId = "STEAM_${item.id}",
+                        appId = "${GameSource.STEAM.name}_${item.id}",
                         name = item.name,
                         iconHash = item.iconHash,
                     )

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -93,7 +93,7 @@ private fun LibraryScreenContent(
     onGoOnline: () -> Unit,
     isOffline: Boolean = false,
 ) {
-    var selectedAppId by remember { mutableStateOf<Int?>(null) }
+    var selectedAppId by remember { mutableStateOf<String?>(null) }
 
     BackHandler(selectedAppId != null) { selectedAppId = null }
     val safePaddingModifier =
@@ -122,10 +122,19 @@ private fun LibraryScreenContent(
                 isOffline = isOffline,
             )
         } else {
+            // Find the LibraryItem from the state based on selectedAppId
+            val selectedLibraryItem = selectedAppId?.let { appId ->
+                state.appInfoList.find { it.appId == appId }
+            }
+            
             LibraryDetailPane(
-                appId = selectedAppId ?: SteamService.INVALID_APP_ID,
+                libraryItem = selectedLibraryItem,
                 onBack = { selectedAppId = null },
-                onClickPlay = { onClickPlay(selectedAppId!!, it) },
+                onClickPlay = { 
+                    selectedLibraryItem?.let { libraryItem ->
+                        onClickPlay(libraryItem.gameId, it) 
+                    }
+                },
             )
         }
     }
@@ -157,7 +166,7 @@ private fun Preview_LibraryScreenContent() {
                     val item = fakeAppInfo(idx)
                     LibraryItem(
                         index = idx,
-                        appId = item.id,
+                        appId = "STEAM_${item.id}",
                         name = item.name,
                         iconHash = item.iconHash,
                     )

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryAppItem.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryAppItem.kt
@@ -1,6 +1,7 @@
 package app.gamenative.ui.screen.library.components
 
 import android.content.res.Configuration
+import app.gamenative.data.GameSource
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -51,11 +52,11 @@ internal fun AppItem(
     onClick: () -> Unit,
 ) {
     // Determine download and install state
-    val downloadInfo = remember(appInfo.appId) { SteamService.getAppDownloadInfo(appInfo.appId) }
+    val downloadInfo = remember(appInfo.appId) { SteamService.getAppDownloadInfo(appInfo.gameId) }
     val downloadProgress = remember(downloadInfo) { downloadInfo?.getProgress() ?: 0f }
     val isDownloading = downloadInfo != null && downloadProgress < 1f
     val isInstalled = remember(appInfo.appId) {
-        SteamService.isAppInstalled(appInfo.appId)
+        SteamService.isAppInstalled(appInfo.gameId)
     }
 
     var appSizeOnDisk by remember { mutableStateOf("") }
@@ -63,7 +64,7 @@ internal fun AppItem(
     LaunchedEffect(Unit) {
         if (isInstalled) {
             appSizeOnDisk = "..."
-            DownloadService.getSizeOnDiskDisplay(appInfo.appId) {  appSizeOnDisk = it }
+            DownloadService.getSizeOnDiskDisplay(appInfo.gameId) {  appSizeOnDisk = it }
         }
     }
 
@@ -212,7 +213,7 @@ private fun Preview_AppItem() {
                         val item = fakeAppInfo(idx)
                         LibraryItem(
                             index = idx,
-                            appId = item.id,
+                            appId = "${GameSource.STEAM.name}_${item.id}",
                             name = item.name,
                             iconHash = item.iconHash,
                             isShared = idx % 2 == 0,

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import app.gamenative.PrefManager
+import app.gamenative.data.LibraryItem
+import app.gamenative.data.GameSource
 import app.gamenative.service.SteamService
 import app.gamenative.ui.data.LibraryState
 import app.gamenative.ui.enums.AppFilter
@@ -19,12 +21,12 @@ import java.util.EnumSet
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun LibraryDetailPane(
-    appId: Int,
+    libraryItem: LibraryItem?,
     onClickPlay: (Boolean) -> Unit,
     onBack: () -> Unit,
 ) {
     Surface {
-        if (appId == SteamService.INVALID_APP_ID) {
+        if (libraryItem == null) {
             // Simply use the regular LibraryListPane with empty data
             val listState = rememberLazyListState()
             val sheetState = rememberModalBottomSheetState()
@@ -52,7 +54,7 @@ internal fun LibraryDetailPane(
             )
         } else {
             AppScreen(
-                appId = appId,
+                libraryItem = libraryItem,
                 onClickPlay = onClickPlay,
                 onBack = onBack,
             )
@@ -71,7 +73,12 @@ private fun Preview_LibraryDetailPane() {
     PrefManager.init(LocalContext.current)
     PluviaTheme {
         LibraryDetailPane(
-            appId = Int.MAX_VALUE,
+            libraryItem = LibraryItem(
+                appId = "STEAM_${Int.MAX_VALUE}",
+                name = "Preview Game",
+                iconHash = "",
+                gameSource = GameSource.STEAM
+            ),
             onClickPlay = { },
             onBack = { },
         )

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
@@ -74,7 +74,7 @@ private fun Preview_LibraryDetailPane() {
     PluviaTheme {
         LibraryDetailPane(
             libraryItem = LibraryItem(
-                appId = "STEAM_${Int.MAX_VALUE}",
+                appId = "${GameSource.STEAM.name}_${Int.MAX_VALUE}",
                 name = "Preview Game",
                 iconHash = "",
                 gameSource = GameSource.STEAM

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryList.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryList.kt
@@ -25,7 +25,7 @@ internal fun LibraryList(
     contentPaddingValues: PaddingValues,
     listState: LazyListState,
     list: List<LibraryItem>,
-    onItemClick: (Int) -> Unit,
+    onItemClick: (String) -> Unit,
 ) {
     if (list.isEmpty()) {
         Box(

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -57,6 +57,7 @@ import app.gamenative.PrefManager
 import app.gamenative.utils.DeviceUtils
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.distinctUntilChanged
+import app.gamenative.data.GameSource
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -268,7 +269,7 @@ private fun Preview_LibraryListPane() {
                     val item = fakeAppInfo(idx)
                     LibraryItem(
                         index = idx,
-                        appId = "STEAM_${item.id}",
+                        appId = "${GameSource.STEAM.name}_${item.id}",
                         name = item.name,
                         iconHash = item.iconHash,
                         isShared = idx % 2 == 0,

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -69,7 +69,7 @@ internal fun LibraryListPane(
     onPageChange: (Int) -> Unit,
     onIsSearching: (Boolean) -> Unit,
     onLogout: () -> Unit,
-    onNavigate: (Int) -> Unit,
+    onNavigate: (String) -> Unit,
     onSearchQuery: (String) -> Unit,
     onNavigateRoute: (String) -> Unit,
     onGoOnline: () -> Unit,
@@ -268,7 +268,7 @@ private fun Preview_LibraryListPane() {
                     val item = fakeAppInfo(idx)
                     LibraryItem(
                         index = idx,
-                        appId = item.id,
+                        appId = "STEAM_${item.id}",
                         name = item.name,
                         iconHash = item.iconHash,
                         isShared = idx % 2 == 0,

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibrarySearchBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibrarySearchBar.kt
@@ -136,7 +136,7 @@ private fun Preview_LibrarySearchBar() {
                         val item = fakeAppInfo(idx)
                         LibraryItem(
                             index = idx,
-                            appId = item.id,
+                            appId = "STEAM_${item.id}",
                             name = item.name,
                             iconHash = item.iconHash,
                         )

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibrarySearchBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibrarySearchBar.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.gamenative.PrefManager
 import app.gamenative.data.LibraryItem
+import app.gamenative.data.GameSource
 import app.gamenative.ui.data.LibraryState
 import app.gamenative.ui.internal.fakeAppInfo
 import app.gamenative.ui.theme.PluviaTheme
@@ -136,7 +137,7 @@ private fun Preview_LibrarySearchBar() {
                         val item = fakeAppInfo(idx)
                         LibraryItem(
                             index = idx,
-                            appId = "STEAM_${item.id}",
+                            appId = "${GameSource.STEAM.name}_${item.id}",
                             name = item.name,
                             iconHash = item.iconHash,
                         )

--- a/app/src/main/java/app/gamenative/utils/ContainerMigrator.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerMigrator.kt
@@ -1,0 +1,202 @@
+package app.gamenative.utils
+
+import android.content.Context
+import com.winlator.core.FileUtils
+import com.winlator.xenvironment.ImageFs
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import timber.log.Timber
+
+/**
+ * Handles migration of legacy container formats.
+ */
+object ContainerMigrator {
+    private const val LATEST_CONTAINER_MIGRATION_VERSION = 1
+
+    /**
+     * Creates a container migration version file to track completed migrations
+     */
+    private fun createContainerMigrationVersionFile(context: Context, version: Int) {
+        val imageFs = ImageFs.find(context)
+        val configDir = imageFs.configDir
+        configDir.mkdirs()
+        val versionFile = File(configDir, ".container_migration_version")
+        try {
+            versionFile.createNewFile()
+            FileUtils.writeString(versionFile, version.toString())
+            Timber.i("Created container migration version file: $version")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to create container migration version file")
+        }
+    }
+
+    /**
+     * Gets the current container migration version, returns 0 if not found
+     */
+    private fun getContainerMigrationVersion(context: Context): Int {
+        val imageFs = ImageFs.find(context)
+        val versionFile = File(imageFs.configDir, ".container_migration_version")
+        return if (versionFile.exists()) {
+            try {
+                FileUtils.readLines(versionFile)[0].toInt()
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to read container migration version")
+                0
+            }
+        } else {
+            0
+        }
+    }
+
+    /**
+     * Checks if container migration is needed by comparing versions
+     */
+    suspend fun isContainerMigrationNeeded(context: Context): Boolean = withContext(Dispatchers.IO) {
+        val currentVersion = getContainerMigrationVersion(context)
+        return@withContext currentVersion < LATEST_CONTAINER_MIGRATION_VERSION
+    }
+
+    /**
+     * Migrates legacy numeric container directories to platform-prefixed format.
+     * Legacy: xuser-12345/ -> New: xuser-STEAM_12345/
+     * Runs only once based on version tracking like ImageFsInstaller
+     */
+    suspend fun migrateLegacyContainersIfNeeded(
+        context: Context,
+        onProgressUpdate: ((currentContainer: String, migratedContainers: Int, totalContainers: Int) -> Unit)? = null,
+        onComplete: ((migratedCount: Int) -> Unit)? = null,
+    ) = withContext(Dispatchers.IO) {
+        try {
+            // Check if migration is needed based on version
+            if (!isContainerMigrationNeeded(context)) {
+                Timber.i("Container migration not needed, already at version $LATEST_CONTAINER_MIGRATION_VERSION")
+                withContext(Dispatchers.Main) {
+                    onComplete?.invoke(0)
+                }
+                return@withContext
+            }
+
+            val imageFs = ImageFs.find(context)
+            val homeDir = File(imageFs.rootDir, "home")
+
+            // Find all legacy numeric container directories
+            val legacyContainers = homeDir.listFiles()?.filter { file ->
+                file.isDirectory() &&
+                    file.name != ImageFs.USER &&
+                    // Skip active symlink
+                    file.name.startsWith("${ImageFs.USER}-") &&
+                    // Must have xuser- prefix
+                    file.name.removePrefix("${ImageFs.USER}-").matches(Regex("\\d+")) &&
+                    // Numeric ID after prefix
+                    File(file, ".container").exists() // Has container config
+            } ?: emptyList()
+
+            val totalContainers = legacyContainers.size
+            var migratedContainers = 0
+
+            Timber.i("Found $totalContainers legacy containers to migrate")
+
+            for (legacyDir in legacyContainers) {
+                val legacyId = legacyDir.name.removePrefix("${ImageFs.USER}-") // Remove xuser- prefix
+                val newContainerId = "STEAM_$legacyId"
+                val newDir = File(homeDir, "${ImageFs.USER}-$newContainerId") // WITH xuser- prefix
+
+                withContext(Dispatchers.Main) {
+                    onProgressUpdate?.invoke(legacyId, migratedContainers, totalContainers)
+                }
+
+                try {
+                    // Handle naming conflicts
+                    var finalContainerId = newContainerId
+                    var finalNewDir = newDir
+                    var counter = 1
+
+                    while (finalNewDir.exists()) {
+                        finalContainerId = "STEAM_$legacyId($counter)"
+                        finalNewDir = File(homeDir, "${ImageFs.USER}-$finalContainerId") // WITH xuser- prefix
+                        counter++
+                    }
+
+                    // Rename directory
+                    if (legacyDir.renameTo(finalNewDir)) {
+                        // Update container config
+                        updateContainerConfig(finalNewDir, finalContainerId)
+
+                        // Update active symlink if this was the active container
+                        val activeSymlink = File(homeDir, ImageFs.USER)
+                        if (activeSymlink.exists() && activeSymlink.canonicalPath.endsWith(legacyId)) {
+                            activeSymlink.delete()
+                            FileUtils.symlink("./${ImageFs.USER}-$finalContainerId", activeSymlink.path)
+                            Timber.i("Updated active symlink to point to $finalContainerId")
+                        }
+
+                        migratedContainers++
+                        Timber.i("Migrated container $legacyId -> $finalContainerId")
+                    } else {
+                        Timber.e("Failed to rename container directory: $legacyId")
+                    }
+                } catch (e: Exception) {
+                    Timber.e(e, "Error migrating container $legacyId")
+                }
+            }
+
+            // Mark migration as complete regardless of success/failure
+            createContainerMigrationVersionFile(context, LATEST_CONTAINER_MIGRATION_VERSION)
+
+            withContext(Dispatchers.Main) {
+                onComplete?.invoke(migratedContainers)
+            }
+
+            Timber.i("Container migration completed: $migratedContainers containers migrated")
+        } catch (e: Exception) {
+            Timber.e(e, "Error during container migration")
+            // Still mark as complete to avoid repeated attempts
+            createContainerMigrationVersionFile(context, LATEST_CONTAINER_MIGRATION_VERSION)
+            withContext(Dispatchers.Main) {
+                onComplete?.invoke(0)
+            }
+        }
+    }
+
+    /**
+     * Checks if there are any legacy containers that need migration
+     * (Kept for backward compatibility, but prefer using isContainerMigrationNeeded)
+     */
+    suspend fun hasLegacyContainers(context: Context): Boolean = withContext(Dispatchers.IO) {
+        try {
+            val imageFs = ImageFs.find(context)
+            val homeDir = File(imageFs.rootDir, "home")
+
+            val legacyContainers = homeDir.listFiles()?.filter { file ->
+                file.isDirectory() &&
+                    file.name != ImageFs.USER &&
+                    // Skip active symlink
+                    file.name.startsWith("${ImageFs.USER}-") &&
+                    // Must have xuser- prefix
+                    file.name.removePrefix("${ImageFs.USER}-").matches(Regex("\\d+")) &&
+                    // Numeric ID after prefix
+                    File(file, ".container").exists() // Has container config
+            } ?: emptyList()
+
+            return@withContext legacyContainers.isNotEmpty()
+        } catch (e: Exception) {
+            Timber.e(e, "Error checking for legacy containers")
+            return@withContext false
+        }
+    }
+
+    private fun updateContainerConfig(containerDir: File, newContainerId: String) {
+        try {
+            val configFile = File(containerDir, ".container")
+            val configContent = FileUtils.readString(configFile)
+            val data = JSONObject(configContent)
+            data.put("id", newContainerId)
+            FileUtils.writeString(configFile, data.toString())
+            Timber.i("Updated container config ID to $newContainerId")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to update container config for $newContainerId")
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -18,12 +18,15 @@ import com.winlator.core.WineThemeManager
 import kotlinx.coroutines.CompletableDeferred
 import com.winlator.inputcontrols.ControlsProfile
 import com.winlator.inputcontrols.InputControlsManager
-import java.io.File
+import com.winlator.xenvironment.ImageFs
 import kotlin.Boolean
 import org.json.JSONArray
 import org.json.JSONObject
 import timber.log.Timber
 import com.winlator.winhandler.WinHandler.PreferredInputApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
 
 object ContainerUtils {
     data class GpuInfo(
@@ -716,6 +719,133 @@ object ContainerUtils {
             containerId.startsWith("STEAM_") -> GameSource.STEAM
             // Add other platforms here..
             else -> GameSource.STEAM // default fallback
+        }
+    }
+
+    /**
+     * Migrates legacy numeric container directories to platform-prefixed format.
+     * Legacy: xuser-12345/ -> New: xuser-STEAM_12345/
+     */
+    suspend fun migrateLegacyContainers(
+        context: Context,
+        onProgressUpdate: (currentContainer: String, migratedContainers: Int, totalContainers: Int) -> Unit,
+        onComplete: (migratedCount: Int) -> Unit,
+    ) = withContext(Dispatchers.IO) {
+        try {
+            val imageFs = ImageFs.find(context)
+            val homeDir = File(imageFs.rootDir, "home")
+            
+            // Find all legacy numeric container directories
+            val legacyContainers = homeDir.listFiles()?.filter { file ->
+                file.isDirectory() && 
+                file.name != ImageFs.USER && // Skip active symlink
+                file.name.startsWith("${ImageFs.USER}-") && // Must have xuser- prefix
+                file.name.removePrefix("${ImageFs.USER}-").matches(Regex("\\d+")) && // Numeric ID after prefix
+                File(file, ".container").exists() // Has container config
+            } ?: emptyList()
+            
+            val totalContainers = legacyContainers.size
+            var migratedContainers = 0
+            
+            if (totalContainers == 0) {
+                withContext(Dispatchers.Main) {
+                    onComplete(0)
+                }
+                return@withContext
+            }
+            
+            Timber.i("Found $totalContainers legacy containers to migrate")
+            
+            for (legacyDir in legacyContainers) {
+                val legacyId = legacyDir.name.removePrefix("${ImageFs.USER}-") // Remove xuser- prefix
+                val newContainerId = "STEAM_$legacyId"
+                val newDir = File(homeDir, "${ImageFs.USER}-$newContainerId") // WITH xuser- prefix
+                
+                withContext(Dispatchers.Main) {
+                    onProgressUpdate(legacyId, migratedContainers, totalContainers)
+                }
+                
+                try {
+                    // Handle naming conflicts
+                    var finalContainerId = newContainerId
+                    var finalNewDir = newDir
+                    var counter = 1
+                    
+                    while (finalNewDir.exists()) {
+                        finalContainerId = "STEAM_$legacyId($counter)"
+                        finalNewDir = File(homeDir, "${ImageFs.USER}-$finalContainerId") // WITH xuser- prefix
+                        counter++
+                    }
+                    
+                    // Rename directory
+                    if (legacyDir.renameTo(finalNewDir)) {
+                        // Update container config
+                        updateContainerConfig(finalNewDir, finalContainerId)
+                        
+                        // Update active symlink if this was the active container
+                        val activeSymlink = File(homeDir, ImageFs.USER)
+                        if (activeSymlink.exists() && activeSymlink.canonicalPath.endsWith(legacyId)) {
+                            activeSymlink.delete()
+                            FileUtils.symlink("./${ImageFs.USER}-$finalContainerId", activeSymlink.path)
+                            Timber.i("Updated active symlink to point to $finalContainerId")
+                        }
+                        
+                        migratedContainers++
+                        Timber.i("Migrated container $legacyId -> $finalContainerId")
+                    } else {
+                        Timber.e("Failed to rename container directory: $legacyId")
+                    }
+                    
+                } catch (e: Exception) {
+                    Timber.e(e, "Error migrating container $legacyId")
+                }
+            }
+            
+            withContext(Dispatchers.Main) {
+                onComplete(migratedContainers)
+            }
+            
+        } catch (e: Exception) {
+            Timber.e(e, "Error during container migration")
+            withContext(Dispatchers.Main) {
+                onComplete(0)
+            }
+        }
+    }
+
+    /**
+     * Checks if there are any legacy containers that need migration
+     */
+    suspend fun hasLegacyContainers(context: Context): Boolean = withContext(Dispatchers.IO) {
+        try {
+            val imageFs = ImageFs.find(context)
+            val homeDir = File(imageFs.rootDir, "home")
+            
+            val legacyContainers = homeDir.listFiles()?.filter { file ->
+                file.isDirectory() && 
+                file.name != ImageFs.USER && // Skip active symlink
+                file.name.startsWith("${ImageFs.USER}-") && // Must have xuser- prefix
+                file.name.removePrefix("${ImageFs.USER}-").matches(Regex("\\d+")) && // Numeric ID after prefix
+                File(file, ".container").exists() // Has container config
+            } ?: emptyList()
+            
+            return@withContext legacyContainers.isNotEmpty()
+        } catch (e: Exception) {
+            Timber.e(e, "Error checking for legacy containers")
+            return@withContext false
+        }
+    }
+
+    private fun updateContainerConfig(containerDir: File, newContainerId: String) {
+        try {
+            val configFile = File(containerDir, ".container")
+            val configContent = FileUtils.readString(configFile)
+            val data = JSONObject(configContent)
+            data.put("id", newContainerId)
+            FileUtils.writeString(configFile, data.toString())
+            Timber.i("Updated container config ID to $newContainerId")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to update container config for $newContainerId")
         }
     }
 }

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -1,6 +1,7 @@
 package app.gamenative.utils
 
 import android.content.Context
+import app.gamenative.data.GameSource
 import app.gamenative.enums.Marker
 import app.gamenative.PrefManager
 import app.gamenative.service.SteamService
@@ -194,14 +195,9 @@ object ContainerUtils {
         )
     }
 
-    fun applyToContainer(context: Context, appId: Int, containerData: ContainerData) {
-        val containerManager = ContainerManager(context)
-        if (containerManager.hasContainer(appId)) {
-            val container = containerManager.getContainerById(appId)
-            applyToContainer(context, container, containerData)
-        } else {
-            throw Exception("Container does not exist for $appId")
-        }
+    fun applyToContainer(context: Context, appId: String, containerData: ContainerData) {
+        val container = getContainer(context, appId)
+        applyToContainer(context, container, containerData)
     }
 
     fun applyToContainer(context: Context, container: Container, containerData: ContainerData) {
@@ -276,7 +272,8 @@ object ContainerUtils {
         container.setLC_ALL(lcAll)
         // If language changed, remove the STEAM_DLL_REPLACED marker so settings regenerate
         if (previousLanguage.lowercase() != containerData.language.lowercase()) {
-            val appDirPath = SteamService.getAppDirPath(container.id)
+            val steamAppId = extractGameIdFromContainerId(container.id)
+            val appDirPath = SteamService.getAppDirPath(steamAppId)
             MarkerUtils.removeMarker(appDirPath, Marker.STEAM_DLL_REPLACED)
             Timber.i("Language changed from '$previousLanguage' to '${containerData.language}'. Cleared STEAM_DLL_REPLACED marker for container ${container.id}.")
         }
@@ -344,23 +341,19 @@ object ContainerUtils {
         }
     }
 
-    fun getContainerId(appId: Int): Int {
-        // TODO: set up containers for each appId+depotId combo (intent extra "container_id")
+    fun getContainerId(appId: String): String {
         return appId
     }
 
-    fun hasContainer(context: Context, appId: Int): Boolean {
-        val containerId = getContainerId(appId)
+    fun hasContainer(context: Context, appId: String): Boolean {
         val containerManager = ContainerManager(context)
-        return containerManager.hasContainer(containerId)
+        return containerManager.hasContainer(appId)
     }
 
-    fun getContainer(context: Context, appId: Int): Container {
-        val containerId = getContainerId(appId)
-
+    fun getContainer(context: Context, appId: String): Container {
         val containerManager = ContainerManager(context)
-        return if (containerManager.hasContainer(containerId)) {
-            containerManager.getContainerById(containerId)
+        return if (containerManager.hasContainer(appId)) {
+            containerManager.getContainerById(appId)
         } else {
             throw Exception("Container does not exist for game $appId")
         }
@@ -368,14 +361,15 @@ object ContainerUtils {
 
     private fun createNewContainer(
         context: Context,
-        appId: Int,
-        containerId: Int,
+        appId: String,
+        containerId: String,
         containerManager: ContainerManager,
         customConfig: ContainerData? = null,
     ): Container {
         // Set up container drives to include app
         val defaultDrives = PrefManager.drives
-        val appDirPath = SteamService.getAppDirPath(appId)
+        val gameId = extractGameIdFromContainerId(appId)
+        val appDirPath = SteamService.getAppDirPath(gameId)
         val drive: Char = Container.getNextAvailableDriveLetter(defaultDrives)
         val drives = "$defaultDrives$drive:$appDirPath"
         Timber.d("Prepared container drives: $drives")
@@ -452,7 +446,7 @@ object ContainerUtils {
                 val deferred = kotlinx.coroutines.CompletableDeferred<Int>()
 
                 // Start the async fetch but wait for it to complete
-                SteamUtils.fetchDirect3DMajor(appId) { dxVersion ->
+                SteamUtils.fetchDirect3DMajor(gameId) { dxVersion ->
                     deferred.complete(dxVersion)
                 }
 
@@ -487,23 +481,21 @@ object ContainerUtils {
         return container
     }
 
-    fun getOrCreateContainer(context: Context, appId: Int): Container {
-        val containerId = getContainerId(appId)
+    fun getOrCreateContainer(context: Context, appId: String): Container {
         val containerManager = ContainerManager(context)
 
-        return if (containerManager.hasContainer(containerId)) {
-            containerManager.getContainerById(containerId)
+        return if (containerManager.hasContainer(appId)) {
+            containerManager.getContainerById(appId)
         } else {
-            createNewContainer(context, appId, containerId, containerManager)
+            createNewContainer(context, appId, appId, containerManager)
         }
     }
 
-    fun getOrCreateContainerWithOverride(context: Context, appId: Int): Container {
-        val containerId = getContainerId(appId)
+    fun getOrCreateContainerWithOverride(context: Context, appId: String): Container {
         val containerManager = ContainerManager(context)
 
-        return if (containerManager.hasContainer(containerId)) {
-            val container = containerManager.getContainerById(containerId)
+        return if (containerManager.hasContainer(appId)) {
+            val container = containerManager.getContainerById(appId)
 
             // Apply temporary override if present (without saving to disk)
             if (IntentLaunchManager.hasTemporaryOverride(appId)) {
@@ -539,7 +531,7 @@ object ContainerUtils {
                 null
             }
 
-            createNewContainer(context, appId, containerId, containerManager, overrideConfig)
+            createNewContainer(context, appId, appId, containerManager, overrideConfig)
         }
     }
 
@@ -690,16 +682,40 @@ object ContainerUtils {
     /**
      * Deletes the container associated with the given appId, if it exists.
      */
-    fun deleteContainer(context: Context, appId: Int) {
-        val containerId = getContainerId(appId)
+    fun deleteContainer(context: Context, appId: String) {
         val manager = ContainerManager(context)
-        if (manager.hasContainer(containerId)) {
+        if (manager.hasContainer(appId)) {
             // Remove the container directory asynchronously
             manager.removeContainerAsync(
-                manager.getContainerById(containerId),
+                manager.getContainerById(appId),
             ) {
-                Timber.i("Deleted container for appId=$appId (containerId=$containerId)")
+                Timber.i("Deleted container for appId=$appId")
             }
+        }
+    }
+
+    /**
+     * Extracts the game ID from a container ID string
+     * Splits on the first underscore and takes the numeric part, handling duplicate suffixes like (1), (2)
+     */
+    fun extractGameIdFromContainerId(containerId: String): Int {
+        val afterUnderscore = containerId.split("_", limit = 2)[1]
+        // Remove duplicate suffix like (1), (2) if present
+        return if (afterUnderscore.contains("(")) {
+            afterUnderscore.substringBefore("(").toInt()
+        } else {
+            afterUnderscore.toInt()
+        }
+    }
+
+    /**
+     * Extracts the game source from a container ID string
+     */
+    fun extractGameSourceFromContainerId(containerId: String): GameSource {
+        return when {
+            containerId.startsWith("STEAM_") -> GameSource.STEAM
+            // Add other platforms here..
+            else -> GameSource.STEAM // default fallback
         }
     }
 }

--- a/app/src/main/java/app/gamenative/utils/GameFeedbackUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/GameFeedbackUtils.kt
@@ -44,19 +44,20 @@ object GameFeedbackUtils {
     suspend fun submitGameFeedback(
         context: Context,
         supabase: SupabaseClient,
-        appId: Int,
+        appId: String,
         rating: Int,
         tags: List<String>,
         notes: String?,
     ) = withContext(Dispatchers.IO) {
         Timber.d("GameFeedbackUtils: Starting submitGameFeedback method with rating=$rating")
         try {
+            val gameId = ContainerUtils.extractGameIdFromContainerId(appId)
             val container = ContainerUtils.getContainer(context, appId)
             val configJson = Json.parseToJsonElement(FileUtils.readString(container.getConfigFile()).replace("\\u0000", "").replace("\u0000", "")).jsonObject
             Timber.d("config string is: " + FileUtils.readString(container.getConfigFile()).replace("\\u0000", "").replace("\u0000", ""))
             Timber.d("configJson: $configJson")
             // Get the game name from container or use a fallback
-            val appInfo = SteamService.getAppInfoOf(appId)!!
+            val appInfo = SteamService.getAppInfoOf(gameId)!!
             val gameName = appInfo.name
             Timber.d("GameFeedbackUtils: Game name: $gameName")
 

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -8,14 +8,9 @@ import app.gamenative.data.DepotInfo
 import app.gamenative.data.LibraryItem
 import app.gamenative.enums.Marker
 import app.gamenative.service.SteamService
-import app.gamenative.utils.ContainerUtils.extractGameIdFromContainerId
 import com.winlator.core.WineRegistryEditor
 import com.winlator.xenvironment.ImageFs
 import `in`.dragonbra.javasteam.util.HardwareUtils
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -33,7 +28,6 @@ import kotlin.io.path.name
 import timber.log.Timber
 import okhttp3.*
 import org.json.JSONObject
-import java.net.URLDecoder
 import java.net.URLEncoder
 
 object SteamUtils {

--- a/app/src/main/java/com/winlator/container/Container.java
+++ b/app/src/main/java/com/winlator/container/Container.java
@@ -40,7 +40,7 @@ public class Container {
     public static final String STEAM_TYPE_LIGHT = "light";
     public static final String STEAM_TYPE_ULTRALIGHT = "ultralight";
     public static final byte MAX_DRIVE_LETTERS = 8;
-    public final int id;
+    public final String id;
     private String name;
     private String screenSize = DEFAULT_SCREEN_SIZE;
     private String envVars = DEFAULT_ENV_VARS;
@@ -140,7 +140,7 @@ public class Container {
         this.executablePath = executablePath != null ? executablePath : "";
     }
 
-    public Container(int id) {
+    public Container(String id) {
         this.id = id;
         this.name = "Container-"+id;
     }

--- a/app/src/main/java/com/winlator/container/ContainerManager.java
+++ b/app/src/main/java/com/winlator/container/ContainerManager.java
@@ -32,7 +32,6 @@ import java.util.concurrent.Future;
 
 public class ContainerManager {
     private final ArrayList<Container> containers = new ArrayList<>();
-    private int maxContainerId = 0;
     private final File homeDir;
     private final Context context;
 
@@ -61,7 +60,6 @@ public class ContainerManager {
 
     private void loadContainers() {
         containers.clear();
-        maxContainerId = 0;
 
         try {
             File[] files = homeDir.listFiles();
@@ -69,12 +67,12 @@ public class ContainerManager {
                 for (File file : files) {
                     if (file.isDirectory()) {
                         if (file.getName().startsWith(ImageFs.USER+"-")) {
-                            Container container = new Container(Integer.parseInt(file.getName().replace(ImageFs.USER+"-", "")));
+                            String containerId = file.getName().replace(ImageFs.USER+"-", "");
+                            Container container = new Container(containerId);
                             container.setRootDir(new File(homeDir, ImageFs.USER+"-"+container.id));
                             JSONObject data = new JSONObject(FileUtils.readString(container.getConfigFile()));
                             container.loadData(data);
                             containers.add(container);
-                            maxContainerId = Math.max(maxContainerId, container.id);
                         }
                     }
                 }
@@ -92,25 +90,17 @@ public class ContainerManager {
         FileUtils.symlink("./"+ImageFs.USER+"-"+container.id, file.getPath());
     }
 
-    public void createContainerAsync(final JSONObject data, Callback<Container> callback) {
-        int id = maxContainerId + 1;
+    public void createContainerAsync(String containerId, final JSONObject data, Callback<Container> callback) {
         final Handler handler = new Handler();
         Executors.newSingleThreadExecutor().execute(() -> {
-            final Container container = createContainer(id, data);
+            final Container container = createContainer(containerId, data);
             handler.post(() -> callback.call(container));
         });
     }
-    public Future<Container> createContainerFuture(final JSONObject data) {
-        int id = maxContainerId + 1;
-        return Executors.newSingleThreadExecutor().submit(() -> createContainer(id, data));
+    public Future<Container> createContainerFuture(String containerId, final JSONObject data) {
+        return Executors.newSingleThreadExecutor().submit(() -> createContainer(containerId, data));
     }
-    public Future<Container> createContainerFuture(int id, final JSONObject data) {
-        return Executors.newSingleThreadExecutor().submit(() -> createContainer(id, data));
-    }
-    public Future<Container> createDefaultContainerFuture(WineInfo wineInfo) {
-        return createDefaultContainerFuture(wineInfo, getNextContainerId());
-    }
-    public Future<Container> createDefaultContainerFuture(WineInfo wineInfo, int containerId) {
+    public Future<Container> createDefaultContainerFuture(WineInfo wineInfo, String containerId) {
         String name = "container_" + containerId;
         Log.d("XServerScreen", "Creating container $name");
         String screenSize = Container.DEFAULT_SCREEN_SIZE;
@@ -173,7 +163,7 @@ public class ContainerManager {
         });
     }
 
-    public Container createContainer(int containerId, JSONObject data) {
+    public Container createContainer(String containerId, JSONObject data) {
         try {
             data.put("id", containerId);
 
@@ -193,7 +183,6 @@ public class ContainerManager {
             }
 
             container.saveData();
-            maxContainerId++;
             containers.add(container);
             return container;
         }
@@ -204,9 +193,11 @@ public class ContainerManager {
     }
 
     private void duplicateContainer(Container srcContainer) {
-        int id = maxContainerId + 1;
+        // Generate a unique ID by appending (1), (2), etc. to the original ID
+        String baseId = srcContainer.id;
+        String newId = generateUniqueContainerId(baseId);
 
-        File dstDir = new File(homeDir, ImageFs.USER+"-"+id);
+        File dstDir = new File(homeDir, ImageFs.USER+"-"+newId);
         if (!dstDir.mkdirs()) return;
 
         if (!FileUtils.copy(srcContainer.getRootDir(), dstDir, (file) -> FileUtils.chmod(file, 0771))) {
@@ -214,7 +205,7 @@ public class ContainerManager {
             return;
         }
 
-        Container dstContainer = new Container(id);
+        Container dstContainer = new Container(newId);
         dstContainer.setRootDir(dstDir);
         dstContainer.setName(srcContainer.getName()+" ("+context.getString(R.string.copy)+")");
         dstContainer.setScreenSize(srcContainer.getScreenSize());
@@ -239,8 +230,24 @@ public class ContainerManager {
         dstContainer.setWineVersion(srcContainer.getWineVersion());
         dstContainer.saveData();
 
-        maxContainerId++;
         containers.add(dstContainer);
+    }
+
+    private String generateUniqueContainerId(String baseId) {
+        // If the base ID doesn't exist, use it as-is
+        if (!hasContainer(baseId)) {
+            return baseId;
+        }
+
+        // Try baseId(1), baseId(2), etc. until we find a unique one
+        int counter = 1;
+        String candidateId;
+        do {
+            candidateId = baseId + "(" + counter + ")";
+            counter++;
+        } while (hasContainer(candidateId));
+
+        return candidateId;
     }
 
     private void removeContainer(Container container) {
@@ -263,16 +270,13 @@ public class ContainerManager {
         return shortcuts;
     }
 
-    public int getNextContainerId() {
-        return maxContainerId + 1;
-    }
-
-    public boolean hasContainer(int id) {
-        for (Container container : containers) if (container.id == id) return true;
+    public boolean hasContainer(String id) {
+        for (Container container : containers) if (container.id.equals(id)) return true;
         return false;
     }
-    public Container getContainerById(int id) {
-        for (Container container : containers) if (container.id == id) return container;
+    
+    public Container getContainerById(String id) {
+        for (Container container : containers) if (container.id.equals(id)) return container;
         return null;
     }
 

--- a/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
@@ -6,6 +6,7 @@ import android.util.Log;
 
 import app.gamenative.enums.Marker;
 import app.gamenative.service.SteamService;
+import app.gamenative.utils.ContainerUtils;
 import app.gamenative.utils.MarkerUtils;
 
 // import com.winlator.MainActivity;
@@ -226,7 +227,8 @@ public abstract class ImageFsInstaller {
         try {
             for (Container container : containerManager.getContainers()) {
                 try {
-                    String mappedPath = SteamService.Companion.getAppDirPath(container.id);
+                    int gameId = ContainerUtils.INSTANCE.extractGameIdFromContainerId(container.id);
+                    String mappedPath = SteamService.Companion.getAppDirPath(gameId);
                     MarkerUtils.INSTANCE.removeMarker(mappedPath, Marker.STEAM_DLL_REPLACED);
                     MarkerUtils.INSTANCE.removeMarker(mappedPath, Marker.STEAM_DLL_RESTORED);
                     Log.i("ImageFsInstaller", "Cleared markers for container: " + container.getName() + " (ID: " + container.id + ")");


### PR DESCRIPTION
**Note, this PR is also included in https://github.com/utkarshdalal/GameNative/pull/144**

This PR is required for supporting platforms other than Steam. Currently the app used Steam id's (ints) as app identifiers. This can create overlapping id's with other platforms so the int has to be changed to a string with prefixed platform. 

The PR will make it a lot easier to start supporting other platforms in the future, but important note: "It will update container ids to be STEAM_123 instead of 123 as well" **So this PR requires a migration (which is included).** 

Steps to test migration:
-> revert to master before this PR.
-> install game
-> play
-> update to this branch.
-> see if it migrates and still plays using the moved container.  (you can tell easily by the loading time of the game).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Namespaced string game IDs (multi-source support) and LibraryItem-driven flows across the app.
  * "Clear all" temporary configuration overrides and migration utilities for legacy containers.

* **UX Improvements**
  * Automatic migration of existing game containers with a migration progress dialog.
  * Unified game details/actions and launch flow using the new ID format; improved splash/launch timing.

* **Reliability**
  * Safer container handling, robust config parsing/validation, and clearer migration/error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->