### PR TITLE
Updated the fallback profile picture image.

### DIFF
--- a/app/src/main/java/app/gamenative/ui/util/Images.kt
+++ b/app/src/main/java/app/gamenative/ui/util/Images.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -67,7 +68,7 @@ internal fun SteamIconImage(
             CircularProgressIndicator()
         },
         failure = {
-            Icon(Icons.Filled.QuestionMark, null)
+            Icon(Icons.Default.AccountCircle, null)
         },
         previewPlaceholder = painterResource(R.drawable.ic_logo_color),
     )


### PR DESCRIPTION
**Note, this PR is also included in https://github.com/utkarshdalal/GameNative/pull/144**

If the steam icon can not be retrieved for whatever reason (or if in the future you use the app without Steam authenticated). Then it's nice to show a user icon instead of a question mark icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Refined the fallback visual for Steam profile images. When an image fails to load, the app now displays a user/avatar icon instead of a question mark, providing clearer context and a more polished look. This update affects all screens showing Steam avatars. No behavioral changes or settings adjustments are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->