### PR TITLE
Removed incorect checkObsoleteOrMissingProperties call on extraData

### DIFF
--- a/app/src/main/java/com/winlator/container/Container.java
+++ b/app/src/main/java/com/winlator/container/Container.java
@@ -639,7 +639,6 @@ public class Container {
                     break;
                 case "extraData" : {
                     JSONObject extraData = data.getJSONObject(key);
-                    checkObsoleteOrMissingProperties(extraData);
                     setExtraData(extraData);
                     break;
                 }


### PR DESCRIPTION
When launching a game it will throw the following errors on new containers:
```
2025-09-16 00:23:57.711 Container                           app.gamenative                       E  Failed to check obsolete or missing properties: org.json.JSONException: No value for wincomponents
2025-09-16 00:23:57.719 Container                           app.gamenative                       E  Failed to check obsolete or missing properties: org.json.JSONException: No value for wincomponents
2025-09-16 00:24:22.077 Container                           app.gamenative                       E  Failed to check obsolete or missing properties: org.json.JSONException: No value for wincomponents
```

This is due to the fact that it does container prop checking on `data` as well as `extradata`. Extra data **does not always contain** a container config. So doing prop checking here will result in errors while the game will still load.

I've removed the `checkObsoleteOrMissingProperties` so the error no longer occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Extra configuration attached to a container is now preserved exactly as provided when loading, preventing unintended changes to user-defined values.
  - Eliminates unexpected defaults or legacy key remapping applied during load for this specific configuration block.
  - Overall container data still undergoes standard validation and cleanup; only the nested extra configuration is excluded from automatic normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->