### PR TITLE
Fixed build by using steamAppId instead of appId

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1202,12 +1202,13 @@ private fun getWineStartCommand(
     val args = if (bootToContainer || appLaunchInfo == null) {
         "\"wfm.exe\""
     } else {
-        val appDirPath = SteamService.getAppDirPath(appId)
+        val steamAppId = ContainerUtils.extractGameIdFromContainerId(appId)
+        val appDirPath = SteamService.getAppDirPath(steamAppId)
         var executablePath = ""
         if (container.executablePath.isNotEmpty()) {
             executablePath = container.executablePath
         } else {
-            executablePath = SteamService.getInstalledExe(appId)
+            executablePath = SteamService.getInstalledExe(steamAppId)
             container.executablePath = executablePath
             container.saveData()
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected detection of Steam game install directories and executables when launching from container-based entries, reducing launch failures and “file not found” errors.
  * Improved reliability when starting installed Steam games outside container-boot mode by accurately mapping container entries to their corresponding Steam apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->