### PR TITLE
always drain processhelper buffer, fix blackscreens

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1029,13 +1029,18 @@ private fun setupXEnvironment(
             "-all",
     )
     // capture debug output to file if either Wine or Box86/64 logging is enabled
-    if (enableWineDebug || enableBox86Logs) {
+    var logFile: File? = null
+    val captureLogs = enableWineDebug || enableBox86Logs
+    if (captureLogs) {
         val wineLogDir = File(context.getExternalFilesDir(null), "wine_logs")
         wineLogDir.mkdirs()
         val logFile = File(wineLogDir, "wine_debug.log")
         if (logFile.exists()) logFile.delete()
-        ProcessHelper.addDebugCallback { line ->
-            logFile.appendText(line + "\n")
+    }
+
+    ProcessHelper.addDebugCallback { line ->
+        if (captureLogs) {
+            logFile?.appendText(line + "\n")
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Adjusted debug logging behavior: log capture now only activates when specific debug options are enabled.
  - Log files are created and written only when these options are turned on; otherwise, no log file is produced.
  - Users relying on logs for troubleshooting may need to enable the relevant debug settings to generate output.
  - This change consolidates how logs are gated and managed during sessions, affecting when and how logs appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->