### PR TITLE
Added supporters from Kofi within app

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/ProfileDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ProfileDialog.kt
@@ -7,10 +7,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Help
 import androidx.compose.material.icons.automirrored.filled.Login
 import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material.icons.automirrored.filled.ReplyAll
+import androidx.compose.material.icons.automirrored.filled.StarHalf
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Help
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.VolunteerActivism
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalButton
@@ -23,8 +28,8 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -59,6 +64,7 @@ fun ProfileDialog(
     }
 
     var selectedItem by remember(state) { mutableStateOf(state) }
+    var showSupporters by remember { mutableStateOf(false) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -116,9 +122,15 @@ fun ProfileDialog(
                 }
 
                 FilledTonalButton(modifier = Modifier.fillMaxWidth(), onClick = { uriHandler.openUri("https://discord.gg/2hKv4VfZfE") }) {
-                    Icon(imageVector = Icons.Default.Help, contentDescription = null)
+                    Icon(imageVector = Icons.AutoMirrored.Filled.Help, contentDescription = null)
                     Spacer(modifier = Modifier.size(ButtonDefaults.IconSize))
                     Text(text = "Help & Support")
+                }
+
+                FilledTonalButton(modifier = Modifier.fillMaxWidth(), onClick = { showSupporters = true }) {
+                    Icon(imageVector = Icons.AutoMirrored.Filled.StarHalf, contentDescription = null)
+                    Spacer(modifier = Modifier.size(ButtonDefaults.IconSize))
+                    Text(text = "Hall of Fame")
                 }
 
                 if(isOffline) {
@@ -142,6 +154,8 @@ fun ProfileDialog(
             }
         },
     )
+
+    SupportersDialog(visible = showSupporters, onDismiss = { showSupporters = false })
 }
 
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)

--- a/app/src/main/java/app/gamenative/ui/component/dialog/SupportersDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/SupportersDialog.kt
@@ -1,0 +1,106 @@
+package app.gamenative.ui.component.dialog
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.gamenative.PluviaApp
+import app.gamenative.utils.KofiSupporter
+import app.gamenative.utils.fetchKofiSupporters
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+fun SupportersDialog(
+    visible: Boolean,
+    onDismiss: () -> Unit,
+) {
+    if (!visible) return
+
+    var supporters by remember { mutableStateOf<List<KofiSupporter>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+
+    LaunchedEffect(Unit) {
+        isLoading = true
+        val data = withContext(Dispatchers.IO) {
+            fetchKofiSupporters(PluviaApp.supabase)
+        }
+        supporters = data
+        isLoading = false
+    }
+
+    val members = remember(supporters) {
+        supporters.filter { it.oneOff == false }.sortedByDescending { it.total ?: 0.0 }
+    }
+    val oneOffs = remember(supporters) {
+        supporters.filter { it.oneOff != false }.sortedByDescending { it.total ?: 0.0 }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        },
+        title = { Text("Hall of Fame") },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                if (isLoading) {
+                    Text("Loading…")
+                } else {
+                    if (members.isNotEmpty()) {
+                        Text(
+                            text = "Members",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp), modifier = Modifier.padding(bottom = 8.dp)) {
+                            members.forEach { sup ->
+                                Text(
+                                    text = (sup.name ?: "Anonymous"),
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    }
+
+                    if (oneOffs.isNotEmpty()) {
+                        Text(
+                            text = "Supporters",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            oneOffs.forEach { sup ->
+                                Text(text = (sup.name ?: "Anonymous"))
+                            }
+                        }
+                    }
+
+                    if (members.isEmpty() && oneOffs.isEmpty()) {
+                        Text("No supporters yet.")
+                    }
+                }
+            }
+        }
+    )
+}
+
+

--- a/app/src/main/java/app/gamenative/utils/SupportersUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SupportersUtils.kt
@@ -1,0 +1,34 @@
+package app.gamenative.utils
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.Columns
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import timber.log.Timber
+
+@Serializable
+data class KofiSupporter(
+    @SerialName("Name") val name: String? = null,
+    @SerialName("OneOff") val oneOff: Boolean? = null,
+    @SerialName("Total") val total: Double? = null,
+)
+
+/**
+ * Fetch supporters from Supabase `kofi_supporters` table.
+ * Only fetches fields needed for display.
+ */
+suspend fun fetchKofiSupporters(supabase: SupabaseClient): List<KofiSupporter> {
+    return try {
+        Timber.d("Fetching Ko-fi supporters from Supabase")
+        supabase
+            .from("kofi_supporters")
+            .select(columns = Columns.list("Name", "OneOff", "Total"))
+            .decodeList<KofiSupporter>()
+    } catch (e: Exception) {
+        Timber.e(e, "Failed to fetch Ko-fi supporters: ${e.message}")
+        emptyList()
+    }
+}
+
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Hall of Fame button in the profile dialog that opens a Supporters dialog.
  - Supporters dialog displays Members and one-time Supporters, sorted by total contributions.
  - Shows a loading state, handles anonymous names, and displays an empty state when applicable.
  - Includes a Close action to dismiss the dialog.
- Style
  - Refreshed icons in the profile dialog, including updated Help and new Hall of Fame, Reply All, Favorite, and Volunteer icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->