### PR TITLE
Don't show "continue offline" when user is offline and a game is running

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -314,7 +314,7 @@ fun PluviaMain(
 
     LaunchedEffect(Unit) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-            if (!state.isSteamConnected && !isConnecting) {
+            if (!state.isSteamConnected && !isConnecting && !SteamService.isGameRunning) {
                 Timber.d("[PluviaMain]: Steam not connected - attempt")
                 isConnecting = true
                 context.startForegroundService(Intent(context, SteamService::class.java))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents Steam reconnection attempts while a game is running, reducing the risk of interruptions, login prompts, or network spikes during gameplay.
  * Improves overall stability of the Steam connection by retrying only when no game is active, minimizing background churn and error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->