### PR TITLE
Only enable dlcs that the user owns

### DIFF
--- a/app/src/main/java/app/gamenative/data/AppInfo.kt
+++ b/app/src/main/java/app/gamenative/data/AppInfo.kt
@@ -11,4 +11,6 @@ data class AppInfo (
     val isDownloaded: Boolean = false,
     @ColumnInfo("downloaded_depots")
     val downloadedDepots: List<Int> = emptyList<Int>(),
+    @ColumnInfo("dlc_depots")
+    val dlcDepots: List<Int> = emptyList<Int>(),
 ){}

--- a/app/src/main/java/app/gamenative/db/PluviaDatabase.kt
+++ b/app/src/main/java/app/gamenative/db/PluviaDatabase.kt
@@ -39,7 +39,7 @@ const val DATABASE_NAME = "pluvia.db"
         Emoticon::class,
         AppInfo::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = false, // Should export once stable.
 )
 @TypeConverters(

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -414,6 +414,10 @@ class SteamService : Service(), IChallengeUrlChanged {
             return runBlocking(Dispatchers.IO) { instance?.appInfoDao?.getInstalledDepots(appId)?.downloadedDepots }
         }
 
+        fun getDlcDepotsOf(appId: Int): List<Int>? {
+            return runBlocking(Dispatchers.IO) { instance?.appInfoDao?.getInstalledDepots(appId)?.dlcDepots }
+        }
+
         fun getAppDownloadInfo(appId: Int): DownloadInfo? {
             return downloadJobs[appId]
         }
@@ -895,8 +899,10 @@ class SteamService : Service(), IChallengeUrlChanged {
                     lastPercent = percent
                 }
                 if (percent >= 100) {
+                    val ownedDlc = runBlocking { getOwnedAppDlc(appId) }
                     MarkerUtils.addMarker(getAppDirPath(appId), Marker.DOWNLOAD_COMPLETE_MARKER)
-                    runBlocking { instance?.appInfoDao?.insert(AppInfo(appId, isDownloaded = true, downloadedDepots = entitledDepotIds)) }
+                    runBlocking { instance?.appInfoDao?.insert(AppInfo(appId, isDownloaded = true, downloadedDepots = entitledDepotIds,
+                        dlcDepots = ownedDlc.values.map { it.dlcAppId }.distinct())) }
                     MarkerUtils.removeMarker(getAppDirPath(appId), Marker.STEAM_DLL_REPLACED)
                 }
             }

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -676,6 +676,19 @@ object SteamUtils {
         if (Files.notExists(configsIni)) Files.createFile(configsIni)
         configsIni.toFile().writeText(iniContent)
 
+        val appIni = settingsDir.resolve("configs.app.ini")
+        val dlcIds = SteamService.getDlcDepotsOf(steamAppId)
+        val dlcLines = dlcIds?.joinToString("\n") { id -> "$id=dlc$id" }
+
+        val appIniContent = """
+            [app::dlcs]
+            unlock_all=0
+            $dlcLines
+        """.trimIndent()
+
+        if (Files.notExists(appIni)) Files.createFile(appIni)
+        appIni.toFile().writeText(appIniContent)
+
         // Write supported languages list
         val supportedLanguagesFile = settingsDir.resolve("supported_languages.txt")
         if (Files.notExists(supportedLanguagesFile)) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically detects and stores owned DLCs for each installed game.
  - Generates and updates Steam settings to include DLC configuration, ensuring DLC depots are recognized after downloads.
  - Improves post-download setup so DLC content is properly enabled without manual configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->