### PR TITLE
Changed the order of drivers and clarified the defaults

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -24,31 +24,31 @@
         <item>SD 8 Elite (SD 8 Elite)</item>
     </string-array>
     <string-array name="turnip_version_entries">
+        <item>25.1.0 (Default)</item>
         <item>25.3.0</item>
         <item>25.2.0</item>
-        <item>25.1.0</item>
         <item>25.0.0</item>
         <item>24.1.0</item>
     </string-array>
     <string-array name="virgl_version_entries">
-        <item>23.1.9</item>
+        <item>23.1.9 (Default)</item>
     </string-array>
     <string-array name="zink_version_entries">
-        <item>22.2.5</item>
+        <item>22.2.5 (Default)</item>
     </string-array>
     <string-array name="vortek_version_entries">
-        <item>2.0</item>
+        <item>2.0 (Default)</item>
     </string-array>
     <string-array name="adreno_version_entries">
-        <item>819.2</item>
+        <item>819.2 (Default)</item>
         <item>805</item>
     </string-array>
     <string-array name="sd8elite_version_entries">
+        <item>800.51 (Default)</item>
         <item>2-842.6</item>
-        <item>800.51</item>
     </string-array>
     <string-array name="audio_driver_entries">
-        <item>ALSA</item>
+        <item>ALSA (Default)</item>
         <item>PulseAudio</item>
     </string-array>
     <string-array name="binding_type_entries">
@@ -63,19 +63,19 @@
         <item>CNC DDraw</item>
     </string-array>
     <string-array name="dxvk_version_entries">
-        <item>2.6.1-gplasync</item>
+        <item>2.6.1-gplasync (Default)</item>
         <item>2.4.1-gplasync</item>
         <item>2.4.1</item>
-        <item>1.10.9-sarek</item>
         <item>async-1.10.3</item>
+        <item>1.10.9-sarek</item>
         <item>1.10.3</item>
         <item>1.9.2</item>
     </string-array>
     <string-array name="vkd3d_version_entries">
+        <item>2.6 (Default)</item>
         <item>2.14.1</item>
         <item>2.13</item>
         <item>2.12</item>
-        <item>2.6</item>
     </string-array>
     <string-array name="dxvk_max_device_memory_entries">
         <item>0 (Default)</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -24,9 +24,9 @@
         <item>SD 8 Elite (SD 8 Elite)</item>
     </string-array>
     <string-array name="turnip_version_entries">
-        <item>25.1.0</item>
-        <item>25.2.0</item>
         <item>25.3.0</item>
+        <item>25.2.0</item>
+        <item>25.1.0</item>
         <item>25.0.0</item>
         <item>24.1.0</item>
     </string-array>
@@ -44,8 +44,8 @@
         <item>805</item>
     </string-array>
     <string-array name="sd8elite_version_entries">
-        <item>800.51</item>
         <item>2-842.6</item>
+        <item>800.51</item>
     </string-array>
     <string-array name="audio_driver_entries">
         <item>ALSA</item>
@@ -64,18 +64,18 @@
     </string-array>
     <string-array name="dxvk_version_entries">
         <item>2.6.1-gplasync</item>
-        <item>1.10.3</item>
-        <item>1.10.9-sarek</item>
-        <item>1.9.2</item>
-        <item>2.4.1</item>
         <item>2.4.1-gplasync</item>
+        <item>2.4.1</item>
+        <item>1.10.9-sarek</item>
         <item>async-1.10.3</item>
+        <item>1.10.3</item>
+        <item>1.9.2</item>
     </string-array>
     <string-array name="vkd3d_version_entries">
-        <item>2.6</item>
-        <item>2.12</item>
-        <item>2.13</item>
         <item>2.14.1</item>
+        <item>2.13</item>
+        <item>2.12</item>
+        <item>2.6</item>
     </string-array>
     <string-array name="dxvk_max_device_memory_entries">
         <item>0 (Default)</item>


### PR DESCRIPTION
The order of the driver entries was all over the place, so I went ahead and reordered them by latest to oldest and added a label to the default entries. In cases where an older version was the default, that was kept at the top.