### PR TITLE
set box64 and dxvk versions when switching between container variants

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -748,6 +748,7 @@ fun ContainerConfigDialog(
                                                     graphicsDriver = defaultDriver,
                                                     graphicsDriverVersion = "",
                                                     graphicsDriverConfig = newCfg.toString(),
+                                                    box64Version = box64Versions[0],
                                                 )
                                             } else {
                                                 // Switch to bionic: set wrapper defaults
@@ -770,12 +771,23 @@ fun ContainerConfigDialog(
                                                 maxDeviceMemoryIndex =
                                                     listOf("0", "512", "1024", "2048", "4096").indexOf("4096").coerceAtLeast(0)
 
+                                                // If transitioning from GLIBC -> BIONIC, set Box64 to default and DXVK to async-1.10.3
+                                                val envSet = EnvVars(config.envVars).apply {
+                                                    put("DXVK_ASYNC", "1")
+                                                }
+                                                val currentConfig = KeyValueSet(config.dxwrapperConfig)
+                                                currentConfig.put("version", "async-1.10.3")
+                                                config = config.copy(dxwrapperConfig = currentConfig.toString())
+
                                                 config = config.copy(
                                                     containerVariant = newVariant,
                                                     wineVersion = newWine,
                                                     graphicsDriver = defaultBionicDriver,
                                                     graphicsDriverVersion = "",
                                                     graphicsDriverConfig = newCfg.toString(),
+                                                    box64Version = box64BionicVersions[0],
+                                                    dxwrapperConfig = currentConfig.toString(),
+                                                    envVars = envSet.toString(),
                                                 )
                                             }
                                         },

--- a/app/src/main/java/com/winlator/container/ContainerManager.java
+++ b/app/src/main/java/com/winlator/container/ContainerManager.java
@@ -49,7 +49,7 @@ public class ContainerManager {
         } else {
             DefaultVersion.VARIANT = Container.BIONIC;
             DefaultVersion.WINE_VERSION = "proton-9.0-arm64ec";
-            Container.DEFAULT_GRAPHICS_DRIVER = "Wrapper";
+            Container.DEFAULT_GRAPHICS_DRIVER = "Wrapper-leegao";
             DefaultVersion.DXVK = "async-1.10.3";
             DefaultVersion.VKD3D = "2.6";
             DefaultVersion.STEAM_TYPE = STEAM_TYPE_LIGHT;

--- a/app/src/main/java/com/winlator/core/DefaultVersion.java
+++ b/app/src/main/java/com/winlator/core/DefaultVersion.java
@@ -6,7 +6,7 @@ import com.winlator.container.Container;
 
 public abstract class DefaultVersion {
     public static final String BOX86 = "0.3.2";
-    public static final String BOX64 = "0.3.7";
+    public static final String BOX64 = "0.3.6";
     public static final String FEXCORE = "2507";
     public static final String WRAPPER = "System";
     public static final String TURNIP = "25.2.0";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default graphics driver assignment for improved compatibility.
  * Improved container variant switching behavior with proper configuration updates.

* **Chores**
  * Updated Box64 version to 0.3.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->