### PR TITLE
Added force dlc toggle

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -247,6 +247,13 @@ object PrefManager {
         set(value) {
             setPref(LAUNCH_REAL_STEAM, value)
         }
+        
+    private val FORCE_DLC = booleanPreferencesKey("force_dlc")
+    var forceDlc: Boolean
+        get() = getPref(FORCE_DLC, false)
+        set(value) {
+            setPref(FORCE_DLC, value)
+        }
 
     private val CPU_LIST = stringPreferencesKey("cpu_list")
     var cpuList: String

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -917,6 +917,16 @@ fun ContainerConfigDialog(
                                         config = config.copy(showFPS = it)
                                     },
                                 )
+                                
+                                SettingsSwitch(
+                                    colors = settingsTileColorsAlt(),
+                                    title = { Text(text = "Force DLC") },
+                                    subtitle = { Text(text = "Only enable if DLCs are not detected or saves with DLC are not working") },
+                                    state = config.forceDlc,
+                                    onCheckedChange = {
+                                        config = config.copy(forceDlc = it)
+                                    },
+                                )
                                 SettingsSwitch(
                                     colors = settingsTileColorsAlt(),
                                     title = { Text(text = "Launch Steam Client (Beta)") },

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -659,8 +659,8 @@ object SteamUtils {
         val configsIni = settingsDir.resolve("configs.user.ini")
         val accountName   = PrefManager.username
         val accountSteamId = SteamService.userSteamId?.convertToUInt64()?.toString() ?: "0"
+        val container = ContainerUtils.getOrCreateContainer(context, appId)
         val language = runCatching {
-            val container = ContainerUtils.getOrCreateContainer(context, appId)
             (container.getExtra("language", null)
                 ?: container.javaClass.getMethod("getLanguage").invoke(container) as? String)
                 ?: "english"
@@ -679,9 +679,10 @@ object SteamUtils {
         val appIni = settingsDir.resolve("configs.app.ini")
         val dlcIds = SteamService.getDlcDepotsOf(steamAppId)
 
+        val forceDlc = container.isForceDlc()
         val appIniContent = buildString {
             appendLine("[app::dlcs]")
-            appendLine("unlock_all=1")
+            appendLine("unlock_all=${if (forceDlc) 1 else 0}")
             dlcIds?.forEach { appendLine("$it=dlc$it") }
         }
 

--- a/app/src/main/java/com/winlator/container/Container.java
+++ b/app/src/main/java/com/winlator/container/Container.java
@@ -119,6 +119,8 @@ public class Container {
     private JSONObject controllerEmulationBindings;
     private boolean gstreamerWorkaround = false;
 
+    private boolean forceDlc = false;
+
     private String containerVariant = DEFAULT_VARIANT;
 
     public String getGraphicsDriverVersion() {
@@ -620,6 +622,9 @@ public class Container {
                 data.put("controllerEmulationBindings", controllerEmulationBindings);
             }
 
+            // Force DLC setting
+            data.put("forceDlc", forceDlc);
+
             if (!WineInfo.isMainWineVersion(wineVersion)) data.put("wineVersion", wineVersion);
             FileUtils.writeString(getConfigFile(), data.toString());
         }
@@ -779,6 +784,9 @@ public class Container {
                 case "controllerEmulationBindings":
                     this.controllerEmulationBindings = data.getJSONObject(key);
                     break;
+                case "forceDlc":
+                    this.forceDlc = data.getBoolean(key);
+                    break;
             }
         }
     }
@@ -878,6 +886,14 @@ public class Container {
 
     public void setEmulateKeyboardMouse(boolean emulate) {
         this.emulateKeyboardMouse = emulate;
+    }
+
+    public boolean isForceDlc() {
+        return forceDlc;
+    }
+
+    public void setForceDlc(boolean forceDlc) {
+        this.forceDlc = forceDlc;
     }
 
     public JSONObject getControllerEmulationBindings() {

--- a/app/src/main/java/com/winlator/container/ContainerData.kt
+++ b/app/src/main/java/com/winlator/container/ContainerData.kt
@@ -75,6 +75,7 @@ data class ContainerData(
     val emulateKeyboardMouse: Boolean = false,
     /** Button->Binding name map (JSON string) for emulation UI persistence **/
     val controllerEmulationBindings: String = "",
+    val forceDlc: Boolean = false,
 ) {
     companion object {
         val Saver = mapSaver(
@@ -124,6 +125,7 @@ data class ContainerData(
                     "language" to state.language,
                     "emulateKeyboardMouse" to state.emulateKeyboardMouse,
                     "controllerEmulationBindings" to state.controllerEmulationBindings,
+                    "forceDlc" to state.forceDlc,
                 )
             },
             restore = { savedMap ->
@@ -172,6 +174,7 @@ data class ContainerData(
                     language = (savedMap["language"] as? String) ?: "english",
                     emulateKeyboardMouse = (savedMap["emulateKeyboardMouse"] as? Boolean) ?: false,
                     controllerEmulationBindings = (savedMap["controllerEmulationBindings"] as? String) ?: "",
+                    forceDlc = (savedMap["forceDlc"] as? Boolean) ?: false,
                 )
             },
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Force DLC" toggle in settings that allows users to control DLC-related configuration options. This setting persists across sessions and influences how the application handles DLC during container initialization and Steam integration setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->