### PR TITLE
Add com.oculus.vrshellsupports_free_resizing to allow window resizing on Oculus Quest headsets

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,14 +45,6 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-
-                <!--
-                 Allows app window to be resized on Oculus Quest VR headsets
-                -->
-                <meta-data
-                android:name="com.oculus.vrshell.supports_free_resizing"
-                android:value="true" />
-
                 <data
                     android:host="pluvia"
                     android:scheme="home" />
@@ -61,6 +53,12 @@
                 <action android:name="app.gamenative.LAUNCH_GAME" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            
+            <!--Allows app window to be resized on Oculus Quest VR headsets-->
+            <meta-data
+                android:name="com.oculus.vrshell.supports_free_resizing"
+                android:value="true" />
+            
         </activity>
         <!-- Launcher icon aliases to allow switching app icon at runtime -->
         <activity-alias


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic/free resizing on Oculus Quest VR devices, improving visual flexibility and compatibility with VR headsets and enhancing UI scaling when running in VR. No other behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->