### PR TITLE
Add timeouts to okhttp

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1903,6 +1903,13 @@ class SteamService : Service(), IChallengeUrlChanged {
                 it.withCellID(PrefManager.cellId)
                 it.withServerListProvider(FileServerListProvider(File(serverListPath)))
                 it.withConnectionTimeout(60000L)
+                it.withHttpClient(
+                    OkHttpClient.Builder()
+                        .connectTimeout(10, TimeUnit.SECONDS)   // Time to establish connection
+                        .readTimeout(60, TimeUnit.SECONDS)      // Max inactivity between reads
+                        .writeTimeout(30, TimeUnit.SECONDS)     // Time for writes
+                        .build(),
+                )
             }
 
             // create our steam client instance


### PR DESCRIPTION
This change allows OKHttp to handle connection timeouts for manifest and depot chunk downloads through java steam. 

This change is for SNAPSHOT 1.8.0-20251119.062901-10 or later. 

I'm sure there is a way through gradle to see which snaphot is current, but an easy check is to go to `in.dragonbra.javasteam.steam.cdn.Client.kt` and check to see if the following lines are removed from companion object. 

```kt
// Lines 42-50
/**
 * Default timeout to use when making requests
 */
var requestTimeout = 10_000L
/**
 * Default timeout to use when reading the resp
 */
var responseBodyTimeout = 60_000L
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced HTTP networking stability through improved timeout configuration for service connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->