### PR TITLE
Revert "Metacritic and Playtime for Steam Games"

### DIFF
--- a/app/src/main/java/app/gamenative/data/LibraryItem.kt
+++ b/app/src/main/java/app/gamenative/data/LibraryItem.kt
@@ -18,7 +18,6 @@ data class LibraryItem(
     val name: String = "",
     val iconHash: String = "",
     val isShared: Boolean = false,
-    val playtimeForever: Int = 0, // playtime in minutes
     val gameSource: GameSource = GameSource.STEAM,
 ) {
     val clientIconUrl: String

--- a/app/src/main/java/app/gamenative/data/SteamApp.kt
+++ b/app/src/main/java/app/gamenative/data/SteamApp.kt
@@ -71,8 +71,6 @@ data class SteamApp(
     val reviewPercentage: Byte = 0,
     @ColumnInfo("controller_support")
     val controllerSupport: ControllerSupport = ControllerSupport.none,
-    @ColumnInfo("playtime_forever")
-    val playtimeForever: Int = 0, // playtime in minutes
 
     // Extended
     @ColumnInfo("demo_of_app_id")

--- a/app/src/main/java/app/gamenative/ui/data/GameDisplayInfo.kt
+++ b/app/src/main/java/app/gamenative/ui/data/GameDisplayInfo.kt
@@ -17,7 +17,6 @@ data class GameDisplayInfo(
     val sizeFromStore: String? = null, // Formatted size from store
     val lastPlayedText: String? = null, // Formatted last played time
     val playtimeText: String? = null, // Formatted playtime
-    val metacriticScore: Int? = null, // Metacritic score (0-100)
     val logoUrl: String? = null, // Logo image URL (for SteamGridDB)
     val capsuleUrl: String? = null, // Capsule/grid image URL (for SteamGridDB)
     val headerUrl: String? = null, // Header image URL (for SteamGridDB, can use grid as header)

--- a/app/src/main/java/app/gamenative/ui/internal/FakeData.kt
+++ b/app/src/main/java/app/gamenative/ui/internal/FakeData.kt
@@ -41,7 +41,6 @@ internal fun fakeAppInfo(idx: Int): SteamApp {
         clientTgaHash = "",
         smallCapsule = mapOf(),
         headerImage = mapOf(),
-        playtimeForever = 62,
         libraryAssets = LibraryAssetsInfo(
             libraryCapsule = LibraryCapsuleInfo(image = mapOf(), image2x = mapOf()),
             libraryHero = LibraryHeroInfo(image = mapOf(), image2x = mapOf()),

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -763,45 +763,6 @@ internal fun AppScreenContent(
                                     )
                                 }
                             }
-
-                            if (displayInfo.playtimeText != null) {
-                                item {
-                                    Column {
-                                        Text(
-                                            text = stringResource(R.string.playtime_forever),
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                                        )
-                                        Spacer(modifier = Modifier.height(4.dp))
-                                        Text(
-                                            text = displayInfo.playtimeText ?: "",
-                                            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold)
-                                        )
-                                    }
-                                }
-                            }
-
-                            if (displayInfo.metacriticScore != null && displayInfo.metacriticScore > 0) {
-                                item {
-                                    Column {
-                                        Text(
-                                            text = stringResource(R.string.metacritic_score),
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                                        )
-                                        Spacer(modifier = Modifier.height(4.dp))
-                                        Text(
-                                            text = "${displayInfo.metacriticScore}/100",
-                                            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
-                                            color = when {
-                                                displayInfo.metacriticScore >= 75 -> Color(0xFF66C955) // Green
-                                                displayInfo.metacriticScore >= 50 -> Color(0xFFFFCC33) // Yellow
-                                                else -> Color(0xFFFF6666) // Red
-                                            }
-                                        )
-                                    }
-                                }
-                            }
                         }
                     }
                 }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
@@ -170,7 +170,7 @@ class CustomGameAppScreen : BaseAppScreen() {
             sizeOnDisk = sizeOnDisk, // Calculated folder size
             sizeFromStore = null, // No store size info
             lastPlayedText = null, // Not tracked
-            playtimeText = null, // Not tracked -> We should look into tracking this anyway via the app.
+            playtimeText = null, // Not tracked
             logoUrl = logoUrl,
             capsuleUrl = capsuleUrl,
             headerUrl = headerUrl,

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -235,11 +235,17 @@ class SteamAppScreen : BaseAppScreen() {
             }
         }
 
-        // Get playtime text from Steam app data (only for Steam games)
-        val playtimeText = if (appInfo.playtimeForever > 0) {
-            SteamUtils.formatPlayTime(appInfo.playtimeForever)
-        } else {
-            null
+        // Get playtime text
+        var playtimeText by remember { mutableStateOf("0 hrs") }
+        LaunchedEffect(gameId) {
+            val steamID = SteamService.userSteamId?.accountID?.toLong()
+            if (steamID != null) {
+                val games = SteamService.getOwnedGames(steamID)
+                val game = games.firstOrNull { it.appId == gameId }
+                playtimeText = if (game != null) {
+                    SteamUtils.formatPlayTime(game.playtimeForever) + " hrs"
+                } else "0 hrs"
+            }
         }
 
         return GameDisplayInfo(
@@ -255,7 +261,6 @@ class SteamAppScreen : BaseAppScreen() {
             sizeFromStore = sizeFromStore,
             lastPlayedText = lastPlayedText,
             playtimeText = playtimeText,
-            metacriticScore = appInfo.metacriticScore.toInt(),
         )
     }
 

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -61,19 +61,13 @@ object SteamUtils {
      * Converts steam time from the playtime of a friend into an approximate double representing hours.
      * @return A string representing how many hours were played, ie: 1.5 hrs
      */
-    fun formatPlayTime(minutes: Int): String {
-       if (minutes < 60) {
-           val unit = if (minutes == 1) "minute" else "minutes"
-           return "$minutes $unit"
-       }
-       val wholeHours = minutes / 60
-       val remMinutes = minutes % 60
-       return if (remMinutes == 0) {
-           val unit = if (wholeHours == 1) "hour" else "hours"
-           "$wholeHours $unit"
-       } else {
-           String.format(Locale.getDefault(), "%.1f hours", minutes / 60.0)
-       }
+    fun formatPlayTime(time: Int): String {
+        val hours = time / 60.0
+        return if (hours % 1 == 0.0) {
+            hours.toInt().toString()
+        } else {
+            String.format(Locale.getDefault(), "%.1f", time / 60.0)
+        }
     }
 
     // Steam strips all non-ASCII characters from usernames and passwords

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -345,8 +345,4 @@
     <string name="install_anyway">Install Anyway</string>
     <string name="remove_content">Remove content?</string>
     <string name="remove_content_confirmation">Are you sure you want to remove %1$s (%2$s)?</string>
-
-    <!-- Game Information -->
-    <string name="metacritic_score">Metacritic Score</string>
-    <string name="playtime_forever">Playtime</string>
 </resources>


### PR DESCRIPTION
Reverts utkarshdalal/GameNative#285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * "Playtime Forever" metric no longer displayed in game details.
  * "Metacritic Score" removed from game details display.

* **Updates**
  * Playtime data now retrieved dynamically for real-time accuracy.
  * Playtime display format updated to numeric hours representation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->