### PR TITLE
Locked posthog version to 3.8.0 to avoid breaking changes and app crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -268,7 +268,7 @@ dependencies {
     testImplementation(libs.zstd.jni)
 
     // Add PostHog Android SDK dependency
-    implementation("com.posthog:posthog-android:3.+")
+    implementation("com.posthog:posthog-android:3.8.0")
 
     // 1) import the platform – it pins *every* Supabase + Ktor module
     implementation(platform("io.github.jan-tennert.supabase:bom:3.1.4"))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostHog Android SDK dependency to a fixed version (3.8.0).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->