### PR TITLE
Fix file not closed warning in Android 14

### DIFF
--- a/app/src/main/java/app/gamenative/utils/FileUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/FileUtils.kt
@@ -91,15 +91,18 @@ object FileUtils {
      */
     fun walkThroughPath(rootPath: Path, maxDepth: Int = 0, action: (Path) -> Unit) {
         if (!Files.exists(rootPath) || !Files.isDirectory(rootPath)) return
-        Files.list(rootPath).forEach {
-            action(it)
-            if (maxDepth != 0 && it.exists() && it.isDirectory()) {
-                walkThroughPath(
-                    rootPath = it,
-                    maxDepth = if (maxDepth > 0) maxDepth - 1 else maxDepth,
-                    action = action,
-                )
+        Files.list(rootPath).use { fileList ->
+            fileList.forEach {
+                action(it)
+                if (maxDepth != 0 && it.exists() && it.isDirectory()) {
+                    walkThroughPath(
+                        rootPath = it,
+                        maxDepth = if (maxDepth > 0) maxDepth - 1 else maxDepth,
+                        action = action,
+                    )
+                }
             }
+            fileList.close()
         }
     }
 


### PR DESCRIPTION
When running GN in Android 14, found this warning in when trying to sync save to steam cloud.

```
StrictMode policy violation: android.os.strictmode.LeakedClosableViolation:
A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
  at android.os.StrictMode$AndroidCloseGuardReporter.report(StrictMode.java:1994)
  at dalvik.system.CloseGuard.warnIfOpen(CloseGuard.java:336)
  at sun.nio.fs.UnixSecureDirectoryStream.finalize(UnixSecureDirectoryStream.java:580)
  at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:339)
  at java.lang.Daemons$FinalizerDaemon.processReference(Daemons.java:324)
  at java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:300)
  at java.lang.Daemons$Daemon.run(Daemons.java:145)
  at java.lang.Thread.run(Thread.java:1012)
Caused by: java.lang.Throwable: Explicit termination method 'close' not called
  at dalvik.system.CloseGuard.openWithCallSite(CloseGuard.java:288)
  at dalvik.system.CloseGuard.open(CloseGuard.java:257)
  at sun.nio.fs.UnixSecureDirectoryStream.<init>(UnixSecureDirectoryStream.java:67)
  at sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:449)
  at java.nio.file.Files.newDirectoryStream(Files.java:457)
  at java.nio.file.Files.list(Files.java:3451)
  at app.gamenative.utils.FileUtils.walkThroughPath(FileUtils.kt:94)
  at app.gamenative.utils.FileUtils.walkThroughPath$lambda$1(FileUtils.kt:97)
  at app.gamenative.utils.FileUtils.$r8$lambda$8ZDpCj6HCacv9FEWoS5Yzcz8Ae0(Unknown Source:0)
  at app.gamenative.utils.FileUtils$$ExternalSyntheticLambda3.invoke(D8$$SyntheticClass:0)
  at app.gamenative.utils.FileUtils.walkThroughPath$lambda$2(FileUtils.kt:94)
  at app.gamenative.utils.FileUtils.$r8$lambda$uewN6_2sQYGsCM7NTcR2rDu3tIs(Unknown Source:0)
  at app.gamenative.utils.FileUtils$$ExternalSyntheticLambda4.accept(D8$$SyntheticClass:0)
  at java.util.Iterator.forEachRemaining(Iterator.java:133)
  at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
  at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:606)
  at app.gamenative.utils.FileUtils.walkThroughPath(FileUtils.kt:94)
  at app.gamenative.utils.FileUtils.walkThroughPath$lambda$1(FileUtils.kt:97)
  at app.gamenative.utils.FileUtils.$r8$lambda$8ZDpCj6HCacv9FEWoS5Yzcz8Ae0(Unknown Source:0)
  at app.gamenative.utils.FileUtils$$ExternalSyntheticLambda3.invoke(D8$$SyntheticClass:0)
  at app.gamenative.utils.FileUtils.walkThroughPath$lambda$2(FileUtils.kt:94)
  at app.gamenative.utils.FileUtils.$r8$lambda$uewN6_2sQYGsCM7NTcR2rDu3tIs(Unknown Source:0)
  at app.gamenative.utils.FileUtils$$ExternalSyntheticLambda4.accept(D8$$SyntheticClass:0)
  at java.util.Iterator.forEachRemaining(Iterator.java:133)
  at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
  at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:606)
  at app.gamenative.utils.FileUtils.walkThroughPath(FileUtils.kt:94)
  at app.gamenative.utils.FileUtils.findFilesRecursive(FileUtils.kt:150)
  at app.gamenative.utils.FileUtils.findFilesRecursive$default(FileUtils.kt:128)
  at app.gamenative.service.SteamAutoCloud$syncUserFiles$1.invokeSuspend$lambda$32(SteamAutoCloud.kt:196)
  at app.gamenative.service.SteamAutoCloud$syncUserFiles$1.$r8$lambda$tUyIN2iSt6pOqUOsivlzT5Dwe4U(Unknown Source:0)
  at app.gamenative.service.SteamAutoCloud$syncUserFiles$1$$ExternalSyntheticLambda3.invoke(D8$$SyntheticClass:0)
  at app.gamenative.service.SteamAutoCloud$syncUserFiles$1.invokeSuspend(SteamAutoCloud.kt:571)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
  at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
  at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:124)
  at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
  at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
  ...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved resource management when enumerating directory contents to ensure directory streams are closed promptly, preventing potential resource leaks. Traversal logic and public behavior remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->