### PR TITLE
Fix sync save file content type

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -455,8 +455,8 @@ object SteamAutoCloud {
 
                             Timber.i("Read $bytesRead byte(s) for block")
 
-                            val mediaType = if (blockRequest.requestHeaders.any { it.name == "Content-Type" }) {
-                                blockRequest.requestHeaders.first { it.name == "Content-Type" }.value.toMediaTypeOrNull()
+                            val mediaType = if (blockRequest.requestHeaders.any { it.name.equals("Content-Type", ignoreCase = true) }) {
+                                blockRequest.requestHeaders.first { it.name.equals("Content-Type", ignoreCase = true) }.value.toMediaTypeOrNull()
                             } else {
                                 "application/octet-stream".toMediaTypeOrNull()
                             }


### PR DESCRIPTION
update upload request content-type to match result from blockRequest.

Tested game save fixed: Witcher 3 and Subnautica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Uploads now preserve and respect each block's Content-Type metadata when present, rather than always using a generic binary type. This ensures file type information is correctly conveyed to the server for accurate processing and reduces misclassification of uploaded data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->