### PR TITLE
Feat: Restart audio component on android audio device changed

### DIFF
--- a/app/src/main/java/com/winlator/xenvironment/XEnvironment.java
+++ b/app/src/main/java/com/winlator/xenvironment/XEnvironment.java
@@ -1,11 +1,19 @@
 package com.winlator.xenvironment;
 
 import android.content.Context;
+import android.media.AudioDeviceCallback;
+import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
 
 import com.winlator.core.FileUtils;
+import com.winlator.xenvironment.components.ALSAServerComponent;
 import com.winlator.xenvironment.components.BionicProgramLauncherComponent;
 import com.winlator.xenvironment.components.GlibcProgramLauncherComponent;
 import com.winlator.xenvironment.components.GuestProgramLauncherComponent;
+import com.winlator.xenvironment.components.PulseAudioComponent;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -18,6 +26,30 @@ public class XEnvironment implements Iterable<EnvironmentComponent> {
 
     private boolean winetricksRunning = false;
 
+    private final AudioManager audioManager;
+    private boolean audioCallbackRegistered = false;
+    private final AudioDeviceCallback audioDeviceCallback = new AudioDeviceCallback() {
+        @Override
+        public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
+            // Handle newly added audio devices (e.g., headphones connected)
+            for (AudioDeviceInfo device : addedDevices) {
+                if (device.isSink()) {
+                    restartAudioComponent();
+                }
+            }
+        }
+
+        @Override
+        public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
+            // Handle removed audio devices (e.g., headphones disconnected)
+            for (AudioDeviceInfo device : removedDevices) {
+                if (device.isSink()) {
+                    restartAudioComponent();
+                }
+            }
+        }
+    };
+
     public synchronized boolean isWinetricksRunning() {
         return winetricksRunning;
     }
@@ -29,6 +61,9 @@ public class XEnvironment implements Iterable<EnvironmentComponent> {
     public XEnvironment(Context context, ImageFs imageFs) {
         this.context = context;
         this.imageFs = imageFs;
+        this.audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        this.audioManager.registerAudioDeviceCallback(audioDeviceCallback, null);
+        this.audioCallbackRegistered = true;
     }
 
     public Context getContext() {
@@ -75,6 +110,11 @@ public class XEnvironment implements Iterable<EnvironmentComponent> {
     }
 
     public void onPause() {
+        if (audioCallbackRegistered) {
+            audioManager.unregisterAudioDeviceCallback(audioDeviceCallback);
+            audioCallbackRegistered = false;
+        }
+
         GuestProgramLauncherComponent guestProgramLauncherComponent = getComponent(GuestProgramLauncherComponent.class);
         if (guestProgramLauncherComponent != null) guestProgramLauncherComponent.suspendProcess();
         GlibcProgramLauncherComponent glibcProgramLauncherComponent = getComponent(GlibcProgramLauncherComponent.class);
@@ -84,11 +124,30 @@ public class XEnvironment implements Iterable<EnvironmentComponent> {
     }
 
     public void onResume() {
+        if (!audioCallbackRegistered) {
+            audioManager.registerAudioDeviceCallback(audioDeviceCallback, null);
+            audioCallbackRegistered = true;
+        }
+
         GuestProgramLauncherComponent guestProgramLauncherComponent = getComponent(GuestProgramLauncherComponent.class);
         if (guestProgramLauncherComponent != null) guestProgramLauncherComponent.resumeProcess();
         GlibcProgramLauncherComponent glibcProgramLauncherComponent = getComponent(GlibcProgramLauncherComponent.class);
         if (glibcProgramLauncherComponent != null) glibcProgramLauncherComponent.resumeProcess();
         BionicProgramLauncherComponent bionicProgramLauncherComponent = getComponent(BionicProgramLauncherComponent.class);
         if (bionicProgramLauncherComponent != null) bionicProgramLauncherComponent.resumeProcess();
+    }
+
+    private void restartAudioComponent() {
+        final ALSAServerComponent alsaServerComponent = getComponent(ALSAServerComponent.class);
+        if (alsaServerComponent != null) {
+            alsaServerComponent.stop();
+            alsaServerComponent.start();
+        }
+
+        final PulseAudioComponent pulseAudioComponent = getComponent(PulseAudioComponent.class);
+        if (pulseAudioComponent != null) {
+            //pulseAudioComponent.stop(); stop is already called inside start function
+            pulseAudioComponent.start();
+        }
     }
 }


### PR DESCRIPTION
Automatically restart audio component on android audio device changed.

It is especially useful if I connect bluetooth device after started the game.

Tested on OneXSugar 1, Android 14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Automatically detects audio device connect/disconnect events (headphones, speakers, etc.) and responds without requiring an app restart.
- Ensures audio subsystems are restarted as needed when device changes occur to maintain stable playback.
- Properly pauses/resumes device monitoring during app pause/resume to avoid spurious events and improve reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->