### PR TITLE
Fix content profile lookup for DXVK and other content packages

### DIFF
--- a/app/src/main/java/com/winlator/contents/ContentsManager.java
+++ b/app/src/main/java/com/winlator/contents/ContentsManager.java
@@ -595,16 +595,35 @@ public class ContentsManager {
         if (type != null && profilesMap.get(type) != null) {
             List<ContentProfile> profiles = profilesMap.get(type);
             Log.d("ContentsManager", "   Found " + profiles.size() + " profiles of type " + type);
-
+    
+            String keyLower = lowerVersionName;
+    
             for (ContentProfile profile : profiles) {
-                Log.d("ContentsManager", "   Checking profile: verName='" + profile.verName + "'");
-                // Match against version name directly (no version code)
-                if (entryName.equalsIgnoreCase(profile.verName)) {
+                String verName = (profile.verName != null) ? profile.verName : "";
+                String verLower = verName.toLowerCase();
+    
+                String typeAndVer = profile.type.toString() + "-" + verName;
+                String typeAndVerLower = typeAndVer.toLowerCase();
+    
+                String fullEntry = ContentsManager.getEntryName(profile);
+                String fullEntryLower = fullEntry.toLowerCase();
+    
+                Log.d(
+                    "ContentsManager",
+                    "   Checking profile: verName='" + profile.verName +
+                            "', typeAndVer='" + typeAndVer +
+                            "', fullEntry='" + fullEntry + "'"
+                );
+    
+                if (keyLower.equals(verLower) ||
+                    keyLower.equals(typeAndVerLower) ||
+                    keyLower.equals(fullEntryLower)) {
                     Log.d("ContentsManager", "   ✅ MATCH FOUND!");
                     return profile;
                 }
             }
-            Log.d("ContentsManager", "   ❌ No matching profile found");
+    
+            Log.d("ContentsManager", "   ❌ No matching profile found in primary lookup");
         } else {
             Log.d("ContentsManager", "   ❌ Type is null or no profiles for this type");
         }


### PR DESCRIPTION
Update `getProfileByEntryName` to match multiple name formats instead of only `verName`.
It now resolves profiles by plain `verName`, by `type-verName`, and by the full `type-verName-verCode` entry name.

This fixes DXVK, VKD3D and other content packages not being applied when the stored entry name does not exactly match `verName`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the profile lookup system with more flexible matching logic that supports multiple naming conventions and configurations, ensuring more reliable profile discovery.
  * Enhanced error diagnostics with improved logging to provide better visibility and troubleshooting insights when profile matching encounters issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->