### PR TITLE
RedistInstall Refactor and openAL Installation

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1843,7 +1843,8 @@ private data class RedistContext(
  */
 private fun getRedistDirectory(
     appId: String,
-    container: Container
+    container: Container,
+    guestProgramLauncherComponent: GuestProgramLauncherComponent
 ): RedistContext? {
     val steamAppId = ContainerUtils.extractGameIdFromContainerId(appId)
     val gameDirPath = SteamService.getAppDirPath(steamAppId)
@@ -1864,7 +1865,7 @@ private fun getRedistDirectory(
         return null
     }
 
-    return null
+    return RedistContext(commonRedistDir, driveLetter, guestProgramLauncherComponent)
 }
 
 private fun installVcRedist(context: RedistContext) {
@@ -2023,9 +2024,7 @@ private fun installRedistributables(
         Timber.tag("installRedist").i("Found ${sharedDepots.size} shared depot(s), checking for redistributables")
 
         // Get redistributable directory context
-        val redistContext = getRedistDirectory(appId, container)?.copy(
-            guestProgramLauncherComponent = guestProgramLauncherComponent
-        ) ?: run {
+        val redistContext = getRedistDirectory(appId, container, guestProgramLauncherComponent) ?: run {
             Timber.tag("installRedist").i("Could not set up redistributable context, skipping installation")
             return
         }


### PR DESCRIPTION
This PR adds the following:

- Readability refactor on installing Redists, so it can call each installation individually in a clear manner.

- **Adds openAL** (3D Audio software typically found in games between 2001 and 2010)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modularized redistributable installation into a context-driven flow for clearer, testable steps.
  * Unified redistributable path and drive resolution to remove scattered logic.
  * Improved progress and error logging under a dedicated install tag.
  * Behavior intact for callers; installation sequence preserved while internal handling is reorganized.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->