### PR TITLE
Restores default controls-0.icp if missing

### DIFF
--- a/app/src/main/java/com/winlator/inputcontrols/InputControlsManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/InputControlsManager.java
@@ -86,6 +86,12 @@ public class InputControlsManager {
                     FileUtils.copy(context, assetPath, targetFile);
                 }
             }
+
+            // Fix if controls-0.icp not exists
+            File file = ControlsProfile.getProfileFile(context, 0);
+            if (!file.isFile()) {
+                FileUtils.copy(context, "inputcontrols/profiles/controls-0.icp", file);
+            }
         }
         catch (IOException e) {}
     }


### PR DESCRIPTION
Ensures that the default controls profile (controls-0.icp) is present by copying it from assets if it's missing.

This prevents issues where users may not have a default controls configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability by ensuring the default input controls profile is automatically restored if it becomes unavailable during system synchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->