### PR TITLE
Fixes hidden DLC compatibility issues

### DIFF
--- a/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
@@ -44,7 +44,7 @@ interface SteamAppDao {
     @Query("SELECT * FROM steam_app WHERE id = :appId")
     suspend fun findApp(appId: Int): SteamApp?
 
-    @Query("SELECT * FROM steam_app AS app WHERE dlc_for_app_id = :appId AND " +
+    @Query("SELECT * FROM steam_app AS app WHERE dlc_for_app_id = :appId AND depots = '{}' AND " +
             " EXISTS (" +
             "   SELECT * FROM steam_license AS license " +
             "     WHERE license.license_type <> 0 AND " +

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -767,7 +767,9 @@ object SteamUtils {
             appendLine("[app::dlcs]")
             appendLine("unlock_all=${if (forceDlc) 1 else 0}")
             dlcIds?.forEach { appendLine("$it=dlc$it") }
-            hiddenDlcApps?.forEach { appendLine("${it.id}=${it.name}") }
+
+            // only add hidden dlc apps if not found in dlcIds
+            hiddenDlcApps?.forEach { if (dlcIds?.contains(it.id) == false) appendLine("${it.id}=dlc${it.id}") }
 
             // Add cloud save config sections if appInfo exists
             if (appInfo != null) {
@@ -852,7 +854,7 @@ object SteamUtils {
                         .replace("{Steam3AccountID}", "{::Steam3AccountID::}")
                     uniqueDirs.add("{::$root::}/$path")
                 }
-                
+
                 uniqueDirs.forEachIndexed { index, dir ->
                     appendLine("dir${index + 1}=$dir")
                 }


### PR DESCRIPTION
Ensures proper handling of hidden DLCs by excluding apps with depots and only adding them to the configuration if they aren't already present in the DLC list.

This prevents issues where hidden DLCs were not correctly recognized and activated.

Already verified it also works with Lies of P DLC support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More precise filtering to exclude non-DLC items from hidden DLC lists, reducing incorrect entries.
  * Hidden DLC entries are no longer duplicated and use a standardized mapping format in generated game configs, improving DLC detection and initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->