### PR TITLE
Excludes OSGI manifest from packaging

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -157,6 +157,9 @@ android {
             excludes += "/DebugProbesKt.bin"
             excludes += "/junit/runner/smalllogo.gif"
             excludes += "/junit/runner/logo.gif"
+
+            // Other excludes
+            excludes += "/META-INF/versions/9/OSGI-INF/MANIFEST.MF"
         }
         jniLibs {
             // 'extractNativeLibs' was not enough to keep the jniLibs and


### PR DESCRIPTION
Excludes the OSGI manifest file to resolve potential conflicts or issues during packaging. This exclusion ensures a cleaner and more compatible build output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build packaging configuration to exclude additional metadata files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->