### PR TITLE
Fix a bug where preset resolutions were not applying correctly.

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -1129,7 +1129,11 @@ fun ContainerConfigDialog(
                                     items = screenSizes,
                                     onItemSelected = {
                                         screenSizeIndex = it
-                                        if (it == 0) showCustomResolutionDialog = true
+                                        if (it == 0) {
+                                            showCustomResolutionDialog = true
+                                        } else {
+                                            applyScreenSizeToConfig()
+                                        }
                                     },
                                 )
                                 // Audio Driver Dropdown
@@ -2091,7 +2095,7 @@ private fun scanExecutablesInADrive(drives: String): List<String> {
         // Recursively scan for .exe files using listFiles with depth limit
         fun scanRecursive(dir: java.io.File, baseDir: java.io.File, depth: Int = 0, maxDepth: Int = 10) {
             if (depth > maxDepth) return
-            
+
             dir.listFiles()?.forEach { file ->
                 if (file.isDirectory) {
                     scanRecursive(file, baseDir, depth + 1, maxDepth)
@@ -2102,7 +2106,7 @@ private fun scanExecutablesInADrive(drives: String): List<String> {
                 }
             }
         }
-        
+
         scanRecursive(aDir, aDir)
 
         // Sort alphabetically and prioritize common game executables


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Screen size presets now apply immediately to the configuration upon selection, with the custom resolution option still available for manual setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->