### PR TITLE
Temporary remove audio switching function

### DIFF
--- a/app/src/main/java/com/winlator/xenvironment/XEnvironment.java
+++ b/app/src/main/java/com/winlator/xenvironment/XEnvironment.java
@@ -26,30 +26,6 @@ public class XEnvironment implements Iterable<EnvironmentComponent> {
 
     private boolean winetricksRunning = false;
 
-    private final AudioManager audioManager;
-    private boolean audioCallbackRegistered = false;
-    private final AudioDeviceCallback audioDeviceCallback = new AudioDeviceCallback() {
-        @Override
-        public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
-            // Handle newly added audio devices (e.g., headphones connected)
-            for (AudioDeviceInfo device : addedDevices) {
-                if (device.isSink()) {
-                    restartAudioComponent();
-                }
-            }
-        }
-
-        @Override
-        public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
-            // Handle removed audio devices (e.g., headphones disconnected)
-            for (AudioDeviceInfo device : removedDevices) {
-                if (device.isSink()) {
-                    restartAudioComponent();
-                }
-            }
-        }
-    };
-
     public synchronized boolean isWinetricksRunning() {
         return winetricksRunning;
     }
@@ -61,9 +37,6 @@ public class XEnvironment implements Iterable<EnvironmentComponent> {
     public XEnvironment(Context context, ImageFs imageFs) {
         this.context = context;
         this.imageFs = imageFs;
-        this.audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-        this.audioManager.registerAudioDeviceCallback(audioDeviceCallback, null);
-        this.audioCallbackRegistered = true;
     }
 
     public Context getContext() {
@@ -125,19 +98,5 @@ public class XEnvironment implements Iterable<EnvironmentComponent> {
         if (glibcProgramLauncherComponent != null) glibcProgramLauncherComponent.resumeProcess();
         BionicProgramLauncherComponent bionicProgramLauncherComponent = getComponent(BionicProgramLauncherComponent.class);
         if (bionicProgramLauncherComponent != null) bionicProgramLauncherComponent.resumeProcess();
-    }
-
-    private void restartAudioComponent() {
-        final ALSAServerComponent alsaServerComponent = getComponent(ALSAServerComponent.class);
-        if (alsaServerComponent != null) {
-            alsaServerComponent.stop();
-            alsaServerComponent.start();
-        }
-
-        final PulseAudioComponent pulseAudioComponent = getComponent(PulseAudioComponent.class);
-        if (pulseAudioComponent != null) {
-            //pulseAudioComponent.stop(); stop is already called inside start function
-            pulseAudioComponent.start();
-        }
     }
 }


### PR DESCRIPTION
Temporary remove this feature, as it behaves differently across games.

Examples:
Subnautica: Working
Nidhogg: Not working

Likely games without proper audio switching handling would fail.

This feature will be continue to work on #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed automatic audio component restart when audio devices are added or removed. Audio device changes will no longer trigger system-level audio restarts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->