### PR TITLE
Updated drm handling so every exe does not need to be unpacked

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1091,13 +1091,13 @@ fun preLaunchApp(
                 }
             }
         }
-        if (!container.isUseLegacyDRM && !container.isLaunchRealSteam && !SteamService.isFileInstallable(context, "experimental-drm-20260101.tzst")) {
+        if (!container.isUseLegacyDRM && !container.isLaunchRealSteam && !SteamService.isFileInstallable(context, "experimental-drm-20260116.tzst")) {
             setLoadingMessage("Downloading extras")
             SteamService.downloadFile(
                 onDownloadProgress = { setLoadingProgress(it / 1.0f) },
                 this,
                 context = context,
-                "experimental-drm-20260101.tzst"
+                "experimental-drm-20260116.tzst"
             ).await()
         }
         if (container.isLaunchRealSteam && !SteamService.isFileInstallable(context, "steam.tzst")) {

--- a/app/src/test/java/app/gamenative/utils/SteamUtilsFileSearchTest.kt
+++ b/app/src/test/java/app/gamenative/utils/SteamUtilsFileSearchTest.kt
@@ -225,9 +225,13 @@ class SteamUtilsFileSearchTest {
         val dosDevicesPath = File(imageFs.wineprefix, "dosdevices/a:")
         dosDevicesPath.mkdirs()
 
-        // Create .original.exe file
+        // Create multiple .original.exe files in different folders
         val origExeFile = File(dosDevicesPath, "game.exe.original.exe")
         origExeFile.writeBytes("original exe content".toByteArray())
+        val nestedDir = File(dosDevicesPath, "bin")
+        nestedDir.mkdirs()
+        val origExeFile2 = File(nestedDir, "game2.exe.original.exe")
+        origExeFile2.writeBytes("original exe content 2".toByteArray())
 
         // Call the actual function
         SteamUtils.restoreOriginalExecutable(context, steamAppId)
@@ -237,6 +241,10 @@ class SteamUtilsFileSearchTest {
         assertTrue("Should restore exe to original location", restoredFile.exists())
         assertEquals("Restored content should match backup",
             "original exe content", restoredFile.readText())
+        val restoredFile2 = File(nestedDir, "game2.exe")
+        assertTrue("Should restore exe to original location in subdirectory", restoredFile2.exists())
+        assertEquals("Restored content should match backup for second exe",
+            "original exe content 2", restoredFile2.readText())
     }
 
     @Test
@@ -645,7 +653,7 @@ class SteamUtilsFileSearchTest {
 
         // Verify game.exe is NOT overwritten after first replaceSteamClientDll call
         assertEquals("game.exe should be overwritten after replaceSteamClientDll",
-            "unpacked exe content", gameExe.readText())
+            "original exe content", gameExe.readText())
 
         // Verify marker was set
         assertTrue("Should add STEAM_COLDCLIENT_USED marker",
@@ -762,8 +770,8 @@ class SteamUtilsFileSearchTest {
             steamAppId.toString(), steamAppIdFile.readText().trim())
 
         // Verify game.exe is NOT overwritten after second replaceSteamClientDll call
-        assertEquals("game.exe should be overwritten after second replaceSteamClientDll",
-            "unpacked exe content", gameExe.readText())
+        assertEquals("game.exe should not be overwritten after second replaceSteamClientDll",
+            "original exe content", gameExe.readText())
 
         // Verify marker was set
         assertTrue("Should add STEAM_COLDCLIENT_USED marker",
@@ -871,7 +879,7 @@ class SteamUtilsFileSearchTest {
 
         // Verify game.exe is NOT overwritten after first replaceSteamClientDll call
         assertEquals("game.exe should not be overwritten after replaceSteamClientDll",
-            "unpacked exe content", gameExe.readText())
+            "original exe content", gameExe.readText())
 
         // Verify marker was set
         assertTrue("Should add STEAM_COLDCLIENT_USED marker",
@@ -917,8 +925,8 @@ class SteamUtilsFileSearchTest {
         SteamUtils.replaceSteamclientDll(context, testAppId)
 
         // Verify restoreUnpackedExecutable overwrites game.exe with game.exe.unpacked.exe content
-        assertEquals("game.exe should be overwritten with game.exe.unpacked.exe content after second replaceSteamClientDll",
-            "unpacked exe content", gameExe.readText())
+        assertEquals("game.exe should be overwritten with game.exe.original.exe content after second replaceSteamClientDll",
+            "original exe content", gameExe.readText())
 
         // Verify steam_settings folder still exists next to steamclient.dll in Steam directory
         assertTrue("steam_settings folder should still exist in Steam directory",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reworked DRM handling so we don't unpack every executable. Steamless now runs only for legacy DRM, and original .exe files are backed up and restored automatically.

- **Refactors**
  - Run Steamless only when useLegacyDRM is true and not launching real Steam.
  - Replace restoreUnpackedExecutable with restoreOriginalExecutable; scans and restores all .original.exe files, including nested folders.
  - Preserve backups: create .original.exe only if missing; avoid overwriting game.exe during Steam client replacement.
  - Updated logs and boot messages; tests adjusted to validate new restore behavior.

- **Dependencies**
  - Bump extras package to experimental-drm-20260116.tzst.
  - Add DllsToInjectFolder=extra_dlls to steam_settings.ini.

<sup>Written for commit 94086d953199568a43e8aa5b623f7672bbb8b69f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced executable restoration with improved error handling and detailed per-file logging for better reliability
  * Refined conditional logic for Steam-related executable processing
  * Better support for handling multiple executables in restoration workflows

* **Chores**
  * Updated DRM support files and configuration to latest version

* **Tests**
  * Updated test expectations for multi-file executable restoration scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->