### PR TITLE
Adds Denuvo preset for Box86/64

### DIFF
--- a/app/src/main/java/com/winlator/box86_64/Box86_64Preset.java
+++ b/app/src/main/java/com/winlator/box86_64/Box86_64Preset.java
@@ -7,6 +7,7 @@ public class Box86_64Preset {
     public static final String COMPATIBILITY = "COMPATIBILITY";
     public static final String INTERMEDIATE = "INTERMEDIATE";
     public static final String PERFORMANCE = "PERFORMANCE";
+    public static final String DENUVO = "DENUVO";
     public static final String UNITY = "UNITY";
     public static final String UNITY_MONO_BLEEDING_EDGE = "UNITY_MONO_BLEEDING_EDGE";
     public static final String CUSTOM = "CUSTOM";

--- a/app/src/main/java/com/winlator/box86_64/Box86_64PresetManager.java
+++ b/app/src/main/java/com/winlator/box86_64/Box86_64PresetManager.java
@@ -80,6 +80,21 @@ public abstract class Box86_64PresetManager {
                 envVars.put("BOX64_UNITYPLAYER", "0");
                 envVars.put("BOX64_MMAP32", "1");
             }
+        } else if (id.equals(Box86_64Preset.DENUVO)) {
+            envVars.put(ucPrefix + "_DYNAREC_SAFEFLAGS", "2");
+            envVars.put(ucPrefix + "_DYNAREC_FASTNAN", "0");
+            envVars.put(ucPrefix + "_DYNAREC_FASTROUND", "0");
+            envVars.put(ucPrefix + "_DYNAREC_X87DOUBLE", "1");
+            envVars.put(ucPrefix + "_DYNAREC_BIGBLOCK", "0");
+            envVars.put(ucPrefix + "_DYNAREC_STRONGMEM", "3");
+            envVars.put(ucPrefix + "_DYNAREC_FORWARD", "512");
+            envVars.put(ucPrefix + "_DYNAREC_CALLRET", "0");
+            envVars.put(ucPrefix + "_DYNAREC_WAIT", "0");
+            if (ucPrefix.equals("BOX64")) {
+                envVars.put("BOX64_AVX", "0");
+                envVars.put("BOX64_UNITYPLAYER", "1");
+                envVars.put("BOX64_MMAP32", "0");
+            }
         } else if (id.equals(Box86_64Preset.UNITY)) {
             envVars.put(ucPrefix + "_DYNAREC_SAFEFLAGS", "1");
             envVars.put(ucPrefix + "_DYNAREC_FASTNAN", "1");
@@ -130,6 +145,7 @@ public abstract class Box86_64PresetManager {
         presets.add(new Box86_64Preset(Box86_64Preset.PERFORMANCE, context.getString(R.string.performance)));
         presets.add(new Box86_64Preset(Box86_64Preset.UNITY, context.getString(R.string.unity)));
         presets.add(new Box86_64Preset(Box86_64Preset.UNITY_MONO_BLEEDING_EDGE, context.getString(R.string.unity_mono_bleeding_edge)));
+        presets.add(new Box86_64Preset(Box86_64Preset.DENUVO, context.getString(R.string.denuvo)));
         for (String[] preset : customPresetsIterator(prefix, context))
             presets.add(new Box86_64Preset(preset[0], preset[1]));
         return presets;

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -43,6 +43,7 @@
     <string name="compatibility">Kompatibilitet</string>
     <string name="intermediate">Mellemtrin</string>
     <string name="performance">Ydelse</string>
+    <string name="denuvo">Denuvo</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
     <string name="title_ubuntufs">Ubuntu FS</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -99,6 +99,7 @@
     <string name="compatibility">Kompatibilität</string>
     <string name="intermediate">Mittel</string>
     <string name="performance">Leistung</string>
+    <string name="denuvo">Denuvo</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
     <string name="title_ubuntufs">Ubuntu FS</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -108,6 +108,7 @@
     <string name="performance">Performance</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
+    <string name="denuvo">Denuvo</string>
     <string name="title_ubuntufs">Ubuntu FS</string>
 
     <!-- Winlator: Win Components -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -108,6 +108,7 @@
     <string name="performance">Prestazioni</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
+    <string name="denuvo">Denuvo</string>
     <string name="title_ubuntufs">Ubuntu FS</string>
 
     <!-- Winlator: Win Components -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -45,6 +45,7 @@
     <string name="performance">Desempenho</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
+    <string name="denuvo">Denuvo</string>
     <string name="title_ubuntufs">Ubuntu FS</string>
 
     <!-- Winlator: Win Components -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -69,7 +69,7 @@
     <string name="destination_library">Bibliotecă</string>
     <string name="destination_downloads">Descărcări</string>
     <string name="destination_friends">Prieteni</string>
-    
+
     <!-- Custom Games -->
     <string name="custom_games_title">Jocuri personalizate</string>
     <string name="custom_games_no_paths">Nicio cale adăugată</string>
@@ -107,6 +107,7 @@
     <string name="performance">Performanță</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
+    <string name="denuvo">Denuvo</string>
     <string name="title_ubuntufs">Ubuntu FS</string>
     <!-- Winlator: Win Components -->
     <string name="direct3d">Direct3D</string>
@@ -184,7 +185,7 @@
     <string name="touchpad_help">Ajutor touchpad</string>
     <string name="hide_controls_with_controller">Ascunde controalele pe ecran când există controller</string>
     <string name="hide_controls_with_controller_description">Ascunde automat controalele pe ecran când un controller fizic este conectat</string>
-        
+
     <!-- Controller Binding Dialog -->
     <string name="select_binding">Selectează acțiunea</string>
     <string name="bind_button">Asociere: %1$s</string>
@@ -245,7 +246,7 @@
     <string name="preset_dpad">D‑Pad</string>
     <string name="preset_left_stick">Stick stânga</string>
     <string name="preset_right_stick">Stick dreapta</string>
-    
+
     <!-- Physical Controller Config -->
     <string name="physical_controller_config">Editor asocieri controller fizic</string>
     <string name="physical_controller_config_subtitle">Configurează mapările butoanelor pentru controllerul fizic</string>
@@ -288,7 +289,7 @@
     <string name="button_home">Home / Guide / PS</string>
     <string name="reset_to_default_bindings">Resetează la asocierile implicite</string>
     <string name="not_set">Nesetat</string>
-    
+
     <!-- Toast -->
     <string name="toast_controls_reset">Controalele au fost resetate</string>
     <string name="toast_failed_log_save">Nu s-a putut salva logcat la destinație</string>
@@ -382,7 +383,7 @@
     <string name="fexcore_env_var_help__maxinst">Numărul maxim de instrucțiuni per bloc de traducere (mai mare = performanță mai bună, stabilitate mai mică)</string>
     <string name="resume_download">Reia</string>
     <string name="pause_download">Pauză</string>
-        
+
     <!-- Library & Game Management -->
     <string name="create_shortcut">Creează shortcut</string>
     <string name="label">Etichetă</string>
@@ -601,7 +602,7 @@
 	<string name="settings_emulation_contents_manager_subtitle">Instalează componente suplimentare (.wcp)</string>
 	<string name="settings_emulation_wine_proton_manager_title">Manager Wine/Proton</string>
 	<string name="settings_emulation_wine_proton_manager_subtitle">Importă versiuni personalizate de Wine/Proton (doar Bionic)</string>
- 
+
 	<!-- Settings: Debug Group -->
 	<string name="settings_debug_title">Depanare</string>
 	<string name="settings_debug_wine_channels_title">Selectează canalele de debug Wine</string>
@@ -703,7 +704,7 @@
 	<string name="library_need_internet">Este necesar internet pentru instalare</string>
 	<string name="library_wifi_only_enabled">Instalare doar prin Wi‑Fi/LAN activată</string>
 	<string name="library_file_count">Fișier %1$d din %2$d</string>
-    
+
 	<!-- PluviaMain: Update & App Info -->
 	<string name="main_update_available_title">Actualizare disponibilă</string>
 	<string name="main_update_available_message">O nouă versiune (%1$s) este disponibilă!%2$s</string>
@@ -803,7 +804,7 @@
 	<string name="library_compatible">Compatibil</string>
 	<string name="library_compatibility_unknown">Necunoscut</string>
 	<string name="library_not_compatible">Necompatibil</string>
-    
+
 	<!-- Best Config Compatibility Messages -->
 	<string name="best_config_exact_gpu_match">Config cunoscut funcționează pe GPU-ul tău</string>
 	<string name="best_config_gpu_family_match">Config cunoscut ar trebui să funcționeze pe GPU-ul tău</string>
@@ -883,7 +884,7 @@
 	<string name="contents_install_success">Conținut instalat cu succes</string>
 	<string name="contents_install_failed">Instalarea conținutului a eșuat</string>
 	<string name="contents_install_error">Eroare la instalare: %1$s</string>
-    
+
 	<!-- Library Status -->
 	<string name="library_status_ready">Gata</string>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -106,6 +106,7 @@
     <string name="compatibility">Сумісність</string>
     <string name="intermediate">Збалансований</string>
     <string name="performance">Продуктивність</string>
+    <string name="denuvo">Denuvo</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
     <string name="title_ubuntufs">Ubuntu FS</string>
@@ -883,7 +884,7 @@
     <string name="contents_install_success">Вміст успішно інстальовано</string>
     <string name="contents_install_failed">Не вдалося інсталювати вміст</string>
     <string name="contents_install_error">Помилка інсталяції: %1$s</string>
-    
+
     <!-- Library Status -->
     <string name="library_status_ready">Готова</string>
     <!-- Wine/Proton Manager -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -105,6 +105,7 @@
     <string name="compatibility">兼容性</string>
     <string name="intermediate">平衡</string>
     <string name="performance">高性能</string>
+    <string name="denuvo">Denuvo</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
     <string name="title_ubuntufs">Ubuntu FS</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -105,6 +105,7 @@
     <string name="compatibility">相容性</string>
     <string name="intermediate">平衡</string>
     <string name="performance">高性能</string>
+    <string name="denuvo">Denuvo</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
     <string name="title_ubuntufs">Ubuntu FS</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,7 @@
     <string name="compatibility">Compatibility</string>
     <string name="intermediate">Intermediate</string>
     <string name="performance">Performance</string>
+    <string name="denuvo">Denuvo</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
     <string name="title_ubuntufs">Ubuntu FS</string>


### PR DESCRIPTION
Adds a new preset designed to improve compatibility with Denuvo-protected applications.

This preset configures dynarec and environment variables to better handle the specific requirements of Denuvo DRM.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Denuvo preset for Box86/64 to improve compatibility with Denuvo-protected games. It adjusts dynarec and Box64 settings and adds localized labels.

- **New Features**
  - New “Denuvo” preset available in the Box86/64 preset list.
  - Dynarec tuned for determinism and stricter memory; disables fast NaN/rounding and uses x87 double precision.
  - Box64-specific: AVX disabled, UnityPlayer enabled, MMAP32 disabled.
  - Added “Denuvo” strings across supported locales.

<sup>Written for commit 36042acd877dff35162c07efacaf49679a2747fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Denuvo preset option to the application's configuration menu, allowing users to select this new optimization profile for improved compatibility and performance. Full localization support is now available across multiple languages including English, Danish, German, French, Italian, Portuguese, Romanian, Ukrainian, Simplified Chinese, and Traditional Chinese, making this feature accessible globally.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->