### PR TITLE
Revert "Adds Denuvo preset for Box86/64 (#432)"

### DIFF
--- a/app/src/main/java/com/winlator/box86_64/Box86_64Preset.java
+++ b/app/src/main/java/com/winlator/box86_64/Box86_64Preset.java
@@ -7,7 +7,6 @@ public class Box86_64Preset {
     public static final String COMPATIBILITY = "COMPATIBILITY";
     public static final String INTERMEDIATE = "INTERMEDIATE";
     public static final String PERFORMANCE = "PERFORMANCE";
-    public static final String DENUVO = "DENUVO";
     public static final String UNITY = "UNITY";
     public static final String UNITY_MONO_BLEEDING_EDGE = "UNITY_MONO_BLEEDING_EDGE";
     public static final String CUSTOM = "CUSTOM";

--- a/app/src/main/java/com/winlator/box86_64/Box86_64PresetManager.java
+++ b/app/src/main/java/com/winlator/box86_64/Box86_64PresetManager.java
@@ -80,21 +80,6 @@ public abstract class Box86_64PresetManager {
                 envVars.put("BOX64_UNITYPLAYER", "0");
                 envVars.put("BOX64_MMAP32", "1");
             }
-        } else if (id.equals(Box86_64Preset.DENUVO)) {
-            envVars.put(ucPrefix + "_DYNAREC_SAFEFLAGS", "2");
-            envVars.put(ucPrefix + "_DYNAREC_FASTNAN", "0");
-            envVars.put(ucPrefix + "_DYNAREC_FASTROUND", "0");
-            envVars.put(ucPrefix + "_DYNAREC_X87DOUBLE", "1");
-            envVars.put(ucPrefix + "_DYNAREC_BIGBLOCK", "0");
-            envVars.put(ucPrefix + "_DYNAREC_STRONGMEM", "3");
-            envVars.put(ucPrefix + "_DYNAREC_FORWARD", "512");
-            envVars.put(ucPrefix + "_DYNAREC_CALLRET", "0");
-            envVars.put(ucPrefix + "_DYNAREC_WAIT", "0");
-            if (ucPrefix.equals("BOX64")) {
-                envVars.put("BOX64_AVX", "0");
-                envVars.put("BOX64_UNITYPLAYER", "1");
-                envVars.put("BOX64_MMAP32", "0");
-            }
         } else if (id.equals(Box86_64Preset.UNITY)) {
             envVars.put(ucPrefix + "_DYNAREC_SAFEFLAGS", "1");
             envVars.put(ucPrefix + "_DYNAREC_FASTNAN", "1");
@@ -145,7 +130,6 @@ public abstract class Box86_64PresetManager {
         presets.add(new Box86_64Preset(Box86_64Preset.PERFORMANCE, context.getString(R.string.performance)));
         presets.add(new Box86_64Preset(Box86_64Preset.UNITY, context.getString(R.string.unity)));
         presets.add(new Box86_64Preset(Box86_64Preset.UNITY_MONO_BLEEDING_EDGE, context.getString(R.string.unity_mono_bleeding_edge)));
-        presets.add(new Box86_64Preset(Box86_64Preset.DENUVO, context.getString(R.string.denuvo)));
         for (String[] preset : customPresetsIterator(prefix, context))
             presets.add(new Box86_64Preset(preset[0], preset[1]));
         return presets;

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -43,7 +43,6 @@
     <string name="compatibility">Kompatibilitet</string>
     <string name="intermediate">Mellemtrin</string>
     <string name="performance">Ydelse</string>
-    <string name="denuvo">Denuvo</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
     <string name="title_ubuntufs">Ubuntu FS</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -99,7 +99,6 @@
     <string name="compatibility">Kompatibilität</string>
     <string name="intermediate">Mittel</string>
     <string name="performance">Leistung</string>
-    <string name="denuvo">Denuvo</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
     <string name="title_ubuntufs">Ubuntu FS</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -108,7 +108,6 @@
     <string name="performance">Performance</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
-    <string name="denuvo">Denuvo</string>
     <string name="title_ubuntufs">Ubuntu FS</string>
 
     <!-- Winlator: Win Components -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -108,7 +108,6 @@
     <string name="performance">Prestazioni</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
-    <string name="denuvo">Denuvo</string>
     <string name="title_ubuntufs">Ubuntu FS</string>
 
     <!-- Winlator: Win Components -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -45,7 +45,6 @@
     <string name="performance">Desempenho</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
-    <string name="denuvo">Denuvo</string>
     <string name="title_ubuntufs">Ubuntu FS</string>
 
     <!-- Winlator: Win Components -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -69,7 +69,7 @@
     <string name="destination_library">Bibliotecă</string>
     <string name="destination_downloads">Descărcări</string>
     <string name="destination_friends">Prieteni</string>
-
+    
     <!-- Custom Games -->
     <string name="custom_games_title">Jocuri personalizate</string>
     <string name="custom_games_no_paths">Nicio cale adăugată</string>
@@ -107,7 +107,6 @@
     <string name="performance">Performanță</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
-    <string name="denuvo">Denuvo</string>
     <string name="title_ubuntufs">Ubuntu FS</string>
     <!-- Winlator: Win Components -->
     <string name="direct3d">Direct3D</string>
@@ -185,7 +184,7 @@
     <string name="touchpad_help">Ajutor touchpad</string>
     <string name="hide_controls_with_controller">Ascunde controalele pe ecran când există controller</string>
     <string name="hide_controls_with_controller_description">Ascunde automat controalele pe ecran când un controller fizic este conectat</string>
-
+        
     <!-- Controller Binding Dialog -->
     <string name="select_binding">Selectează acțiunea</string>
     <string name="bind_button">Asociere: %1$s</string>
@@ -246,7 +245,7 @@
     <string name="preset_dpad">D‑Pad</string>
     <string name="preset_left_stick">Stick stânga</string>
     <string name="preset_right_stick">Stick dreapta</string>
-
+    
     <!-- Physical Controller Config -->
     <string name="physical_controller_config">Editor asocieri controller fizic</string>
     <string name="physical_controller_config_subtitle">Configurează mapările butoanelor pentru controllerul fizic</string>
@@ -289,7 +288,7 @@
     <string name="button_home">Home / Guide / PS</string>
     <string name="reset_to_default_bindings">Resetează la asocierile implicite</string>
     <string name="not_set">Nesetat</string>
-
+    
     <!-- Toast -->
     <string name="toast_controls_reset">Controalele au fost resetate</string>
     <string name="toast_failed_log_save">Nu s-a putut salva logcat la destinație</string>
@@ -383,7 +382,7 @@
     <string name="fexcore_env_var_help__maxinst">Numărul maxim de instrucțiuni per bloc de traducere (mai mare = performanță mai bună, stabilitate mai mică)</string>
     <string name="resume_download">Reia</string>
     <string name="pause_download">Pauză</string>
-
+        
     <!-- Library & Game Management -->
     <string name="create_shortcut">Creează shortcut</string>
     <string name="label">Etichetă</string>
@@ -611,7 +610,7 @@
 	<string name="settings_emulation_contents_manager_subtitle">Instalează componente suplimentare (.wcp)</string>
 	<string name="settings_emulation_wine_proton_manager_title">Manager Wine/Proton</string>
 	<string name="settings_emulation_wine_proton_manager_subtitle">Importă versiuni personalizate de Wine/Proton (doar Bionic)</string>
-
+ 
 	<!-- Settings: Debug Group -->
 	<string name="settings_debug_title">Depanare</string>
 	<string name="settings_debug_wine_channels_title">Selectează canalele de debug Wine</string>
@@ -713,7 +712,7 @@
 	<string name="library_need_internet">Este necesar internet pentru instalare</string>
 	<string name="library_wifi_only_enabled">Instalare doar prin Wi‑Fi/LAN activată</string>
 	<string name="library_file_count">Fișier %1$d din %2$d</string>
-
+    
 	<!-- PluviaMain: Update & App Info -->
 	<string name="main_update_available_title">Actualizare disponibilă</string>
 	<string name="main_update_available_message">O nouă versiune (%1$s) este disponibilă!%2$s</string>
@@ -816,7 +815,7 @@
 	<string name="library_compatible">Compatibil</string>
 	<string name="library_compatibility_unknown">Necunoscut</string>
 	<string name="library_not_compatible">Necompatibil</string>
-
+    
 	<!-- Best Config Compatibility Messages -->
 	<string name="best_config_exact_gpu_match">Config cunoscut funcționează pe GPU-ul tău</string>
 	<string name="best_config_gpu_family_match">Config cunoscut ar trebui să funcționeze pe GPU-ul tău</string>
@@ -896,7 +895,7 @@
 	<string name="contents_install_success">Conținut instalat cu succes</string>
 	<string name="contents_install_failed">Instalarea conținutului a eșuat</string>
 	<string name="contents_install_error">Eroare la instalare: %1$s</string>
-
+    
 	<!-- Library Status -->
 	<string name="library_status_ready">Gata</string>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -106,7 +106,6 @@
     <string name="compatibility">Сумісність</string>
     <string name="intermediate">Збалансований</string>
     <string name="performance">Продуктивність</string>
-    <string name="denuvo">Denuvo</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
     <string name="title_ubuntufs">Ubuntu FS</string>
@@ -896,7 +895,7 @@
     <string name="contents_install_success">Вміст успішно інстальовано</string>
     <string name="contents_install_failed">Не вдалося інсталювати вміст</string>
     <string name="contents_install_error">Помилка інсталяції: %1$s</string>
-
+    
     <!-- Library Status -->
     <string name="library_status_ready">Готова</string>
     <!-- Wine/Proton Manager -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -105,7 +105,6 @@
     <string name="compatibility">兼容性</string>
     <string name="intermediate">平衡</string>
     <string name="performance">高性能</string>
-    <string name="denuvo">Denuvo</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
     <string name="title_ubuntufs">Ubuntu FS</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -105,7 +105,6 @@
     <string name="compatibility">相容性</string>
     <string name="intermediate">平衡</string>
     <string name="performance">高性能</string>
-    <string name="denuvo">Denuvo</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
     <string name="title_ubuntufs">Ubuntu FS</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,7 +106,6 @@
     <string name="compatibility">Compatibility</string>
     <string name="intermediate">Intermediate</string>
     <string name="performance">Performance</string>
-    <string name="denuvo">Denuvo</string>
     <string name="unity">Unity</string>
     <string name="unity_mono_bleeding_edge">Unity Mono Bleeding Edge</string>
     <string name="title_ubuntufs">Ubuntu FS</string>


### PR DESCRIPTION
This reverts commit 15ba1bfbc8d536ae58fdccde52c6fc9c87b1aca8.

The denuvo preset is unnecessary as running P5R in Compatibilty with Proton 9 x86_64 already gives the maximum performance and devuno compatibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the Denuvo preset from Box86/64. Proton 9 x86_64 in Compatibility mode already provides the needed performance and Denuvo support (e.g., P5R), so the preset was redundant.

- **Refactors**
  - Deleted Box86_64Preset.DENUVO and its env var handling in Box86_64PresetManager.
  - Removed the "Denuvo" option from the preset list.
  - Cleaned up localized strings across all languages.

<sup>Written for commit 29951ed9417a221ad0cf5fb2d2f6d94915a8cb5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Denuvo preset configuration and localization strings from all supported languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->