### PR TITLE
Fix: Adds missing braces to if statements on Bionic Component

### DIFF
--- a/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
@@ -405,21 +405,24 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
         Log.d("Extraction", "fexcoreVersion in use: " + fexcoreVersion);
 
         ContentProfile wowboxprofile = contentsManager.getProfileByEntryName("wowbox64-" + wowbox64Version);
-        if (wowboxprofile != null)
+        if (wowboxprofile != null) {
             contentsManager.applyContent(wowboxprofile);
-        else
+        } else {
             Log.d("Extraction", "Extracting box64Version: " + wowbox64Version);
             TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, environment.getContext(), "wowbox64/wowbox64-" + wowbox64Version + ".tzst", system32dir);
+        }
         container.putExtra("box64Version", wowbox64Version);
         containerDataChanged = true;
 
         ContentProfile fexprofile = contentsManager.getProfileByEntryName("fexcore-" + fexcoreVersion);
-        if (fexprofile != null)
+        if (fexprofile != null) {
             contentsManager.applyContent(fexprofile);
-        else
+        } else {
             Log.d("Extraction", "Extracting fexcoreVersion: " + fexcoreVersion);
             TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, environment.getContext(), "fexcore/fexcore-" + fexcoreVersion + ".tzst", system32dir);
+        }
         container.putExtra("fexcoreVersion", fexcoreVersion);
+
         containerDataChanged = true;
         if (containerDataChanged) container.saveData();
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added missing braces to two if/else blocks in extractEmulatorsDlls to ensure correct control flow when applying or extracting wowbox64 and fexcore content. Prevents unintended execution and makes future changes safer.

<sup>Written for commit 727020d4e6a7791ccfd7a7c19372405dc57e2cb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for better maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->