### PR TITLE
Fix: Conditionally adds SteamClientComponent

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1833,7 +1833,10 @@ private fun setupXEnvironment(
     )
     environment.addComponent(XServerComponent(xServer, UnixSocketConfig.createSocket(rootPath, UnixSocketConfig.XSERVER_PATH)))
     environment.addComponent(NetworkInfoUpdateComponent())
-    environment.addComponent(SteamClientComponent())
+
+    if (!container.isLaunchRealSteam) {
+        environment.addComponent(SteamClientComponent())
+    }
 
     // environment.addComponent(SteamClientComponent(UnixSocketConfig.createSocket(
     //     rootPath,


### PR DESCRIPTION
Only adds the SteamClientComponent if the container is not launching real Steam.

This change is part of the effort to remove steampipe when using the real Steam client.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Conditionally adds SteamClientComponent only when the container is not launching the real Steam client. This supports removing steampipe for real Steam runs and prevents redundant Steam initialization.

<sup>Written for commit dd9eb786feeebd63d48c697f6719ef158820a84b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed X Server component initialization logic to properly respect Steam launch mode configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->