### PR TITLE
Added "deck_emu" variable to TU_DEBUG options so that latest turnip c…

### DIFF
--- a/app/src/main/java/com/winlator/core/envvars/EnvVarInfo.kt
+++ b/app/src/main/java/com/winlator/core/envvars/EnvVarInfo.kt
@@ -198,7 +198,7 @@ data class EnvVarInfo(
                 possibleValues = listOf(
                     "startup", "nir", "nobin", "sysmem", "gmem", "forcebin", "layout", "noubwc", "nomultipos",
                     "nolrz", "nolrzfc", "perf", "perfc", "flushall", "syncdraw", "push_consts_per_stage", "rast_order",
-                    "unaligned_store", "log_skip_gmem_ops", "dynamic", "bos", "3d_load", "fdm", "noconform", "rd",
+                    "unaligned_store", "log_skip_gmem_ops", "dynamic", "bos", "3d_load", "fdm", "noconform", "rd", "deck_emu"
                 ),
             ),
             "DXVK_HUD" to EnvVarInfo(


### PR DESCRIPTION
…an work on 8 elite drivers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added "deck_emu" to TU_DEBUG options to enable the latest turnip to work with 8 Elite drivers and improve compatibility.

<sup>Written for commit 36424e70c01111e2297c89b47084db43bfeb4082. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "deck_emu" as a selectable option for the TU_DEBUG environment variable, expanding configuration choices for advanced debugging and emulation settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->