### PR TITLE
Fix execution of Epic Games exes with spaces

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2048,7 +2048,7 @@ private fun getWineStartCommand(
         val epicCommand = "A:\\$relativePath".replace("/", "\\")
 
         Timber.tag("XServerScreen").i("Epic launch command: \"$epicCommand\"")
-        // Quote the path to handle any special characters properly (defensive programming)
+
         return "winhandler.exe \"$epicCommand\""
     } else if (isCustomGame) {
         // For Custom Games, we can launch even without appLaunchInfo


### PR DESCRIPTION
This PR updates the launcher command for Epic to properly preserve spaces by wrapping the .exe with quotes to avoid the breaking of the launch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quote the Epic game executable path in the winhandler.exe command to preserve spaces and prevent launch failures. Updated logging to show the quoted command for easier debugging.

<sup>Written for commit a1cc3b957d2f215efe5c24f9c9132b1a7d154be4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Epic game launcher command handling to properly support file paths containing spaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->