### PR TITLE
fix(): filter out Unreal Engine dev applications

### DIFF
--- a/app/src/main/java/app/gamenative/db/dao/EpicGameDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/EpicGameDao.kt
@@ -61,7 +61,7 @@ interface EpicGameDao {
     @Query("SELECT * FROM epic_games WHERE base_game_app_name IS NOT NULL AND is_dlc = true")
     fun getAllDlcTitles(): Flow<List<EpicGame>>
 
-    @Query("SELECT * FROM epic_games WHERE title LIKE '%' || :searchQuery || '%' ORDER BY title ASC")
+    @Query("SELECT * FROM epic_games WHERE is_dlc = false AND namespace != 'ue' AND title LIKE '%' || :searchQuery || '%' ORDER BY title ASC")
     fun searchByTitle(searchQuery: String): Flow<List<EpicGame>>
 
     @Query("DELETE FROM epic_games")

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -420,13 +420,6 @@ class LibraryViewModel @Inject constructor(
                         true
                     }
                 }
-                .filter { game ->
-                    if (game.isDLC) {
-                        false
-                    } else {
-                        true
-                    }
-                }
                 .toList()
 
             val epicEntries = filteredEpicGames.map { game ->


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter out Unreal Engine–related apps across Epic lists and search by excluding namespace 'ue' at the DB level. Consolidate DLC filtering in the DAO and remove the redundant check in the view model.

- **Bug Fixes**
  - Added "AND namespace != 'ue'" to getAll() and searchByTitle() so UE tools/samples no longer appear.
  - Removed duplicate DLC filtering in LibraryViewModel; DAO enforces is_dlc = false.

<sup>Written for commit 22ec638e13b487c68b95773b69dc6a38d5fc20cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Epic storefront listings now include DLC items when viewing Epic games in the library.
  * General game lists and title searches now exclude entries from a specific internal namespace, reducing irrelevant results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->