### PR TITLE
New wrapper 2026

### DIFF
--- a/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
+++ b/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
@@ -212,7 +212,7 @@ object ManifestComponentHelper {
     fun versionExists(version: String, available: List<String>): Boolean {
         if (version.isEmpty()) return false
         val trimmed = version.trim()
-        return available.any { it.equals(trimmed, ignoreCase = true) }
+        return available.any { it.equals(trimmed, ignoreCase = true) || StringUtils.parseIdentifier(it).equals(trimmed) }
     }
 
     fun findManifestEntryForVersion(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the graphics wrapper and driver stack, refreshes sensible defaults, and rebuilds the Container Config dialog into a stable, tabbed UI. Adds Turnip Gen8 support, new DXVK/Zink assets, better GPU detection, and safer driver fallbacks.

- **New Features**
  - Added DXVK 1.11.1-sarek and Zink DLL assets; included Turnip_Gen8_V23 driver and updated Turnip entries.
  - New defaults: DXVK 2.4.1-gplasync, wrapper turnip26.0.0_R8, async cache on; Adreno 8 Elite profile; 8 GB VRAM option.
  - Split ContainerConfigDialog into tabs (General, Graphics, Wine, Emulation, Controller, Drives, Environment, Advanced, WinComponents) with a shared ContainerConfigState to prevent UI crashes.
  - GPU/Vulkan: JNI vendor ID query, GPU device/vendor lookup from gpu_cards.json, new GALLIUM_HUD env var.
  - Image FS version bumped to v26.

- **Bug Fixes**
  - Fixed driver extraction and cleanup (removes stale wrapper files when switching); warn and fall back to System when a selected Adrenotools driver is missing.
  - Correctly import drivers/contents with spaces and restore “install from manifest” behavior; stop normalizing manifest IDs.
  - arm64ec-specific OpenGL components handling; auto-disable the PATCH_OPCONSTCOMP SPIR-V pass for DXVK 1.11.1-sarek; ensure Vulkan resources are cleaned up.

<sup>Written for commit 866e533d2a71bfb98c76db872e8c562dccc57401. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Broadened version-matching logic to accept trimmed input and additional identifier forms, improving flexibility and consistency when resolving versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->