### PR TITLE
fix(): Ignore the steam game check when non-steam game is prelaunched.

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1178,24 +1178,27 @@ fun preLaunchApp(
         containerManager.activateContainer(container)
 
         // If another game is running on this account elsewhere, prompt user first (cross-app session)
-        try {
-            val currentPlaying = SteamService.getSelfCurrentlyPlayingAppId()
-            if (!isOffline && currentPlaying != null && currentPlaying != gameId) {
-                val otherGameName = SteamService.getAppInfoOf(currentPlaying)?.name ?: "another game"
-                setLoadingDialogVisible(false)
-                setMessageDialogState(
-                    MessageDialogState(
-                        visible = true,
-                        type = DialogType.ACCOUNT_SESSION_ACTIVE,
-                        title = context.getString(R.string.main_app_running_title),
-                        message = context.getString(R.string.main_app_running_message, otherGameName),
-                        confirmBtnText = context.getString(R.string.main_play_anyway),
-                        dismissBtnText = context.getString(R.string.cancel),
-                    ),
-                )
-                return@launch
-            }
-        } catch (_: Exception) { /* ignore persona read errors */ }
+        val isSteamGame = ContainerUtils.extractGameSourceFromContainerId(appId) == GameSource.STEAM
+        if(isSteamGame) {
+            try {
+                val currentPlaying = SteamService.getSelfCurrentlyPlayingAppId()
+                if (!isOffline && currentPlaying != null && currentPlaying != gameId) {
+                    val otherGameName = SteamService.getAppInfoOf(currentPlaying)?.name ?: "another game"
+                    setLoadingDialogVisible(false)
+                    setMessageDialogState(
+                        MessageDialogState(
+                            visible = true,
+                            type = DialogType.ACCOUNT_SESSION_ACTIVE,
+                            title = context.getString(R.string.main_app_running_title),
+                            message = context.getString(R.string.main_app_running_message, otherGameName),
+                            confirmBtnText = context.getString(R.string.main_play_anyway),
+                            dismissBtnText = context.getString(R.string.cancel),
+                        ),
+                    )
+                    return@launch
+                }
+            } catch (_: Exception) { /* ignore persona read errors */ }
+        }
 
         // For Custom Games, bypass Steam Cloud operations entirely and proceed to launch
         if (isCustomGame) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip the Steam “currently playing” check when prelaunching non‑Steam games. This removes the false “account session active” prompt and lets non‑Steam titles start without interruption.

- **Bug Fixes**
  - Run the Steam session check only if the container source is Steam (using ContainerUtils.extractGameSourceFromContainerId).

<sup>Written for commit cebf5a6a27643ca1a8bb81c76f867c46334bec2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unwanted "another game running" prompts appearing for non-Steam games. The alert now displays only when launching Steam games.

* **New Features**
  * Custom Games now launch with a streamlined process that bypasses Steam Cloud synchronization, enabling faster game startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->