### PR TITLE
Include STEAMGRIDDB api key as secret for automatically image fetch support

### DIFF
--- a/.github/workflows/app-release-signed.yml
+++ b/.github/workflows/app-release-signed.yml
@@ -63,7 +63,7 @@ jobs:
         cat <<EOF > local.properties
         POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}
         POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
-        STEAMGRIDDB_API_KEY=${{ secrets.STEAMGRIDDB_API_KEY}}
+        STEAMGRIDDB_API_KEY=${{ secrets.STEAMGRIDDB_API_KEY }}
         SUPABASE_URL=${{ secrets.SUPABASE_URL }}
         SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}
         EOF


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add STEAMGRIDDB API key to the release workflow and write it to local.properties. This enables automatic image fetching from SteamGridDB in signed Android builds.

<sup>Written for commit de0a78febddd9ee60ab4fb5560a4ba052a1096b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release build configuration to include additional API credentials for the signed application build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->