### PR TITLE
Fixed issue with some Epic Games not downloading (Required Header version parsing)

### DIFF
--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -683,8 +683,8 @@ class EpicDownloadManager @Inject constructor(
 
             // Epic chunks can have different header sizes (62 or 66 bytes)
             // Minimum viable header is 62 bytes
-            if (headerSize < 62) {
-                throw Exception("Invalid header size: $headerSize (minimum 62 bytes required)")
+            if (headerSize < 62 || headerSize > 66) {
+                throw Exception("Invalid header size: $headerSize (expected 62-66 bytes)")
             }
 
             // Read the remaining header bytes


### PR DESCRIPTION
Overview:

This fixes the parsing issue of a small number of games not downloading correctly.


Technical Details:

There are two versions of the header: V2 and v3.

V2 uses 62 bytes and V3 uses 66 Bytes.

We were only considering the 66 byte-length headers and it was failing. 

Now appropriately checks the version and checks the header as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved download compatibility to support multiple header format versions.
  * Added validation and buffer protection to prevent data corruption from invalid headers.
  * Enhanced diagnostic logging to better track and troubleshoot download operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->