### PR TITLE
feat(imagefs): avoid extraction when changing container variant

### DIFF
--- a/app/src/main/java/com/winlator/core/FileUtils.java
+++ b/app/src/main/java/com/winlator/core/FileUtils.java
@@ -25,15 +25,21 @@ import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Stack;
 import java.util.UUID;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -177,6 +183,45 @@ public abstract class FileUtils {
             return files == null || files.length == 0;
         }
         else return targetFile.length() == 0;
+    }
+
+    public static void mergeDirectoryRecursively(File srcFile, File dstFile, OnFileMergedListener onProgress) throws IOException {
+        Path source = srcFile.toPath();
+        Path target = dstFile.toPath();
+
+        Files.createDirectories(target);
+
+        AtomicLong totalFiles = new AtomicLong(0);
+        try (var stream = Files.walk(source)) {
+            stream.filter(Files::isRegularFile)
+                .forEach(p -> totalFiles.incrementAndGet());
+        }
+
+        long total = totalFiles.get();
+        AtomicLong processed = new AtomicLong(0);
+
+        Files.walkFileTree(source, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                Path targetDir = target.resolve(source.relativize(dir));
+                Files.createDirectories(targetDir);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Path targetFile = target.resolve(source.relativize(file));
+                Files.copy(file, targetFile, LinkOption.NOFOLLOW_LINKS, StandardCopyOption.REPLACE_EXISTING);
+
+                long done = processed.incrementAndGet();
+
+                if (onProgress != null) {
+                    onProgress.onFileMerged(done, total);
+                }
+
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 
     public static boolean copy(File srcFile, File dstFile) {

--- a/app/src/main/java/com/winlator/core/OnFileMergedListener.java
+++ b/app/src/main/java/com/winlator/core/OnFileMergedListener.java
@@ -1,0 +1,5 @@
+package com.winlator.core;
+
+public interface OnFileMergedListener {
+    void onFileMerged(long done, long filesCount);
+}

--- a/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
@@ -6,6 +6,8 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import app.gamenative.R;
 import app.gamenative.enums.Marker;
 import app.gamenative.service.SteamService;
@@ -77,6 +79,7 @@ public abstract class ImageFsInstaller {
         for (String version : versions) {
             File downloaded = new File(imageFs.getFilesDir(), version + ".txz");
             File outFile = new File(rootDir, "/opt/" + version);
+            if (outFile.exists()) continue;
             outFile.mkdirs();
             TarCompressorUtils.extract(
                 TarCompressorUtils.Type.XZ,
@@ -98,44 +101,7 @@ public abstract class ImageFsInstaller {
         // dialog.show(R.string.installing_system_files);
         return Executors.newSingleThreadExecutor().submit(() -> {
             clearRootDir(context, rootDir);
-            final byte compressionRatio = 22;
-            String imagefsFile = containerVariant.equals(Container.GLIBC) ? "imagefs_gamenative.txz" : "imagefs_bionic.txz";
-            File downloaded = new File(imageFs.getFilesDir(), imagefsFile);
-
-            boolean success = false;
-
-            if (Arrays.asList(context.getAssets().list("")).contains(imagefsFile) == true){
-                final long contentLength = (long) (FileUtils.getSize(assetManager, imagefsFile) * (100.0f / compressionRatio));
-                AtomicLong totalSizeRef = new AtomicLong();
-                Log.d("Extraction", "extracting " + imagefsFile);
-
-                success = TarCompressorUtils.extract(TarCompressorUtils.Type.XZ, assetManager, imagefsFile, rootDir, (file, size) -> {
-                    if (size > 0) {
-                        long totalSize = totalSizeRef.addAndGet(size);
-                        if (onProgress != null) {
-                            final int progress = (int) (((float) totalSize / contentLength) * 100);
-                            onProgress.call(progress);
-                        }
-                    }
-                    return file;
-                });
-            }
-
-            else if (downloaded.exists()){
-                final long contentLength = (long) (FileUtils.getSize(downloaded) * (100.0f / compressionRatio));
-                AtomicLong totalSizeRef = new AtomicLong();
-                Log.d("Extraction", "extracting " + imagefsFile);
-                success = TarCompressorUtils.extract(TarCompressorUtils.Type.XZ, downloaded, rootDir, (file, size) -> {
-                    if (size > 0) {
-                        long totalSize = totalSizeRef.addAndGet(size);
-                        if (onProgress != null) {
-                            final int progress = (int) (((float) totalSize / contentLength) * 100);
-                            onProgress.call(progress);
-                        }
-                    }
-                    return file;
-                });
-            }
+            boolean success = extractImageFs(context, assetManager, containerVariant, onProgress, imageFs, rootDir);
 
             if (success) {
                 Log.d("ImageFsInstaller", "Successfully installed system files");
@@ -156,6 +122,76 @@ public abstract class ImageFsInstaller {
             return success;
             // dialog.closeOnUiThread();
         });
+    }
+
+    private static void mergeImageFsFolder(Context context, String containerVariant, File rootDir, Callback<Integer> onProgress, Boolean isCleanInstall) throws IOException {
+        File variantDir = getVariantDir(context, containerVariant);
+        FileUtils.mergeDirectoryRecursively(variantDir, rootDir, (done, filesCount) -> {
+            if (onProgress == null) return;
+
+            int progress = (int) (((float) done / filesCount) * 100);
+            if (isCleanInstall) {
+                onProgress.call(progress / 2 + 50);
+            } else {
+                onProgress.call(progress);
+            }
+        });
+    }
+
+    private static boolean extractImageFs(Context context, AssetManager assetManager, String containerVariant, Callback<Integer> onProgress, ImageFs imageFs, File rootDir) throws IOException {
+        final byte compressionRatio = 22;
+
+        String imagefsFile = containerVariant.equals(Container.GLIBC) ? "imagefs_gamenative.txz" : "imagefs_bionic.txz";
+        File downloaded = new File(context.getFilesDir(), imagefsFile);
+
+        File variantDir = getVariantDir(context, containerVariant);
+        if (variantDir.exists()) {
+            mergeImageFsFolder(context, containerVariant, rootDir, onProgress, false);
+            return true;
+        }
+
+
+        boolean success = false;
+
+        if (Arrays.asList(context.getAssets().list("")).contains(imagefsFile) == true){
+            final long contentLength = (long) (FileUtils.getSize(assetManager, imagefsFile) * (100.0f / compressionRatio));
+            AtomicLong totalSizeRef = new AtomicLong();
+            Log.d("Extraction", "extracting " + imagefsFile);
+
+            success = TarCompressorUtils.extract(TarCompressorUtils.Type.XZ, assetManager, imagefsFile, variantDir, (file, size) -> {
+                if (size > 0) {
+                    long totalSize = totalSizeRef.addAndGet(size);
+                    if (onProgress != null) {
+                        final int progress = (int) (((float) totalSize / contentLength) * 100 / 2);
+                        onProgress.call(progress);
+                    }
+                }
+                return file;
+            });
+        }
+
+        else if (downloaded.exists()){
+            final long contentLength = (long) (FileUtils.getSize(downloaded) * (100.0f / compressionRatio));
+            AtomicLong totalSizeRef = new AtomicLong();
+            Log.d("Extraction", "extracting " + imagefsFile);
+            success = TarCompressorUtils.extract(TarCompressorUtils.Type.XZ, downloaded, variantDir, (file, size) -> {
+                if (size > 0) {
+                    long totalSize = totalSizeRef.addAndGet(size);
+                    if (onProgress != null) {
+                        final int progress = (int) (((float) totalSize / contentLength) * 100 / 2);
+                        onProgress.call(progress);
+                    }
+                }
+                return file;
+            });
+        }
+        mergeImageFsFolder(context, containerVariant, rootDir, onProgress, true);
+        return success;
+    }
+
+    @NonNull
+    private static File getVariantDir(Context context, String containerVariant) {
+        return new File(context.getFilesDir(), containerVariant.equals(Container.GLIBC) ? "glibc/imagefs" : "bionic/imagefs");
     }
 
     private static void installGuestLibs(Context ctx) {
@@ -216,19 +252,6 @@ public abstract class ImageFsInstaller {
             return false;
         }
 
-        // Get bundled versions from resource arrays
-        String[] bionicWineEntries = context.getResources().getStringArray(R.array.bionic_wine_entries);
-        String[] glibcWineEntries = context.getResources().getStringArray(R.array.glibc_wine_entries);
-
-        // Check if it's a bundled version
-        for (String version : bionicWineEntries) {
-            if (lowerName.equals(version.toLowerCase())) return false;
-        }
-        for (String version : glibcWineEntries) {
-            if (lowerName.equals(version.toLowerCase())) return false;
-        }
-
-        // It's Wine/Proton but not bundled, so it's imported
         return true;
     }
 


### PR DESCRIPTION
# Description

This PR solves #452, changes include:

- Extract imagefs file to `{variant}/imagefs` if needed
- Move imagefs file from `{variant}/imagefs` to `imagefs`
- Skip removing proton and wine file in `/opt` folder (as discussed in #452)

## Test

Tested on retroid pocket 5

### Before

~30s - 1min load time

https://github.com/user-attachments/assets/4750cb37-0b74-455f-a542-7c1fa1ae1209

### After

~6s load time

https://github.com/user-attachments/assets/ae4d4074-a23e-425a-b46b-180518f1f136







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid re-extracting imagefs when switching between glibc and bionic by storing a per-variant imagefs and merging it into the root on change. Cuts load time from ~30–60s to ~6s and addresses #452.

- **New Features**
  - Extract imagefs to variant dirs: glibc/imagefs or bionic/imagefs, then merge into root on switch.
  - Added recursive directory merge with progress reporting.
  - Skip removing Wine/Proton in /opt and don’t reinstall if already present.

<sup>Written for commit 17955fac78cf579e9837e5f2c248fded3ddd620f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add recursive directory merge with progress reporting and a progress callback interface.
  * Centralized image filesystem extraction flow that handles assets and downloads uniformly.

* **Improvements**
  * Better variant-specific directory handling and adjusted progress calculations during extraction/merge.

* **Bug Fixes / Performance**
  * Skip redundant re-installation when target already exists, reducing unnecessary work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->