### PR TITLE
Fix Epic working directory issue with launching games

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2049,9 +2049,6 @@ private fun getWineStartCommand(
             return "\"explorer.exe\""
         }
 
-
-
-
         // Convert to relative path from install directory
         val relativePath = exePath.removePrefix(game.installPath).removePrefix("/")
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Epic games failing to launch by setting the working directory to the executable’s folder. This ensures titles that depend on their local working dir start correctly when using Wine.

<sup>Written for commit 93e23a61ff0982ed4d405269ef2c533094e1daba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Epic Games launch compatibility by ensuring proper working directory configuration for game executables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->