### PR TITLE
Always apply known config on first launch of steam.

### DIFF
--- a/app/src/main/java/app/gamenative/utils/BestConfigService.kt
+++ b/app/src/main/java/app/gamenative/utils/BestConfigService.kt
@@ -768,6 +768,24 @@ object BestConfigService {
                 if (filteredJson.has("useLegacyDRM") && !filteredJson.isNull("useLegacyDRM")) {
                     resultMap["useLegacyDRM"] = filteredJson.optBoolean("useLegacyDRM", PrefManager.useLegacyDRM)
                 }
+                if (filteredJson.has("envVars") && !filteredJson.isNull("envVars")) {
+                    resultMap["envVars"] = filteredJson.optString("envVars", PrefManager.envVars)
+                }
+                if (filteredJson.has("cpuList") && !filteredJson.isNull("cpuList")) {
+                    resultMap["cpuList"] = filteredJson.optString("cpuList", PrefManager.cpuList)
+                }
+                if (filteredJson.has("cpuListWoW64") && !filteredJson.isNull("cpuListWoW64")) {
+                    resultMap["cpuListWoW64"] = filteredJson.optString("cpuListWoW64", PrefManager.cpuListWoW64)
+                }
+                if (filteredJson.has("audioDriver") && !filteredJson.isNull("audioDriver")) {
+                    resultMap["audioDriver"] = filteredJson.optString("audioDriver", PrefManager.audioDriver)
+                }
+                if (filteredJson.has("wincomponents") && !filteredJson.isNull("wincomponents")) {
+                    resultMap["wincomponents"] = filteredJson.optString("wincomponents", PrefManager.winComponents)
+                }
+                if (filteredJson.has("videoMemorySize") && !filteredJson.isNull("videoMemorySize")) {
+                    resultMap["videoMemorySize"] = filteredJson.optString("videoMemorySize", PrefManager.videoMemorySize)
+                }
 
                 return resultMap
             }

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -362,6 +362,12 @@ object ContainerUtils {
                     ?: updatedData
                 "useLegacyDRM" -> value?.let { updatedData.copy(useLegacyDRM = it as? Boolean ?: updatedData.useLegacyDRM) } ?: updatedData
                 "unpackFiles" -> value?.let { updatedData.copy(unpackFiles = it as? Boolean ?: updatedData.unpackFiles) } ?: updatedData
+                "envVars" -> value?.let { updatedData.copy(envVars = it as? String ?: updatedData.envVars) } ?: updatedData
+                "cpuList" -> value?.let { updatedData.copy(cpuList = it as? String ?: updatedData.cpuList) } ?: updatedData
+                "cpuListWoW64" -> value?.let { updatedData.copy(cpuListWoW64 = it as? String ?: updatedData.cpuListWoW64) } ?: updatedData
+                "audioDriver" -> value?.let { updatedData.copy(audioDriver = it as? String ?: updatedData.audioDriver) } ?: updatedData
+                "wincomponents" -> value?.let { updatedData.copy(wincomponents = it as? String ?: updatedData.wincomponents) } ?: updatedData
+                "videoMemorySize" -> value?.let { updatedData.copy(videoMemorySize = it as? String ?: updatedData.videoMemorySize) } ?: updatedData
                 else -> updatedData
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply the full validated known config on the first Steam launch so containers get all best-config settings immediately, including env vars, CPU lists, audio driver, Win components, and video memory size. Set applyKnownConfig=true on first run and use applyBestConfigMapToContainerData for safe, consistent field mapping.

<sup>Written for commit 61cd03f17f2c61641726bb4d135b58584d60e431. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container initialization so additional configuration fields (envVars, cpuList, cpuListWoW64, audioDriver, wincomponents, videoMemorySize) from the best-available config are applied on creation, ensuring more settings are respected at first run.

* **Refactor**
  * Consolidated best-config merging into a single, consistent application path for cleaner and more reliable handling of configuration fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->