### PR TITLE
fix(): Epic Integration -  Ignore invalid platforms for Epic Games

### DIFF
--- a/app/src/main/java/app/gamenative/service/epic/EpicManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicManager.kt
@@ -593,8 +593,6 @@ class EpicManager @Inject constructor(
             false
         }
 
-
-
         Timber.d("Game $appName - CloudSaveFolder: $saveFolder, CloudIncludeList: ${parsedAttributes.cloudIncludeList}, CanRunOffline: $canRunOffline")
 
         return EpicGame(


### PR DESCRIPTION
Added checks for the initial library refresh and for parsing game data to ignore non-windows applications/games.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows only Windows-compatible Epic games during the initial library refresh. Adds clear skip logs and fixes the refresh query so valid Windows titles aren’t missed.

- **Bug Fixes**
  - Safely parse platform arrays; skip non-Windows (Win32/Windows) titles only when platform data exists.
  - Added explicit “invalid app” and “invalid platform” logs for skipped items.
  - Fixed the initial refresh query; removed later platform parsing and any DB-level filtering.

<sup>Written for commit 019dd42a24222667c54af0094ee24b371383592f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Library filtering now more reliably restricts displayed Epic Games to Windows-compatible titles.
  * Per-item platform detection during sync improved for more accurate library results.
  * Sync now skips non-Windows or unsupported entries earlier, with clearer skip messages to aid troubleshooting.
  * Parsing tweaks reduce false positives so unsupported items no longer appear in your library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->