### PR TITLE
Fix incorrect OpenGL label in container config

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -131,7 +131,7 @@ internal fun winComponentsItemTitleRes(string: String): Int {
         "directx" -> R.string.directx
         "vcrun2010" -> R.string.vcrun2010
         "wmdecoder" -> R.string.wmdecoder
-        "opengl" -> R.string.wmdecoder
+        "opengl" -> R.string.opengl
         else -> throw IllegalArgumentException("No string res found for Win Components title: $string")
     }
 }


### PR DESCRIPTION
Caught a small bug where the OpenGL option was displaying the wrong text label ("Windows Media Decoder" instead of "OpenGL"). Just pointed it to the correct string resource.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the OpenGL option label in the container config so it shows "OpenGL" instead of "Windows Media Decoder". Updated the string mapping to point "opengl" to R.string.opengl.

<sup>Written for commit 5249fd5689b64e7191afc7e6040adf2652748851. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a mislabeled option in the Container Configuration dialog: the OpenGL item now displays the proper title instead of an unrelated label.
  * Improves clarity when selecting the graphics backend, reducing confusion during setup.
  * Ensures consistent wording across the interface and better alignment with the actual setting, including improved localization and accessibility announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->