### PR TITLE
Use "Remove" button for Custom Games

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -502,8 +502,13 @@ internal fun AppScreenContent(
                             colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.primary),
                             contentPadding = PaddingValues(16.dp)
                         ) {
+                            val buttonText = if (ContainerUtils.extractGameSourceFromContainerId(displayInfo.appId) == app.gamenative.data.GameSource.CUSTOM_GAME) {
+                                stringResource(R.string.remove)
+                            } else {
+                                stringResource(R.string.uninstall)
+                            }
                             Text(
-                                text = stringResource(R.string.uninstall),
+                                text = buttonText,
                                 style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
                             )
                         }


### PR DESCRIPTION
Updated the "Uninstall" button to say "Remove" when viewing a Custom Game, since we don't actually delete the game files from the disk, only the library entry.

Implemented using `extractGameSourceFromContainerId` as suggested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Library screen to show “Remove” instead of “Uninstall” for Custom Games, since we only remove the library entry and don’t delete files. The label switches based on source using ContainerUtils.extractGameSourceFromContainerId.

<sup>Written for commit 447277b40961c45272c78a0fdc18a41eac4fe0a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button terminology in library management. The delete action now displays "Remove" for custom games and "Uninstall" for other apps, providing more accurate and context-specific labels to guide users through deletion actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->