### PR TITLE
Fix wrong key used in the opengl Win component label

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -131,7 +131,7 @@ internal fun winComponentsItemTitleRes(string: String): Int {
         "directx" -> R.string.directx
         "vcrun2010" -> R.string.vcrun2010
         "wmdecoder" -> R.string.wmdecoder
-        "opengl" -> R.string.wmdecoder
+        "opengl" -> R.string.opengl
         else -> throw IllegalArgumentException("No string res found for Win Components title: $string")
     }
 }


### PR DESCRIPTION
### Rationale
Duplicated label, which can be confusing at start.
### What Changed
Just the label used for opengl Win Component, now reflecting its original meaning.
### Impact
None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the label mapping for the OpenGL Win component so it displays “OpenGL” instead of duplicating “WM Decoder.” This fixes the UI confusion in ContainerConfigDialog.

<sup>Written for commit f6f55f6f0a861a545ae5f08adfdcbc39a1990da0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the title display text for the OpenGL component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->