### PR TITLE
Clarify build requirements and add asset download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,16 @@ You can support GameNative on Ko-fi at https://ko-fi.com/gamenative
 
 ## Building
 ### IF YOU JUST WANT TO USE THE APP, PLEASE SEE THE HOW TO USE SECTION ABOVE. THIS IS ONLY NEEDED IF YOU WANT TO CONTRIBUTE FOR DEVELOPMENT.
-1. I use a normal build in Android studio. Hit me up if you can't figure out how to build.
-2. You may need to download some additional files and place them in the `src/main/assets` folder.
-These files are available on request for legitimate development purposes. Please write to me on Discord and I can share them with you there.
+
+1. Open the project in Android Studio and build normally. Requires Android NDK `22.1.7171670` and Java 17+.
+
+2. **Runtime assets (optional):** The app compiles without these, but you need them to test game launching:
+   - `imagefs_gamenative.txz` - Linux root filesystem with Wine/Proton (~300-500MB)
+   - `imagefs_patches_gamenative.tzst` - Filesystem patches
+   - `imagefs_bionic.txz` - Alternative bionic-based root filesystem
+   
+   Download automatically on first app launch, or run: `./scripts/download-dev-assets.sh`
+
 3. **SteamGridDB API Key (Optional):** To enable automatic fetching of game images for Custom Games, add your SteamGridDB API key to `local.properties`:
    ```
    STEAMGRIDDB_API_KEY=your_api_key_here

--- a/scripts/download-dev-assets.sh
+++ b/scripts/download-dev-assets.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Downloads runtime assets for testing game launching during development.
+# The app compiles without these, but needs them to execute games.
+
+set -e
+
+CDN="https://downloads.gamenative.app"
+DEST="app/src/main/assets"
+FILES=("imagefs_gamenative.txz" "imagefs_patches_gamenative.tzst" "imagefs_bionic.txz")
+
+[ ! -d "$DEST" ] && echo "Error: Run from GameNative root directory" && exit 1
+
+for file in "${FILES[@]}"; do
+    [ -f "$DEST/$file" ] && echo "Skipping $file (exists)" && continue
+    echo "Downloading $file..."
+    curl -fL "$CDN/$file" -o "$DEST/$file" || echo "Failed: $file"
+done
+
+echo "Done"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified Android build requirements (NDK 22.1.7171670 and Java 17+) and added a script to download runtime assets for testing game launching. This reduces manual setup for contributors.

- **New Features**
  - scripts/download-dev-assets.sh: Fetches imagefs_gamenative.txz, imagefs_patches_gamenative.tzst, and imagefs_bionic.txz to app/src/main/assets; skips existing files and must be run from repo root.
  - Assets are optional for compiling but required to run games; they also auto-download on first app launch.

<sup>Written for commit 9184b4fb36af0c0afa01b1e8e3addf36ff056998. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions with modernized Android Studio workflow and updated system requirements.
  * Added optional runtime assets with automatic download capability on first launch.
  * Enhanced SteamGridDB API Key configuration documentation with retrieval details and graceful fallback behavior.

* **Chores**
  * Added asset download helper for development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->