### PR TITLE
Revert "Update unpack files to run steamless on all relevant exes instead of …"

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
@@ -331,6 +331,15 @@ fun GeneralTabContent(
             state = config.launchRealSteam,
             onCheckedChange = { state.config.value = config.copy(launchRealSteam = it) },
         )
+        if (config.launchRealSteam) {
+            SettingsSwitch(
+                colors = settingsTileColorsAlt(),
+                title = { Text(text = stringResource(R.string.allow_steam_updates)) },
+                subtitle = { Text(text = stringResource(R.string.allow_steam_updates_description)) },
+                state = config.allowSteamUpdates,
+                onCheckedChange = { state.config.value = config.copy(allowSteamUpdates = it) },
+            )
+        }
         val steamTypeItems = listOf("Normal", "Light", "Ultra Light")
         val currentSteamTypeIndex = when (config.steamType.lowercase()) {
             Container.STEAM_TYPE_LIGHT -> 1

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1998,7 +1998,7 @@ private fun getWineStartCommand(
         if (controllerVdfText.isNullOrEmpty()) {
             Timber.tag("XServerScreen").i("No steam controller VDF resolved for $gameId")
         } else {
-            Timber.tag("XServerScreen").i("Resolved steam controller VDF for $gameId")
+            Timber.tag("XServerScreen").i("Resolved steam controller VDF for $gameId:\n$controllerVdfText")
         }
     }
 
@@ -2532,73 +2532,68 @@ private fun unpackExecutableFile(
 
         output = StringBuilder()
 
-        if (!container.isLaunchRealSteam) {
-            val exePaths = if (container.isUnpackFiles) {
-                val scanned = ContainerUtils.scanExecutablesInADrive(container.drives)
-                val filtered = ContainerUtils.filterExesForUnpacking(scanned)
-                if (filtered.isEmpty()) listOf(container.executablePath).filter { it.isNotEmpty() } else filtered
-            } else {
-                listOf(container.executablePath).filter { it.isNotEmpty() }
-            }
-            if (exePaths.isEmpty()) {
+        if (!container.isLaunchRealSteam && !container.isUnpackFiles) {
+            val executablePath = container.executablePath
+            if (executablePath.isEmpty()) {
                 Timber.w("No executable path set, skipping Steamless")
             } else {
                 PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Handling DRM..."))
-                for ((index, executablePath) in exePaths.withIndex()) {
-                    if (exePaths.size > 1) {
-                        PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Handling DRM (${index + 1}/${exePaths.size})"))
-                    }
-                    var batchFile: File? = null
-                    try {
-                        // Normalize path: use forward slashes for Unix format, backslashes for Windows
-                        val normalizedPath = executablePath.replace('/', '\\')
-                        val windowsPath = "A:\\$normalizedPath"
 
-                        // Create a batch file that Wine can execute, to handle paths with spaces in them
-                        batchFile = File(imageFs.getRootDir(), "tmp/steamless_wrapper.bat")
-                        batchFile.parentFile?.mkdirs()
-                        batchFile.writeText("@echo off\r\nz:\\Steamless\\Steamless.CLI.exe \"$windowsPath\"\r\n")
+                var batchFile: File? = null
+                try {
+                    // Normalize path: container.executablePath uses forward slashes, convert to Windows format
+                    val normalizedPath = executablePath.replace('/', '\\')
+                    val windowsPath = "A:\\$normalizedPath"
 
-                        val slCmd = "wine z:\\tmp\\steamless_wrapper.bat"
-                        val slOutput = guestProgramLauncherComponent.execShellCommand(slCmd)
-                        output.append(slOutput)
-                        Timber.i("Finished processing executable. Result: $output")
-                    } catch (e: Exception) {
-                        Timber.e(e, "Error running Steamless on $executablePath")
-                        output.append("Error processing $executablePath: ${e.message}\n")
-                    } finally {
-                        batchFile?.delete()
-                    }
+                    // Create a batch file that Wine can execute, to handle paths with spaces in them
+                    batchFile = File(imageFs.getRootDir(), "tmp/steamless_wrapper.bat")
+                    batchFile.parentFile?.mkdirs()
+                    batchFile.writeText("@echo off\r\nz:\\Steamless\\Steamless.CLI.exe \"$windowsPath\"\r\n")
 
-                    // Process file moving for the executable
-                    try {
-                        val unixPath = executablePath.replace('\\', '/')
-                        val exe = File(imageFs.wineprefix + "/dosdevices/a:/" + unixPath)
-                        val unpackedExe = File(
-                            imageFs.wineprefix + "/dosdevices/a:/" + unixPath + ".unpacked.exe",
-                        )
-                        val originalExe = File(
-                            imageFs.wineprefix + "/dosdevices/a:/" + unixPath + ".original.exe",
-                        )
+                    val slCmd = "wine z:\\tmp\\steamless_wrapper.bat"
+                    val slOutput = guestProgramLauncherComponent.execShellCommand(slCmd)
+                    output.append(slOutput)
+                    Timber.i("Finished processing executable. Result: $output")
+                } catch (e: Exception) {
+                    Timber.e(e, "Error running Steamless on $executablePath")
+                    output.append("Error processing $executablePath: ${e.message}\n")
+                } finally {
+                    // Clean up batch file
+                    batchFile?.delete()
+                }
 
-                        val windowsPathForLog = "A:\\${executablePath.replace('/', '\\')}"
-                        Timber.i("Moving files for $windowsPathForLog")
-                        if (exe.exists() && unpackedExe.exists()) {
-                            if (originalExe.exists()) {
-                                Timber.i("Original backup exists for $windowsPathForLog; skipping overwrite")
-                            } else {
-                                Files.copy(exe.toPath(), originalExe.toPath(), REPLACE_EXISTING)
-                            }
-                            Files.copy(unpackedExe.toPath(), exe.toPath(), REPLACE_EXISTING)
-                            Timber.i("Successfully moved files for $windowsPathForLog")
+                // Process file moving for the executable
+                try {
+                    // container.executablePath uses forward slashes (Unix format)
+                    // Use as-is for File operations (forward slashes work on Unix/Android)
+                    val unixPath = executablePath.replace('\\', '/')
+                    val exe = File(imageFs.wineprefix + "/dosdevices/a:/" + unixPath)
+                    val unpackedExe = File(
+                        imageFs.wineprefix + "/dosdevices/a:/" + unixPath + ".unpacked.exe",
+                    )
+                    val originalExe = File(
+                        imageFs.wineprefix + "/dosdevices/a:/" + unixPath + ".original.exe",
+                    )
+
+                    // For logging, show Windows format
+                    val windowsPath = "A:\\${executablePath.replace('/', '\\')}"
+
+                    Timber.i("Moving files for $windowsPath")
+                    if (exe.exists() && unpackedExe.exists()) {
+                        if (originalExe.exists()) {
+                            Timber.i("Original backup exists for $windowsPath; skipping overwrite")
                         } else {
-                            val errorMsg =
-                                "Either exe or unpacked exe does not exist for $windowsPathForLog. Exe: ${exe.exists()}, Unpacked: ${unpackedExe.exists()}"
-                            Timber.w(errorMsg)
+                            Files.copy(exe.toPath(), originalExe.toPath(), REPLACE_EXISTING)
                         }
-                    } catch (e: Exception) {
-                        Timber.e(e, "Error moving files for $executablePath")
+                        Files.copy(unpackedExe.toPath(), exe.toPath(), REPLACE_EXISTING)
+                        Timber.i("Successfully moved files for $windowsPath")
+                    } else {
+                        val errorMsg =
+                            "Either exe or unpacked exe does not exist for $windowsPath. Exe: ${exe.exists()}, Unpacked: ${unpackedExe.exists()}"
+                        Timber.w(errorMsg)
                     }
+                } catch (e: Exception) {
+                    Timber.e(e, "Error moving files for $executablePath")
                 }
             }
         } else {

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -387,7 +387,6 @@ object ContainerUtils {
             container.getExtra("language", "english")
         }
         val previousForceDlc: Boolean = container.isForceDlc
-        val previousUnpackFiles: Boolean = container.isUnpackFiles
         val userRegFile = File(container.rootDir, ".wine/user.reg")
         WineRegistryEditor(userRegFile).use { registryEditor ->
             registryEditor.setStringValue("Software\\Wine\\Direct3D", "renderer", containerData.renderer)
@@ -450,9 +449,6 @@ object ContainerUtils {
         container.setForceDlc(containerData.forceDlc)
         container.setUseLegacyDRM(containerData.useLegacyDRM)
         container.setUnpackFiles(containerData.unpackFiles)
-        if (previousUnpackFiles != containerData.unpackFiles && containerData.unpackFiles) {
-            container.setNeedsUnpacking(true)
-        }
         container.putExtra("sharpnessEffect", containerData.sharpnessEffect)
         container.putExtra("sharpnessLevel", containerData.sharpnessLevel.toString())
         container.putExtra("sharpnessDenoise", containerData.sharpnessDenoise.toString())
@@ -1099,15 +1095,6 @@ object ContainerUtils {
         }
 
         return executables
-    }
-
-    /**
-     * Filters a list of exe paths to exclude system/utility executables (e.g. uninstallers, setup, crash handlers).
-     * Used when unpackFiles is enabled to determine which exes to run Steamless on.
-     */
-    fun filterExesForUnpacking(exePaths: List<String>): List<String> = exePaths.filter { path ->
-        val fileName = path.substringAfterLast('/').substringAfterLast('\\').lowercase()
-        !isSystemExecutable(fileName)
     }
 
     /**

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -331,10 +331,19 @@ object SteamUtils {
         val iniFile = File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/ColdClientLoader.ini")
         iniFile.parentFile?.mkdirs()
 
-        val injectionSection = """
+        // Only include DllsToInjectFolder if unpackFiles is enabled
+        val injectionSection = if (container.isUnpackFiles) {
+            """
+                [Injection]
+                IgnoreLoaderArchDifference=1
+                DllsToInjectFolder=extra_dlls
+            """
+        } else {
+            """
                 [Injection]
                 IgnoreLoaderArchDifference=1
             """
+        }
 
         iniFile.writeText(
             """
@@ -679,10 +688,18 @@ object SteamUtils {
         val imageFs = ImageFs.find(context)
         val container = ContainerUtils.getOrCreateContainer(context, appId)
         val cfgFile = File(imageFs.wineprefix, "drive_c/Program Files (x86)/Steam/steam.cfg")
-        if (!cfgFile.exists()){
-            cfgFile.parentFile?.mkdirs()
-            Files.createFile(cfgFile.toPath())
-            cfgFile.writeText("BootStrapperInhibitAll=Enable\nBootStrapperForceSelfUpdate=False")
+        if (container.isAllowSteamUpdates){
+            Timber.i("Allowing steam updates, deleting the steam.cfg file")
+            if (cfgFile.exists()){
+                Timber.i("Allowing steam updates and file exists, deleting the steam.cfg file")
+                cfgFile.delete()
+            }
+        } else {
+            if (!cfgFile.exists()){
+                cfgFile.parentFile?.mkdirs()
+                Files.createFile(cfgFile.toPath())
+                cfgFile.writeText("BootStrapperInhibitAll=Enable\nBootStrapperForceSelfUpdate=False")
+            }
         }
 
         // Update or modify localconfig.vdf

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -751,7 +751,7 @@
     <!-- TODO: Manual review - Container Configuration: Steam Integration (missing) -->
     <string name="use_legacy_drm">Brug ældre DRM</string>
     <string name="unpack_files">Udpak filer</string>
-    <string name="unpack_files_description">Brug kun, hvis du får \'Application Load Error 3:0000065432\'.</string>
+    <string name="unpack_files_description">Brug kun, hvis du får \'Application Load Error\'. Kan reducere FPS.</string>
 
     <!-- TODO: Manual review - Library Status -->
     <string name="library_status_ready">Klar</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -452,7 +452,7 @@
     <!-- Container Configuration: Steam Integration -->
     <string name="use_legacy_drm">Legacy DRM verwenden</string>
     <string name="unpack_files">Dateien entpacken</string>
-    <string name="unpack_files_description">Nur verwenden, wenn \'Application Load Error 3:0000065432\' auftritt.</string>
+    <string name="unpack_files_description">Nur verwenden, wenn \'Application Load Error\' auftritt. Kann die FPS reduzieren.</string>
     <string name="force_dlc">DLC erzwingen</string>
     <string name="force_dlc_description">Nur aktivieren, falls DLCs nicht erkannt werden oder Spielstände mit DLC nicht funktionieren</string>
     <string name="launch_steam_client_beta">Steam-Client starten (Beta)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -477,7 +477,7 @@
     <!-- Container Configuration: Steam Integration -->
     <string name="use_legacy_drm">Utiliser le DRM hérité</string>
     <string name="unpack_files">Décompresser les fichiers</string>
-    <string name="unpack_files_description">Utiliser uniquement si vous obtenez \'Application Load Error 3:0000065432\'.</string>
+    <string name="unpack_files_description">Utiliser uniquement si vous obtenez \'Application Load Error\'. Peut réduire les FPS.</string>
     <string name="force_dlc">Forcer les DLC</string>
     <string name="force_dlc_description">N\'activer que si les DLC ne sont pas détectés ou si les sauvegardes avec DLC ne fonctionnent pas</string>
     <string name="launch_steam_client_beta">Lancer le client Steam (Bêta)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -481,7 +481,7 @@
     <!-- Container Configuration: Steam Integration -->
     <string name="use_legacy_drm">Usa DRM Legacy</string>
     <string name="unpack_files">Estrai file</string>
-    <string name="unpack_files_description">Usa solo se ottieni \'Application Load Error 3:0000065432\'.</string>
+    <string name="unpack_files_description">Usa solo se ottieni \'Application Load Error\'. Può ridurre gli FPS.</string>
     <string name="force_dlc">Forza DLC</string>
     <string name="force_dlc_description">Abilita solo se i DLC non vengono rilevati o i salvataggi con DLC non funzionano</string>
     <string name="launch_steam_client_beta">Avvia Client Steam (Beta)</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -489,7 +489,7 @@
     <!-- Container Configuration: Steam Integration -->
     <string name="use_legacy_drm">Użyj Legacy DRM</string>
     <string name="unpack_files">Rozpakuj pliki</string>
-    <string name="unpack_files_description">Używaj tylko w przypadku błędu \'Application Load Error 3:0000065432\'.</string>
+    <string name="unpack_files_description">Używaj tylko w przypadku błędu \'Application Load Error\'. Może zmniejszyć FPS.</string>
     <string name="force_dlc">Wymuś DLC</string>
     <string name="force_dlc_description">Włącz tylko jeśli DLC nie są wykrywane lub zapisy z DLC nie działają</string>
     <string name="launch_steam_client_beta">Uruchom Klienta Steam (Beta)</string>
@@ -590,7 +590,7 @@
     <string name="driver_manager">Menedżer sterowników</string>
     <string name="select_a_driver">Wybierz sterownik</string>
     <string name="import_zip_from_device">Importuj ZIP z urządzenia</string>
-
+    
     <!-- Contents Manager -->
     <string name="contents_manager">Menedżer zawartości</string>
     <string name="import_wcp_from_device">Importuj .wcp z urządzenia</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -751,7 +751,7 @@
     <!-- TODO: Revisão manual - Container Configuration: Steam Integration (faltando) -->
     <string name="use_legacy_drm">Usar DRM legado</string>
     <string name="unpack_files">Descompactar arquivos</string>
-    <string name="unpack_files_description">Use apenas se receber \'Application Load Error 3:0000065432\'.</string>
+    <string name="unpack_files_description">Use apenas se receber \'Application Load Error\'. Pode reduzir FPS.</string>
 
     <!-- TODO: Revisão manual - Library Status -->
     <string name="library_status_ready">Pronto</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -482,7 +482,7 @@
     <!-- Container Configuration: Steam Integration -->
 	<string name="use_legacy_drm">Folosește DRM vechi</string>
 	<string name="unpack_files">Dezarhivează fișiere</string>
-	<string name="unpack_files_description">Folosește doar dacă primești \'Application Load Error 3:0000065432\'.</string>
+	<string name="unpack_files_description">Folosește doar dacă primești \'Application Load Error\'. Poate reduce FPS.</string>
 	<string name="force_dlc">Forțează DLC</string>
 	<string name="force_dlc_description">Activează doar dacă DLC‑urile nu sunt detectate sau salvările cu DLC nu funcționează</string>
 	<string name="launch_steam_client_beta">Pornește Steam Client (Beta)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -473,7 +473,7 @@
     <!-- Container Configuration: Steam Integration -->
     <string name="use_legacy_drm">Попередній метод DRM</string>
     <string name="unpack_files">Розпакувати файли</string>
-    <string name="unpack_files_description">Використовувати лише якщо з\'являється \'Application Load Error 3:0000065432\'.</string>
+    <string name="unpack_files_description">Використовувати лише якщо з\'являється \'Application Load Error\'. Може знизити FPS.</string>
     <string name="force_dlc">Примусити DLC</string>
     <string name="force_dlc_description">Увімкнути лише тоді, якщо не виявлено DLC або не працюють збереження з DLC</string>
     <string name="launch_steam_client_beta">Запустити клієнт Steam (Бета)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -490,7 +490,7 @@
     <!-- Container Configuration: Steam Integration -->
     <string name="use_legacy_drm">Use Legacy DRM</string>
     <string name="unpack_files">Unpack Files</string>
-    <string name="unpack_files_description">Only use if you get \'Application Load Error 3:0000065432\'.</string>
+    <string name="unpack_files_description">Only use if you get \'Application Load Error\'. May reduce FPS.</string>
     <string name="force_dlc">Force DLC</string>
     <string name="force_dlc_description">Only enable if DLCs are not detected or saves with DLC are not working</string>
     <string name="launch_steam_client_beta">Launch Steam Client (Beta)</string>

--- a/manifest.json
+++ b/manifest.json
@@ -652,7 +652,7 @@
     ],
     "fexcore": [
       {
-        "id": "2601-217d039-0",
+        "id": "2601-217d039",
         "name": "FEX 2601-217d039",
         "url": "https://downloads.gamenative.app/FEXCore-2601-217d039.wcp",
         "variant": "bionic"


### PR DESCRIPTION
Reverts utkarshdalal/GameNative#506

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that ran Steamless on all detected executables. Restores the earlier behavior and adds a toggle to allow Steam client updates when launching real Steam.

- **New Features**
  - Added “Allow Steam updates” when Launch Real Steam is enabled. Automatically deletes or creates steam.cfg to allow or block updates.

- **Bug Fixes**
  - Restored Steamless handling to only process the configured executable and only when Unpack Files is off (no drive scan or multi-exe processing).
  - Only writes DllsToInjectFolder to ColdClientLoader.ini when Unpack Files is on.
  - Updated “Unpack Files” help text across locales (generic Application Load Error + FPS note), corrected FEX manifest id, and improved controller VDF logging.

<sup>Written for commit 799a6be477a81e0428f648926e3ef6c6dcf6a5c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Steam update setting toggle (available when launching Real Steam client)

* **Documentation**
  * Updated "Unpack Files" feature descriptions across all languages to reflect generic error references and note potential performance impact

<!-- end of auto-generated comment: release notes by coderabbit.ai -->