### PR TITLE
on unpack, add back the dll to inject in addition to running steamles…

### DIFF
--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -331,10 +331,19 @@ object SteamUtils {
         val iniFile = File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/ColdClientLoader.ini")
         iniFile.parentFile?.mkdirs()
 
-        val injectionSection = """
+        // Only include DllsToInjectFolder if unpackFiles is enabled
+        val injectionSection = if (container.isUnpackFiles) {
+            """
+                [Injection]
+                IgnoreLoaderArchDifference=1
+                DllsToInjectFolder=extra_dlls
+            """
+        } else {
+            """
                 [Injection]
                 IgnoreLoaderArchDifference=1
             """
+        }
 
         iniFile.writeText(
             """


### PR DESCRIPTION
…s on all exes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore DLL injection when unpack mode is enabled by setting DllsToInjectFolder=extra_dlls in ColdClientLoader.ini. Keeps injection off for normal runs to avoid side effects.

<sup>Written for commit 5b9f7aef367078fa191f6ee12c936cf2ed320450. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DLL injection configuration handling to conditionally apply injection folder settings only when files are unpacked, preventing unnecessary configuration in other scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->