### PR TITLE
feat: add steam force cloud sync up/down

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -967,7 +967,7 @@ class SteamAppScreen : BaseAppScreen() {
                         withContext(Dispatchers.Main) {
                             Toast.makeText(
                                 context,
-                                "Uploading local saves to cloud...",
+                                context.getString(R.string.steam_cloud_uploading_local_saves),
                                 Toast.LENGTH_SHORT
                             ).show()
                         }
@@ -983,21 +983,24 @@ class SteamAppScreen : BaseAppScreen() {
                                 SyncResult.Success -> {
                                     Toast.makeText(
                                         context,
-                                        "Successfully uploaded local saves to cloud",
+                                        context.getString(R.string.steam_cloud_upload_success),
                                         Toast.LENGTH_SHORT
                                     ).show()
                                 }
                                 SyncResult.UpToDate -> {
                                     Toast.makeText(
                                         context,
-                                        "Cloud saves are already up to date",
+                                        context.getString(R.string.steam_cloud_upload_up_to_date),
                                         Toast.LENGTH_SHORT
                                     ).show()
                                 }
                                 else -> {
                                     Toast.makeText(
                                         context,
-                                        "Failed to upload saves: ${syncResult.syncResult}",
+                                        context.getString(
+                                            R.string.steam_cloud_upload_failed,
+                                            syncResult.syncResult
+                                        ),
                                         Toast.LENGTH_SHORT
                                     ).show()
                                 }
@@ -1037,7 +1040,7 @@ class SteamAppScreen : BaseAppScreen() {
                         withContext(Dispatchers.Main) {
                             Toast.makeText(
                                 context,
-                                "Downloading cloud saves...",
+                                context.getString(R.string.steam_cloud_downloading_remote_saves),
                                 Toast.LENGTH_SHORT
                             ).show()
                         }
@@ -1053,21 +1056,24 @@ class SteamAppScreen : BaseAppScreen() {
                                 SyncResult.Success -> {
                                     Toast.makeText(
                                         context,
-                                        "Successfully downloaded cloud saves",
+                                        context.getString(R.string.steam_cloud_download_success),
                                         Toast.LENGTH_SHORT
                                     ).show()
                                 }
                                 SyncResult.UpToDate -> {
                                     Toast.makeText(
                                         context,
-                                        "Local saves are already up to date",
+                                        context.getString(R.string.steam_cloud_download_up_to_date),
                                         Toast.LENGTH_SHORT
                                     ).show()
                                 }
                                 else -> {
                                     Toast.makeText(
                                         context,
-                                        "Failed to download saves: ${syncResult.syncResult}",
+                                        context.getString(
+                                            R.string.steam_cloud_download_failed,
+                                            syncResult.syncResult
+                                        ),
                                         Toast.LENGTH_SHORT
                                     ).show()
                                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,14 @@
     <string name="steam_cloud_sync_success">Cloud sync completed successfully</string>
     <string name="steam_cloud_sync_up_to_date">Save files are already up to date</string>
     <string name="steam_cloud_sync_failed">Cloud sync failed: %s</string>
+    <string name="steam_cloud_uploading_local_saves">Uploading local saves to cloud…</string>
+    <string name="steam_cloud_upload_success">Successfully uploaded local saves to cloud</string>
+    <string name="steam_cloud_upload_up_to_date">Cloud saves are already up to date</string>
+    <string name="steam_cloud_upload_failed">Failed to upload saves: %s</string>
+    <string name="steam_cloud_downloading_remote_saves">Downloading cloud saves…</string>
+    <string name="steam_cloud_download_success">Successfully downloaded cloud saves</string>
+    <string name="steam_cloud_download_up_to_date">Local saves are already up to date</string>
+    <string name="steam_cloud_download_failed">Failed to download saves: %s</string>
     <string name="steam_not_logged_in">You must be logged into Steam to use this feature</string>
     <string name="steam_storage_permission_required">Storage permission required</string>
     <string name="steam_container_reset_success">Container reset to defaults</string>


### PR DESCRIPTION
Force upload and Force download cloud saves, per:

https://discord.com/channels/1378308569287622737/1472280625808674857

sticking with only Steam for now, GOG and Epic could do similar treatment but I've not tested those yet. This worked pretty well in my tests however!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds manual “Force Upload Local” and “Force Download Remote” actions for Steam cloud saves with localized status toasts. Steam only for now.

- **New Features**
  - New Steam app menu options to force-upload local saves to cloud or force-download cloud saves to local (uses Local/Remote SaveLocation).
  - Localized progress and result toasts (uploading/downloading, success, up-to-date, failure) and login checks for Steam.
  - Activates the game container, resolves save paths before syncing, and emits PostHog events: cloud_upload_forced and cloud_download_forced.

<sup>Written for commit f2ccbebcef60fad5856a9de827ded843e4e3ae89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added menu options to force upload local saves to Steam Cloud or force download cloud saves to local storage, with Steam login and container checks and real-time status toasts.
  * New UI strings for upload/download status and results.
* **Chores**
  * Emits analytics events when forced upload/download actions are triggered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->