### PR TITLE
Fix rumble on devices such as Ayn Odin 2

### DIFF
--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -576,10 +576,10 @@ public class WinHandler {
             while (running) {
                 // --- MODIFIED: Get the current profile state on EVERY loop iteration ---
                 try {
-                    final ControlsProfile profile = inputControlsView.getProfile();
-                    final boolean useVirtualGamepad = profile != null && profile.isVirtualGamepad();
-                    // This condition now uses the fresh, up-to-date 'useVirtualGamepad' variable
-                    if (gamepadBuffer != null && (currentController != null || useVirtualGamepad)) {
+                    // Always poll for rumble if gamepad buffer exists, regardless of controller state
+                    // This ensures vibration works with built-in controllers (like Ayn Odin 2)
+                    // even when virtual gamepad mode is disabled
+                    if (gamepadBuffer != null) {
                         // Read the rumble values from the shared memory file.
                         short lowFreq = gamepadBuffer.getShort(32);
                         short highFreq = gamepadBuffer.getShort(34);


### PR DESCRIPTION
The rumble poller now always runs when the gamepad buffer exists, regardless of virtual gamepad mode or controller detection state. This ensures rumble works on devices with built-in controllers (like Ayn Odin 2) even when the on-screen controller overlay is disabled.

The existing fallback logic (try controller vibrator -> fall back to device rumble) ensures both external controllers and built-in controllers work correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing vibration when on-screen controls are disabled by always polling the rumble buffer. Restores haptics for built-in controllers like the Ayn Odin 2 while keeping a safe fallback to device vibration.

- **Bug Fixes**
  - Always run rumble poller when gamepadBuffer exists, regardless of virtual gamepad or controller detection.
  - Fallback flow: try controller vibrator first; otherwise use device vibrator with haptic curve (renamed phoneVibrator to deviceVibrator and clarified comments).

<sup>Written for commit 990db2ccc6ff13d0bdc9943163f6261e1bdb59c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller vibration and rumble reliability by changing polling to read rumble data whenever a gamepad buffer exists, regardless of virtual gamepad enablement or current controller state
  * Refined vibration fallback to ensure consistent haptic feedback when a physical controller is unavailable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->