### PR TITLE
Added better support for pocket taco/8bitdo flippad type portrait con…

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2,6 +2,7 @@ package app.gamenative.ui.screen.xserver
 
 import android.app.Activity
 import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Build
 import android.util.Log
@@ -10,6 +11,7 @@ import android.view.ViewGroup
 import android.view.WindowInsets
 import android.view.inputmethod.InputMethodManager
 import android.widget.FrameLayout
+import android.widget.LinearLayout
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
@@ -43,6 +45,7 @@ import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.pointerInteropFilter
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
@@ -319,6 +322,7 @@ fun XServerScreen(
     var isKeyboardVisible = false
     var areControlsVisible by remember { mutableStateOf(false) }
     var isEditMode by remember { mutableStateOf(false) }
+    var gameRoot by remember { mutableStateOf<View?>(null) }
     // Snapshot of element positions before entering edit mode (for cancel behavior)
     var elementPositionsSnapshot by remember { mutableStateOf<Map<com.winlator.inputcontrols.ControlElement, Pair<Int, Int>>>(emptyMap()) }
     var showElementEditor by remember { mutableStateOf(false) }
@@ -640,6 +644,7 @@ fun XServerScreen(
         }
     }
 
+    val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
     // var launchedView by rememberSaveable { mutableStateOf(false) }
     Box(modifier = Modifier.fillMaxSize()) {
         AndroidView(
@@ -652,23 +657,40 @@ fun XServerScreen(
                     ?.dispatchTouchEvent(event) == true
                 if (overlayHandled) return@pointerInteropFilter true
 
-                // If controls are visible, let them handle it first
-                val controlsHandled = if (areControlsVisible) {
-                    PluviaApp.inputControlsView?.onTouchEvent(event) ?: false
+                if (isPortrait) {
+                    gameRoot?.dispatchTouchEvent(event)
                 } else {
-                    false
+                    val controlsHandled = if (areControlsVisible) {
+                        PluviaApp.inputControlsView?.onTouchEvent(event) ?: false
+                    } else {
+                        false
+                    }
+                    if (!controlsHandled) {
+                        PluviaApp.touchpadView?.onTouchEvent(event)
+                    }
                 }
-
-                // If controls didn't handle it or aren't visible, send to touchMouse
-                if (!controlsHandled) {
-                    PluviaApp.touchpadView?.onTouchEvent(event)
-                }
-
                 true
             },
         factory = { context ->
             Timber.i("Creating XServerView and XServer")
-            val frameLayout = FrameLayout(context)
+            val isPortrait = context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+            val dm = context.resources.displayMetrics
+            val controlsHeightPortrait = dm.widthPixels * 9 / 16
+            val mainRoot = if (isPortrait) {
+                LinearLayout(context).apply {
+                    orientation = LinearLayout.VERTICAL
+                    setBackgroundColor(Color.TRANSPARENT)
+                }
+            } else {
+                FrameLayout(context)
+            }
+            val frameLayout = if (isPortrait) {
+                val top = FrameLayout(context)
+                mainRoot.addView(top, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f))
+                top
+            } else {
+                mainRoot as FrameLayout
+            }
             val appId = appId
             val existingXServer =
                 PluviaApp.xEnvironment
@@ -971,8 +993,16 @@ fun XServerScreen(
 
 
 
-            // Add InputControlsView on top of XServerView
-            frameLayout.addView(icView)
+            // Add InputControlsView (portrait: inside fixed-height container at bottom; landscape: overlay)
+            if (isPortrait) {
+                val controlsContainer = FrameLayout(context).apply {
+                    setBackgroundColor(Color.BLACK)
+                }
+                mainRoot.addView(controlsContainer, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, controlsHeightPortrait))
+                controlsContainer.addView(icView)
+            } else {
+                frameLayout.addView(icView)
+            }
             val configuredExternalMode = ExternalDisplayInputController.fromConfig(container.externalDisplayMode)
             val swapEnabled = container.isExternalDisplaySwap
 
@@ -1032,7 +1062,7 @@ fun XServerScreen(
                 } else {
                     null
                 }
-            frameLayout.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+            mainRoot.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
                 override fun onViewAttachedToWindow(v: View) {}
 
                 override fun onViewDetachedFromWindow(v: View) {
@@ -1097,7 +1127,7 @@ fun XServerScreen(
                 PluviaApp.touchpadView?.setTouchscreenMouseDisabled(true);
             }
 
-            frameLayout
+            mainRoot
 
             // } else {
             //     Log.d("XServerScreen", "Creating XServerView without creating XServer")
@@ -1106,16 +1136,10 @@ fun XServerScreen(
             // xServerView
         },
         update = { view ->
-            // View's been inflated or state read in this block has been updated
-            // Add logic here if necessary
-            // view.requestFocus()
+            gameRoot = view
         },
         onRelease = { view ->
-            // view.releasePointerCapture()
-            // pointerEventListener?.let {
-            //     view.removePointerEventListener(pointerEventListener)
-            //     view.onRelease()
-            // }
+            gameRoot = null
         },
     )
 


### PR DESCRIPTION
…trollers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a portrait-specific layout and touch routing to better support Pocket TACO/8BitDo FlipPad-style controllers. Game stays on top; controls live in a fixed-height bottom panel for a more consistent feel.

- **New Features**
  - Portrait layout: game on top; controls in a bottom container sized to 9:16 of screen width (black background).
  - Touch routing: in portrait, events go directly to the game view; landscape behavior unchanged (controls first, then touchpad).

<sup>Written for commit 8e97aa3414529883585fae1dd397b642662022a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Added adaptive control layout system that automatically adjusts placement based on device orientation (portrait displays controls at the bottom; landscape as overlay)
  * Enhanced touch input dispatch and event routing to optimize interactions across different screen orientations
  * Improved internal view management for better stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->