### PR TITLE
fix: prevent crashes from stale intents after process death

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1253,7 +1253,13 @@ fun PluviaMain(
                                         MainActivity.wasLaunchedViaExternalIntent = false
                                         (context as? android.app.Activity)?.finish()
                                     } else {
-                                        navController.popBackStack()
+                                        // pop to Home to avoid loops after process death
+                                        val popped = navController.popBackStack(PluviaScreen.Home.route, inclusive = false)
+                                        if (!popped) {
+                                            navController.navigate(PluviaScreen.Home.route) {
+                                                popUpTo(navController.graph.id) { inclusive = true }
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -267,8 +267,19 @@ fun XServerScreen(
         isExiting.set(false)
     }
 
+    // after process death the container may no longer exist
     val container = remember(appId) {
-        ContainerUtils.getContainer(context, appId)
+        try {
+            ContainerUtils.getContainer(context, appId)
+        } catch (e: Exception) {
+            Timber.e(e, "Container unavailable for $appId, likely process death")
+            null
+        }
+    }
+
+    if (container == null) {
+        LaunchedEffect(Unit) { navigateBack() }
+        return
     }
 
     val suspendPolicy = remember(container.id) { container.suspendPolicy }


### PR DESCRIPTION
## Summary
- Guard `getContainer()` in XServerScreen — if container is gone after process death, navigate back instead of crashing
- Pop to Home (not just one level) when exiting XServer, with fallback to clear entire backstack if Home is missing

## Test plan
- [ ] Kill app process while game is running, reopen via recent tasks — should land on Home, not crash
- [ ] Normal game launch/exit flow still works as before

Fixes #619