### PR TITLE
fix: pass FEXCore preset from container to launcher

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1832,6 +1832,9 @@ private fun setupXEnvironment(
         guestProgramLauncherComponent.box86Version = container.box86Version
         guestProgramLauncherComponent.box86Preset = container.box86Preset
         guestProgramLauncherComponent.box64Preset = container.box64Preset
+        if (guestProgramLauncherComponent is BionicProgramLauncherComponent) {
+            guestProgramLauncherComponent.setFEXCorePreset(container.fexCorePreset)
+        }
         guestProgramLauncherComponent.setPreUnpack {
             unpackExecutableFile(
                 context = context,
@@ -1947,6 +1950,7 @@ private fun setupXEnvironment(
         Timber.i("Box64 Preset: ${container.box64Preset}")
         Timber.i("Box86 Version: ${container.box86Version}")
         Timber.i("Box86 Preset: ${container.box86Preset}")
+        Timber.i("FEXCore Preset: ${container.fexCorePreset}")
         Timber.i("CPU List: ${container.cpuList}")
         Timber.i("CPU List WoW64: ${container.cpuListWoW64}")
         Timber.i("Env Vars (Container Base): ${container.envVars}") // Log base container vars


### PR DESCRIPTION
## Summary
- Fixes #561
- `container.fexCorePreset` was persisted and loaded correctly but never passed to `BionicProgramLauncherComponent` at launch time
- ARM64EC games always ran with `INTERMEDIATE` FEXCore preset regardless of user configuration
- Adds missing `setFEXCorePreset()` call alongside existing box86/box64 preset bridging

## Verification
Boot to container desktop, open `cmd.exe`, run `set FEX`. Env vars should match the configured preset (e.g. PERFORMANCE → `FEX_TSOENABLED=0`). Before fix, always shows INTERMEDIATE values (`FEX_TSOENABLED=1`, `FEX_VECTORTSOENABLED=0`).

## Test plan
- [ ] Set FEXCore preset to PERFORMANCE, launch ARM64EC game, verify `FEX_TSOENABLED=0` inside container
- [ ] Set FEXCore preset to STABILITY, launch ARM64EC game, verify `FEX_MULTIBLOCK=0` inside container
- [ ] Verify x86_64 (non-ARM64EC) bionic path unaffected
- [ ] Verify glibc path unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass the configured FEXCore preset from the container to the ARM64EC launcher so games use the user-selected preset. Also logs the preset; fixes ARM64EC previously always running with INTERMEDIATE; x86_64 bionic and glibc paths remain unchanged.

<sup>Written for commit 9a2cd5c01d0ceec3ef87012c0d860518a135ba45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FEXCore preset handling during X server environment setup to ensure better compatibility with certain runtime components; added preset logging to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->