### PR TITLE
Streamlined launch dependencies retrieval flow

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -86,11 +86,7 @@ import com.google.android.play.core.splitcompat.SplitCompat
 import com.winlator.container.Container
 import com.winlator.container.ContainerData
 import com.winlator.container.ContainerManager
-import com.winlator.core.TarCompressorUtils
-import com.winlator.xenvironment.ImageFs
-import com.winlator.xenvironment.ImageFsInstaller
 import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientObjects.ECloudPendingRemoteOperation
-import java.io.File
 import java.util.Date
 import java.util.EnumSet
 import kotlin.reflect.KFunction2
@@ -1197,70 +1193,12 @@ fun preLaunchApp(
         }
 
         // Check if this is a Custom Game and validate executable selection before installing components
-        // Skip the check if booting to container (Open Container menu option)
         val isCustomGame = gameSource == GameSource.CUSTOM_GAME
 
         // set up Ubuntu file system
         SplitCompat.install(context)
-        if (!SteamService.isImageFsInstallable(context, container.containerVariant)) {
-            setLoadingMessage("Downloading first-time files")
-            SteamService.downloadImageFs(
-                onDownloadProgress = { setLoadingProgress(it / 1.0f) },
-                this,
-                variant = container.containerVariant,
-                context = context,
-            ).await()
-        }
-        if (container.containerVariant.equals(Container.GLIBC) &&
-            !SteamService.isFileInstallable(context, "imagefs_patches_gamenative.tzst")
-        ) {
-            setLoadingMessage("Downloading Wine")
-            SteamService.downloadImageFsPatches(
-                onDownloadProgress = { setLoadingProgress(it / 1.0f) },
-                this,
-                context = context,
-            ).await()
-        } else {
-            if (container.wineVersion.contains("proton-9.0-arm64ec") &&
-                !SteamService.isFileInstallable(context, "proton-9.0-arm64ec.txz")
-            ) {
-                setLoadingMessage("Downloading arm64ec Proton")
-                SteamService.downloadFile(
-                    onDownloadProgress = { setLoadingProgress(it / 1.0f) },
-                    this,
-                    context = context,
-                    "proton-9.0-arm64ec.txz",
-                ).await()
-            } else if (container.wineVersion.contains("proton-9.0-x86_64") &&
-                !SteamService.isFileInstallable(context, "proton-9.0-x86_64.txz")
-            ) {
-                setLoadingMessage("Downloading x86_64 Proton")
-                SteamService.downloadFile(
-                    onDownloadProgress = { setLoadingProgress(it / 1.0f) },
-                    this,
-                    context = context,
-                    "proton-9.0-x86_64.txz",
-                ).await()
-            }
-            if (container.wineVersion.contains("proton-9.0-x86_64") || container.wineVersion.contains("proton-9.0-arm64ec")) {
-                val protonVersion = container.wineVersion
-                val imageFs = ImageFs.find(context)
-                val outFile = File(imageFs.rootDir, "/opt/$protonVersion")
-                val binDir = File(outFile, "bin")
-                if (!binDir.exists() || !binDir.isDirectory) {
-                    Timber.i("Extracting $protonVersion to /opt/")
-                    setLoadingMessage("Extracting $protonVersion")
-                    setLoadingProgress(-1f)
-                    val downloaded = File(imageFs.getFilesDir(), "$protonVersion.txz")
-                    TarCompressorUtils.extract(
-                        TarCompressorUtils.Type.XZ,
-                        downloaded,
-                        outFile,
-                    )
-                }
-            }
-        }
 
+        // Ensure launch dependencies (imagefs, Wine/Proton, DRM, Steam client, install)
         if (!isOffline) {
             try {
                 LaunchDependencies().ensureLaunchDependencies(
@@ -1285,52 +1223,7 @@ fun preLaunchApp(
                 )
                 return@launch
             }
-        } else {
-            Timber.tag("preLaunchApp").e("Offline mode, skipping launch dependencies")
         }
-
-        if (!container.isUseLegacyDRM && !container.isLaunchRealSteam &&
-            !SteamService.isFileInstallable(context, "experimental-drm-20260116.tzst")
-        ) {
-            setLoadingMessage("Downloading extras")
-            SteamService.downloadFile(
-                onDownloadProgress = { setLoadingProgress(it / 1.0f) },
-                this,
-                context = context,
-                "experimental-drm-20260116.tzst",
-            ).await()
-        }
-        if (container.isLaunchRealSteam && !SteamService.isFileInstallable(context, "steam.tzst")) {
-            setLoadingMessage(context.getString(R.string.main_downloading_steam))
-            SteamService.downloadSteam(
-                onDownloadProgress = { setLoadingProgress(it / 1.0f) },
-                this,
-                context = context,
-            ).await()
-        }
-        if (container.isLaunchRealSteam && !SteamService.isFileInstallable(context, "steam-token.tzst")) {
-            setLoadingMessage("Downloading steam-token")
-            SteamService.downloadFile(
-                onDownloadProgress = { setLoadingProgress(it / 1.0f) },
-                this,
-                context = context,
-                "steam-token.tzst",
-            ).await()
-        }
-
-        val loadingMessage = if (container.containerVariant.equals(Container.GLIBC)) {
-            context.getString(R.string.main_installing_glibc)
-        } else {
-            context.getString(R.string.main_installing_bionic)
-        }
-        setLoadingMessage(loadingMessage)
-        val imageFsInstallSuccess =
-            ImageFsInstaller.installIfNeededFuture(context, context.assets, container) { progress ->
-                // Log.d("XServerScreen", "$progress")
-                setLoadingProgress(progress / 100f)
-            }.get()
-        setLoadingMessage(context.getString(R.string.main_loading))
-        setLoadingProgress(-1f)
 
         // must activate container before downloading save files
         containerManager.activateContainer(container)

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -72,10 +72,8 @@ import app.gamenative.ui.screen.login.UserLoginScreen
 import app.gamenative.ui.screen.settings.SettingsScreen
 import app.gamenative.ui.screen.xserver.XServerScreen
 import app.gamenative.ui.theme.PluviaTheme
-import app.gamenative.utils.BestConfigService
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.CustomGameScanner
-import app.gamenative.utils.ManifestInstaller
 import app.gamenative.utils.GameFeedbackUtils
 import app.gamenative.utils.IntentLaunchManager
 import app.gamenative.utils.UpdateChecker
@@ -1164,30 +1162,6 @@ fun preLaunchApp(
                         actionBtnText = AppOptionMenuType.EditContainer.text,
                     ),
                 )
-                return@launch
-            }
-        }
-
-        // download any manifest components (wine/proton, dxvk, etc.) missing from config
-        if (gameSource == GameSource.STEAM) {
-            try {
-                val configJson = Json.parseToJsonElement(container.containerJson).jsonObject
-                val missingRequests = BestConfigService.resolveMissingManifestInstallRequests(
-                    context, configJson, "exact_gpu_match",
-                )
-                for (request in missingRequests) {
-                    setLoadingMessage(context.getString(R.string.main_downloading_entry, request.entry.name))
-                    try {
-                        ManifestInstaller.installManifestEntry(
-                            context, request.entry, request.isDriver, request.contentType,
-                        ) { progress -> setLoadingProgress(progress.coerceIn(0f, 1f)) }
-                    } catch (e: Exception) {
-                        Timber.e(e, "Failed to install ${request.entry.name}, continuing")
-                    }
-                }
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to install manifest components")
-                setLoadingDialogVisible(false)
                 return@launch
             }
         }

--- a/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
+++ b/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
@@ -12,6 +12,7 @@ import app.gamenative.utils.launchdependencies.LaunchDependencyCallbacks
 import app.gamenative.utils.launchdependencies.LaunchDependency
 import app.gamenative.utils.launchdependencies.ProtonPackageDependency
 import app.gamenative.utils.launchdependencies.SteamClientDependency
+import app.gamenative.utils.launchdependencies.SteamManifestDependency
 import app.gamenative.utils.launchdependencies.SteamTokenDependency
 import com.winlator.container.Container
 
@@ -27,6 +28,7 @@ class LaunchDependencies {
         private val launchDependencies: List<LaunchDependency> = listOf(
             ImageFsBaseDependency,
             ImageFsPatchesDependency,
+            SteamManifestDependency,
             ProtonPackageDependency("proton-9.0-arm64ec.txz", "arm64ec"),
             ProtonPackageDependency("proton-9.0-x86_64.txz", "x86_64"),
             DrmExtrasDependency,

--- a/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
+++ b/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
@@ -3,6 +3,7 @@ package app.gamenative.utils
 import android.content.Context
 import app.gamenative.R
 import app.gamenative.data.GameSource
+import app.gamenative.utils.launchdependencies.DrmExtrasDependency
 import app.gamenative.utils.launchdependencies.GogScriptInterpreterDependency
 import app.gamenative.utils.launchdependencies.ImageFsBaseDependency
 import app.gamenative.utils.launchdependencies.ImageFsInstallDependency
@@ -28,6 +29,7 @@ class LaunchDependencies {
             ImageFsPatchesDependency,
             ProtonPackageDependency("proton-9.0-arm64ec.txz", "arm64ec"),
             ProtonPackageDependency("proton-9.0-x86_64.txz", "x86_64"),
+            DrmExtrasDependency,
             SteamClientDependency,
             SteamTokenDependency,
             ImageFsInstallDependency,

--- a/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
+++ b/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import app.gamenative.R
 import app.gamenative.data.GameSource
 import app.gamenative.utils.launchdependencies.GogScriptInterpreterDependency
+import app.gamenative.utils.launchdependencies.ImageFsBaseDependency
+import app.gamenative.utils.launchdependencies.ImageFsInstallDependency
+import app.gamenative.utils.launchdependencies.ImageFsPatchesDependency
 import app.gamenative.utils.launchdependencies.LaunchDependencyCallbacks
 import app.gamenative.utils.launchdependencies.LaunchDependency
 import app.gamenative.utils.launchdependencies.ProtonPackageDependency
@@ -21,10 +24,13 @@ const val LOADING_PROGRESS_UNKNOWN: Float = -1f
 class LaunchDependencies {
     companion object {
         private val launchDependencies: List<LaunchDependency> = listOf(
+            ImageFsBaseDependency,
+            ImageFsPatchesDependency,
             ProtonPackageDependency("proton-9.0-arm64ec.txz", "arm64ec"),
             ProtonPackageDependency("proton-9.0-x86_64.txz", "x86_64"),
             SteamClientDependency,
             SteamTokenDependency,
+            ImageFsInstallDependency,
             GogScriptInterpreterDependency,
         )
     }

--- a/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
+++ b/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
@@ -7,6 +7,8 @@ import app.gamenative.utils.launchdependencies.GogScriptInterpreterDependency
 import app.gamenative.utils.launchdependencies.LaunchDependencyCallbacks
 import app.gamenative.utils.launchdependencies.LaunchDependency
 import app.gamenative.utils.launchdependencies.ProtonPackageDependency
+import app.gamenative.utils.launchdependencies.SteamClientDependency
+import app.gamenative.utils.launchdependencies.SteamTokenDependency
 import com.winlator.container.Container
 
 const val LOADING_PROGRESS_UNKNOWN: Float = -1f
@@ -21,6 +23,8 @@ class LaunchDependencies {
         private val launchDependencies: List<LaunchDependency> = listOf(
             ProtonPackageDependency("proton-9.0-arm64ec.txz", "arm64ec"),
             ProtonPackageDependency("proton-9.0-x86_64.txz", "x86_64"),
+            SteamClientDependency,
+            SteamTokenDependency,
             GogScriptInterpreterDependency,
         )
     }

--- a/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
+++ b/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
@@ -6,6 +6,7 @@ import app.gamenative.data.GameSource
 import app.gamenative.utils.launchdependencies.GogScriptInterpreterDependency
 import app.gamenative.utils.launchdependencies.LaunchDependencyCallbacks
 import app.gamenative.utils.launchdependencies.LaunchDependency
+import app.gamenative.utils.launchdependencies.ProtonPackageDependency
 import com.winlator.container.Container
 
 const val LOADING_PROGRESS_UNKNOWN: Float = -1f
@@ -18,6 +19,8 @@ const val LOADING_PROGRESS_UNKNOWN: Float = -1f
 class LaunchDependencies {
     companion object {
         private val launchDependencies: List<LaunchDependency> = listOf(
+            ProtonPackageDependency("proton-9.0-arm64ec.txz", "arm64ec"),
+            ProtonPackageDependency("proton-9.0-x86_64.txz", "x86_64"),
             GogScriptInterpreterDependency,
         )
     }

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/DrmExtrasDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/DrmExtrasDependency.kt
@@ -1,0 +1,32 @@
+package app.gamenative.utils.launchdependencies
+
+import android.content.Context
+import app.gamenative.R
+import app.gamenative.data.GameSource
+import app.gamenative.service.SteamService
+import com.winlator.container.Container
+import kotlinx.coroutines.coroutineScope
+
+/** DRM extras (conditional on container flags). */
+internal object DrmExtrasDependency : LaunchDependency {
+    override fun appliesTo(container: Container, gameSource: GameSource, gameId: Int) =
+        !container.isUseLegacyDRM && !container.isLaunchRealSteam
+    override fun isSatisfied(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        SteamService.isFileInstallable(context, "experimental-drm-20260116.tzst")
+    override fun getLoadingMessage(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        context.getString(R.string.main_downloading_extras)
+    override suspend fun install(
+        context: Context,
+        container: Container,
+        callbacks: LaunchDependencyCallbacks,
+        gameSource: GameSource,
+        gameId: Int,
+    ) = coroutineScope {
+        SteamService.downloadFile(
+            onDownloadProgress = callbacks.setLoadingProgress,
+            parentScope = this,
+            context = context,
+            "experimental-drm-20260116.tzst",
+        ).await()
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/ImageFsBaseDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/ImageFsBaseDependency.kt
@@ -1,0 +1,31 @@
+package app.gamenative.utils.launchdependencies
+
+import android.content.Context
+import app.gamenative.R
+import app.gamenative.data.GameSource
+import app.gamenative.service.SteamService
+import com.winlator.container.Container
+import kotlinx.coroutines.coroutineScope
+
+/** ImageFs base (first-time files) for the container variant. */
+internal object ImageFsBaseDependency : LaunchDependency {
+    override fun appliesTo(container: Container, gameSource: GameSource, gameId: Int) = true
+    override fun isSatisfied(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        SteamService.isImageFsInstallable(context, container.containerVariant)
+    override fun getLoadingMessage(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        context.getString(R.string.main_downloading_first_time_files)
+    override suspend fun install(
+        context: Context,
+        container: Container,
+        callbacks: LaunchDependencyCallbacks,
+        gameSource: GameSource,
+        gameId: Int,
+    ) = coroutineScope {
+        SteamService.downloadImageFs(
+            onDownloadProgress = callbacks.setLoadingProgress,
+            parentScope = this,
+            variant = container.containerVariant,
+            context = context,
+        ).await()
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/ImageFsInstallDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/ImageFsInstallDependency.kt
@@ -1,0 +1,52 @@
+package app.gamenative.utils.launchdependencies
+
+import android.content.Context
+import app.gamenative.R
+import app.gamenative.data.GameSource
+import com.winlator.container.Container
+import com.winlator.xenvironment.ImageFsInstaller
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/** ImageFs install (glibc/bionic) – always last. */
+internal object ImageFsInstallDependency : LaunchDependency {
+    override fun appliesTo(container: Container, gameSource: GameSource, gameId: Int) = true
+    override fun isSatisfied(context: Context, container: Container, gameSource: GameSource, gameId: Int): Boolean =
+        !ImageFsInstaller.needsInstall(context, container)
+    override fun getLoadingMessage(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        if (container.containerVariant.equals(Container.GLIBC, ignoreCase = true)) {
+            context.getString(R.string.main_installing_glibc)
+        } else {
+            context.getString(R.string.main_installing_bionic)
+        }
+    override suspend fun install(
+        context: Context,
+        container: Container,
+        callbacks: LaunchDependencyCallbacks,
+        gameSource: GameSource,
+        gameId: Int,
+    ) {
+        withContext(kotlinx.coroutines.Dispatchers.IO) {
+            suspendCancellableCoroutine<Unit> { cont ->
+                val future = ImageFsInstaller.installIfNeededFuture(context, context.assets, container) { progress ->
+                    callbacks.setLoadingProgress(progress / 100f)
+                }
+                cont.invokeOnCancellation { future.cancel(true) }
+                try {
+                    val result = future.get() as Boolean
+                    if (cont.isActive) {
+                        if (result) {
+                            cont.resume(Unit)
+                        } else {
+                            cont.resumeWithException(IllegalStateException("ImageFs install completed but returned false"))
+                        }
+                    }
+                } catch (e: Exception) {
+                    if (cont.isActive) cont.resumeWithException(e)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/ImageFsPatchesDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/ImageFsPatchesDependency.kt
@@ -1,0 +1,32 @@
+package app.gamenative.utils.launchdependencies
+
+import android.content.Context
+import app.gamenative.R
+import app.gamenative.data.GameSource
+import app.gamenative.service.SteamService
+import com.winlator.container.Container
+import kotlinx.coroutines.coroutineScope
+
+/** Wine imagefs patches (GLIBC only). */
+internal object ImageFsPatchesDependency : LaunchDependency {
+    private const val FILE = "imagefs_patches_gamenative.tzst"
+    override fun appliesTo(container: Container, gameSource: GameSource, gameId: Int) =
+        container.containerVariant.equals(Container.GLIBC, ignoreCase = true)
+    override fun isSatisfied(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        SteamService.isFileInstallable(context, FILE)
+    override fun getLoadingMessage(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        context.getString(R.string.main_downloading_wine)
+    override suspend fun install(
+        context: Context,
+        container: Container,
+        callbacks: LaunchDependencyCallbacks,
+        gameSource: GameSource,
+        gameId: Int,
+    ) = coroutineScope {
+        SteamService.downloadImageFsPatches(
+            onDownloadProgress = callbacks.setLoadingProgress,
+            parentScope = this,
+            context = context,
+        ).await()
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/ProtonPackageDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/ProtonPackageDependency.kt
@@ -1,0 +1,69 @@
+package app.gamenative.utils.launchdependencies
+
+import android.content.Context
+import app.gamenative.R
+import app.gamenative.data.GameSource
+import app.gamenative.service.SteamService
+import app.gamenative.utils.LOADING_PROGRESS_UNKNOWN
+import com.winlator.container.Container
+import com.winlator.core.TarCompressorUtils
+import com.winlator.xenvironment.ImageFs
+import java.io.File
+import kotlinx.coroutines.coroutineScope
+import timber.log.Timber
+
+/** A Proton package: download .txz and extract to /opt if needed. */
+internal class ProtonPackageDependency(
+    private val fileName: String,
+    private val displayName: String,
+) : LaunchDependency {
+    override fun appliesTo(container: Container, gameSource: GameSource, gameId: Int): Boolean {
+        val expectedArchive = "${container.wineVersion}.txz"
+        return fileName == expectedArchive
+    }
+    override fun isSatisfied(context: Context, container: Container, gameSource: GameSource, gameId: Int): Boolean {
+        if (!SteamService.isFileInstallable(context, fileName)) return false
+        val imageFs = ImageFs.find(context)
+        val outFile = File(imageFs.rootDir, "/opt/${container.wineVersion}")
+        val binDir = File(outFile, "bin")
+        return binDir.exists() && binDir.isDirectory
+    }
+    override fun getLoadingMessage(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        context.getString(R.string.main_downloading_proton, displayName)
+    override suspend fun install(
+        context: Context,
+        container: Container,
+        callbacks: LaunchDependencyCallbacks,
+        gameSource: GameSource,
+        gameId: Int,
+    ) = coroutineScope {
+        if (!SteamService.isFileInstallable(context, fileName)) {
+            SteamService.downloadFile(
+                onDownloadProgress = callbacks.setLoadingProgress,
+                parentScope = this,
+                context = context,
+                fileName,
+            ).await()
+        }
+        val protonVersion = container.wineVersion
+        val imageFs = ImageFs.find(context)
+        val outFile = File(imageFs.rootDir, "/opt/$protonVersion")
+        val binDir = File(outFile, "bin")
+        if (!binDir.exists() || !binDir.isDirectory) {
+            Timber.i("Extracting $fileName to /opt/")
+            callbacks.setLoadingMessage(context.getString(R.string.main_extracting_proton, protonVersion))
+            callbacks.setLoadingProgress(LOADING_PROGRESS_UNKNOWN)
+            val downloaded = File(imageFs.getFilesDir(), fileName)
+            try {
+                TarCompressorUtils.extract(
+                    TarCompressorUtils.Type.XZ,
+                    downloaded,
+                    outFile,
+                )
+            } catch (e: Exception) {
+                Timber.e(e, "ProtonPackageDependency: failed to extract archive path=%s", downloaded.absolutePath)
+                throw e
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/SteamClientDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/SteamClientDependency.kt
@@ -1,0 +1,30 @@
+package app.gamenative.utils.launchdependencies
+
+import android.content.Context
+import app.gamenative.R
+import app.gamenative.data.GameSource
+import app.gamenative.service.SteamService
+import com.winlator.container.Container
+import kotlinx.coroutines.coroutineScope
+
+/** Steam client (when launching real Steam). */
+internal object SteamClientDependency : LaunchDependency {
+    override fun appliesTo(container: Container, gameSource: GameSource, gameId: Int) = container.isLaunchRealSteam
+    override fun isSatisfied(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        SteamService.isFileInstallable(context, "steam.tzst")
+    override fun getLoadingMessage(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        context.getString(R.string.main_downloading_steam)
+    override suspend fun install(
+        context: Context,
+        container: Container,
+        callbacks: LaunchDependencyCallbacks,
+        gameSource: GameSource,
+        gameId: Int,
+    ) = coroutineScope {
+        SteamService.downloadSteam(
+            onDownloadProgress = callbacks.setLoadingProgress,
+            parentScope = this,
+            context = context,
+        ).await()
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/SteamManifestDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/SteamManifestDependency.kt
@@ -1,0 +1,46 @@
+package app.gamenative.utils.launchdependencies
+
+import android.content.Context
+import app.gamenative.R
+import app.gamenative.data.GameSource
+import app.gamenative.utils.BestConfigService
+import app.gamenative.utils.ManifestInstaller
+import com.winlator.container.Container
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import timber.log.Timber
+
+/** Steam manifest components (wine/proton, dxvk, etc.) missing from container config. */
+internal object SteamManifestDependency : LaunchDependency {
+    override fun appliesTo(container: Container, gameSource: GameSource, gameId: Int) =
+        gameSource == GameSource.STEAM
+
+    override fun isSatisfied(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        false // Resolved in install(); skip would require suspend resolveMissingManifestInstallRequests
+
+    override fun getLoadingMessage(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        context.getString(R.string.main_downloading_entry, "manifest components")
+
+    override suspend fun install(
+        context: Context,
+        container: Container,
+        callbacks: LaunchDependencyCallbacks,
+        gameSource: GameSource,
+        gameId: Int,
+    ) {
+        val configJson = Json.parseToJsonElement(container.containerJson).jsonObject
+        val missingRequests = BestConfigService.resolveMissingManifestInstallRequests(
+            context, configJson, "exact_gpu_match",
+        )
+        for (request in missingRequests) {
+            callbacks.setLoadingMessage(context.getString(R.string.main_downloading_entry, request.entry.name))
+            try {
+                ManifestInstaller.installManifestEntry(
+                    context, request.entry, request.isDriver, request.contentType,
+                ) { progress -> callbacks.setLoadingProgress(progress.coerceIn(0f, 1f)) }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to install ${request.entry.name}, continuing")
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/SteamTokenDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/SteamTokenDependency.kt
@@ -1,0 +1,32 @@
+package app.gamenative.utils.launchdependencies
+
+import android.content.Context
+import app.gamenative.R
+import app.gamenative.data.GameSource
+import app.gamenative.service.SteamService
+import com.winlator.container.Container
+import kotlinx.coroutines.coroutineScope
+
+/** Steam token (when launching real Steam). */
+internal object SteamTokenDependency : LaunchDependency {
+    private const val FILE = "steam-token.tzst"
+    override fun appliesTo(container: Container, gameSource: GameSource, gameId: Int) = container.isLaunchRealSteam
+    override fun isSatisfied(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        SteamService.isFileInstallable(context, FILE)
+    override fun getLoadingMessage(context: Context, container: Container, gameSource: GameSource, gameId: Int) =
+        context.getString(R.string.main_downloading_steam_token)
+    override suspend fun install(
+        context: Context,
+        container: Container,
+        callbacks: LaunchDependencyCallbacks,
+        gameSource: GameSource,
+        gameId: Int,
+    ) = coroutineScope {
+        SteamService.downloadFile(
+            onDownloadProgress = callbacks.setLoadingProgress,
+            parentScope = this,
+            context = context,
+            FILE,
+        ).await()
+    }
+}

--- a/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
@@ -194,14 +194,28 @@ public abstract class ImageFsInstaller {
 
     private static void chmod(File f) { if (f.exists()) FileUtils.chmod(f, 0755);}
 
+    /**
+     * Returns true if the ImageFs install (glibc/bionic) needs to be run for this container.
+     * Lightweight check only; does not perform work.
+     * If container is null, returns true (install required).
+     */
+    public static boolean needsInstall(Context context, Container container) {
+        if (container == null) {
+            return true;
+        }
+        ImageFs imageFs = ImageFs.find(context);
+        return !imageFs.isValid() || imageFs.getVersion() < LATEST_VERSION || !imageFs.getVariant().equals(container.getContainerVariant());
+    }
+
     public static Future<Boolean> installIfNeededFuture(final Context context, AssetManager assetManager) {
         return installIfNeededFuture(context, assetManager, null, null);
     }
     public static Future<Boolean> installIfNeededFuture(final Context context, AssetManager assetManager, Container container, Callback<Integer> onProgress) {
         ImageFs imageFs = ImageFs.find(context);
-        if (!imageFs.isValid() || imageFs.getVersion() < LATEST_VERSION || !imageFs.getVariant().equals(container.getContainerVariant())) {
+        if (needsInstall(context, container)) {
             Log.d("ImageFsInstaller", "Installing image from assets");
-            return installFromAssetsFuture(context, assetManager, container.getContainerVariant(), onProgress);
+            String variant = container != null ? container.getContainerVariant() : imageFs.getVariant();
+            return installFromAssetsFuture(context, assetManager, variant, onProgress);
         } else {
             Log.d("ImageFsInstaller", "Image FS already valid and at latest version");
             return Executors.newSingleThreadExecutor().submit(() -> true);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -775,7 +775,12 @@
     <!-- PluviaMain: Game Launch -->
     <string name="main_downloading_entry">Downloading %s</string>
     <string name="main_downloading_steam">Downloading Steam...</string>
-
+    <string name="main_downloading_first_time_files">Downloading first-time files...</string>
+    <string name="main_downloading_wine">Downloading Wine...</string>
+    <string name="main_downloading_extras">Downloading extras...</string>
+    <string name="main_downloading_steam_token">Downloading Steam token...</string>
+    <string name="main_downloading_proton">Downloading %1$s Proton...</string>
+    <string name="main_extracting_proton">Extracting %1$s...</string>
     <string name="main_installing_glibc">Installing glibc components...</string>
     <string name="main_installing_bionic">Installing Bionic components...</string>
     <string name="main_loading">Loading...</string>


### PR DESCRIPTION
Extracted retrieving launch dependencies + streamlined the flow.
If we have another (doesn't matter which platform) Just add a new launch dependency file and configure it in the `ALL_LAUNCH_DEPENDENCIES` list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during game launch with user-facing failure dialogs

* **New Features**
  * Enhanced pre-launch preparation with centralized dependency management
  * Added detailed status messages for downloads and setup steps (Proton, Steam client, DRM components)
  * Better progress tracking during first-time file downloads and installations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->