### PR TITLE
fix: prevent OOM in ExeIconExtractor for large EXEs

### DIFF
--- a/app/src/main/java/app/gamenative/utils/ExeIconExtractor.kt
+++ b/app/src/main/java/app/gamenative/utils/ExeIconExtractor.kt
@@ -170,7 +170,7 @@ object ExeIconExtractor {
         if (groupDataEntryOff < 0 || groupDataEntryOff + 16 > rsrcRawSize) return false
         val groupDataRva = bb.getInt(groupDataEntryOff)
         val groupSize = bb.getInt(groupDataEntryOff + 4)
-        if (groupSize <= 0) return false
+        if (groupSize < 6) return false // GRPICONDIR header is 6 bytes
         val groupDataOff = rvaToRsrc(groupDataRva)
         if (groupDataOff < 0 || groupDataOff + groupSize > rsrcRawSize) return false
 


### PR DESCRIPTION
## Summary
- Fixes #568
- `tryExtractMainIcon()` was reading the entire EXE into a `ByteArray` — large game executables (100MB+) cause OOM on Android
- Now reads only PE headers (~4KB) to locate the `.rsrc` section, then reads only that section (typically a few hundred KB, capped at 10MB)
- Same PE parsing logic and ICO output format, just doesn't load the full executable
- Uses Long arithmetic in section bounds check to prevent Int overflow on large VAs
- Validates full 4-byte PE signature (`PE\0\0`) instead of just first two bytes
- Fixes ICO directory sizing — only allocates entries for icons with valid data, preventing zero-padded ghost slots and misaligned offsets
- Guards leaf-level resource entries against unexpected isSubdir flag
- Caps cumulative icon data size to prevent OOM from overlapping resource entries in malformed PEs
- Rejects non-positive groupSize in resource directory parsing

## Test plan
- [ ] Add a custom game with a large EXE (100MB+) — should extract icon without crashing
- [ ] Verify extracted icon displays correctly in list view
- [ ] Verify small EXEs still extract correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized icon extraction to use bounded memory reads instead of loading entire files into memory, improving efficiency for large executable files.
  * Enhanced robustness with improved bounds checking and error handling during extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->