### PR TITLE
feat: icon-as-banner fallback for grid views

### DIFF
--- a/app/src/main/java/app/gamenative/ui/util/Images.kt
+++ b/app/src/main/java/app/gamenative/ui/util/Images.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
@@ -46,7 +47,7 @@ internal fun ListItemImage(
             CircularProgressIndicator()
         },
         failure = {
-            onFailure()
+            SideEffect { onFailure() }
             Icon(Icons.Filled.QuestionMark, null)
         },
         previewPlaceholder = painterResource(R.drawable.ic_logo_color),


### PR DESCRIPTION
## Summary
- When grid banner fails to load, show game icon centered on `surfaceVariant` background instead of just dimmed placeholder
- If icon also fails, falls back to existing text-overlay behavior
- Hoists `iconUrl` resolution so both LIST and GRID paths can use it
- Keys `iconUrl` remember on `gameSource` and `paneType` so correct icon source is used per view
- Guards against infinite recomposition loop (Landscapist failure blocks are composable lambdas that re-fire every recomposition)
- Grid views use `findCachedIconForCustomGame` to avoid OOM from EXE extraction on UI thread

Closes #572

## Test plan
- [ ] Add custom game with large EXE (has extracted icon, no SteamGridDB images) → grid capsule/hero shows icon on colored bg
- [ ] Steam game with missing banner → same fallback behavior
- [ ] Game with SteamGridDB images → unchanged, shows banner as before
- [ ] Switch between LIST/GRID views → no stale state
- [ ] Large library with custom games → no jank on refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a solid-banner fallback icon when an item's primary image fails, improving visual consistency in list and grid views.
  * Uses cached and alternate icon sources for custom games to reduce missing or incorrect icons.

* **Bug Fixes**
  * Prevents repeated reload/recomposition loops and resets fallback state when view or image changes.
  * Ensures fallback banner hides if its secondary image fails; failure callbacks now run with safer lifecycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->