### PR TITLE
Streamlined cloud sync for all platforms

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -73,6 +73,9 @@ import app.gamenative.ui.screen.xserver.XServerScreen
 import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.CustomGameScanner
+import app.gamenative.utils.cloudSync.CloudSyncOutcome
+import app.gamenative.utils.cloudSync.CloudSyncParams
+import app.gamenative.utils.syncCloudSaves
 import app.gamenative.utils.GameFeedbackUtils
 import app.gamenative.utils.IntentLaunchManager
 import app.gamenative.utils.UpdateChecker
@@ -1147,10 +1150,6 @@ fun preLaunchApp(
             }
         }
 
-        // Check if this is a Custom Game and validate executable selection before installing components
-        // Skip the check if booting to container (Open Container menu option)
-        val isCustomGame = gameSource == GameSource.CUSTOM_GAME
-
         // set up Ubuntu file system
         SplitCompat.install(context)
         if (!SteamService.isImageFsInstallable(context, container.containerVariant)) {
@@ -1279,273 +1278,47 @@ fun preLaunchApp(
             } catch (_: Exception) { /* ignore persona read errors */ }
         }
 
-        // For Custom Games, bypass Steam Cloud operations entirely and proceed to launch
-        if (isCustomGame) {
-            Timber.tag("preLaunchApp").i("Custom Game detected for $appId — skipping Steam Cloud sync and launching container")
-            setLoadingDialogVisible(false)
-            onSuccess(context, appId)
-            return@launch
-        }
-
-        // For GOG Games, sync cloud saves before launch (executable already verified above via GOGService.getLaunchExecutable)
-        val isGOGGame = gameSource == GameSource.GOG
-        if (isGOGGame) {
-            Timber.tag("GOG").i("[Cloud Saves] GOG Game detected for $appId — syncing cloud saves before launch")
-
-            // Sync cloud saves (download latest saves before playing)
-            Timber.tag("GOG").d("[Cloud Saves] Starting pre-game download sync for $appId")
-            val syncSuccess = app.gamenative.service.gog.GOGService.syncCloudSaves(
-                context = context,
-                appId = appId,
-            )
-
-            if (!syncSuccess) {
-                Timber.tag("GOG").w("[Cloud Saves] Download sync failed for $appId, proceeding with launch anyway")
-                // Don't block launch on sync failure - log warning and continue
-            } else {
-                Timber.tag("GOG").i("[Cloud Saves] Download sync completed successfully for $appId")
-            }
-
-            setLoadingDialogVisible(false)
-            onSuccess(context, appId)
-            return@launch
-        }
-
-        // For Epic Games, sync cloud saves before launch (executable already verified above via EpicService.getLaunchExecutable)
-        val isEpicGame = gameSource == GameSource.EPIC
-        if (isEpicGame) {
-            // Handle Cloud Saves
-            Timber.tag("Epic").i("[Cloud Saves] Epic Game detected for $appId — syncing cloud saves before launch")
-            // Sync cloud saves (download latest saves before playing)
-            Timber.tag("Epic").d("[Cloud Saves] Starting pre-game download sync for $appId")
-            val syncSuccess = app.gamenative.service.epic.EpicCloudSavesManager.syncCloudSaves(
-                context = context,
-                appId = gameId,
-            )
-
-            if (!syncSuccess) {
-                Timber.tag("Epic").w("[Cloud Saves] Download sync failed for $appId, proceeding with launch anyway")
-                // Don't block launch on sync failure - log warning and continue
-            } else {
-                Timber.tag("Epic").i("[Cloud Saves] Download sync completed successfully for $appId")
-            }
-
-            // Delete Ownership Token if exists
-            Timber.tag("Epic").i("[Ownership Tokens] Cleaning up launch tokens for Epic games...")
-            EpicService.cleanupLaunchTokens(context)
-
-            setLoadingDialogVisible(false)
-            onSuccess(context, appId)
-            return@launch
-        }
-
         if (skipCloudSync) {
-            Timber.tag("preLaunchApp").w("Skipping Steam Cloud sync for $appId by user request")
             setLoadingDialogVisible(false)
             onSuccess(context, appId)
             return@launch
         }
 
-        // For Steam games, sync save files and check no pending remote operations are running
-        val prefixToPath: (String) -> String = { prefix ->
-            PathType.from(prefix).toAbsPath(context, gameId, SteamService.userSteamId!!.accountID)
-        }
-        setLoadingMessage("Syncing cloud saves")
-        setLoadingProgress(-1f)
-        val postSyncInfo = SteamService.beginLaunchApp(
-            appId = gameId,
-            prefixToPath = prefixToPath,
+        val syncParams = CloudSyncParams(
+            appId = appId,
+            gameId = gameId,
             ignorePendingOperations = ignorePendingOperations,
             preferredSave = preferredSave,
-            parentScope = this,
+            useTemporaryOverride = useTemporaryOverride,
+            retryCount = retryCount,
             isOffline = isOffline,
-            onProgress = { message, progress ->
-                setLoadingMessage(message)
-                setLoadingProgress(if (progress < 0) -1f else progress)
-            },
-        ).await()
-
+            scope = this,
+        )
+        val outcome = syncCloudSaves(
+            context = context,
+            container = container,
+            params = syncParams,
+            setLoadingMessage = setLoadingMessage,
+            setLoadingProgress = setLoadingProgress,
+        )
         setLoadingDialogVisible(false)
 
-        when (postSyncInfo.syncResult) {
-            SyncResult.Conflict -> {
-                setMessageDialogState(
-                    MessageDialogState(
-                        visible = true,
-                        type = DialogType.SYNC_CONFLICT,
-                        title = context.getString(R.string.main_save_conflict_title),
-                        message = context.getString(
-                            R.string.main_save_conflict_message,
-                            Date(postSyncInfo.localTimestamp).toString(),
-                            Date(postSyncInfo.remoteTimestamp).toString(),
-                        ),
-                        dismissBtnText = context.getString(R.string.main_keep_local),
-                        confirmBtnText = context.getString(R.string.main_keep_remote),
-                    ),
-                )
-            }
-
-            SyncResult.InProgress -> {
-                if (useTemporaryOverride && retryCount < 5) {
-                    // For intent launches, retry after a short delay (max 5 retries = ~10 seconds)
-                    Timber.i("Sync in progress for intent launch, retrying in 2 seconds... (attempt ${retryCount + 1}/5)")
-                    delay(2000)
-                    preLaunchApp(
-                        context = context,
-                        appId = appId,
-                        ignorePendingOperations = ignorePendingOperations,
-                        preferredSave = preferredSave,
-                        useTemporaryOverride = useTemporaryOverride,
-                        setLoadingDialogVisible = setLoadingDialogVisible,
-                        setLoadingProgress = setLoadingProgress,
-                        setLoadingMessage = setLoadingMessage,
-                        setMessageDialogState = setMessageDialogState,
-                        onSuccess = onSuccess,
-                        retryCount = retryCount + 1,
-                        bootToContainer = bootToContainer,
-                    )
-                } else {
-                    setMessageDialogState(
-                        MessageDialogState(
-                            visible = true,
-                            type = DialogType.SYNC_IN_PROGRESS,
-                            title = context.getString(R.string.sync_error_title),
-                            message = context.getString(R.string.main_sync_in_progress_launch_anyway_message),
-                            confirmBtnText = context.getString(R.string.main_launch_anyway),
-                            dismissBtnText = context.getString(R.string.main_wait),
-                        ),
-                    )
-                }
-            }
-
-            SyncResult.UnknownFail,
-            SyncResult.DownloadFail,
-            SyncResult.UpdateFail,
-            -> {
-                setMessageDialogState(
-                    MessageDialogState(
-                        visible = true,
-                        type = DialogType.SYNC_FAIL,
-                        title = context.getString(R.string.sync_error_title),
-                        message = context.getString(R.string.main_sync_failed, postSyncInfo.syncResult.toString()),
-                        dismissBtnText = context.getString(R.string.ok),
-                    ),
-                )
-            }
-
-            SyncResult.PendingOperations -> {
-                Timber.i(
-                    "Pending remote operations:${
-                        postSyncInfo.pendingRemoteOperations.map { pro ->
-                            "\n\tmachineName: ${pro.machineName}" +
-                                "\n\ttimestamp: ${Date(pro.timeLastUpdated * 1000L)}" +
-                                "\n\toperation: ${pro.operation}"
-                        }.joinToString("\n")
-                    }",
-                )
-                if (postSyncInfo.pendingRemoteOperations.size == 1) {
-                    val pro = postSyncInfo.pendingRemoteOperations.first()
-                    val gameName = SteamService.getAppInfoOf(ContainerUtils.extractGameIdFromContainerId(appId))?.name ?: ""
-                    val dateStr = Date(pro.timeLastUpdated * 1000L).toString()
-                    when (pro.operation) {
-                        ECloudPendingRemoteOperation.k_ECloudPendingRemoteOperationUploadInProgress -> {
-                            // maybe this should instead wait for the upload to finish and then
-                            // launch the app
-                            setMessageDialogState(
-                                MessageDialogState(
-                                    visible = true,
-                                    type = DialogType.PENDING_UPLOAD_IN_PROGRESS,
-                                    title = context.getString(R.string.main_upload_in_progress_title),
-                                    message = context.getString(
-                                        R.string.main_upload_in_progress_message,
-                                        gameName,
-                                        pro.machineName,
-                                        dateStr,
-                                    ),
-                                    dismissBtnText = context.getString(R.string.ok),
-                                ),
-                            )
-                        }
-
-                        ECloudPendingRemoteOperation.k_ECloudPendingRemoteOperationUploadPending -> {
-                            setMessageDialogState(
-                                MessageDialogState(
-                                    visible = true,
-                                    type = DialogType.PENDING_UPLOAD,
-                                    title = context.getString(R.string.main_pending_upload_title),
-                                    message = context.getString(
-                                        R.string.main_pending_upload_message,
-                                        gameName,
-                                        pro.machineName,
-                                        dateStr,
-                                    ),
-                                    confirmBtnText = context.getString(R.string.main_play_anyway),
-                                    dismissBtnText = context.getString(R.string.cancel),
-                                ),
-                            )
-                        }
-
-                        ECloudPendingRemoteOperation.k_ECloudPendingRemoteOperationAppSessionActive -> {
-                            setMessageDialogState(
-                                MessageDialogState(
-                                    visible = true,
-                                    type = DialogType.APP_SESSION_ACTIVE,
-                                    title = context.getString(R.string.main_app_running_title),
-                                    message = context.getString(
-                                        R.string.main_app_running_other_device,
-                                        pro.machineName,
-                                        gameName,
-                                        dateStr,
-                                    ),
-                                    confirmBtnText = context.getString(R.string.main_play_anyway),
-                                    dismissBtnText = context.getString(R.string.cancel),
-                                ),
-                            )
-                        }
-
-                        ECloudPendingRemoteOperation.k_ECloudPendingRemoteOperationAppSessionSuspended -> {
-                            // I don't know what this means, yet
-                            setMessageDialogState(
-                                MessageDialogState(
-                                    visible = true,
-                                    type = DialogType.APP_SESSION_SUSPENDED,
-                                    title = context.getString(R.string.sync_error_title),
-                                    message = context.getString(R.string.main_app_session_suspended),
-                                    dismissBtnText = context.getString(R.string.ok),
-                                ),
-                            )
-                        }
-
-                        ECloudPendingRemoteOperation.k_ECloudPendingRemoteOperationNone -> {
-                            // why are we here
-                            setMessageDialogState(
-                                MessageDialogState(
-                                    visible = true,
-                                    type = DialogType.PENDING_OPERATION_NONE,
-                                    title = context.getString(R.string.sync_error_title),
-                                    message = context.getString(R.string.main_pending_operation_none),
-                                    dismissBtnText = context.getString(R.string.ok),
-                                ),
-                            )
-                        }
-                    }
-                } else {
-                    // this should probably be handled differently
-                    setMessageDialogState(
-                        MessageDialogState(
-                            visible = true,
-                            type = DialogType.MULTIPLE_PENDING_OPERATIONS,
-                            title = context.getString(R.string.sync_error_title),
-                            message = context.getString(R.string.main_multiple_pending_operations),
-                            dismissBtnText = context.getString(R.string.ok),
-                        ),
-                    )
-                }
-            }
-
-            SyncResult.UpToDate,
-            SyncResult.Success,
-            -> onSuccess(context, appId)
+        when (outcome) {
+            is CloudSyncOutcome.Proceed -> onSuccess(context, appId)
+            is CloudSyncOutcome.ShowDialog -> setMessageDialogState(outcome.state)
+            is CloudSyncOutcome.Retry -> preLaunchApp(
+                context = context,
+                appId = appId,
+                ignorePendingOperations = ignorePendingOperations,
+                preferredSave = preferredSave,
+                useTemporaryOverride = useTemporaryOverride,
+                setLoadingDialogVisible = setLoadingDialogVisible,
+                setLoadingProgress = setLoadingProgress,
+                setLoadingMessage = setLoadingMessage,
+                setMessageDialogState = setMessageDialogState,
+                onSuccess = onSuccess,
+                retryCount = retryCount + 1,
+            )
         }
     }
 }

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1301,11 +1301,16 @@ fun preLaunchApp(
             setLoadingMessage = setLoadingMessage,
             setLoadingProgress = setLoadingProgress,
         )
-        setLoadingDialogVisible(false)
 
         when (outcome) {
-            is CloudSyncOutcome.Proceed -> onSuccess(context, appId)
-            is CloudSyncOutcome.ShowDialog -> setMessageDialogState(outcome.state)
+            is CloudSyncOutcome.Proceed -> {
+                setLoadingDialogVisible(false)
+                onSuccess(context, appId)
+            }
+            is CloudSyncOutcome.ShowDialog -> {
+                setLoadingDialogVisible(false)
+                setMessageDialogState(outcome.state)
+            }
             is CloudSyncOutcome.Retry -> preLaunchApp(
                 context = context,
                 appId = appId,
@@ -1318,6 +1323,7 @@ fun preLaunchApp(
                 setMessageDialogState = setMessageDialogState,
                 onSuccess = onSuccess,
                 retryCount = retryCount + 1,
+                isOffline = isOffline,
             )
         }
     }

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -16,11 +16,11 @@ import app.gamenative.enums.PathType
 import app.gamenative.events.AndroidEvent
 import app.gamenative.events.SteamEvent
 import app.gamenative.service.SteamService
-import app.gamenative.service.epic.EpicCloudSavesManager
 import app.gamenative.ui.data.MainState
 import app.gamenative.ui.screen.PluviaScreen
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.IntentLaunchManager
+import app.gamenative.utils.uploadCloudSaves
 import app.gamenative.utils.SteamUtils
 import app.gamenative.utils.UpdateInfo
 import com.materialkolor.PaletteStyle
@@ -288,56 +288,16 @@ class MainViewModel @Inject constructor(
             Timber.tag("Exit").i("Got game id: $gameId")
             SteamService.notifyRunningProcesses()
 
-            // Check if this is a GOG or Epic game and sync cloud saves
-            val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
-            if (gameSource == GameSource.GOG) {
-                Timber.tag("GOG").i("[Cloud Saves] GOG Game detected for $appId — syncing cloud saves after close")
-                // Sync cloud saves (upload local changes to cloud)
-                // Run in background, don't block UI
-                viewModelScope.launch(Dispatchers.IO) {
-                    try {
-                        Timber.tag("GOG").d("[Cloud Saves] Starting post-game upload sync for $appId")
-                        val syncSuccess = app.gamenative.service.gog.GOGService.syncCloudSaves(
-                            context = context,
-                            appId = appId,
-                            preferredAction = "upload",
-                        )
-                        if (syncSuccess) {
-                            Timber.tag("GOG").i("[Cloud Saves] Upload sync completed successfully for $appId")
-                        } else {
-                            Timber.tag("GOG").w("[Cloud Saves] Upload sync failed for $appId")
-                        }
-                    } catch (e: Exception) {
-                        Timber.tag("GOG").e(e, "[Cloud Saves] Exception during upload sync for $appId")
-                    }
-                }
-            } else if (gameSource == GameSource.EPIC) {
-                Timber.tag("Epic").i("[Cloud Saves] Epic Game detected for $appId — syncing cloud saves after close")
-                // Sync cloud saves (upload local changes to cloud)
-                // Run in background, don't block UI
-                viewModelScope.launch(Dispatchers.IO) {
-                    try {
-                        Timber.tag("Epic").d("[Cloud Saves] Starting post-game upload sync for $gameId")
-                        val syncSuccess = app.gamenative.service.epic.EpicCloudSavesManager.syncCloudSaves(
-                            context = context,
-                            appId = gameId,
-                            preferredAction = "upload",
-                        )
-                        if (syncSuccess) {
-                            Timber.tag("Epic").i("[Cloud Saves] Upload sync completed successfully for $gameId")
-                        } else {
-                            Timber.tag("Epic").w("[Cloud Saves] Upload sync failed for $gameId")
-                        }
-                    } catch (e: Exception) {
-                        Timber.tag("Epic").e(e, "[Cloud Saves] Exception during upload sync for $gameId")
-                    }
-                }
-            } else {
-                // For Steam games, sync cloud saves
-                SteamService.closeApp(gameId, isOffline.value) { prefix ->
+            // Upload local cloud saves after exit; dispatches to GOG, Epic, or Steam.
+            uploadCloudSaves(
+                context = context,
+                appId = appId,
+                gameId = gameId,
+                isOffline = isOffline.value,
+                prefixToPath = { prefix ->
                     PathType.from(prefix).toAbsPath(context, gameId, SteamService.userSteamId!!.accountID)
-                }.await()
-            }
+                },
+            )
 
             // Prompt user to save temporary container configuration if one was applied
             if (hadTemporaryOverride) {

--- a/app/src/main/java/app/gamenative/utils/CloudSavePlatforms.kt
+++ b/app/src/main/java/app/gamenative/utils/CloudSavePlatforms.kt
@@ -9,6 +9,7 @@ import app.gamenative.utils.cloudSync.GOGCloudSavePlatform
 import app.gamenative.utils.cloudSync.SteamCloudSavePlatform
 import app.gamenative.utils.ContainerUtils
 import com.winlator.container.Container
+import timber.log.Timber
 
 private val ALL_CLOUD_SAVE_PLATFORMS: List<CloudSavePlatform> = listOf(
     GOGCloudSavePlatform,
@@ -17,7 +18,7 @@ private val ALL_CLOUD_SAVE_PLATFORMS: List<CloudSavePlatform> = listOf(
 )
 
 /**
- * Returns the cloud save platform that applies to this container (at most one).
+ * Returns the cloud save platforms that apply to this container (e.g. GOG, Epic, Steam).
  */
 fun getCloudSyncPlatforms(container: Container): List<CloudSavePlatform> =
     ALL_CLOUD_SAVE_PLATFORMS.filter { it.appliesTo(container) }
@@ -29,8 +30,9 @@ data class CloudSaveCallbacks(
 )
 
 /**
- * Sync (download/merge) cloud saves before launch.
+ * Sync (download/merge) cloud saves before launch for all matching platforms.
  * Returns [CloudSyncOutcome] (Proceed, ShowDialog, or Retry); caller applies the outcome.
+ * Runs each platform in order; returns the first non-Proceed outcome if any, otherwise Proceed.
  */
 suspend fun syncCloudSaves(
     context: Context,
@@ -41,18 +43,19 @@ suspend fun syncCloudSaves(
 ): CloudSyncOutcome {
     val callbacks = CloudSaveCallbacks(setLoadingMessage, setLoadingProgress)
     val platforms = getCloudSyncPlatforms(container)
-    return if (platforms.isEmpty()) {
-        CloudSyncOutcome.Proceed
-    } else {
-        val platform = platforms.single()
+    for (platform in platforms) {
         setLoadingMessage(platform.getLoadingMessage(context, container))
-        platform.sync(context, container, params, callbacks)
+        when (val outcome = platform.sync(context, container, params, callbacks)) {
+            CloudSyncOutcome.Proceed -> { /* continue to next platform */ }
+            is CloudSyncOutcome.ShowDialog, is CloudSyncOutcome.Retry -> return outcome
+        }
     }
+    return CloudSyncOutcome.Proceed
 }
 
 /**
- * Upload local cloud saves after the game has exited.
- * Dispatches to the platform that applies to this app (GOG, Epic, or Steam); no-op if none apply.
+ * Upload local cloud saves after the game has exited for all matching platforms.
+ * No-op if none apply.
  */
 suspend fun uploadCloudSaves(
     context: Context,
@@ -61,8 +64,14 @@ suspend fun uploadCloudSaves(
     isOffline: Boolean,
     prefixToPath: (String) -> String,
 ) {
-    val container = ContainerUtils.getContainer(context, appId)
+    val container = try {
+        ContainerUtils.getContainer(context, appId)
+    } catch (e: Exception) {
+        Timber.tag("CloudSavePlatforms").e(e, "uploadCloudSaves: container not found for appId=$appId")
+        return
+    }
     val platforms = getCloudSyncPlatforms(container)
-    if (platforms.isEmpty()) return
-    platforms.single().upload(context, appId, gameId, isOffline, prefixToPath)
+    for (platform in platforms) {
+        platform.upload(context, appId, gameId, isOffline, prefixToPath)
+    }
 }

--- a/app/src/main/java/app/gamenative/utils/CloudSavePlatforms.kt
+++ b/app/src/main/java/app/gamenative/utils/CloudSavePlatforms.kt
@@ -7,6 +7,7 @@ import app.gamenative.utils.cloudSync.CloudSyncParams
 import app.gamenative.utils.cloudSync.EpicCloudSavePlatform
 import app.gamenative.utils.cloudSync.GOGCloudSavePlatform
 import app.gamenative.utils.cloudSync.SteamCloudSavePlatform
+import app.gamenative.utils.ContainerUtils
 import com.winlator.container.Container
 
 private val ALL_CLOUD_SAVE_PLATFORMS: List<CloudSavePlatform> = listOf(
@@ -47,4 +48,21 @@ suspend fun syncCloudSaves(
         setLoadingMessage(platform.getLoadingMessage(context, container))
         platform.sync(context, container, params, callbacks)
     }
+}
+
+/**
+ * Upload local cloud saves after the game has exited.
+ * Dispatches to the platform that applies to this app (GOG, Epic, or Steam); no-op if none apply.
+ */
+suspend fun uploadCloudSaves(
+    context: Context,
+    appId: String,
+    gameId: Int,
+    isOffline: Boolean,
+    prefixToPath: (String) -> String,
+) {
+    val container = ContainerUtils.getContainer(context, appId)
+    val platforms = getCloudSyncPlatforms(container)
+    if (platforms.isEmpty()) return
+    platforms.single().upload(context, appId, gameId, isOffline, prefixToPath)
 }

--- a/app/src/main/java/app/gamenative/utils/CloudSavePlatforms.kt
+++ b/app/src/main/java/app/gamenative/utils/CloudSavePlatforms.kt
@@ -1,0 +1,50 @@
+package app.gamenative.utils
+
+import android.content.Context
+import app.gamenative.utils.cloudSync.CloudSavePlatform
+import app.gamenative.utils.cloudSync.CloudSyncOutcome
+import app.gamenative.utils.cloudSync.CloudSyncParams
+import app.gamenative.utils.cloudSync.EpicCloudSavePlatform
+import app.gamenative.utils.cloudSync.GOGCloudSavePlatform
+import app.gamenative.utils.cloudSync.SteamCloudSavePlatform
+import com.winlator.container.Container
+
+private val ALL_CLOUD_SAVE_PLATFORMS: List<CloudSavePlatform> = listOf(
+    GOGCloudSavePlatform,
+    EpicCloudSavePlatform,
+    SteamCloudSavePlatform,
+)
+
+/**
+ * Returns the cloud save platform that applies to this container (at most one).
+ */
+fun getCloudSyncPlatforms(container: Container): List<CloudSavePlatform> =
+    ALL_CLOUD_SAVE_PLATFORMS.filter { it.appliesTo(container) }
+
+/** Callbacks for progress during cloud save. */
+data class CloudSaveCallbacks(
+    val setLoadingMessage: (String) -> Unit,
+    val setLoadingProgress: (Float) -> Unit,
+)
+
+/**
+ * Sync (download/merge) cloud saves before launch.
+ * Returns [CloudSyncOutcome] (Proceed, ShowDialog, or Retry); caller applies the outcome.
+ */
+suspend fun syncCloudSaves(
+    context: Context,
+    container: Container,
+    params: CloudSyncParams,
+    setLoadingMessage: (String) -> Unit,
+    setLoadingProgress: (Float) -> Unit,
+): CloudSyncOutcome {
+    val callbacks = CloudSaveCallbacks(setLoadingMessage, setLoadingProgress)
+    val platforms = getCloudSyncPlatforms(container)
+    return if (platforms.isEmpty()) {
+        CloudSyncOutcome.Proceed
+    } else {
+        val platform = platforms.single()
+        setLoadingMessage(platform.getLoadingMessage(context, container))
+        platform.sync(context, container, params, callbacks)
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/cloudSync/CloudSavePlatform.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/CloudSavePlatform.kt
@@ -1,0 +1,25 @@
+package app.gamenative.utils.cloudSync
+
+import android.content.Context
+import app.gamenative.utils.CloudSaveCallbacks
+import com.winlator.container.Container
+
+/**
+ * A cloud-sync step that may run before launch (GOG sync, Epic sync, Steam sync).
+ * At most one applies per container; runs after [ensureLaunchDependencies] and container activation.
+ */
+interface CloudSavePlatform {
+    /** Whether this sync applies to the given container. */
+    fun appliesTo(container: Container): Boolean
+
+    /** Message shown while this sync is running. */
+    fun getLoadingMessage(context: Context, container: Container): String
+
+    /** Sync (download/merge) before launch; returns [CloudSyncOutcome] (Proceed, ShowDialog, or Retry). */
+    suspend fun sync(
+        context: Context,
+        container: Container,
+        params: CloudSyncParams,
+        callbacks: CloudSaveCallbacks,
+    ): CloudSyncOutcome
+}

--- a/app/src/main/java/app/gamenative/utils/cloudSync/CloudSavePlatform.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/CloudSavePlatform.kt
@@ -22,4 +22,19 @@ interface CloudSavePlatform {
         params: CloudSyncParams,
         callbacks: CloudSaveCallbacks,
     ): CloudSyncOutcome
+
+    /**
+     * Upload local cloud saves after the game has exited.
+     * Only the platform that applies to this app runs; others no-op.
+     * [prefixToPath] is used by Steam to resolve cloud save paths; other platforms ignore it.
+     */
+    suspend fun upload(
+        context: Context,
+        appId: String,
+        gameId: Int,
+        isOffline: Boolean,
+        prefixToPath: (String) -> String,
+    ) {
+        // Default: no-op (platforms that support post-exit upload override this).
+    }
 }

--- a/app/src/main/java/app/gamenative/utils/cloudSync/CloudSyncOutcome.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/CloudSyncOutcome.kt
@@ -1,0 +1,17 @@
+package app.gamenative.utils.cloudSync
+
+import app.gamenative.ui.component.dialog.state.MessageDialogState
+
+/**
+ * Result of running cloud sync. [syncCloudSaves] takes care of all sync outcomes;
+ * the caller only applies the returned outcome.
+ *
+ * [Proceed] = sync succeeded (or skipped), caller should continue to launch (e.g. call onSuccess).
+ * [ShowDialog] = show this dialog; caller should not launch until user dismisses.
+ * [Retry] = caller should retry the launch flow (e.g. call preLaunchApp again with retryCount+1).
+ */
+sealed class CloudSyncOutcome {
+    data object Proceed : CloudSyncOutcome()
+    data class ShowDialog(val state: MessageDialogState) : CloudSyncOutcome()
+    data object Retry : CloudSyncOutcome()
+}

--- a/app/src/main/java/app/gamenative/utils/cloudSync/CloudSyncParams.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/CloudSyncParams.kt
@@ -1,0 +1,20 @@
+package app.gamenative.utils.cloudSync
+
+import app.gamenative.enums.SaveLocation
+import kotlinx.coroutines.CoroutineScope
+
+
+/**
+ * Parameters for cloud sync (Steam needs most of these).
+ * [syncCloudSaves] resolves all sync outcomes and returns Proceed / ShowDialog / Retry.
+ */
+data class CloudSyncParams(
+    val appId: String,
+    val gameId: Int,
+    val ignorePendingOperations: Boolean = false,
+    val preferredSave: SaveLocation = SaveLocation.None,
+    val useTemporaryOverride: Boolean = false,
+    val retryCount: Int = 0,
+    val isOffline: Boolean = false,
+    val scope: CoroutineScope,
+)

--- a/app/src/main/java/app/gamenative/utils/cloudSync/CloudSyncParams.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/CloudSyncParams.kt
@@ -3,7 +3,6 @@ package app.gamenative.utils.cloudSync
 import app.gamenative.enums.SaveLocation
 import kotlinx.coroutines.CoroutineScope
 
-
 /**
  * Parameters for cloud sync (Steam needs most of these).
  * [syncCloudSaves] resolves all sync outcomes and returns Proceed / ShowDialog / Retry.

--- a/app/src/main/java/app/gamenative/utils/cloudSync/EpicCloudSavePlatform.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/EpicCloudSavePlatform.kt
@@ -1,0 +1,35 @@
+package app.gamenative.utils.cloudSync
+
+import android.content.Context
+import app.gamenative.R
+import app.gamenative.service.epic.EpicService
+import app.gamenative.utils.ContainerUtils
+import app.gamenative.data.GameSource
+import app.gamenative.utils.CloudSaveCallbacks
+import com.winlator.container.Container
+import timber.log.Timber
+
+/** Epic cloud save sync and launch token cleanup before launch. */
+internal object EpicCloudSavePlatform : CloudSavePlatform {
+    override fun appliesTo(container: Container) =
+        ContainerUtils.extractGameSourceFromContainerId(container.id) == GameSource.EPIC
+
+    override fun getLoadingMessage(context: Context, container: Container) =
+        context.getString(R.string.main_syncing_cloud_saves)
+
+    override suspend fun sync(
+        context: Context,
+        container: Container,
+        params: CloudSyncParams,
+        callbacks: CloudSaveCallbacks,
+    ): CloudSyncOutcome {
+        Timber.tag("Epic").i("[Cloud Saves] Epic Game detected for ${params.appId} — syncing cloud saves before launch")
+        app.gamenative.service.epic.EpicCloudSavesManager.syncCloudSaves(
+            context = context,
+            appId = params.gameId,
+        )
+        Timber.tag("Epic").i("[Ownership Tokens] Cleaning up launch tokens for Epic games...")
+        EpicService.cleanupLaunchTokens(context)
+        return CloudSyncOutcome.Proceed
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/cloudSync/EpicCloudSavePlatform.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/EpicCloudSavePlatform.kt
@@ -32,4 +32,19 @@ internal object EpicCloudSavePlatform : CloudSavePlatform {
         EpicService.cleanupLaunchTokens(context)
         return CloudSyncOutcome.Proceed
     }
+
+    override suspend fun upload(
+        context: Context,
+        appId: String,
+        gameId: Int,
+        isOffline: Boolean,
+        prefixToPath: (String) -> String,
+    ) {
+        Timber.tag("Epic").i("[Cloud Saves] Epic Game detected for $appId — uploading cloud saves after close")
+        app.gamenative.service.epic.EpicCloudSavesManager.syncCloudSaves(
+            context = context,
+            appId = gameId,
+            preferredAction = "upload",
+        )
+    }
 }

--- a/app/src/main/java/app/gamenative/utils/cloudSync/EpicCloudSavePlatform.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/EpicCloudSavePlatform.kt
@@ -3,10 +3,13 @@ package app.gamenative.utils.cloudSync
 import android.content.Context
 import app.gamenative.R
 import app.gamenative.service.epic.EpicService
+import app.gamenative.ui.component.dialog.state.MessageDialogState
+import app.gamenative.ui.enums.DialogType
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.data.GameSource
 import app.gamenative.utils.CloudSaveCallbacks
 import com.winlator.container.Container
+import kotlinx.coroutines.CancellationException
 import timber.log.Timber
 
 /** Epic cloud save sync and launch token cleanup before launch. */
@@ -23,13 +26,28 @@ internal object EpicCloudSavePlatform : CloudSavePlatform {
         params: CloudSyncParams,
         callbacks: CloudSaveCallbacks,
     ): CloudSyncOutcome {
-        Timber.tag("Epic").i("[Cloud Saves] Epic Game detected for ${params.appId} — syncing cloud saves before launch")
-        app.gamenative.service.epic.EpicCloudSavesManager.syncCloudSaves(
-            context = context,
-            appId = params.gameId,
-        )
-        Timber.tag("Epic").i("[Ownership Tokens] Cleaning up launch tokens for Epic games...")
-        EpicService.cleanupLaunchTokens(context)
+        Timber.tag("Epic").i("[Cloud Saves] Epic Game detected for appId=${params.appId} gameId=${params.gameId} — syncing cloud saves before launch")
+        try {
+            app.gamenative.service.epic.EpicCloudSavesManager.syncCloudSaves(
+                context = context,
+                appId = params.gameId,
+            )
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Timber.tag("Epic").e(e, "[Cloud Saves] Sync failed for ${params.appId}")
+            return CloudSyncOutcome.ShowDialog(
+                MessageDialogState(
+                    visible = true,
+                    type = DialogType.SYNC_FAIL,
+                    title = context.getString(R.string.sync_error_title),
+                    message = context.getString(R.string.main_sync_failed, e.message ?: e.toString()),
+                    dismissBtnText = context.getString(R.string.ok),
+                ),
+            )
+        } finally {
+            Timber.tag("Epic").i("[Ownership Tokens] Cleaning up launch tokens for Epic games...")
+            EpicService.cleanupLaunchTokens(context)
+        }
         return CloudSyncOutcome.Proceed
     }
 
@@ -40,11 +58,20 @@ internal object EpicCloudSavePlatform : CloudSavePlatform {
         isOffline: Boolean,
         prefixToPath: (String) -> String,
     ) {
+        if (isOffline) {
+            Timber.tag("Epic").i("[Cloud Saves] Skipping upload for $appId (isOffline=true)")
+            return
+        }
         Timber.tag("Epic").i("[Cloud Saves] Epic Game detected for $appId — uploading cloud saves after close")
-        app.gamenative.service.epic.EpicCloudSavesManager.syncCloudSaves(
-            context = context,
-            appId = gameId,
-            preferredAction = "upload",
-        )
+        try {
+            app.gamenative.service.epic.EpicCloudSavesManager.syncCloudSaves(
+                context = context,
+                appId = gameId,
+                preferredAction = "upload",
+            )
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Timber.tag("Epic").e(e, "[Cloud Saves] Upload failed for $appId")
+        }
     }
 }

--- a/app/src/main/java/app/gamenative/utils/cloudSync/GOGCloudSavePlatform.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/GOGCloudSavePlatform.kt
@@ -29,4 +29,19 @@ internal object GOGCloudSavePlatform : CloudSavePlatform {
         )
         return CloudSyncOutcome.Proceed
     }
+
+    override suspend fun upload(
+        context: Context,
+        appId: String,
+        gameId: Int,
+        isOffline: Boolean,
+        prefixToPath: (String) -> String,
+    ) {
+        Timber.tag("GOG").i("[Cloud Saves] GOG Game detected for $appId — uploading cloud saves after close")
+        app.gamenative.service.gog.GOGService.syncCloudSaves(
+            context = context,
+            appId = appId,
+            preferredAction = "upload",
+        )
+    }
 }

--- a/app/src/main/java/app/gamenative/utils/cloudSync/GOGCloudSavePlatform.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/GOGCloudSavePlatform.kt
@@ -2,11 +2,14 @@ package app.gamenative.utils.cloudSync
 
 import android.content.Context
 import app.gamenative.R
+import app.gamenative.ui.component.dialog.state.MessageDialogState
+import app.gamenative.ui.enums.DialogType
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.data.GameSource
 import app.gamenative.utils.CloudSaveCallbacks
 import com.winlator.container.Container
 import timber.log.Timber
+import kotlinx.coroutines.CancellationException
 
 /** GOG cloud save sync before launch. */
 internal object GOGCloudSavePlatform : CloudSavePlatform {
@@ -23,11 +26,25 @@ internal object GOGCloudSavePlatform : CloudSavePlatform {
         callbacks: CloudSaveCallbacks,
     ): CloudSyncOutcome {
         Timber.tag("GOG").i("[Cloud Saves] GOG Game detected for ${params.appId} — syncing cloud saves before launch")
-        app.gamenative.service.gog.GOGService.syncCloudSaves(
-            context = context,
-            appId = params.appId,
-        )
-        return CloudSyncOutcome.Proceed
+        return try {
+            app.gamenative.service.gog.GOGService.syncCloudSaves(
+                context = context,
+                appId = params.appId,
+            )
+            CloudSyncOutcome.Proceed
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Timber.tag("GOG").e(e, "[Cloud Saves] Sync failed for ${params.appId}")
+            CloudSyncOutcome.ShowDialog(
+                MessageDialogState(
+                    visible = true,
+                    type = DialogType.SYNC_FAIL,
+                    title = context.getString(R.string.sync_error_title),
+                    message = context.getString(R.string.main_sync_failed, e.message ?: e.toString()),
+                    dismissBtnText = context.getString(R.string.ok),
+                ),
+            )
+        }
     }
 
     override suspend fun upload(
@@ -38,10 +55,15 @@ internal object GOGCloudSavePlatform : CloudSavePlatform {
         prefixToPath: (String) -> String,
     ) {
         Timber.tag("GOG").i("[Cloud Saves] GOG Game detected for $appId — uploading cloud saves after close")
-        app.gamenative.service.gog.GOGService.syncCloudSaves(
-            context = context,
-            appId = appId,
-            preferredAction = "upload",
-        )
+        try {
+            app.gamenative.service.gog.GOGService.syncCloudSaves(
+                context = context,
+                appId = appId,
+                preferredAction = "upload",
+            )
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Timber.tag("GOG").e(e, "[Cloud Saves] Upload failed for $appId")
+        }
     }
 }

--- a/app/src/main/java/app/gamenative/utils/cloudSync/GOGCloudSavePlatform.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/GOGCloudSavePlatform.kt
@@ -1,0 +1,32 @@
+package app.gamenative.utils.cloudSync
+
+import android.content.Context
+import app.gamenative.R
+import app.gamenative.utils.ContainerUtils
+import app.gamenative.data.GameSource
+import app.gamenative.utils.CloudSaveCallbacks
+import com.winlator.container.Container
+import timber.log.Timber
+
+/** GOG cloud save sync before launch. */
+internal object GOGCloudSavePlatform : CloudSavePlatform {
+    override fun appliesTo(container: Container) =
+        ContainerUtils.extractGameSourceFromContainerId(container.id) == GameSource.GOG
+
+    override fun getLoadingMessage(context: Context, container: Container) =
+        context.getString(R.string.main_syncing_cloud_saves)
+
+    override suspend fun sync(
+        context: Context,
+        container: Container,
+        params: CloudSyncParams,
+        callbacks: CloudSaveCallbacks,
+    ): CloudSyncOutcome {
+        Timber.tag("GOG").i("[Cloud Saves] GOG Game detected for ${params.appId} — syncing cloud saves before launch")
+        app.gamenative.service.gog.GOGService.syncCloudSaves(
+            context = context,
+            appId = params.appId,
+        )
+        return CloudSyncOutcome.Proceed
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/cloudSync/SteamCloudSavePlatform.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/SteamCloudSavePlatform.kt
@@ -180,6 +180,14 @@ internal object SteamCloudSavePlatform : CloudSavePlatform {
                             message = context.getString(R.string.main_pending_operation_none),
                             dismissBtnText = context.getString(R.string.ok),
                         )
+                    else ->
+                        MessageDialogState(
+                            visible = true,
+                            type = DialogType.PENDING_OPERATION_NONE,
+                            title = context.getString(R.string.sync_error_title),
+                            message = context.getString(R.string.main_pending_operation_none),
+                            dismissBtnText = context.getString(R.string.ok),
+                        )
                 }
             } else {
                 MessageDialogState(
@@ -205,6 +213,13 @@ internal object SteamCloudSavePlatform : CloudSavePlatform {
         isOffline: Boolean,
         prefixToPath: (String) -> String,
     ) {
-        SteamService.closeApp(gameId, isOffline, prefixToPath).await()
+        Timber.tag("Steam").i("[Cloud Saves] Steam Game detected for $appId — uploading cloud saves after close")
+        try {
+            SteamService.closeApp(gameId, isOffline, prefixToPath).await()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Timber.tag("Steam").e(e, "[Cloud Saves] Upload failed for $appId")
+        }
+
     }
 }

--- a/app/src/main/java/app/gamenative/utils/cloudSync/SteamCloudSavePlatform.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/SteamCloudSavePlatform.kt
@@ -197,4 +197,14 @@ internal object SteamCloudSavePlatform : CloudSavePlatform {
         SyncResult.Success,
         -> CloudSyncOutcome.Proceed
     }
+
+    override suspend fun upload(
+        context: Context,
+        appId: String,
+        gameId: Int,
+        isOffline: Boolean,
+        prefixToPath: (String) -> String,
+    ) {
+        SteamService.closeApp(gameId, isOffline, prefixToPath).await()
+    }
 }

--- a/app/src/main/java/app/gamenative/utils/cloudSync/SteamCloudSavePlatform.kt
+++ b/app/src/main/java/app/gamenative/utils/cloudSync/SteamCloudSavePlatform.kt
@@ -1,0 +1,200 @@
+package app.gamenative.utils.cloudSync
+
+import android.content.Context
+import app.gamenative.R
+import app.gamenative.data.PostSyncInfo
+import app.gamenative.enums.PathType
+import app.gamenative.enums.SyncResult
+import app.gamenative.service.SteamService
+import app.gamenative.ui.component.dialog.state.MessageDialogState
+import app.gamenative.ui.enums.DialogType
+import app.gamenative.utils.ContainerUtils
+import app.gamenative.data.GameSource
+import app.gamenative.utils.CloudSaveCallbacks
+import com.winlator.container.Container
+import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientObjects.ECloudPendingRemoteOperation
+import java.util.Date
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import timber.log.Timber
+
+const val LOADING_PROGRESS_UNKNOWN: Float = -1f
+
+/** Steam cloud save sync before launch. Resolves all sync outcomes (Proceed / ShowDialog / Retry) inline. */
+internal object SteamCloudSavePlatform : CloudSavePlatform {
+    override fun appliesTo(container: Container) =
+        ContainerUtils.extractGameSourceFromContainerId(container.id) == GameSource.STEAM
+
+    override fun getLoadingMessage(context: Context, container: Container) =
+        context.getString(R.string.main_syncing_cloud_saves)
+
+    override suspend fun sync(
+        context: Context,
+        container: Container,
+        params: CloudSyncParams,
+        callbacks: CloudSaveCallbacks,
+    ): CloudSyncOutcome = coroutineScope {
+        val prefixToPath: (String) -> String = { prefix ->
+            PathType.from(prefix).toAbsPath(context, params.gameId, SteamService.userSteamId!!.accountID)
+        }
+        callbacks.setLoadingMessage(getLoadingMessage(context, container))
+        callbacks.setLoadingProgress(LOADING_PROGRESS_UNKNOWN)
+        val postSyncInfo = SteamService.beginLaunchApp(
+            appId = params.gameId,
+            prefixToPath = prefixToPath,
+            ignorePendingOperations = params.ignorePendingOperations,
+            preferredSave = params.preferredSave,
+            parentScope = params.scope,
+            isOffline = params.isOffline,
+            onProgress = { message, progress ->
+                callbacks.setLoadingMessage(message)
+                callbacks.setLoadingProgress(if (progress < 0) -1f else progress)
+            },
+        ).await()
+        resolveResult(postSyncInfo, context, params.appId, params.useTemporaryOverride, params.retryCount)
+    }
+
+    private suspend fun resolveResult(
+        postSyncInfo: PostSyncInfo,
+        context: Context,
+        appId: String,
+        useTemporaryOverride: Boolean,
+        retryCount: Int,
+    ): CloudSyncOutcome = when (postSyncInfo.syncResult) {
+        SyncResult.Conflict -> CloudSyncOutcome.ShowDialog(
+            MessageDialogState(
+                visible = true,
+                type = DialogType.SYNC_CONFLICT,
+                title = context.getString(R.string.main_save_conflict_title),
+                message = context.getString(
+                    R.string.main_save_conflict_message,
+                    Date(postSyncInfo.localTimestamp).toString(),
+                    Date(postSyncInfo.remoteTimestamp).toString(),
+                ),
+                dismissBtnText = context.getString(R.string.main_keep_local),
+                confirmBtnText = context.getString(R.string.main_keep_remote),
+            ),
+        )
+
+        SyncResult.InProgress -> {
+            if (useTemporaryOverride && retryCount < 5) {
+                Timber.i("Sync in progress for intent launch, retrying in 2 seconds... (attempt ${retryCount + 1}/5)")
+                delay(2000)
+                CloudSyncOutcome.Retry
+            } else {
+                CloudSyncOutcome.ShowDialog(
+                    MessageDialogState(
+                        visible = true,
+                        type = DialogType.SYNC_IN_PROGRESS,
+                        title = context.getString(R.string.sync_error_title),
+                        message = context.getString(R.string.main_sync_in_progress_launch_anyway_message),
+                        confirmBtnText = context.getString(R.string.main_launch_anyway),
+                        dismissBtnText = context.getString(R.string.main_wait),
+                    ),
+                )
+            }
+        }
+
+        SyncResult.UnknownFail,
+        SyncResult.DownloadFail,
+        SyncResult.UpdateFail,
+        -> CloudSyncOutcome.ShowDialog(
+            MessageDialogState(
+                visible = true,
+                type = DialogType.SYNC_FAIL,
+                title = context.getString(R.string.sync_error_title),
+                message = context.getString(R.string.main_sync_failed, postSyncInfo.syncResult.toString()),
+                dismissBtnText = context.getString(R.string.ok),
+            ),
+        )
+
+        SyncResult.PendingOperations -> {
+            Timber.i(
+                "Pending remote operations:${
+                    postSyncInfo.pendingRemoteOperations.map { pro ->
+                        "\n\tmachineName: ${pro.machineName}" +
+                            "\n\ttimestamp: ${Date(pro.timeLastUpdated * 1000L)}" +
+                            "\n\toperation: ${pro.operation}"
+                    }.joinToString("\n")
+                }",
+            )
+            val state = if (postSyncInfo.pendingRemoteOperations.size == 1) {
+                val pro = postSyncInfo.pendingRemoteOperations.first()
+                val gameName = SteamService.getAppInfoOf(ContainerUtils.extractGameIdFromContainerId(appId))?.name ?: ""
+                val dateStr = Date(pro.timeLastUpdated * 1000L).toString()
+                when (pro.operation) {
+                    ECloudPendingRemoteOperation.k_ECloudPendingRemoteOperationUploadInProgress ->
+                        MessageDialogState(
+                            visible = true,
+                            type = DialogType.PENDING_UPLOAD_IN_PROGRESS,
+                            title = context.getString(R.string.main_upload_in_progress_title),
+                            message = context.getString(
+                                R.string.main_upload_in_progress_message,
+                                gameName,
+                                pro.machineName,
+                                dateStr,
+                            ),
+                            dismissBtnText = context.getString(R.string.ok),
+                        )
+                    ECloudPendingRemoteOperation.k_ECloudPendingRemoteOperationUploadPending ->
+                        MessageDialogState(
+                            visible = true,
+                            type = DialogType.PENDING_UPLOAD,
+                            title = context.getString(R.string.main_pending_upload_title),
+                            message = context.getString(
+                                R.string.main_pending_upload_message,
+                                gameName,
+                                pro.machineName,
+                                dateStr,
+                            ),
+                            confirmBtnText = context.getString(R.string.main_play_anyway),
+                            dismissBtnText = context.getString(R.string.cancel),
+                        )
+                    ECloudPendingRemoteOperation.k_ECloudPendingRemoteOperationAppSessionActive ->
+                        MessageDialogState(
+                            visible = true,
+                            type = DialogType.APP_SESSION_ACTIVE,
+                            title = context.getString(R.string.main_app_running_title),
+                            message = context.getString(
+                                R.string.main_app_running_other_device,
+                                pro.machineName,
+                                gameName,
+                                dateStr,
+                            ),
+                            confirmBtnText = context.getString(R.string.main_play_anyway),
+                            dismissBtnText = context.getString(R.string.cancel),
+                        )
+                    ECloudPendingRemoteOperation.k_ECloudPendingRemoteOperationAppSessionSuspended ->
+                        MessageDialogState(
+                            visible = true,
+                            type = DialogType.APP_SESSION_SUSPENDED,
+                            title = context.getString(R.string.sync_error_title),
+                            message = context.getString(R.string.main_app_session_suspended),
+                            dismissBtnText = context.getString(R.string.ok),
+                        )
+                    ECloudPendingRemoteOperation.k_ECloudPendingRemoteOperationNone ->
+                        MessageDialogState(
+                            visible = true,
+                            type = DialogType.PENDING_OPERATION_NONE,
+                            title = context.getString(R.string.sync_error_title),
+                            message = context.getString(R.string.main_pending_operation_none),
+                            dismissBtnText = context.getString(R.string.ok),
+                        )
+                }
+            } else {
+                MessageDialogState(
+                    visible = true,
+                    type = DialogType.MULTIPLE_PENDING_OPERATIONS,
+                    title = context.getString(R.string.sync_error_title),
+                    message = context.getString(R.string.main_multiple_pending_operations),
+                    dismissBtnText = context.getString(R.string.ok),
+                )
+            }
+            CloudSyncOutcome.ShowDialog(state)
+        }
+
+        SyncResult.UpToDate,
+        SyncResult.Success,
+        -> CloudSyncOutcome.Proceed
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -778,6 +778,7 @@
     <string name="main_sync_in_progress_launch_anyway_message">Cloud save sync for this game is already running. You can wait and try again, or launch anyway without syncing (may cause save conflicts).</string>
     <string name="main_launch_anyway">Launch anyway</string>
     <string name="main_wait">Wait</string>
+    <string name="main_syncing_cloud_saves">Syncing cloud saves...</string>
     <string name="main_sync_failed">Failed to sync save files: %s.</string>
 
     <!-- PluviaMain: Pending Operations -->


### PR DESCRIPTION
Extracted cloud saves feature.
If we have another (doesn't matter which platform) Just add a new cloud save platform file and configure it in the list. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlines cloud save sync before launch and uploads after exit across Steam, GOG, and Epic with one modular flow. We run all matching platforms in order; the first non-proceed outcome decides continue, show dialog, or retry.

- **Refactors**
  - Introduced CloudSavePlatform (Steam/GOG/Epic), CloudSyncParams, CloudSyncOutcome, and CloudSaveCallbacks; shared “Syncing cloud saves...” string.
  - Added getCloudSyncPlatforms, syncCloudSaves, and uploadCloudSaves; pre-launch now returns Proceed/Dialog/Retry, post-exit uploads dispatch via platforms (Epic skipped when offline).
  - Moved Epic launch token cleanup into the Epic step; replaced per-platform logic in PluviaMain and MainViewModel with centralized helpers.

- **New Features**
  - Add new cloud save platforms by implementing CloudSavePlatform and registering them; they run in both pre-launch sync and post-exit upload.

<sup>Written for commit d810fe1ce4aadd4e8f2cf8328c4ac38b80be5808. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified cloud save sync flow across Steam, GOG, and Epic with consistent pre-launch outcomes (proceed, dialog, retry).
  * Automatic post-exit upload of cloud saves for applicable platforms.
  * New "Syncing cloud saves..." loading message shown during sync operations.

* **Improvements**
  * Richer conflict, in-progress, and failure dialogs with contextual details and better progress reporting.
  * Improved retry logic and more reliable handling of edge cases for smoother launches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->