### PR TITLE
fix: auto-download missing wine/proton on first launch

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -71,8 +71,10 @@ import app.gamenative.ui.screen.login.UserLoginScreen
 import app.gamenative.ui.screen.settings.SettingsScreen
 import app.gamenative.ui.screen.xserver.XServerScreen
 import app.gamenative.ui.theme.PluviaTheme
+import app.gamenative.utils.BestConfigService
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.CustomGameScanner
+import app.gamenative.utils.ManifestInstaller
 import app.gamenative.utils.GameFeedbackUtils
 import app.gamenative.utils.IntentLaunchManager
 import app.gamenative.utils.UpdateChecker
@@ -91,6 +93,8 @@ import java.util.Date
 import java.util.EnumSet
 import kotlin.reflect.KFunction2
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -1147,6 +1151,30 @@ fun preLaunchApp(
             }
         }
 
+        // download any manifest components (wine/proton, dxvk, etc.) missing from config
+        if (gameSource == GameSource.STEAM) {
+            try {
+                val configJson = Json.parseToJsonElement(container.containerJson).jsonObject
+                val missingRequests = BestConfigService.resolveMissingManifestInstallRequests(
+                    context, configJson, "exact_gpu_match",
+                )
+                for (request in missingRequests) {
+                    setLoadingMessage(context.getString(R.string.main_downloading_entry, request.entry.name))
+                    try {
+                        ManifestInstaller.installManifestEntry(
+                            context, request.entry, request.isDriver, request.contentType,
+                        ) { progress -> setLoadingProgress(progress.coerceIn(0f, 1f)) }
+                    } catch (e: Exception) {
+                        Timber.e(e, "Failed to install ${request.entry.name}, continuing")
+                    }
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to install manifest components")
+                setLoadingDialogVisible(false)
+                return@launch
+            }
+        }
+
         // Check if this is a Custom Game and validate executable selection before installing components
         // Skip the check if booting to container (Open Container menu option)
         val isCustomGame = gameSource == GameSource.CUSTOM_GAME
@@ -1239,6 +1267,7 @@ fun preLaunchApp(
                 "steam-token.tzst",
             ).await()
         }
+
         val loadingMessage = if (container.containerVariant.equals(Container.GLIBC)) {
             context.getString(R.string.main_installing_glibc)
         } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -755,7 +755,9 @@
     <string name="main_open_discord">Open Discord</string>
 
     <!-- PluviaMain: Game Launch -->
+    <string name="main_downloading_entry">Downloading %s</string>
     <string name="main_downloading_steam">Downloading Steam...</string>
+
     <string name="main_installing_glibc">Installing glibc components...</string>
     <string name="main_installing_bionic">Installing Bionic components...</string>
     <string name="main_loading">Loading...</string>


### PR DESCRIPTION
## Summary
- Download missing manifest components (wine/proton, dxvk, box64, etc.) in `preLaunchApp()` with progress UI, so first-launch with an undownloaded Proton version works
- Guard in `XServerScreen` to show a toast instead of crashing if wine/proton is still missing after download
- Filter SIGKILL/SIGTERM (137/143) from game termination error handler — these are normal quit signals

Closes #580

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically downloads missing Wine/Proton and related components during Steam pre-launch with progress and localized messages, so first runs work without manual setup. Normal quits no longer show false errors, and launches fail fast if the executable is missing.

- **New Features**
  - Auto-download missing manifest entries (Wine/Proton, DXVK, Box64) for Steam games in preLaunchApp with progress UI and localized “Downloading %s”.

- **Bug Fixes**
  - Fail fast before downloads if no launch executable is found.
  - Abort launch with a toast if Wine/Proton is unavailable (guard in XServerScreen).
  - Continue installing other components if one download fails (per-request error handling).
  - Ignore exit codes 137/143 (SIGKILL/SIGTERM) to avoid false error dialogs.

<sup>Written for commit 91ab0fee2af3e48817d84fa44075ad93b99b62e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and on-demand downloading of missing manifest components during Steam launches, with per-item progress feedback.

* **Bug Fixes**
  * Prevents game launches when Wine/Proton is not properly installed to avoid incomplete-start failures.

* **Refactor**
  * Consolidated and simplified manifest installation flow; removed redundant pre-install checks in favor of streamlined error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->