### PR TITLE
feat: suspend game on overlay menu invoke

### DIFF
--- a/app/src/main/java/app/gamenative/MainActivity.kt
+++ b/app/src/main/java/app/gamenative/MainActivity.kt
@@ -270,8 +270,8 @@ class MainActivity : ComponentActivity() {
         // disable auto-stop when returning to foreground
         SteamService.autoStopWhenIdle = false
 
-        // Resume game if it was running
-        if (SteamService.keepAlive) {
+        // Resume game if it was running and not currently suspended by the navigation overlay
+        if (SteamService.keepAlive && !PluviaApp.isOverlayPaused) {
             PluviaApp.xEnvironment?.onResume()
             Timber.d("Game resumed")
         }

--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -117,6 +117,9 @@ class PluviaApp : SplitCompatApplication() {
         var inputControlsManager: InputControlsManager? = null
         var touchpadView: TouchpadView? = null
 
+        @JvmField
+        var isOverlayPaused: Boolean = false
+
         // Supabase client for game feedback
         lateinit var supabase: SupabaseClient
             private set

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -328,6 +328,7 @@ fun XServerScreen(
     var showElementEditor by remember { mutableStateOf(false) }
     var elementToEdit by remember { mutableStateOf<com.winlator.inputcontrols.ControlElement?>(null) }
     var showPhysicalControllerDialog by remember { mutableStateOf(false) }
+    var isOverlayPaused by remember { mutableStateOf(false) }
 
     fun startExitWatchForUnmappedGameWindow(window: Window) {
         val winHandler = xServerView?.getxServer()?.winHandler ?: return
@@ -424,7 +425,13 @@ fun XServerScreen(
         }
 
         Timber.i("BackHandler")
-        NavigationDialog(
+
+        // Suspend game and audio while the navigation overlay is visible.
+        PluviaApp.xEnvironment?.onPause()
+        isOverlayPaused = true
+        PluviaApp.isOverlayPaused = true
+
+        val navDialog = NavigationDialog(
             context,
             object : NavigationDialog.NavigationListener {
                 override fun onNavigationItemSelected(itemId: Int) {
@@ -562,12 +569,25 @@ fun XServerScreen(
                             } else {
                                 PostHog.capture(event = "game_closed")
                             }
+                            // Resume processes before exiting so they can receive SIGTERM cleanly.
+                            PluviaApp.xEnvironment?.onResume()
+                            isOverlayPaused = false
+                            PluviaApp.isOverlayPaused = false
                             exit(xServerView!!.getxServer().winHandler, PluviaApp.xEnvironment, frameRating, currentAppInfo, container, onExit, navigateBack)
                         }
                     }
                 }
             }
-        ).show()
+        )
+        // Resume game when the overlay closes via back press, outside tap, or any non-exit item.
+        navDialog.setOnDismissListener {
+            if (PluviaApp.isOverlayPaused) {
+                PluviaApp.xEnvironment?.onResume()
+                isOverlayPaused = false
+                PluviaApp.isOverlayPaused = false
+            }
+        }
+        navDialog.show()
     }
 
     DisposableEffect(container) {


### PR DESCRIPTION
https://github.com/utkarshdalal/GameNative/pull/542 but instead of an additional button in overlay, it just suspends when you invoke menu, resumes when you dismiss menu. tested all other options in the menu, sleeping and nav away under suspend states, rapid wake sleep, and exit while suspend without issues.


Inspired by this decky plugin I love for Steam Deck:
https://github.com/popsUlfr/SDH-PauseGames

A few use cases I find this nice for:

- games like dark souls, I can pause it even though the game does not naturally pause
- some handhelds if I have lock screen disabled and they get bumped and waken up, now this will turn on screen but not ramp up CPU and melt the device in my pocket, an iPod lock of sorts
- on something like the Thor, I might multitask on secondary screen, but I do not want to let the game idle and spend resources, nor swipe it away and risk it getting purged from memory
- Still testing, but in some cases where I observed lengthy suspends caused the app to crash on next wake, not seeing that here, need more time with it to say for sure


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suspend the game when the navigation overlay opens and resume when it closes. This saves resources and effectively adds a pause for games without one.

- **New Features**
  - Pauses X environment and audio when the navigation menu opens; resumes on dismiss or any non-exit action.
  - Introduces PluviaApp.isOverlayPaused to track overlay state and prevent unintended auto-resume on foreground.
  - Resumes processes before exit to handle clean shutdown (SIGTERM).
  - Updates MainActivity to skip resume while the overlay pause is active.

<sup>Written for commit bd7718cccde8fbeb5bcf7424071f025b915a5b62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game pause and resume logic when navigation overlays are displayed, ensuring the game properly pauses when overlays appear and automatically resumes when they are dismissed or closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->