### PR TITLE
fix: replace hardcoded app ID paths with BuildConfig.APPLICATION_ID

### DIFF
--- a/app/src/main/cpp/extras/evshim.c
+++ b/app/src/main/cpp/extras/evshim.c
@@ -166,12 +166,16 @@ static void initialize_all_pads(void)
     if (players > MAX_GAMEPADS) players = MAX_GAMEPADS;
 
 
+    const char *data_dir = getenv("EVSHIM_DATA_DIR");
+    if (!data_dir) data_dir = "/data/data/app.gamenative";
+
     /* per-player setup */
     for (int i = 0; i < players; ++i) {
 
         char path[256];
         snprintf(path, sizeof path,
-                 "/data/data/app.gamenative/files/imagefs/tmp/gamepad%s.mem",
+                 "%s/files/imagefs/tmp/gamepad%s.mem",
+                 data_dir,
                  (i == 0) ? "" : (char[2]){'0' + i, '\0'});
 
         /* open once – store for reader + writer */

--- a/app/src/main/java/com/winlator/container/Container.java
+++ b/app/src/main/java/com/winlator/container/Container.java
@@ -14,6 +14,8 @@ import com.winlator.fexcore.FEXCorePreset;
 import com.winlator.winhandler.WinHandler;
 import com.winlator.xenvironment.ImageFs;
 
+import app.gamenative.BuildConfig;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -21,6 +23,7 @@ import java.io.File;
 import java.util.Iterator;
 
 public class Container {
+    private static final String DATA_DIR = "/data/data/" + BuildConfig.APPLICATION_ID;
     public enum XrControllerMapping {
         BUTTON_A, BUTTON_B, BUTTON_X, BUTTON_Y, BUTTON_GRIP, BUTTON_TRIGGER,
         THUMBSTICK_UP, THUMBSTICK_DOWN, THUMBSTICK_LEFT, THUMBSTICK_RIGHT
@@ -45,14 +48,14 @@ public class Container {
     public static final String DEFAULT_WINCOMPONENTS = "direct3d=1,directsound=1,directmusic=0,directshow=0,directplay=0,vcrun2010=1,wmdecoder=1,opengl=0";
     public static final String FALLBACK_WINCOMPONENTS = "direct3d=1,directsound=1,directmusic=1,directshow=1,directplay=1,vcrun2010=1,wmdecoder=1,opengl=0";
     public static final String[] MEDIACONV_ENV_VARS = {
-            "MEDIACONV_AUDIO_DUMP_FILE=/data/data/app.gamenative/files/imagefs/home/xuser/audio.dmp",
-            "MEDIACONV_VIDEO_DUMP_FILE=/data/data/app.gamenative/files/imagefs/home/xuser/video.dmp",
-            "MEDIACONV_VIDEO_TRANSCODED_FILE=/data/data/app.gamenative/files/imagefs/home/xuser/transcoded.mkv",
-            "MEDIACONV_AUDIO_TRANSCODED_FILE=/data/data/app.gamenative/files/imagefs/home/xuser/transcoded.wav",
-            "MEDIACONV_BLANK_AUDIO_FILE=/data/data/app.gamenative/files/imagefs/home/xuser/blank.wav",
-            "MEDIACONV_BLANK_VIDEO_FILE=/data/data/app.gamenative/files/imagefs/home/xuser/blank.mkv",
+            "MEDIACONV_AUDIO_DUMP_FILE=" + DATA_DIR + "/files/imagefs/home/xuser/audio.dmp",
+            "MEDIACONV_VIDEO_DUMP_FILE=" + DATA_DIR + "/files/imagefs/home/xuser/video.dmp",
+            "MEDIACONV_VIDEO_TRANSCODED_FILE=" + DATA_DIR + "/files/imagefs/home/xuser/transcoded.mkv",
+            "MEDIACONV_AUDIO_TRANSCODED_FILE=" + DATA_DIR + "/files/imagefs/home/xuser/transcoded.wav",
+            "MEDIACONV_BLANK_AUDIO_FILE=" + DATA_DIR + "/files/imagefs/home/xuser/blank.wav",
+            "MEDIACONV_BLANK_VIDEO_FILE=" + DATA_DIR + "/files/imagefs/home/xuser/blank.mkv",
     };
-    public static final String DEFAULT_DRIVES = "D:"+Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)+"E:/data/data/app.gamenative/storage";
+    public static final String DEFAULT_DRIVES = "D:"+Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)+"E:" + DATA_DIR + "/storage";
     public static final String DEFAULT_VARIANT = DefaultVersion.VARIANT;
     public static final String DEFAULT_WINE_VERSION = DefaultVersion.WINE_VERSION;
     public static final byte STARTUP_SELECTION_NORMAL = 0;

--- a/app/src/main/java/com/winlator/core/DXVKHelper.java
+++ b/app/src/main/java/com/winlator/core/DXVKHelper.java
@@ -17,7 +17,7 @@ public class DXVKHelper {
 
     public static void setEnvVars(Context context, KeyValueSet config, EnvVars envVars) {
         ImageFs imageFs = ImageFs.find(context);
-        envVars.put("DXVK_STATE_CACHE_PATH", "/data/data/app.gamenative/files/imagefs"+ImageFs.CACHE_PATH);
+        envVars.put("DXVK_STATE_CACHE_PATH", imageFs.getRootDir().getPath()+ImageFs.CACHE_PATH);
         envVars.put("DXVK_LOG_LEVEL", "none");
 
         File rootDir = ImageFs.find(context).getRootDir();

--- a/app/src/main/java/com/winlator/core/WineUtils.java
+++ b/app/src/main/java/com/winlator/core/WineUtils.java
@@ -38,7 +38,7 @@ public abstract class WineUtils {
                 missingDrives += "D:" + android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DOWNLOADS);
             }
             if (!currentDrives.contains("E:")) {
-                missingDrives += "E:/data/data/app.gamenative/storage";
+                missingDrives += "E:/data/data/" + app.gamenative.BuildConfig.APPLICATION_ID + "/storage";
             }
             String updatedDrives = missingDrives + currentDrives;
             container.setDrives(updatedDrives);
@@ -50,7 +50,7 @@ public abstract class WineUtils {
         for (String[] drive : container.drivesIterator()) {
             File linkTarget = new File(drive[1]);
             String path = linkTarget.getAbsolutePath();
-            if (!linkTarget.isDirectory() && path.endsWith("/app.gamenative/storage")) {
+            if (!linkTarget.isDirectory() && path.endsWith("/" + app.gamenative.BuildConfig.APPLICATION_ID + "/storage")) {
                 linkTarget.mkdirs();
                 FileUtils.chmod(linkTarget, 0771);
             }

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 
+import app.gamenative.BuildConfig;
 import timber.log.Timber;
 
 public class WinHandler {
@@ -519,8 +520,9 @@ public class WinHandler {
     public void start() {
         try {
             this.localhost = InetAddress.getLocalHost();
+            String tmpDir = "/data/data/" + BuildConfig.APPLICATION_ID + "/files/imagefs/tmp";
             // Player 1 (currentController) gets the original non-numbered file
-            String p1_mem_path = "/data/data/app.gamenative/files/imagefs/tmp/gamepad.mem";
+            String p1_mem_path = tmpDir + "/gamepad.mem";
             File p1_memFile = new File(p1_mem_path);
             p1_memFile.getParentFile().mkdirs();
             try (RandomAccessFile raf = new RandomAccessFile(p1_memFile, "rw")) {
@@ -530,7 +532,7 @@ public class WinHandler {
                 Log.i(TAG, "Successfully created and mapped gamepad file for Player 1");
             }
             for (int i = 0; i < extraGamepadBuffers.length; i++) {
-                String extra_mem_path = "/data/data/app.gamenative/files/imagefs/tmp/gamepad" + (i + 1) + ".mem";
+                String extra_mem_path = tmpDir + "/gamepad" + (i + 1) + ".mem";
                 File extra_memFile = new File(extra_mem_path);
                 try (RandomAccessFile raf = new RandomAccessFile(extra_memFile, "rw")) {
                     raf.setLength(64);

--- a/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
@@ -49,6 +49,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 
+import app.gamenative.BuildConfig;
 import app.gamenative.PluviaApp;
 import app.gamenative.events.AndroidEvent;
 import app.gamenative.service.SteamService;
@@ -182,14 +183,15 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
 
         // Get the number of enabled players directly from ControllerManager.
         final int enabledPlayerCount = MAX_PLAYERS;
+        String tmpDir = "/data/data/" + BuildConfig.APPLICATION_ID + "/files/imagefs/tmp";
         for (int i = 0; i < enabledPlayerCount; i++) {
             String memPath;
             if (i == 0) {
                 // Player 1 uses the original, non-numbered path that is known to work.
-                memPath = "/data/data/app.gamenative/files/imagefs/tmp/gamepad.mem";
+                memPath = tmpDir + "/gamepad.mem";
             } else {
                 // Players 2, 3, 4 use a 1-based index.
-                memPath = "/data/data/app.gamenative/files/imagefs/tmp/gamepad" + i + ".mem";
+                memPath = tmpDir + "/gamepad" + i + ".mem";
             }
 
             File memFile = new File(memPath);
@@ -301,6 +303,7 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
         envVars.put("LD_PRELOAD", ld_preload);
 
         envVars.put("EVSHIM_SHM_NAME", "controller-shm0");
+        envVars.put("EVSHIM_DATA_DIR", "/data/data/" + BuildConfig.APPLICATION_ID);
 
         // Check for specific shared memory libraries
 //        if ((new File(imageFs.getLibDir(), "libandroid-sysvshm.so")).exists()){


### PR DESCRIPTION
## Problem

`/data/data/app.gamenative` is hardcoded in several Java and C files. Any build variant with `applicationIdSuffix` (e.g. `.debug`, `.gold`) breaks:

- Gamepad input (memory-mapped `gamepad.mem` files not found)
- Wine E: drive mount
- DXVK state cache path
- Mediaconv dump/transcoded file paths

## Fix

- Java side: use `BuildConfig.APPLICATION_ID` to construct paths at runtime
- C side (`evshim.c`): read new `EVSHIM_DATA_DIR` env var, fall back to `app.gamenative`

## Important: imagefs rebuild required

The `libevshim.so` bundled in the imagefs must be rebuilt from the updated `evshim.c`. Without this, the evshim won't read `EVSHIM_DATA_DIR` and gamepad input will remain broken for non-default app IDs.

## Files changed

| File | Change |
|---|---|
| `Container.java` | `DATA_DIR` constant from `BuildConfig.APPLICATION_ID`; used in `MEDIACONV_ENV_VARS` and `DEFAULT_DRIVES` |
| `DXVKHelper.java` | `DXVK_STATE_CACHE_PATH` uses `imageFs.getRootDir()` |
| `WineUtils.java` | E: drive path and storage dir check use `BuildConfig.APPLICATION_ID` |
| `WinHandler.java` | gamepad.mem paths derived from `BuildConfig.APPLICATION_ID` |
| `BionicProgramLauncherComponent.java` | gamepad.mem paths + sets `EVSHIM_DATA_DIR` env var |
| `evshim.c` | reads `EVSHIM_DATA_DIR` env var (fallback: `app.gamenative`) |

## Testing

- `./gradlew compileDebugKotlin` passes
- No remaining hardcoded `/data/data/app.gamenative` in modified files (except comment + C fallback)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded /data/data/app.gamenative paths with BuildConfig.APPLICATION_ID and EVSHIM_DATA_DIR so build variants (e.g., .debug, .gold) work correctly. This fixes gamepad input, Wine E: drive mounts, DXVK state cache, and mediaconv paths for non-default app IDs.

- **Bug Fixes**
  - Java: derive data dir from BuildConfig.APPLICATION_ID; update gamepad.mem paths, Wine E: drive, DXVK_STATE_CACHE_PATH, and mediaconv env vars.
  - C (evshim): read EVSHIM_DATA_DIR with a fallback to app.gamenative.

- **Migration**
  - Rebuild imagefs to include the updated libevshim.so; without it, evshim won’t read EVSHIM_DATA_DIR and gamepad input stays broken for non-default app IDs.

<sup>Written for commit 8f1af1684dc31164dedb33d1a4ee5abd9a9291e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved application file path handling by transitioning from hardcoded directory references to dynamic, application-specific paths. This enhancement ensures more reliable file location management and better compatibility across different application instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #618