### PR TITLE
feat: add toggle for auto-apply known config

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -906,6 +906,12 @@ object PrefManager {
         get() = getPref(APP_LANGUAGE, "")
         set(value) = setPref(APP_LANGUAGE, value)
 
+    // auto-apply known config from BestConfigService on first container creation
+    private val AUTO_APPLY_KNOWN_CONFIG = booleanPreferencesKey("auto_apply_known_config")
+    var autoApplyKnownConfig: Boolean
+        get() = getPref(AUTO_APPLY_KNOWN_CONFIG, true)
+        set(value) = setPref(AUTO_APPLY_KNOWN_CONFIG, value)
+
     // Game compatibility cache (JSON string)
     private val GAME_COMPATIBILITY_CACHE = stringPreferencesKey("game_compatibility_cache")
     var gameCompatibilityCache: String

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupEmulation.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupEmulation.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
+import app.gamenative.PrefManager
 import app.gamenative.R
 import app.gamenative.ui.component.dialog.Box64PresetsDialog
 import app.gamenative.ui.component.dialog.ContainerConfigDialog
@@ -16,6 +17,7 @@ import app.gamenative.ui.theme.settingsTileColors
 import app.gamenative.utils.ContainerUtils
 import com.alorma.compose.settings.ui.SettingsGroup
 import com.alorma.compose.settings.ui.SettingsMenuLink
+import com.alorma.compose.settings.ui.SettingsSwitch
 
 @Composable
 fun SettingsGroupEmulation() {
@@ -80,6 +82,17 @@ fun SettingsGroupEmulation() {
             title = { Text(text = stringResource(R.string.settings_emulation_default_config_title)) },
             subtitle = { Text(text = stringResource(R.string.settings_emulation_default_config_subtitle)) },
             onClick = { showConfigDialog = true },
+        )
+        var autoApplyKnownConfig by rememberSaveable { mutableStateOf(PrefManager.autoApplyKnownConfig) }
+        SettingsSwitch(
+            colors = settingsTileColors(),
+            state = autoApplyKnownConfig,
+            title = { Text(text = stringResource(R.string.settings_emulation_auto_apply_known_config_title)) },
+            subtitle = { Text(text = stringResource(R.string.settings_emulation_auto_apply_known_config_subtitle)) },
+            onCheckedChange = {
+                autoApplyKnownConfig = it
+                PrefManager.autoApplyKnownConfig = it
+            },
         )
         SettingsMenuLink(
             colors = settingsTileColors(),

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -697,7 +697,7 @@ object ContainerUtils {
 
         // Check for cached best config (only for Steam games, only if no custom config provided)
         var bestConfigMap: Map<String, Any?>? = null
-        if (gameSource == GameSource.STEAM && customConfig == null) {
+        if (gameSource == GameSource.STEAM && customConfig == null && PrefManager.autoApplyKnownConfig) {
             try {
                 val gameId = extractGameIdFromContainerId(appId)
                 val appInfo = SteamService.getAppInfoOf(gameId)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -620,6 +620,8 @@
     <string name="settings_emulation_default_config_title">Modify Default Config</string>
     <string name="settings_emulation_default_config_subtitle">The initial container settings for each game (does not affect already installed games)</string>
     <string name="settings_emulation_default_config_dialog_title">Default Container Config</string>
+    <string name="settings_emulation_auto_apply_known_config_title">Auto-apply known config</string>
+    <string name="settings_emulation_auto_apply_known_config_subtitle">Automatically apply recommended settings for Steam games on first launch</string>
     <string name="settings_emulation_box64_presets_title">Box64 Presets</string>
     <string name="settings_emulation_box64_presets_subtitle">View, modify, and create Box64 presets</string>
     <string name="settings_emulation_driver_manager_title">Driver Manager</string>


### PR DESCRIPTION
## Summary

- Adds a settings toggle to enable/disable auto-applying known (BestConfigService) settings for Steam games on first container creation
- Default: enabled (preserves current behavior)
- When disabled, containers use the default config instead of fetching recommended settings

## Test plan

- [ ] Toggle off → create new Steam container → verify default config is used, not BestConfigService
- [ ] Toggle on → create new Steam container → verify known config is applied as before
- [ ] Verify toggle state persists across app restarts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a toggle in Settings → Emulation to control auto-applying known BestConfigService settings for new Steam game containers. Default is on; when off, new containers use the default config instead of recommended settings.

- **New Features**
  - New auto_apply_known_config preference with a Settings switch that persists across restarts.
  - Applies only on first Steam container creation; custom configs still take priority.
  - Gated BestConfigService fetch in ContainerUtils; added titles/subtitles in strings and UI.

<sup>Written for commit 7fd16563ebaeab6085c2255d733ae183487a8c83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting to control automatic application of known configurations. Users can now toggle auto-apply on or off in the Emulation settings. When enabled, the app automatically applies cached best configurations; when disabled, auto-apply is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->