### PR TITLE
fix: set affinity masks after container setup, not at construction

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -709,11 +709,7 @@ fun XServerScreen(
                 frameLayout.addView(PluviaApp.touchpadView)
                 PluviaApp.touchpadView?.setMoveCursorToTouchpoint(PrefManager.getBoolean("move_cursor_to_touchpoint", false))
                 getxServer().winHandler = WinHandler(getxServer(), this)
-                win32AppWorkarounds = Win32AppWorkarounds(
-                    getxServer(),
-                    taskAffinityMask,
-                    taskAffinityMaskWoW64,
-                )
+                win32AppWorkarounds = Win32AppWorkarounds(getxServer())
                 touchMouse = TouchMouse(getxServer())
                 keyboard = Keyboard(getxServer())
                 if (!bootToContainer) {
@@ -820,6 +816,7 @@ fun XServerScreen(
 
                             taskAffinityMask = ProcessHelper.getAffinityMask(container.getCPUList(true)).toShort().toInt()
                             taskAffinityMaskWoW64 = ProcessHelper.getAffinityMask(container.getCPUListWoW64(true)).toShort().toInt()
+                            win32AppWorkarounds?.setTaskAffinityMasks(taskAffinityMask, taskAffinityMaskWoW64)
                             containerVariantChanged = container.containerVariant != imageFs.variant
                             firstTimeBoot = container.getExtra("appVersion").isEmpty() || containerVariantChanged
                             needsUnpacking = container.isNeedsUnpacking

--- a/app/src/main/java/com/winlator/core/Win32AppWorkarounds.java
+++ b/app/src/main/java/com/winlator/core/Win32AppWorkarounds.java
@@ -12,8 +12,8 @@ import timber.log.Timber;
 /* loaded from: classes.dex */
 public class Win32AppWorkarounds {
     private final XServer xServer;
-    private final short taskAffinityMask;
-    private final short taskAffinityMaskWoW64;
+    private volatile short taskAffinityMask;
+    private volatile short taskAffinityMaskWoW64;
 
     private interface DXWrapperConfigWorkaround extends Workaround {
         void setValue(String str, KeyValueSet keyValueSet);
@@ -59,8 +59,11 @@ public class Win32AppWorkarounds {
         }
     }
 
-    public Win32AppWorkarounds(XServer xServer, int taskAffinityMask, int taskAffinityMaskWoW64) {
+    public Win32AppWorkarounds(XServer xServer) {
         this.xServer = xServer;
+    }
+
+    public void setTaskAffinityMasks(int taskAffinityMask, int taskAffinityMaskWoW64) {
         this.taskAffinityMask = (short) taskAffinityMask;
         this.taskAffinityMaskWoW64 = (short) taskAffinityMaskWoW64;
     }


### PR DESCRIPTION
Fixes #559

## Summary
- `Win32AppWorkarounds` was constructed with `taskAffinityMask=0` because the actual values were computed later in a background thread
- Made mask fields `volatile` (non-final) with a setter, called after the masks are computed in the setup thread

## Test plan
- [ ] Launch a game and verify process affinities are applied
- [ ] Verify container config dialog still shows correct CPU affinity checkboxes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply CPU affinity masks after container setup instead of at Win32AppWorkarounds construction so the correct masks are used. Fixes cases where async mask computation led to mask=0 and wrong process affinities.

- **Bug Fixes**
  - Made mask fields volatile and added setTaskAffinityMasks; removed mask args from Win32AppWorkarounds constructor.
  - XServerScreen now sets masks after computing taskAffinityMask and taskAffinityMaskWoW64.

<sup>Written for commit d86f685bc1b4a617a81f2f43575ccdda480675e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured task affinity mask configuration in the Windows compatibility layer. Masks are now applied via a dedicated setter method after instantiation instead of during initialization, improving modularity while maintaining existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->