### PR TITLE
Gen 2 downloader simply doesn't have release date

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -124,15 +124,16 @@ class GOGAppScreen : BaseAppScreen() {
         // Parse GOG's ISO 8601 release date string to Unix timestamp
         // GOG returns dates like "2022-08-18T17:50:00+0300" (without colon in timezone)
         // GameDisplayInfo expects Unix timestamp in SECONDS, not milliseconds
-        val releaseDateTimestamp = if (game?.releaseDate?.isNotEmpty() == true) {
+        val rawReleaseDate = game?.releaseDate
+        val releaseDateTimestamp = if (!rawReleaseDate.isNullOrEmpty() && rawReleaseDate != "null") {
             try {
                 val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ")
-                val timestampMillis = java.time.ZonedDateTime.parse(game.releaseDate, formatter).toInstant().toEpochMilli()
+                val timestampMillis = java.time.ZonedDateTime.parse(rawReleaseDate, formatter).toInstant().toEpochMilli()
                 val timestampSeconds = timestampMillis / 1000
-                Timber.tag(TAG).d("Parsed release date '${game.releaseDate}' -> $timestampSeconds seconds (${java.util.Date(timestampMillis)})")
+                Timber.tag(TAG).d("Parsed release date '$rawReleaseDate' -> $timestampSeconds seconds (${java.util.Date(timestampMillis)})")
                 timestampSeconds
             } catch (e: Exception) {
-                Timber.tag(TAG).w(e, "Failed to parse release date: ${game.releaseDate}")
+                Timber.tag(TAG).d("Release date not parseable (ignored): $rawReleaseDate")
                 0L
             }
         } else {


### PR DESCRIPTION
Logs are flooded with an error during GOG gen 2 downloading. It doesn't have release date so i've tightened the check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop error logs during GOG Gen 2 downloads by safely handling missing or "null" release dates. Parsing now runs only on valid values; failures default to 0 and are logged at debug.

- **Bug Fixes**
  - Validate releaseDate before parsing (null, empty, or "null" string).
  - Downgrade parse failures to debug and ignore invalid values.

<sup>Written for commit b9dd92a8ddab079a7ecfd4d47ad57e196a76d76f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release date handling for GOG games with enhanced validation and error checking. The app now properly validates and processes release dates before attempting to parse them, gracefully handling edge cases such as empty, null, or invalid date formats to ensure more reliable and accurate display of game release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->