### PR TITLE
Dont perform steam specific task on non steam platforms

### DIFF
--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -255,13 +255,16 @@ class MainViewModel @Inject constructor(
 
             val apiJob = viewModelScope.async(Dispatchers.IO) {
                 val container = ContainerUtils.getOrCreateContainer(context, appId)
-                if (container.isLaunchRealSteam()) {
-                    SteamUtils.restoreSteamApi(context, appId)
-                } else {
-                    if (container.isUseLegacyDRM) {
-                        SteamUtils.replaceSteamApi(context, appId)
+                val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
+                if (gameSource == GameSource.STEAM) {
+                    if (container.isLaunchRealSteam()) {
+                        SteamUtils.restoreSteamApi(context, appId)
                     } else {
-                        SteamUtils.replaceSteamclientDll(context, appId)
+                        if (container.isUseLegacyDRM) {
+                            SteamUtils.replaceSteamApi(context, appId)
+                        } else {
+                            SteamUtils.replaceSteamclientDll(context, appId)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When launching a game in a platform other then steam, it will log a crash in the background. This PR will simply not run the steam specific code so it wont crash.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash when launching non-Steam games by running Steam-specific code only when the game source is Steam. Non-Steam launches now skip SteamUtils calls, stopping background crash logs.

<sup>Written for commit 50afd21e0185d816278f966f2f7e5468fad9ec84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Steam game launch handling to conditionally manage Steam API operations based on the detected game source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->