### PR TITLE
Added game fixes system + added registry keys for Fallout games

### DIFF
--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1454315831.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1454315831.kt
@@ -1,0 +1,8 @@
+package app.gamenative.gamefixes
+
+val GOG_Fix_1454315831: GameFix = RegistryKeyFix(
+    registryKey = "Software\\Wow6432Node\\Bethesda Softworks\\Fallout3",
+    defaultValues = mapOf(
+        "Installed Path" to INSTALL_PATH_PLACEHOLDER,
+    ),
+)

--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1454587428.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1454587428.kt
@@ -1,0 +1,8 @@
+package app.gamenative.gamefixes
+
+val GOG_Fix_1454587428: GameFix = RegistryKeyFix(
+    registryKey = "Software\\Wow6432Node\\Bethesda Softworks\\FalloutNV",
+    defaultValues = mapOf(
+        "Installed Path" to INSTALL_PATH_PLACEHOLDER,
+    ),
+)

--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1998527297.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1998527297.kt
@@ -1,0 +1,8 @@
+package app.gamenative.gamefixes
+
+val GOG_Fix_1998527297: GameFix = RegistryKeyFix(
+    registryKey = "Software\\Wow6432Node\\Bethesda Softworks\\Fallout4",
+    defaultValues = mapOf(
+        "InstalledPath" to INSTALL_PATH_PLACEHOLDER,
+    ),
+)

--- a/app/src/main/java/app/gamenative/gamefixes/GameFix.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFix.kt
@@ -1,0 +1,12 @@
+package app.gamenative.gamefixes
+
+import android.content.Context
+
+interface GameFix {
+    fun apply(
+        context: Context,
+        gameId: String,
+        installPath: String,
+        installPathWindows: String,
+    ): Boolean
+}

--- a/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
@@ -1,0 +1,41 @@
+package app.gamenative.gamefixes
+
+import android.content.Context
+import app.gamenative.data.GameSource
+import app.gamenative.utils.ContainerUtils
+import app.gamenative.service.gog.GOGConstants
+import app.gamenative.service.gog.GOGService
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+
+object GameFixesRegistry {
+    private const val GAME_DRIVE_LETTER = "A"
+
+    private val fixes: Map<Pair<GameSource, String>, GameFix> = mapOf(
+        GameSource.GOG to "1454315831" to GOG_Fix_1454315831,
+        GameSource.GOG to "1998527297" to GOG_Fix_1998527297,
+        GameSource.GOG to "1454587428" to GOG_Fix_1454587428,
+    )
+
+    fun applyFor(context: Context, appId: String) {
+        val source = ContainerUtils.extractGameSourceFromContainerId(appId)
+        val gameId = ContainerUtils.extractGameIdFromContainerId(appId)?.toString() ?: return
+        val fix = fixes[source to gameId] ?: return
+        val (installPath, installPathWindows) = resolvePaths(context, source, gameId) ?: return
+        fix.apply(context, gameId, installPath, installPathWindows)
+    }
+
+    private fun resolvePaths(context: Context, source: GameSource, gameId: String): Pair<String, String>? {
+        return when (source) {
+            GameSource.GOG -> {
+                val game = runBlocking(Dispatchers.IO) { GOGService.getGOGGameOf(gameId) } ?: return null
+                if (!game.isInstalled) return null
+                val path = game.installPath.ifEmpty { GOGConstants.getGameInstallPath(game.title) }
+                if (path.isEmpty() || !File(path).exists()) return null
+                path to "$GAME_DRIVE_LETTER:\\"
+            }
+            else -> null
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/gamefixes/RegistryKeyFix.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/RegistryKeyFix.kt
@@ -1,0 +1,48 @@
+package app.gamenative.gamefixes
+
+import android.content.Context
+import com.winlator.core.WineRegistryEditor
+import com.winlator.xenvironment.ImageFs
+import timber.log.Timber
+import java.io.File
+
+const val INSTALL_PATH_PLACEHOLDER = "<InstallPath>"
+
+class RegistryKeyFix(
+    private val registryKey: String,
+    private val defaultValues: Map<String, String>,
+) : GameFix {
+    override fun apply(
+        context: Context,
+        gameId: String,
+        installPath: String,
+        installPathWindows: String,
+    ): Boolean {
+        val imageFs = ImageFs.find(context)
+        val systemRegFile = File(imageFs.wineprefix, "system.reg")
+        if (!systemRegFile.exists()) {
+            Timber.tag("GameFixes").w("system.reg not found at ${systemRegFile.absolutePath}")
+            return false
+        }
+        val installPathWin = installPathWindows.replace("/", "\\")
+        val values = defaultValues.mapValues { (_, v) ->
+            if (v == INSTALL_PATH_PLACEHOLDER) installPathWin else v
+        }
+        return try {
+            WineRegistryEditor(systemRegFile).use { editor ->
+                editor.setCreateKeyIfNotExist(true)
+                for ((name, value) in values) {
+                    val existing = editor.getStringValue(registryKey, name, null)
+                    if (existing == null || existing.isEmpty()) {
+                        editor.setStringValue(registryKey, name, value)
+                        Timber.tag("GameFixes").d("Set registry $registryKey $name for game $gameId")
+                    }
+                }
+            }
+            true
+        } catch (e: Exception) {
+            Timber.tag("GameFixes").e(e, "Failed to apply registry fix for game $gameId")
+            false
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -61,6 +61,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
 import app.gamenative.data.GameSource
+import app.gamenative.gamefixes.GameFixesRegistry
 import app.gamenative.data.LaunchInfo
 import app.gamenative.data.LibraryItem
 import app.gamenative.data.SteamApp
@@ -1833,6 +1834,11 @@ private fun setupXEnvironment(
             guestProgramLauncherComponent.setFEXCorePreset(container.fexCorePreset)
         }
         guestProgramLauncherComponent.setPreUnpack {
+            try {
+                GameFixesRegistry.applyFor(context, appId)
+            } catch (e: Exception) {
+                Timber.tag("GameFixes").w(e, "Game fixes failed in preUnpack")
+            }
             unpackExecutableFile(
                 context = context,
                 needsUnpacking = container.isNeedsUnpacking,


### PR DESCRIPTION
This Pr includes a game-specific fixes system which is useable by all game sources. For now it fixes Fallout 3,4, and new vegas, but allows for many more.

Fallout games are just registry keys added. But this system also allows for adding DLL files for instance:
Example of that:
```
package app.gamenative.gamefixes

/**
 * Example DLL inclusion fix. Place DLL at: context.filesDir/gamefixes_dlls/redist/MyFix.dll
 * Add (GameSource.GOG to "0") to GameFixesRegistry.fixes to enable.
 */
val GOG_Fix_0: GameFix = DllInclusionFix(
    dllRelativePath = "redist/MyFix.dll",
    targetSubdir = "",
)
```

```
package app.gamenative.gamefixes

import android.content.Context
import timber.log.Timber
import java.io.File

/**
 * Copies a DLL from a source path into the game install directory.
 * Source is relative to [dllBaseDir] (e.g. context.filesDir / "gamefixes_dlls").
 * [targetSubdir] is a subdir under install path (e.g. "" for game root, "subfolder" for installPath/subfolder).
 */
class DllInclusionFix(
    private val dllRelativePath: String,
    private val targetSubdir: String = "",
    private val dllBaseDir: (Context) -> File = { ctx -> File(ctx.filesDir, "gamefixes_dlls") },
) : GameFix {
    override fun apply(
        context: Context,
        gameId: String,
        installPath: String,
        installPathWindows: String,
    ): Boolean {
        val baseDir = dllBaseDir(context)
        val sourceFile = File(baseDir, dllRelativePath)
        if (!sourceFile.isFile) {
            Timber.tag("GameFixes").w("DLL not found: ${sourceFile.absolutePath}")
            return false
        }
        val targetDir = if (targetSubdir.isEmpty()) File(installPath) else File(installPath, targetSubdir)
        targetDir.mkdirs()
        val targetFile = File(targetDir, sourceFile.name)
        return try {
            sourceFile.copyTo(targetFile, overwrite = true)
            Timber.tag("GameFixes").d("Copied ${sourceFile.name} to game dir for game $gameId")
            true
        } catch (e: Exception) {
            Timber.tag("GameFixes").e(e, "Failed to copy DLL for game $gameId")
            false
        }
    }
}
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a game-specific fixes framework that runs before launch. Adds registry fixes for GOG Fallout 3/4/New Vegas so Wine detects install paths and the games start reliably.

- New Features
  - GameFix interface and RegistryKeyFix to write missing values to Wine system.reg.
  - GameFixesRegistry maps (source, gameId) to fixes, resolves GOG install paths, and runs during pre-unpack.
  - Sets Bethesda registry keys for Fallout 3, New Vegas, and 4 (Installed Path/InstalledPath under Software\Wow6432Node\Bethesda Softworks\...).

<sup>Written for commit 3aa216d681b26d96ddf8167e9b82dc9578a2d3e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic game fixes for select GOG titles now apply during setup
  * Enhanced installation path detection and registry configuration for improved game compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->