### PR TITLE
fix: allow state and page to resume on app refocus instead of rerouting to login and library

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -261,7 +261,7 @@ fun PluviaMain(
                                         Timber.tag("IntentLaunch").i("Applied container config override for app ${launchRequest.appId}")
                                     }
 
-                                    if (navController.currentDestination?.route != PluviaScreen.Home.route) {
+                                    if (navController.currentDestination?.route == PluviaScreen.LoginUser.route) {
                                         navController.navigate(PluviaScreen.Home.route) {
                                             popUpTo(navController.graph.startDestinationId) {
                                                 saveState = false
@@ -281,7 +281,10 @@ fun PluviaMain(
                                         onSuccess = viewModel::launchApp,
                                     )
                                 }
-                            } else if (PluviaApp.xEnvironment == null) {
+                            } else if (
+                                PluviaApp.xEnvironment == null &&
+                                navController.currentDestination?.route == PluviaScreen.LoginUser.route
+                            ) {
                                 Timber.i("Navigating to library")
                                 navController.navigate(PluviaScreen.Home.route)
 
@@ -426,9 +429,6 @@ fun PluviaMain(
                 app.gamenative.service.epic.EpicService.start(context)
             }
 
-            if (SteamService.isLoggedIn && !SteamService.keepAlive && navController.currentDestination?.route == PluviaScreen.LoginUser.route) {
-                navController.navigate(PluviaScreen.Home.route)
-            }
         }
     }
 


### PR DESCRIPTION
https://discord.com/channels/1378308569287622737/1474986033031544972

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the current screen and state when returning to the app, instead of redirecting to Login/Library. Settings and Edit Container now stay open while multitasking.

- **Bug Fixes**
  - Redirect to Home only when on the Login screen and remove auto-redirects after Steam login; use a non-saveable hasAttemptedInitialSteamConnect to run the initial Steam connect once per app session.

<sup>Written for commit d79536f3fc5068b7320d2d37b8f10ba187bfc58a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App now attempts Steam connectivity only once on initial startup, reducing redundant attempts and improving startup stability.
  * Prevents unexpected automatic navigation to Home — navigation to Home now occurs only from the login screen, and initial steps won't push users away from their current screen.
  * Stops an automatic Home redirect when Steam is logged in but not kept alive, avoiding disruptive route changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->