### PR TITLE
fix: steamgriddb hero predicate never matched for custom games

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryAppItem.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryAppItem.kt
@@ -236,7 +236,7 @@ internal fun AppItem(
                                             val folder = java.io.File(path)
                                             val heroFile = folder.listFiles()?.firstOrNull { file ->
                                                 file.name.startsWith("steamgriddb_hero") &&
-                                                    !file.name.contains("grid") &&
+                                                    !file.name.contains("grid_") &&
                                                     (
                                                         file.name.endsWith(".png", ignoreCase = true) ||
                                                             file.name.endsWith(".jpg", ignoreCase = true) ||

--- a/app/src/main/java/app/gamenative/utils/SteamGridDB.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamGridDB.kt
@@ -447,7 +447,7 @@ object SteamGridDB {
         }?.isNotEmpty() == true
         val existingHero = gameFolder.listFiles { file ->
             file.isFile && file.name.startsWith("steamgriddb_hero", ignoreCase = true) &&
-            !file.name.contains("grid", ignoreCase = true) &&
+            !file.name.contains("grid_", ignoreCase = true) &&
             (file.name.endsWith(".png", ignoreCase = true) || file.name.endsWith(".jpg", ignoreCase = true) || file.name.endsWith(".webp", ignoreCase = true))
         }?.isNotEmpty() == true
         val existingLogo = gameFolder.listFiles { file ->
@@ -467,7 +467,7 @@ object SteamGridDB {
             }?.firstOrNull()
             val heroFile = gameFolder.listFiles { file ->
                 file.isFile && file.name.startsWith("steamgriddb_hero", ignoreCase = true) &&
-                !file.name.contains("grid", ignoreCase = true) &&
+                !file.name.contains("grid_", ignoreCase = true) &&
                 (file.name.endsWith(".png", ignoreCase = true) || file.name.endsWith(".jpg", ignoreCase = true) || file.name.endsWith(".webp", ignoreCase = true))
             }?.firstOrNull()
             val logoFile = gameFolder.listFiles { file ->
@@ -507,7 +507,7 @@ object SteamGridDB {
         } else {
             gameFolder.listFiles { file ->
                 file.isFile && file.name.startsWith("steamgriddb_hero", ignoreCase = true) &&
-                !file.name.contains("grid", ignoreCase = true) &&
+                !file.name.contains("grid_", ignoreCase = true) &&
                 (file.name.endsWith(".png", ignoreCase = true) || file.name.endsWith(".jpg", ignoreCase = true) || file.name.endsWith(".webp", ignoreCase = true))
             }?.firstOrNull()?.absolutePath
         }


### PR DESCRIPTION
## Summary
- The file search predicate for SteamGridDB hero images in custom game list/hero views was dead code
- `file.name.startsWith("steamgriddb_hero") && !file.name.contains("grid")` always fails because `"steamgriddb_hero"` contains `"grid"`
- Changed to `!file.name.contains("grid_")` which correctly excludes `steamgriddb_grid_hero` variants while matching `steamgriddb_hero`

## Test plan
- [ ] Add a custom game, fetch SteamGridDB images
- [ ] Verify hero images appear in list/hero grid views
- [ ] Verify grid_hero images still display correctly in GRID_HERO mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SteamGridDB hero image selection for custom games by correcting the filename filter to skip only grid_hero variants. Applied in LibraryAppItem and SteamGridDB so hero images are detected and shown in list and hero views.

<sup>Written for commit 17e04ac6452b3bcd844457f47b776650d862ee15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined hero image selection for Custom Games in the library list view to include additional eligible image files that were previously excluded.
  * Result: more appropriate cover images may now appear for some games in the library, improving visual accuracy and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #617