### PR TITLE
fix: library content hidden behind soft navigation bar

### DIFF
--- a/app/src/main/java/app/gamenative/enums/StatusBarMode.kt
+++ b/app/src/main/java/app/gamenative/enums/StatusBarMode.kt
@@ -1,0 +1,7 @@
+package app.gamenative.enums
+
+enum class StatusBarMode(val text: String) {
+    EDGE_TO_EDGE("Immersive"),
+    HIDDEN("Hidden"),
+    INSET("Standard"),
+}

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -45,6 +45,7 @@ import app.gamenative.R
 import app.gamenative.data.GameSource
 import app.gamenative.data.PostSyncInfo
 import app.gamenative.enums.AppTheme
+import app.gamenative.enums.StatusBarMode
 import app.gamenative.enums.LoginResult
 import app.gamenative.enums.PathType
 import app.gamenative.enums.SaveLocation
@@ -387,8 +388,7 @@ fun PluviaMain(
             // Log.d("PluviaMain", "Screen changed to $currentScreen, resetting some values")
             // TODO: remove this if statement once XServerScreen orientation change bug is fixed
             if (state.currentScreen != PluviaScreen.XServer) {
-                // Hide or show status bar based on if in game or not
-                val shouldShowStatusBar = !PrefManager.hideStatusBarWhenNotInGame
+                val shouldShowStatusBar = PrefManager.statusBarMode != StatusBarMode.HIDDEN
                 PluviaApp.events.emit(AndroidEvent.SetSystemUIVisibility(shouldShowStatusBar))
 
                 // reset system ui visibility based on user preference

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.displayCutoutPadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -63,6 +64,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.gamenative.PrefManager
+import app.gamenative.enums.StatusBarMode
 import app.gamenative.R
 import app.gamenative.data.LibraryItem
 import app.gamenative.data.GameSource
@@ -204,15 +206,14 @@ private fun LibraryScreenContent(
         }
     }
 
+    val statusBarMode = PrefManager.statusBarMode
+
     // Apply top padding differently for list vs game detail pages.
-    // On the game page we want to hide the top padding when the status bar is hidden.
     val safePaddingModifier = if (selectedLibraryItem != null) {
-        // Detail (game) page: use actual status bar height when status bar is visible,
-        // or 0.dp when status bar is hidden
-        val topPadding = if (PrefManager.hideStatusBarWhenNotInGame) {
-            0.dp
-        } else {
-            WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+        val topPadding = when (statusBarMode) {
+            StatusBarMode.HIDDEN -> 0.dp
+            StatusBarMode.INSET -> WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+            StatusBarMode.EDGE_TO_EDGE -> WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
         }
         Modifier.padding(top = topPadding)
     } else {
@@ -220,8 +221,15 @@ private fun LibraryScreenContent(
         Modifier.displayCutoutPadding()
     }
 
+    val navBarModifier = if (statusBarMode == StatusBarMode.INSET) {
+        Modifier.navigationBarsPadding()
+    } else {
+        Modifier
+    }
+
     Box(
         Modifier.background(MaterialTheme.colorScheme.background)
+        .then(navBarModifier)
         .then(safePaddingModifier)) {
         if (selectedLibraryItem == null) {
             LibraryListPane(

--- a/app/src/main/java/app/gamenative/utils/PaddingUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/PaddingUtils.kt
@@ -4,21 +4,19 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.gamenative.PrefManager
+import app.gamenative.enums.StatusBarMode
 
 object `PaddingUtils` {
     /**
-     * Creates padding values with conditional top padding based on status bar visibility.
-     * When hideStatusBar is true, top padding is 0.dp, otherwise it uses defaultPadding.
-     * All other sides use defaultPadding.
-     *
-     * @param defaultPadding The default padding to use for start, end, bottom, and top (when status bar is visible)
-     * @return PaddingValues with the appropriate padding values
+     * Creates padding values with conditional top padding based on [StatusBarMode].
+     * When mode is [StatusBarMode.HIDDEN], top padding is 0.dp; otherwise uses [defaultPadding].
+     * All other sides always use [defaultPadding].
      */
     fun statusBarAwarePadding(
         defaultPadding: Dp = 16.dp
     ): PaddingValues {
 
-        val hideStatusBar = PrefManager.hideStatusBarWhenNotInGame
+        val hideStatusBar = PrefManager.statusBarMode == StatusBarMode.HIDDEN
 
         return PaddingValues(
             top = if (hideStatusBar) 0.dp else defaultPadding,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -664,8 +664,8 @@
     <string name="settings_interface_title">Interface</string>
     <string name="settings_interface_external_links_title">Open web links externally</string>
     <string name="settings_interface_external_links_subtitle">Links open with your main web browser</string>
-    <string name="settings_interface_hide_statusbar_title">Hide status bar when not in game</string>
-    <string name="settings_interface_hide_statusbar_subtitle">Hide Android status bar in game list, settings, etc. App will restart when changed.</string>
+    <string name="settings_interface_statusbar_mode_title">Status bar mode</string>
+    <string name="settings_interface_statusbar_mode_restart_message">Changing the status bar mode requires the app to restart. Do you want to continue?</string>
     <string name="settings_interface_icon_style">Icon style</string>
     <string name="settings_interface_wifi_only_title">Download only over Wi-Fi</string>
     <string name="settings_interface_wifi_only_subtitle">Prevent downloads on cellular data</string>


### PR DESCRIPTION
## Summary
- Add `navigationBarsPadding()` to the library screen container so content isn't hidden behind the soft navbar

Closes #621

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Library content hidden behind the soft navigation bar by applying navigationBarsPadding only in Standard mode. Replaces the old status bar toggle with a 3‑mode setting (Immersive, Hidden, Standard) and migrates existing prefs automatically.

- **New Features**
  - Added StatusBarMode enum and updated system UI handling to respect each mode.
  - Settings: new Status bar mode picker (SingleChoiceDialog) with restart prompt and current mode shown as the subtitle.

<sup>Written for commit a0312a3004dc896bfe12fa3365149458d40a62b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Status bar mode" setting with three options — Immersive, Hidden, Standard — selectable via a dialog; changing it prompts an app restart to apply.
  * Settings UI now shows the current mode as the subtitle and opens a choice dialog instead of a toggle.

* **Bug Fixes**
  * Library screen now consistently accounts for status and navigation bar padding so content no longer overlaps system UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->