### PR TITLE
Added fix for not showing partial downloads for GOG

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -8,6 +8,8 @@ import app.gamenative.service.gog.api.GOGApiClient
 import app.gamenative.service.gog.api.GOGManifestMeta
 import app.gamenative.service.gog.api.GOGManifestParser
 import app.gamenative.service.gog.api.V1DepotFile
+import app.gamenative.enums.Marker
+import app.gamenative.utils.MarkerUtils
 import app.gamenative.utils.Net
 import org.json.JSONArray
 import org.json.JSONObject
@@ -376,6 +378,10 @@ class GOGDownloadManager @Inject constructor(
             // Step 8: Download chunks
             Timber.tag("GOG").i("Downoading Chunks for game $gameId")
 
+            // Mark download as in-progress so UI and install checks can detect partial installs
+            installPath.mkdirs()
+            MarkerUtils.addMarker(installPath.absolutePath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+
             downloadInfo.updateStatusMessage("Downloading chunks...")
 
             val chunkCacheDir = File(installPath, ".gog_chunks")
@@ -391,6 +397,7 @@ class GOGDownloadManager @Inject constructor(
             )
 
             if (downloadResult.isFailure) {
+                MarkerUtils.removeMarker(installPath.absolutePath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
                 return@withContext downloadResult
             }
 
@@ -402,6 +409,7 @@ class GOGDownloadManager @Inject constructor(
 
             val assembleResult = assembleFiles(gameFiles, chunkCacheDir, gameInstallDir, downloadInfo)
             if (assembleResult.isFailure) {
+                MarkerUtils.removeMarker(installPath.absolutePath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
                 return@withContext assembleResult
             }
 
@@ -436,6 +444,9 @@ class GOGDownloadManager @Inject constructor(
             app.gamenative.PluviaApp.events.emitJava(
                 app.gamenative.events.AndroidEvent.DownloadStatusChanged(gameId.toIntOrNull() ?: 0, false),
             )
+
+            // Ensure in-progress marker is cleared on failure
+            MarkerUtils.removeMarker(installPath.absolutePath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
 
             Result.failure(e)
         }
@@ -504,6 +515,8 @@ class GOGDownloadManager @Inject constructor(
         downloadInfo.setProgress(1.0f)
         downloadInfo.setActive(false)
         downloadInfo.emitProgressChange()
+        MarkerUtils.removeMarker(installPath.absolutePath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+        MarkerUtils.addMarker(installPath.absolutePath, Marker.DOWNLOAD_COMPLETE_MARKER)
         app.gamenative.PluviaApp.events.emitJava(
             app.gamenative.events.AndroidEvent.DownloadStatusChanged(gameId.toIntOrNull() ?: 0, false),
         )

--- a/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
@@ -466,6 +466,7 @@ class GOGManager @Inject constructor(
                 val gameId = libraryItem.gameId.toString()
                 val installPath = getGameInstallPath(gameId, libraryItem.name)
                 val installDir = File(installPath)
+                val wasInstalled = MarkerUtils.hasMarker(installPath, Marker.DOWNLOAD_COMPLETE_MARKER)
 
                 // Delete the manifest file
                 val manifestPath = File(context.filesDir, "manifests/$gameId")
@@ -481,25 +482,24 @@ class GOGManager @Inject constructor(
                         Timber.i("Successfully deleted game directory: $installPath")
                     } else {
                         Timber.w("Failed to delete some game files")
+                        return@withContext Result.failure(Exception("Failed to fully delete at $installPath"))
                     }
                 } else {
                     Timber.w("GOG game directory doesn't exist: $installPath")
                 }
 
-                // Remove all markers
-                val appDirPath = getAppDirPath(libraryItem.appId)
-                MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
-                MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+                MarkerUtils.removeMarker(installPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+                MarkerUtils.removeMarker(installPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
 
-                // Update database - mark as not installed
-                val game = getGameFromDbById(gameId)
-                if (game != null) {
-                    val updatedGame = game.copy(isInstalled = false, installPath = "")
-                    gogGameDao.update(updatedGame)
-                    Timber.d("Updated database: game marked as not installed")
+                if (wasInstalled) {
+                    val game = getGameFromDbById(gameId)
+                    if (game != null) {
+                        val updatedGame = game.copy(isInstalled = false, installPath = "")
+                        gogGameDao.update(updatedGame)
+                        Timber.d("Updated database: game marked as not installed")
+                    }
                 }
 
-                // Delete container (must run on Main thread)
                 withContext(Dispatchers.Main) {
                     ContainerUtils.deleteContainer(context, libraryItem.appId)
                 }

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -305,7 +305,7 @@ class GOGService : Service() {
             instance.activeDownloads[gameId] = downloadInfo
 
             // Launch download in service scope so it runs independently
-            instance.scope.launch {
+            val job = instance.scope.launch {
                 try {
                     Timber.d("[Download] Starting download for game $gameId")
                     val commonRedistDir = File(installPath, "_CommonRedist")
@@ -364,6 +364,7 @@ class GOGService : Service() {
                     Timber.d("[Download] Finished for game $gameId, progress: ${downloadInfo.getProgress()}, active: ${downloadInfo.isActive()}")
                 }
             }
+            downloadInfo.setDownloadJob(job)
 
             return Result.success(downloadInfo)
         }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -17,8 +17,11 @@ import androidx.compose.ui.res.stringResource
 import app.gamenative.R
 import app.gamenative.data.GOGGame
 import app.gamenative.data.LibraryItem
+import app.gamenative.enums.Marker
 import app.gamenative.service.gog.GOGConstants
 import app.gamenative.service.gog.GOGService
+import app.gamenative.utils.MarkerUtils
+import java.io.File
 import app.gamenative.ui.data.AppMenuOption
 import app.gamenative.ui.data.GameDisplayInfo
 import app.gamenative.ui.enums.AppOptionMenuType
@@ -201,9 +204,9 @@ class GOGAppScreen : BaseAppScreen() {
     }
 
     override fun hasPartialDownload(context: Context, libraryItem: LibraryItem): Boolean {
-        // GOG downloads cannot be paused/resumed, so never show as having partial download
-        // This prevents the UI from showing a resume button
-        return false
+        if (isDownloading(context, libraryItem) || isInstalled(context, libraryItem)) return false
+        val installPath = GOGConstants.getGameInstallPath(libraryItem.name)
+        return File(installPath).exists() && !MarkerUtils.hasMarker(installPath, Marker.DOWNLOAD_COMPLETE_MARKER)
     }
 
     override fun onDownloadInstallClick(context: Context, libraryItem: LibraryItem, onClickPlay: (Boolean) -> Unit) {
@@ -211,7 +214,7 @@ class GOGAppScreen : BaseAppScreen() {
         // GOGService expects numeric gameId
         val gameId = libraryItem.gameId.toString()
         val downloadInfo = GOGService.getDownloadInfo(gameId)
-        val isDownloading = downloadInfo != null && (downloadInfo.getProgress() ?: 0f) < 1f
+        val isDownloading = isDownloading(context, libraryItem)
         val installed = isInstalled(context, libraryItem)
 
         Timber.tag(TAG).d("onDownloadInstallClick: appId=${libraryItem.appId}, isDownloading=$isDownloading, installed=$installed")
@@ -219,7 +222,7 @@ class GOGAppScreen : BaseAppScreen() {
         if (isDownloading) {
             // Cancel ongoing download
             Timber.tag(TAG).i("Cancelling GOG download for: ${libraryItem.appId}")
-            downloadInfo.cancel()
+            downloadInfo?.cancel()
             GOGService.cleanupDownload(gameId)
         } else if (installed) {
             // Already installed: launch game
@@ -227,34 +230,39 @@ class GOGAppScreen : BaseAppScreen() {
             onClickPlay(false)
         } else {
             // Show install confirmation dialog
-            Timber.tag(TAG).i("Showing install confirmation dialog for: ${libraryItem.appId}")
-            kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
-                try {
-                    val game = GOGService.getGOGGameOf(gameId)
+            showGOGInstallConfirmationDialog(context, libraryItem)
+        }
+    }
 
-                    // Calculate sizes
-                    val downloadSize = app.gamenative.utils.StorageUtils.formatBinarySize(game?.downloadSize ?: 0L)
-                    val availableSpace = app.gamenative.utils.StorageUtils.formatBinarySize(
-                        app.gamenative.utils.StorageUtils.getAvailableSpace(app.gamenative.service.gog.GOGConstants.defaultGOGGamesPath)
-                    )
+    private fun showGOGInstallConfirmationDialog(context: Context, libraryItem: LibraryItem) {
+        val gameId = libraryItem.gameId.toString()
+        Timber.tag(TAG).i("Showing install confirmation dialog for: ${libraryItem.appId}")
+        kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
+            try {
+                val game = GOGService.getGOGGameOf(gameId)
 
-                    val message = context.getString(
-                        R.string.gog_install_confirmation_message,
-                        downloadSize,
-                        availableSpace
-                    )
-                    val state = app.gamenative.ui.component.dialog.state.MessageDialogState(
-                        visible = true,
-                        type = app.gamenative.ui.enums.DialogType.INSTALL_APP,
-                        title = context.getString(R.string.gog_install_game_title),
-                        message = message,
-                        confirmBtnText = context.getString(R.string.download),
-                        dismissBtnText = context.getString(R.string.cancel)
-                    )
-                    BaseAppScreen.showInstallDialog(libraryItem.appId, state)
-                } catch (e: Exception) {
-                    Timber.e(e, "Failed to show install dialog for: ${libraryItem.appId}")
-                }
+                // Calculate sizes
+                val downloadSize = app.gamenative.utils.StorageUtils.formatBinarySize(game?.downloadSize ?: 0L)
+                val availableSpace = app.gamenative.utils.StorageUtils.formatBinarySize(
+                    app.gamenative.utils.StorageUtils.getAvailableSpace(app.gamenative.service.gog.GOGConstants.defaultGOGGamesPath)
+                )
+
+                val message = context.getString(
+                    R.string.gog_install_confirmation_message,
+                    downloadSize,
+                    availableSpace
+                )
+                val state = app.gamenative.ui.component.dialog.state.MessageDialogState(
+                    visible = true,
+                    type = app.gamenative.ui.enums.DialogType.INSTALL_APP,
+                    title = context.getString(R.string.gog_install_game_title),
+                    message = message,
+                    confirmBtnText = context.getString(R.string.download),
+                    dismissBtnText = context.getString(R.string.cancel)
+                )
+                BaseAppScreen.showInstallDialog(libraryItem.appId, state)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to show install dialog for: ${libraryItem.appId}")
             }
         }
     }
@@ -311,40 +319,39 @@ class GOGAppScreen : BaseAppScreen() {
 
     override fun onPauseResumeClick(context: Context, libraryItem: LibraryItem) {
         Timber.tag(TAG).i("onPauseResumeClick: appId=${libraryItem.appId}")
-        // GOG downloads cannot be paused - only canceled
-        // This method should not be called for GOG since hasPartialDownload returns false,
-        // but if it is called, just cancel the download
         val gameId = libraryItem.gameId.toString()
         val downloadInfo = GOGService.getDownloadInfo(gameId)
+        val isDownloading = isDownloading(context, libraryItem)
 
-        if (downloadInfo != null) {
+        if (isDownloading) {
             Timber.tag(TAG).i("Cancelling GOG download: ${libraryItem.appId}")
-            downloadInfo.cancel()
+            downloadInfo?.cancel()
             GOGService.cleanupDownload(gameId)
+        } else {
+            // Partial data only: "Resume" means start/restart install – show install confirmation
+            showGOGInstallConfirmationDialog(context, libraryItem)
         }
     }
 
     override fun onDeleteDownloadClick(context: Context, libraryItem: LibraryItem) {
         Timber.tag(TAG).i("onDeleteDownloadClick: appId=${libraryItem.appId}")
-        // GOGService expects numeric gameId
-        val gameId = libraryItem.gameId.toString()
-        val downloadInfo = GOGService.getDownloadInfo(gameId)
-        val isDownloading = downloadInfo != null && (downloadInfo.getProgress() ?: 0f) < 1f
-        val isInstalled = isInstalled(context, libraryItem)
-        Timber.tag(TAG).d("onDeleteDownloadClick: appId=${libraryItem.appId}, isDownloading=$isDownloading, isInstalled=$isInstalled")
-
-        if (isDownloading) {
-            // Cancel download immediately if currently downloading
-            Timber.tag(TAG).i("Cancelling active download for GOG game: ${libraryItem.appId}")
-            downloadInfo.cancel()
-            GOGService.cleanupDownload(gameId)
-            android.widget.Toast.makeText(
-                context,
-                "Download cancelled",
-                android.widget.Toast.LENGTH_SHORT,
-            ).show()
-        } else if (isInstalled) {
-            // Show uninstall confirmation dialog
+        val isDownloadingFlag = isDownloading(context, libraryItem)
+        val isInstalledFlag = isInstalled(context, libraryItem)
+        val hasPartial = hasPartialDownload(context, libraryItem)
+        Timber.tag(TAG).d("onDeleteDownloadClick: appId=${libraryItem.appId}, isDownloading=$isDownloadingFlag, isInstalled=$isInstalledFlag, hasPartial=$hasPartial")
+        if (isDownloadingFlag || hasPartial) {
+            showInstallDialog(
+                libraryItem.appId,
+                app.gamenative.ui.component.dialog.state.MessageDialogState(
+                    visible = true,
+                    type = app.gamenative.ui.enums.DialogType.CANCEL_APP_DOWNLOAD,
+                    title = context.getString(R.string.cancel_download_prompt_title),
+                    message = context.getString(R.string.library_delete_download_message),
+                    confirmBtnText = context.getString(R.string.yes),
+                    dismissBtnText = context.getString(R.string.no),
+                )
+            )
+        } else if (isInstalledFlag) {
             Timber.tag(TAG).i("Showing uninstall dialog for: ${libraryItem.appId}")
             showUninstallDialog(libraryItem.appId)
         }
@@ -591,6 +598,45 @@ class GOGAppScreen : BaseAppScreen() {
                     {
                         BaseAppScreen.hideInstallDialog(appId)
                         performDownload(context, libraryItem) {}
+                    }
+                }
+                app.gamenative.ui.enums.DialogType.CANCEL_APP_DOWNLOAD -> {
+                    {
+                        BaseAppScreen.hideInstallDialog(appId)
+                        val gameId = libraryItem.gameId.toString()
+                        CoroutineScope(Dispatchers.IO).launch {
+                            val downloadInfo = GOGService.getDownloadInfo(gameId)
+                            val wasDownloading = downloadInfo != null &&
+                                downloadInfo.isActive() &&
+                                (downloadInfo.getProgress() ?: 0f) < 1f
+                            downloadInfo?.cancel()
+                            downloadInfo?.awaitCompletion()
+                            GOGService.cleanupDownload(gameId)
+
+                            val isInstalledAfterCancel = GOGService.isGameInstalled(gameId)
+                            if (isInstalledAfterCancel) {
+                                // Download completed and game ended up installed; don't show "Download cancelled"
+                                return@launch
+                            }
+
+                            val result = GOGService.deleteGame(context, libraryItem)
+                            withContext(Dispatchers.Main) {
+                                if (wasDownloading && !isInstalledAfterCancel) {
+                                    android.widget.Toast.makeText(
+                                        context,
+                                        "Download cancelled",
+                                        android.widget.Toast.LENGTH_SHORT,
+                                    ).show()
+                                }
+                                if (result.isFailure) {
+                                    android.widget.Toast.makeText(
+                                        context,
+                                        "Failed to delete download: ${result.exceptionOrNull()?.message}",
+                                        android.widget.Toast.LENGTH_LONG,
+                                    ).show()
+                                }
+                            }
+                        }
                     }
                 }
                 else -> null


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show partial GOG downloads using install-folder markers, and add a safer cancel/delete flow for incomplete installs. Resume now restarts the install when not downloading, with confirmation dialogs, job-aware cancellation, and clearer errors.

- **New Features**
  - Detect partial installs by finding a game folder without DOWNLOAD_COMPLETE; show Resume + Delete on GOG cards.
  - Set DOWNLOAD_IN_PROGRESS at start; clear on failure; set DOWNLOAD_COMPLETE on success; remove markers on delete.
  - Confirm cancel/delete for active or partial downloads; wait for the download job to finish, then clean up and surface errors.
  - Delete removes the folder and manifest; only updates the DB if the game was previously fully installed, and returns failure if files remain.

<sup>Written for commit bae689fe08ccbff1ff72bd25a31ef6a57306e390. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects in-progress vs completed GOG downloads using on-disk markers, enabling clearer Resume, Reinstall, or Delete choices.
  * New install confirmation and cancel-download dialogs with improved flows for pause, resume, cancel and uninstall.
  * Downloads are now tracked so UI can more reliably pause, cancel and reflect active download state.

* **Bug Fixes**
  * Safer delete/uninstall handling to avoid incorrect uninstall state and improved error reporting on partial-delete failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->