### PR TITLE
fix: capture external mouse pointer on first event

### DIFF
--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -58,9 +58,12 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     private Runnable delayedPress;
 
     private boolean pressExecuted;
+    private final boolean capturePointerOnExternalMouse;
+    private boolean pointerCaptureRequested;
 
     public TouchpadView(Context context, XServer xServer, boolean capturePointerOnExternalMouse) {
         super(context);
+        this.capturePointerOnExternalMouse = capturePointerOnExternalMouse;
         this.fingers = new Finger[4];
         this.numFingers = (byte) 0;
         this.sensitivity = 1.0f;
@@ -79,20 +82,21 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         setBackground(createTransparentBackground());
         setClickable(true);
         setFocusable(true);
-        setFocusableInTouchMode(false);
         int screenWidth = AppUtils.getScreenWidth();
         int screenHeight = AppUtils.getScreenHeight();
         ScreenInfo screenInfo = xServer.screenInfo;
         updateXform(screenWidth, screenHeight, screenInfo.width, screenInfo.height);
         if (capturePointerOnExternalMouse) {
+            setFocusableInTouchMode(true);
             setOnCapturedPointerListener(this);
-            setOnClickListener(new View.OnClickListener() { // from class: com.winlator.widget.TouchpadView$$ExternalSyntheticLambda0
-                @Override // android.view.View.OnClickListener
-                public final void onClick(View view) {
-                    requestPointerCapture();
-                }
-            });
         }
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        // allow re-capture after app returns from background
+        if (hasFocus) pointerCaptureRequested = false;
     }
 
     private static StateListDrawable createTransparentBackground() {
@@ -598,6 +602,15 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     }
 
     public boolean onExternalMouseEvent(MotionEvent event) {
+        // one-shot: capture external mouse on first event, don't re-capture after user release
+        if (capturePointerOnExternalMouse && !pointerCaptureRequested) {
+            pointerCaptureRequested = true;
+            if (!hasFocus() && !requestFocus()) {
+                Log.w("TouchpadView", "requestFocus() failed, skipping pointer capture");
+            } else {
+                requestPointerCapture();
+            }
+        }
         boolean handled = false;
         if (event.isFromSource(InputDevice.SOURCE_MOUSE)) {
             int actionButton = event.getActionButton();
@@ -617,7 +630,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
                         if (xServer.isRelativeMouseMovement())
                             xServer.getWinHandler().mouseEvent(MouseEventFlags.MIDDLEDOWN, 0, 0, 0);
                         else
-                            xServer.injectPointerButtonPress(Pointer.Button.BUTTON_MIDDLE); // Add this line for middle mouse button press
+                            xServer.injectPointerButtonPress(Pointer.Button.BUTTON_MIDDLE);
                     }
                     handled = true;
                     break;
@@ -636,7 +649,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
                         if (xServer.isRelativeMouseMovement())
                             xServer.getWinHandler().mouseEvent(MouseEventFlags.MIDDLEUP, 0, 0, 0);
                         else
-                            xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_MIDDLE); // Add this line for middle mouse button release
+                            xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_MIDDLE);
                     }
                     handled = true;
                     break;


### PR DESCRIPTION
Fixes #625

**Root cause:** `TouchpadView.setOnClickListener` was supposed to call `requestPointerCapture()`, but onClick never fires because TouchpadView is under XServerView and InputControlsView in the FrameLayout z-order. Additionally, `setFocusableInTouchMode(false)` prevented `requestFocus()` from succeeding, which is required before `requestPointerCapture()`.

**Fix:** Move pointer capture request to `onExternalMouseEvent` (reached via event bus, not view touch dispatch), enable `focusableInTouchMode`, remove dead onClick listener.

**Tested with:** Logitech MX Master 3S over Bluetooth.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture external mouse pointer on the first event so pointer capture works even when TouchpadView is behind other views. Fixes #625.

- **Bug Fixes**
  - Move pointer capture to onExternalMouseEvent since onClick never fired due to z-order.
  - Enable focusableInTouchMode only when capturePointerOnExternalMouse is true so focus and capture succeed.
  - One-shot capture on the first external mouse event; reset after window regains focus to allow capture again after returning from background.

<sup>Written for commit bf08f18c5158a75bd220b2a260b772e6351abf53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * One-shot pointer capture now occurs on the first external mouse event for more reliable capture behavior.
  * Focus behavior updated to enable focus when external-mouse capture is enabled, improving mouse interactions.
  * Pointer-capture state resets when the app regains window focus, preventing stale capture state after backgrounding.
  * Clicking no longer forces pointer capture automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->