### PR TITLE
fix: replace boolean literals with 0/1 in Room queries

### DIFF
--- a/app/src/main/java/app/gamenative/db/dao/EpicGameDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/EpicGameDao.kt
@@ -49,7 +49,7 @@ interface EpicGameDao {
     @Query("SELECT * FROM epic_games WHERE app_name = :appName")
     suspend fun getByAppName(appName: String): EpicGame?
 
-    @Query("SELECT * FROM epic_games WHERE is_dlc = false AND namespace != 'ue' ORDER BY title ASC")
+    @Query("SELECT * FROM epic_games WHERE is_dlc = 0 AND namespace != 'ue' ORDER BY title ASC")
     fun getAll(): Flow<List<EpicGame>>
 
     @Query("SELECT * FROM epic_games WHERE is_installed = :isInstalled ORDER BY title ASC")
@@ -58,14 +58,14 @@ interface EpicGameDao {
     @Query("SELECT * FROM epic_games WHERE base_game_app_name = (SELECT catalog_id FROM epic_games WHERE id = :appId)")
     fun getDLCForTitle(appId: Int): Flow<List<EpicGame>>
 
-    @Query("SELECT * FROM epic_games WHERE base_game_app_name IS NOT NULL AND is_dlc = true")
+    @Query("SELECT * FROM epic_games WHERE base_game_app_name IS NOT NULL AND is_dlc = 1")
     fun getAllDlcTitles(): Flow<List<EpicGame>>
 
-    @Query("SELECT * FROM epic_games WHERE is_dlc = false AND namespace != 'ue' AND title LIKE '%' || :searchQuery || '%' ORDER BY title ASC")
+    @Query("SELECT * FROM epic_games WHERE is_dlc = 0 AND namespace != 'ue' AND title LIKE '%' || :searchQuery || '%' ORDER BY title ASC")
     fun searchByTitle(searchQuery: String): Flow<List<EpicGame>>
 
     // Only delete non-installed games from DB - Need to preserve any currently installed games.
-    @Query("DELETE FROM epic_games WHERE is_installed = false")
+    @Query("DELETE FROM epic_games WHERE is_installed = 0")
     suspend fun deleteAllNonInstalledGames()
 
     @Query("SELECT COUNT(*) FROM epic_games")

--- a/app/src/main/java/app/gamenative/db/dao/GOGGameDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/GOGGameDao.kt
@@ -34,22 +34,22 @@ interface GOGGameDao {
     @Query("SELECT * FROM gog_games WHERE id = :gameId")
     suspend fun getById(gameId: String): GOGGame?
 
-    @Query("SELECT * FROM gog_games WHERE exclude = false ORDER BY title ASC")
+    @Query("SELECT * FROM gog_games WHERE exclude = 0 ORDER BY title ASC")
     fun getAll(): Flow<List<GOGGame>>
 
-    @Query("SELECT * FROM gog_games WHERE exclude = false ORDER BY title ASC")
+    @Query("SELECT * FROM gog_games WHERE exclude = 0 ORDER BY title ASC")
     suspend fun getAllAsList(): List<GOGGame>
 
-    @Query("SELECT * FROM gog_games WHERE is_installed = :isInstalled AND exclude = false ORDER BY title ASC")
+    @Query("SELECT * FROM gog_games WHERE is_installed = :isInstalled AND exclude = 0 ORDER BY title ASC")
     fun getByInstallStatus(isInstalled: Boolean): Flow<List<GOGGame>>
 
-    @Query("SELECT * FROM gog_games WHERE exclude = false AND title LIKE '%' || :searchQuery || '%' ORDER BY title ASC")
+    @Query("SELECT * FROM gog_games WHERE exclude = 0 AND title LIKE '%' || :searchQuery || '%' ORDER BY title ASC")
     fun searchByTitle(searchQuery: String): Flow<List<GOGGame>>
 
-    @Query("DELETE FROM gog_games WHERE is_installed = false")
+    @Query("DELETE FROM gog_games WHERE is_installed = 0")
     suspend fun deleteAllNonInstalledGames()
 
-    @Query("SELECT COUNT(*) FROM gog_games WHERE exclude = false")
+    @Query("SELECT COUNT(*) FROM gog_games WHERE exclude = 0")
     fun getCount(): Flow<Int>
 
     @Query("SELECT id FROM gog_games")


### PR DESCRIPTION
Fixes #628

SQLite doesn't have boolean literals — `true`/`false` are parsed as column identifiers, not values. Replaced with `0`/`1` in 10 `@Query` annotations across EpicGameDao and GOGGameDao.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced true/false with 0/1 in Room queries so SQLite evaluates conditions correctly across EpicGameDao and GOGGameDao. Fixes #628.

- **Bug Fixes**
  - Updated 10 @Query uses to 0/1 for is_dlc, is_installed, and exclude.
  - Restores correct filtering, search, counts, and cleanup deletes.

<sup>Written for commit 92422cae997020334b02a32c4ad44248b50ecadb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

