### PR TITLE
Fix: SQLite crashes on Android 10 

### DIFF
--- a/app/src/main/java/app/gamenative/db/dao/EpicGameDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/EpicGameDao.kt
@@ -49,7 +49,7 @@ interface EpicGameDao {
     @Query("SELECT * FROM epic_games WHERE app_name = :appName")
     suspend fun getByAppName(appName: String): EpicGame?
 
-    @Query("SELECT * FROM epic_games WHERE is_dlc = false AND namespace != 'ue' ORDER BY title ASC")
+    @Query("SELECT * FROM epic_games WHERE is_dlc = 0 AND namespace != 'ue' ORDER BY title ASC")
     fun getAll(): Flow<List<EpicGame>>
 
     @Query("SELECT * FROM epic_games WHERE is_installed = :isInstalled ORDER BY title ASC")
@@ -58,14 +58,14 @@ interface EpicGameDao {
     @Query("SELECT * FROM epic_games WHERE base_game_app_name = (SELECT catalog_id FROM epic_games WHERE id = :appId)")
     fun getDLCForTitle(appId: Int): Flow<List<EpicGame>>
 
-    @Query("SELECT * FROM epic_games WHERE base_game_app_name IS NOT NULL AND is_dlc = true")
+    @Query("SELECT * FROM epic_games WHERE base_game_app_name IS NOT NULL AND is_dlc = 1")
     fun getAllDlcTitles(): Flow<List<EpicGame>>
 
-    @Query("SELECT * FROM epic_games WHERE is_dlc = false AND namespace != 'ue' AND title LIKE '%' || :searchQuery || '%' ORDER BY title ASC")
+    @Query("SELECT * FROM epic_games WHERE is_dlc = 0 AND namespace != 'ue' AND title LIKE '%' || :searchQuery || '%' ORDER BY title ASC")
     fun searchByTitle(searchQuery: String): Flow<List<EpicGame>>
 
     // Only delete non-installed games from DB - Need to preserve any currently installed games.
-    @Query("DELETE FROM epic_games WHERE is_installed = false")
+    @Query("DELETE FROM epic_games WHERE is_installed = 0")
     suspend fun deleteAllNonInstalledGames()
 
     @Query("SELECT COUNT(*) FROM epic_games")

--- a/app/src/main/java/app/gamenative/db/dao/GOGGameDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/GOGGameDao.kt
@@ -34,22 +34,22 @@ interface GOGGameDao {
     @Query("SELECT * FROM gog_games WHERE id = :gameId")
     suspend fun getById(gameId: String): GOGGame?
 
-    @Query("SELECT * FROM gog_games WHERE exclude = false ORDER BY title ASC")
+    @Query("SELECT * FROM gog_games WHERE exclude = 0 ORDER BY title ASC")
     fun getAll(): Flow<List<GOGGame>>
 
-    @Query("SELECT * FROM gog_games WHERE exclude = false ORDER BY title ASC")
+    @Query("SELECT * FROM gog_games WHERE exclude = 0 ORDER BY title ASC")
     suspend fun getAllAsList(): List<GOGGame>
 
-    @Query("SELECT * FROM gog_games WHERE is_installed = :isInstalled AND exclude = false ORDER BY title ASC")
+    @Query("SELECT * FROM gog_games WHERE is_installed = :isInstalled AND exclude = 0 ORDER BY title ASC")
     fun getByInstallStatus(isInstalled: Boolean): Flow<List<GOGGame>>
 
-    @Query("SELECT * FROM gog_games WHERE exclude = false AND title LIKE '%' || :searchQuery || '%' ORDER BY title ASC")
+    @Query("SELECT * FROM gog_games WHERE exclude = 0 AND title LIKE '%' || :searchQuery || '%' ORDER BY title ASC")
     fun searchByTitle(searchQuery: String): Flow<List<GOGGame>>
 
-    @Query("DELETE FROM gog_games WHERE is_installed = false")
+    @Query("DELETE FROM gog_games WHERE is_installed = 0")
     suspend fun deleteAllNonInstalledGames()
 
-    @Query("SELECT COUNT(*) FROM gog_games WHERE exclude = false")
+    @Query("SELECT COUNT(*) FROM gog_games WHERE exclude = 0")
     fun getCount(): Flow<Int>
 
     @Query("SELECT id FROM gog_games")


### PR DESCRIPTION
Some Room `@Query` SQL used `true`/`false` literals. On older device/SQLite version, those were parsed as identifiers (e.g. column `false`) and caused:
  `SQLiteException: no such column: false`.

fixing by flipping true/false to 1/0


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SQLite crashes on Android 10 by replacing boolean literals in Room queries with 1/0. Prevents "no such column: false" and keeps game lists, search, and cleanup working on older devices.

- **Bug Fixes**
  - Swapped true/false to 1/0 in EpicGameDao and GOGGameDao queries (is_dlc, exclude, is_installed).
  - No schema changes; behavior is unchanged on newer Android/SQLite versions.

<sup>Written for commit 49a1e15161941217f8ed7ace1cebbcc428f48ac7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database query conditions for accurate filtering of game types (DLC and base games) and installation status throughout the game library, improving search accuracy and data consistency.
  * Resolved database query evaluation issues to ensure correct retrieval and display of game library information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->