### PR TITLE
fix: serve cached images when device has no internet

### DIFF
--- a/app/src/main/java/app/gamenative/MainActivity.kt
+++ b/app/src/main/java/app/gamenative/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.LocalContext
 import coil.ImageLoader
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
+import coil.intercept.Interceptor
 import coil.request.CachePolicy
 import app.gamenative.events.AndroidEvent
 import app.gamenative.service.SteamService
@@ -48,7 +49,13 @@ import com.winlator.core.AppUtils
 import com.winlator.inputcontrols.ControllerManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import java.util.Collections
 import java.util.EnumSet
+import java.util.concurrent.atomic.AtomicBoolean
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import kotlin.math.abs
 import okio.Path.Companion.toOkioPath
 import timber.log.Timber
@@ -56,7 +63,36 @@ import timber.log.Timber
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
+    // ignore VPN and mesh transports — they don't reliably indicate internet
+    private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+        private val validated = Collections.synchronizedSet(mutableSetOf<Network>())
+
+        private fun skip(caps: NetworkCapabilities) =
+            caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN) ||
+                caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI_AWARE) ||
+                caps.hasTransport(NetworkCapabilities.TRANSPORT_LOWPAN)
+
+        override fun onCapabilitiesChanged(network: Network, caps: NetworkCapabilities) {
+            if (skip(caps)) return
+            if (caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)) {
+                validated.add(network)
+            } else {
+                validated.remove(network)
+            }
+            _hasInternet.set(validated.isNotEmpty())
+        }
+
+        override fun onLost(network: Network) {
+            validated.remove(network)
+            _hasInternet.set(validated.isNotEmpty())
+        }
+    }
+
     companion object {
+        // updated by NetworkCallback, read by Coil interceptor
+        private val _hasInternet = AtomicBoolean(false)
+        val hasInternet: Boolean get() = _hasInternet.get()
+
         private var totalIndex = 0
 
         private var currentOrientationChangeValue: Int = 0
@@ -141,6 +177,15 @@ class MainActivity : ComponentActivity() {
 
         handleLaunchIntent(intent)
 
+        // track real network state (callback filters out VPN/mesh transports)
+        val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        cm.registerNetworkCallback(
+            NetworkRequest.Builder()
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .build(),
+            networkCallback,
+        )
+
         // Prevent device from sleeping while app is open
         AppUtils.keepScreenOn(this)
 
@@ -184,10 +229,20 @@ class MainActivity : ComponentActivity() {
                     .diskCachePolicy(CachePolicy.ENABLED)
                     .diskCache(diskCache)
                     .components {
+                        // serve cached images when device has no internet
+                        add(Interceptor { chain ->
+                            val request = if (!hasInternet) {
+                                chain.request.newBuilder()
+                                    .networkCachePolicy(CachePolicy.DISABLED)
+                                    .build()
+                            } else {
+                                chain.request
+                            }
+                            chain.proceed(request)
+                        })
                         add(IconDecoder.Factory())
                         add(AnimatedPngDecoder.Factory())
                     }
-                    // .logger(logger)
                     .build()
             }
 
@@ -237,6 +292,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+
+        val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        cm.unregisterNetworkCallback(networkCallback)
 
         PluviaApp.events.emit(AndroidEvent.ActivityDestroyed)
 


### PR DESCRIPTION
Closes #634

- Register a `ConnectivityManager.NetworkCallback` that tracks validated networks (filtering out VPN/mesh transports which don't reliably indicate internet)
- Add a Coil `Interceptor` that sets `networkCachePolicy(DISABLED)` when offline, forcing Coil to serve from disk cache without attempting network requests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve cached images when the device has no internet by detecting validated connectivity and skipping Coil network requests. This prevents broken thumbnails and network errors while offline.

- **Bug Fixes**
  - Track validated internet via ConnectivityManager.NetworkCallback (ignores VPN/Wi‑Fi Aware/LoWPAN).
  - Add a Coil interceptor that disables network access when offline, serving images from disk cache.
  - Register/unregister the network callback in the activity lifecycle.

<sup>Written for commit a92ae2045a4f39d16aed2f0fc593bff1e8b7866f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved offline support: image loading now adapts to connectivity and serves cached images when offline.
  * Smarter connectivity detection to more reliably determine internet availability and adjust app behavior.
* **Bug Fixes**
  * Reduced unnecessary network usage when internet is unavailable, improving load reliability and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->