### PR TITLE
Remove unnecessary bitness depot filter

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -202,20 +202,14 @@ class GOGDownloadManager @Inject constructor(
                 )
             }
 
-            // Step 4: Filter depots by OS bitness
-            val bitnessDepots = parser.filterDepotsByBitness(languageDepots, bitness = "64")
-            if (bitnessDepots.isEmpty()) {
-                return@withContext Result.failure(Exception("No 64-bit depots found for language: $effectiveLang"))
-            }
-
             // Filter by ownership to exclude unowned DLC depots
             val ownedGameIds = gogManager.getAllGameIds()
-            val depots = parser.filterDepotsByOwnership(bitnessDepots, ownedGameIds)
+            val depots = parser.filterDepotsByOwnership(languageDepots, ownedGameIds)
             if (depots.isEmpty()) {
                 return@withContext Result.failure(Exception("No owned depots found for language: $effectiveLang"))
             }
 
-            Timber.tag("GOG").d("Found ${depots.size} owned depot(s) for $effectiveLang (64-bit)")
+            Timber.tag("GOG").d("Found ${depots.size} owned depot(s) for $effectiveLang")
             depots.forEachIndexed { index, depot ->
                 Timber.tag("GOG").d("  Depot $index: productId=${depot.productId}, manifest=${depot.manifest}, size=${depot.size}, compressedSize=${depot.compressedSize}")
             }
@@ -534,8 +528,7 @@ class GOGDownloadManager @Inject constructor(
             // Gen 1: do not filter by language — some games put main content in a depot tagged with another
             // language (or no tag), so filtering to en-US can leave only a small depot and skip the main one.
             downloadInfo.updateStatusMessage("Filtering depots...")
-            val bitnessDepots = parser.filterDepotsByBitness(gameManifest.depots, bitness = "64")
-            val depots = parser.filterDepotsByOwnership(bitnessDepots, ownedGameIds)
+            val depots = parser.filterDepotsByOwnership(gameManifest.depots, ownedGameIds)
             if (depots.isEmpty()) {
                 return@withContext Result.failure(Exception("No owned depots found"))
             }

--- a/app/src/main/java/app/gamenative/service/gog/api/GOGManifestParser.kt
+++ b/app/src/main/java/app/gamenative/service/gog/api/GOGManifestParser.kt
@@ -97,22 +97,6 @@ class GOGManifestParser @Inject constructor() {
     }
 
     /**
-     * Filter depots based on OS bitness
-     *
-     * @param depots List of depots to filter
-     * @param bitness Target bitness (e.g., "64", "32")
-     * @return Filtered list of depots matching bitness
-     */
-    fun filterDepotsByBitness(depots: List<Depot>, bitness: String = "64"): List<Depot> {
-        val filtered = depots.filter { depot ->
-            depot.osBitness == null || depot.osBitness.contains(bitness)
-        }
-
-        Timber.tag(TAG).d("Filtered ${filtered.size}/${depots.size} depots for bitness: $bitness")
-        return filtered
-    }
-
-    /**
      * Filter depots based on ownership
      *
      * @param depots List of depots to filter

--- a/app/src/test/java/app/gamenative/service/gog/api/GOGManifestParserTest.kt
+++ b/app/src/test/java/app/gamenative/service/gog/api/GOGManifestParserTest.kt
@@ -182,30 +182,6 @@ class GOGManifestParserTest {
     }
 
     @Test
-    fun testFilterDepotsByBitness() {
-        val depot64 = createTestDepot().copy(osBitness = listOf("64"))
-        val depot32 = createTestDepot().copy(osBitness = listOf("32"))
-        val depotBoth = createTestDepot().copy(osBitness = listOf("32", "64"))
-        val depots = listOf(depot64, depot32, depotBoth)
-
-        val result = parser.filterDepotsByBitness(depots, "64")
-
-        assertEquals(2, result.size)
-        assertTrue(result.any { it.osBitness?.contains("64") == true })
-    }
-
-    @Test
-    fun testFilterDepotsByBitness_nullBitnessIncluded() {
-        val depotWithBitness = createTestDepot().copy(osBitness = listOf("64"))
-        val depotNoBitness = createTestDepot().copy(osBitness = null)
-        val depots = listOf(depotWithBitness, depotNoBitness)
-
-        val result = parser.filterDepotsByBitness(depots, "64")
-
-        assertEquals(2, result.size) // Both should be included
-    }
-
-    @Test
     fun testFilterDepotsByOwnership() {
         val ownedDepot = createTestDepot().copy(productId = "12345")
         val unownedDepot = createTestDepot().copy(productId = "67890")


### PR DESCRIPTION
This was a TODO to check. I check it, can be removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the 32/64-bit depot filter across GOG downloads to avoid excluding valid depots and align with Heroic/gogdl. Depots are now filtered only by language (where applicable) and ownership.

- **Refactors**
  - Deleted filterDepotsByBitness from GOGManifestParser and removed its tests.
  - Updated GOGDownloadManager to stop bitness filtering and cleaned up logs.

<sup>Written for commit e55f7d300864a34e006a946b353e9176f4425f66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed 64-bit (bitness) filtering from game depot selection; depots are now filtered by language first, then ownership.
  * Downstream flows updated to operate on language-filtered depots and log messages adjusted accordingly.

* **Tests**
  * Removed test coverage related to bitness-based filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->