### PR TITLE
Added vredist launch dependency (need help getting this to auto-install)

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -9,6 +9,7 @@ import app.gamenative.service.gog.api.GOGManifestMeta
 import app.gamenative.service.gog.api.GOGManifestParser
 import app.gamenative.service.gog.api.V1DepotFile
 import app.gamenative.utils.Net
+import com.winlator.core.FileUtils
 import org.json.JSONArray
 import org.json.JSONObject
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -1017,7 +1018,27 @@ class GOGDownloadManager @Inject constructor(
             downloadInfo = downloadInfo,
         )
         if (result.isSuccess) {
+            // Mark progress complete
             onProgress(1f)
+
+            // HACK: create a symlink that scriptinterpreter.exe can use as a "full path with drive letter".
+            // For per-game installs we download into <installPath>/_CommonRedist. When that is the case and
+            // ISI is among the requested dependencies, create:
+            //   _CommonRedist/ISI/rootdir -> <installPath>
+            // so that /DIR=A:\_CommonRedist\ISI\rootdir points to the actual game root.
+            if (redistDir.name == "_CommonRedist" && dependencyIds.contains("ISI")) {
+                val installDir = redistDir.parentFile
+                if (installDir != null && installDir.isDirectory) {
+                    val isiDir = File(redistDir, "ISI")
+                    if (isiDir.isDirectory) {
+                        val rootDirLink = File(isiDir, "rootdir")
+                        FileUtils.symlink(installDir, rootDirLink)
+                        Timber.tag("GOG").d(
+                            "Created scriptinterpreter rootdir symlink: ${rootDirLink.absolutePath} -> ${installDir.absolutePath}",
+                        )
+                    }
+                }
+            }
         }
         result
     }

--- a/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
@@ -782,49 +782,51 @@ class GOGManager @Inject constructor(
         return "\"$windowsPath\""
     }
 
-    /**
-     * Runs GOG scriptinterpreter.exe before launch when the game's _gog_manifest.json has scriptInterpreter true.
-     * Uses scriptinterpreter from the game dir (_CommonRedist/ISI/scriptinterpreter.exe).
+       /**
+     * Returns command parts to run GOG scriptinterpreter.exe for each product (when required by
+     * _gog_manifest.json). Used by pre-launch steps to prepend to the game launch command so it runs
+     * in the same Wine session. Returns empty list if not needed or not available.
      */
-    fun runScriptInterpreterIfNeeded(
-        appId: String,
-        guestProgramLauncherComponent: GuestProgramLauncherComponent,
-    ) {
-        val gameId = ContainerUtils.extractGameIdFromContainerId(appId)
-        Timber.tag("GOG").i("runScriptInterpreterIfNeeded: appId=$appId")
-        val game = runBlocking { getGameFromDbById(gameId.toString()) } ?: return
+    fun getScriptInterpreterPartsForLaunch(appId: String): List<String> {
+        val gameId = ContainerUtils.extractGameIdFromContainerId(appId) ?: return emptyList()
+        val game = runBlocking { getGameFromDbById(gameId.toString()) } ?: return emptyList()
+
         val computedPath = getGameInstallPath(gameId.toString(), game.title)
         val gameInstallPath = when {
             game.installPath.isNotEmpty() && File(game.installPath).exists() -> game.installPath
             else -> computedPath
         }
+
         val gameInstallDir = File(gameInstallPath)
-        if (!GOGManifestUtils.needsScriptInterpreter(gameInstallDir)) return
-        val root = GOGManifestUtils.readLocalManifest(gameInstallDir) ?: return
+        if (!GOGManifestUtils.needsScriptInterpreter(gameInstallDir)) return emptyList()
+
+        val root = GOGManifestUtils.readLocalManifest(gameInstallDir) ?: return emptyList()
         val isiRelativePath = "_CommonRedist/ISI/scriptinterpreter.exe"
-        if (!File(gameInstallPath, isiRelativePath).exists()) {
-            Timber.tag("GOG").w("scriptinterpreter.exe not found at $isiRelativePath, skipping setup")
-            return
-        }
+        if (!File(gameInstallPath, isiRelativePath).exists()) return emptyList()
+
         val isiRelativePathWin = isiRelativePath.replace('/', '\\')
         val gameDriveLetter = "A"
         val buildId = root.optString("buildId", "")
         val versionName = root.optString("versionName", "")
         val langCode = root.optString("language", "en").let { if (it.length <= 2) "$it-US" else it }
-        val language = when {
-            langCode.startsWith("en") -> "English"
-            else -> "English"
-        }
-        val productsArray = root.optJSONArray("products") ?: return
+        val language = "English"
+        val productsArray = root.optJSONArray("products") ?: return emptyList()
 
+        val parts = mutableListOf<String>()
         for (i in 0 until productsArray.length()) {
             val product = productsArray.getJSONObject(i)
             val productId = product.optString("productId", "")
             if (productId.isEmpty()) continue
+
             val exePathWin = "$gameDriveLetter:\\$isiRelativePathWin"
+            // HACK: /DIR and /supportDir point to a \"rootdir\" folder inside ISI, which is a symlink
+            // to the actual game install root (created during redist download). This gives
+            // scriptinterpreter a full path with drive + folder name while still resolving
+            // to the game directory that the drive letter is mapped to.
+            val dirAndSupport = "$gameDriveLetter:\\_CommonRedist\\ISI\\rootdir"
             val args = listOf(
                 "/VERYSILENT",
-                "/DIR=$gameDriveLetter:\\",
+                "/DIR=$dirAndSupport",
                 "/Language=$language",
                 "/LANG=$language",
                 "/ProductId=$productId",
@@ -832,25 +834,15 @@ class GOGManager @Inject constructor(
                 "/buildId=$buildId",
                 "/versionName=$versionName",
                 "/lang-code=$langCode",
-                "/supportDir=$gameDriveLetter:\\",
+                "/supportDir=$dirAndSupport",
                 "/nodesktopshorctut",
                 "/nodesktopshortcut",
             ).joinToString(" ")
-            val exePathEscaped = exePathWin.replace("\\", "\\\\")
-            val argsEscaped = args.replace("\\", "\\\\")
-            val cmd = "wine $exePathEscaped $argsEscaped"
-            Timber.tag("GOG").i("Running scriptinterpreter for product $productId")
-            val previousWorkingDir = guestProgramLauncherComponent.workingDir
-            try {
-                PluviaApp.events.emit(app.gamenative.events.AndroidEvent.SetBootingSplashText("Running GOG script interpreter..."))
-                guestProgramLauncherComponent.workingDir = gameInstallDir
-                guestProgramLauncherComponent.execShellCommand(cmd, true)
-            } catch (e: Exception) {
-                Timber.tag("GOG").e(e, "scriptinterpreter failed for product $productId")
-            } finally {
-                guestProgramLauncherComponent.workingDir = previousWorkingDir
-            }
+
+            parts.add("$exePathWin $args")
         }
+
+        return parts
     }
 
     // ==========================================================================

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -288,13 +288,6 @@ class GOGService : Service() {
                 ?: Result.failure(Exception("Service not available"))
         }
 
-        fun runScriptInterpreterIfNeeded(
-            appId: String,
-            guestProgramLauncherComponent: com.winlator.xenvironment.components.GuestProgramLauncherComponent,
-        ) {
-            getInstance()?.gogManager?.runScriptInterpreterIfNeeded(appId, guestProgramLauncherComponent)
-        }
-
         fun downloadGame(context: Context, gameId: String, installPath: String, containerLanguage: String): Result<DownloadInfo?> {
             val instance = getInstance() ?: return Result.failure(Exception("Service not available"))
 

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1903,7 +1903,6 @@ private fun setupXEnvironment(
             } catch (e: Exception) {
                 Timber.tag("GameFixes").w(e, "Game fixes failed in preUnpack")
             }
-            PreLaunchSteps().run(context, appId, container, guestProgramLauncherComponent, gameSource)
             unpackExecutableFile(
                 context = context,
                 needsUnpacking = container.isNeedsUnpacking,
@@ -2057,6 +2056,38 @@ private fun setupXEnvironment(
     )
     return environment
 }
+
+/**
+ * Builds the pre-launch cmd /c chain from [PreLaunchSteps] (VC Redist, GOG scriptinterpreter, etc.).
+ * Returns empty if no steps contribute.
+ */
+private fun buildPreLaunchChain(
+    context: Context,
+    appId: String,
+    container: Container,
+    gameSource: GameSource,
+): String = PreLaunchSteps().buildChain(context, appId, container, gameSource)
+
+/**
+ * If a pre-launch chain exists, prepends it to the launch command so steps run in the same Wine session as the game.
+ */
+private fun maybeWrapWithPreLaunchChain(
+    context: Context,
+    appId: String,
+    container: Container,
+    gameSource: GameSource,
+    baseCommand: String,
+): String {
+    val chain = buildPreLaunchChain(context, appId, container, gameSource)
+    if (chain.isEmpty()) return baseCommand
+    val tail = if (baseCommand.startsWith("winhandler.exe ")) {
+        baseCommand.removePrefix("winhandler.exe ").trimStart()
+    } else {
+        baseCommand
+    }
+    return "winhandler.exe cmd /c \"$chain$tail\""
+}
+
 private fun getWineStartCommand(
     context: Context,
     appId: String,
@@ -2098,9 +2129,9 @@ private fun getWineStartCommand(
     }
 
     val args = if (testGraphics) {
-        "\"Z:/opt/apps/TestD3D.exe\""
+        "Z:/opt/apps/TestD3D.exe"
     } else if (bootToContainer) {
-        "\"wfm.exe\""
+        "wfm.exe"
     } else if (isGOGGame) {
         // For GOG games, use GOGService to get the launch command
         Timber.tag("XServerScreen").i("Launching GOG game: $gameId")
@@ -2123,7 +2154,7 @@ private fun getWineStartCommand(
         )
 
         Timber.tag("XServerScreen").i("GOG launch command: $gogCommand")
-        return "winhandler.exe $gogCommand"
+        return maybeWrapWithPreLaunchChain(context, appId, container, gameSource, "winhandler.exe $gogCommand")
     } else if (isEpicGame) {
         // For Epic games, get the launch command
         Timber.tag("XServerScreen").i("Launching Epic game: $gameId")
@@ -2133,7 +2164,7 @@ private fun getWineStartCommand(
 
         if (game == null || !game.isInstalled || game.installPath.isEmpty()) {
             Timber.tag("XServerScreen").e("Cannot launch: Epic game not installed")
-            return "\"explorer.exe\""
+            return maybeWrapWithPreLaunchChain(context, appId, container, gameSource, "winhandler.exe explorer.exe")
         }
 
         // Use container's configured executable path if available, otherwise auto-detect and persist
@@ -2152,7 +2183,7 @@ private fun getWineStartCommand(
 
         if (exePath.isEmpty()) {
             Timber.tag("XServerScreen").e("Cannot launch: executable not found for Epic game")
-            return "\"explorer.exe\""
+            return maybeWrapWithPreLaunchChain(context, appId, container, gameSource, "winhandler.exe explorer.exe")
         }
 
         // Convert to relative path from install directory
@@ -2206,7 +2237,7 @@ private fun getWineStartCommand(
             .replace(Regex("-epicovt=(\"[^\"]*\"|[^ ]+)"), "-epicovt=[REDACTED]")
         Timber.tag("XServerScreen").i("Epic launch command: $redactedCommand")
 
-        return launchCommand
+        return maybeWrapWithPreLaunchChain(context, appId, container, gameSource, launchCommand)
     } else if (gameSource == GameSource.AMAZON) {
         // For Amazon games, convert appId (integer) to productId (Amazon UUID string)
         val appIdInt = runCatching { ContainerUtils.extractGameIdFromContainerId(appId) }.getOrNull()
@@ -2221,7 +2252,7 @@ private fun getWineStartCommand(
         
         if (installPath.isNullOrEmpty()) {
             Timber.tag("XServerScreen").e("Cannot launch: Amazon game not installed")
-            return "\"explorer.exe\""
+            return maybeWrapWithPreLaunchChain(context, appId, container, gameSource, "winhandler.exe explorer.exe")
         }
 
         // ── Try fuel.json first (Amazon's launch manifest) ──────────────
@@ -2276,7 +2307,7 @@ private fun getWineStartCommand(
 
                 if (exeFile == null) {
                     Timber.tag("XServerScreen").e("Cannot find executable for Amazon game")
-                    return "\"explorer.exe\""
+                    return maybeWrapWithPreLaunchChain(context, appId, container, gameSource, "winhandler.exe explorer.exe")
                 }
                 Timber.tag("XServerScreen").d("Heuristic selected exe: ${exeFile.path}")
                 exeFile.relativeTo(File(installPath)).path
@@ -2370,7 +2401,7 @@ private fun getWineStartCommand(
             "winhandler.exe \"$amazonCommand\""
         }
 
-        return launchCommand
+        return maybeWrapWithPreLaunchChain(context, appId, container, gameSource, launchCommand)
     } else if (isCustomGame) {
         // For Custom Games, we can launch even without appLaunchInfo
         // Use the executable path from container config. If missing, try to auto-detect
@@ -2390,7 +2421,7 @@ private fun getWineStartCommand(
             // Attempt auto-detection only when we have the physical folder path
             if (gameFolderPath == null) {
                 Timber.tag("XServerScreen").e("Could not find A: drive for Custom Game: $appId")
-                return "winhandler.exe \"wfm.exe\""
+                return maybeWrapWithPreLaunchChain(context, appId, container, gameSource, "winhandler.exe wfm.exe")
             }
             val auto = CustomGameScanner.findUniqueExeRelativeToFolder(gameFolderPath!!)
             if (auto != null) {
@@ -2400,13 +2431,13 @@ private fun getWineStartCommand(
                 container.saveData()
             } else {
                 Timber.tag("XServerScreen").w("No unique executable found for Custom Game: $appId")
-                return "winhandler.exe \"wfm.exe\""
+                return maybeWrapWithPreLaunchChain(context, appId, container, gameSource, "winhandler.exe wfm.exe")
             }
         }
 
         if (gameFolderPath == null) {
             Timber.tag("XServerScreen").e("Could not find A: drive for Custom Game: $appId")
-            return "winhandler.exe \"wfm.exe\""
+            return maybeWrapWithPreLaunchChain(context, appId, container, gameSource, "winhandler.exe wfm.exe")
         }
 
         // Set working directory to the game folder
@@ -2420,7 +2451,7 @@ private fun getWineStartCommand(
     } else if (appLaunchInfo == null) {
         // For Steam games, we need appLaunchInfo
         Timber.tag("XServerScreen").w("appLaunchInfo is null for Steam game: $appId")
-        "\"wfm.exe\""
+        "wfm.exe"
     } else {
         if (container.isLaunchRealSteam) {
             // Launch Steam with the applaunch parameter to start the game
@@ -2459,7 +2490,7 @@ private fun getWineStartCommand(
         }
     }
 
-    return "winhandler.exe $args"
+    return maybeWrapWithPreLaunchChain(context, appId, container, gameSource, "winhandler.exe $args")
 }
 private fun getSteamlessTarget(
     appId: String,

--- a/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
+++ b/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
@@ -8,8 +8,6 @@ import app.gamenative.utils.launchdependencies.LaunchDependencyCallbacks
 import app.gamenative.utils.launchdependencies.LaunchDependency
 import com.winlator.container.Container
 
-const val LOADING_PROGRESS_UNKNOWN: Float = -1f
-
 /**
  * Ensures all dependencies required to launch a container are downloaded and installed.
  * Reports progress via the given callbacks.

--- a/app/src/main/java/app/gamenative/utils/PreLaunchSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreLaunchSteps.kt
@@ -4,35 +4,40 @@ import android.content.Context
 import app.gamenative.data.GameSource
 import app.gamenative.utils.launchdependencies.GogScriptInterpreterPreLaunchStep
 import app.gamenative.utils.launchdependencies.PreLaunchStep
+import app.gamenative.utils.launchdependencies.VcRedistPreLaunchStep
 import com.winlator.container.Container
-import com.winlator.xenvironment.components.GuestProgramLauncherComponent
-import timber.log.Timber
 
 /**
- * Runs all pre-launch steps that apply to a container/app.
- * Each step is run in order; exceptions are caught and logged per step so one failure does not block others.
+ * Registry for all pre-launch steps.
+ * Each applicable step contributes fragments to a single `cmd /c` chain run in the main Wine session.
+ * A short delay is inserted between each fragment so installer children (e.g. msiexec) can finish.
  */
 class PreLaunchSteps {
     companion object {
         private val preLaunchSteps: List<PreLaunchStep> = listOf(
+            VcRedistPreLaunchStep,
             GogScriptInterpreterPreLaunchStep,
         )
     }
 
-    fun run(
+    /**
+     * Builds the pre-launch chain string by collecting [PreLaunchStep.getChainFragments] from each
+     * applicable step and joining with " & " between each fragment. Returns empty if none.
+     */
+    fun buildChain(
         context: Context,
         appId: String,
         container: Container,
-        guestProgramLauncherComponent: GuestProgramLauncherComponent,
         gameSource: GameSource,
-    ) {
+    ): String {
+        val parts = mutableListOf<String>()
         for (step in preLaunchSteps) {
             if (!step.appliesTo(container, appId, gameSource)) continue
-            try {
-                step.run(context, appId, container, guestProgramLauncherComponent, gameSource)
-            } catch (e: Exception) {
-                Timber.tag("PreLaunchSteps").e(e, "Pre-launch step failed: ${step::class.simpleName}")
+            for (fragment in step.getChainFragments(context, appId, container, gameSource)) {
+                val trimmed = fragment.trim()
+                if (trimmed.isNotEmpty()) parts.add(trimmed)
             }
         }
+        return if (parts.isEmpty()) "" else parts.joinToString(" & ") + " & "
     }
 }

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/GogScriptInterpreterPreLaunchStep.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/GogScriptInterpreterPreLaunchStep.kt
@@ -6,18 +6,15 @@ import app.gamenative.service.gog.GOGService
 import com.winlator.container.Container
 import com.winlator.xenvironment.components.GuestProgramLauncherComponent
 
-/** Pre-launch step that runs GOG scriptinterpreter.exe when required by the game manifest. */
+/** Pre-launch step that adds GOG scriptinterpreter.exe to the chain when required by the game manifest. */
 object GogScriptInterpreterPreLaunchStep : PreLaunchStep {
     override fun appliesTo(container: Container, appId: String, gameSource: GameSource): Boolean =
         gameSource == GameSource.GOG
 
-    override fun run(
+    override fun getChainFragments(
         context: Context,
         appId: String,
         container: Container,
-        guestProgramLauncherComponent: GuestProgramLauncherComponent,
         gameSource: GameSource,
-    ) {
-        GOGService.runScriptInterpreterIfNeeded(appId, guestProgramLauncherComponent)
-    }
+    ): List<String> = GOGService.getInstance()?.gogManager?.getScriptInterpreterPartsForLaunch(appId) ?: emptyList()
 }

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/PreLaunchStep.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/PreLaunchStep.kt
@@ -3,25 +3,24 @@ package app.gamenative.utils.launchdependencies
 import android.content.Context
 import app.gamenative.data.GameSource
 import com.winlator.container.Container
-import com.winlator.xenvironment.components.GuestProgramLauncherComponent
 
 /**
- * A single pre-launch step (e.g. GOG scriptinterpreter, game-specific setup).
- * Steps are run in preUnpack when the environment is ready, before the game executable runs.
+ * A single pre-launch step (e.g. VC Redist, GOG scriptinterpreter).
+ * Each step contributes fragments to a single `cmd /c` chain run in the main Wine session.
  */
 interface PreLaunchStep {
     /** Whether this step applies to the given container/app. */
     fun appliesTo(container: Container, appId: String, gameSource: GameSource): Boolean
 
     /**
-     * Run this step. Called only when [appliesTo] is true.
-     * Exceptions should be caught by the registry so one failing step does not block others.
+     * Fragments to append to the pre-launch `cmd /c` chain (e.g. one command per element).
+     * Only called when [appliesTo] is true. Return empty list if nothing to run.
+     * [PreLaunchSteps] joins all fragments from all steps with " & ".
      */
-    fun run(
+    fun getChainFragments(
         context: Context,
         appId: String,
         container: Container,
-        guestProgramLauncherComponent: GuestProgramLauncherComponent,
         gameSource: GameSource,
-    )
+    ): List<String>
 }

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/VcRedistPreLaunchStep.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/VcRedistPreLaunchStep.kt
@@ -1,0 +1,68 @@
+package app.gamenative.utils.launchdependencies
+
+import android.content.Context
+import app.gamenative.data.GameSource
+import com.winlator.container.Container
+import com.winlator.xenvironment.ImageFs
+import java.io.File
+
+/**
+ * Installs Visual C++ Redistributables by contributing to the main Wine session's cmd /c chain.
+ * Map: full Windows path (directory + exe) -> args. If the exe exists on the host, that command is added.
+ */
+object VcRedistPreLaunchStep : PreLaunchStep {
+
+    /** Drive letter -> (context, container, pathUnderDrive) -> host directory. */
+    private val driveMap: Map<String, (Context, Container, String) -> File?> = mapOf(
+        "Z" to { ctx, _, path ->
+            File(ImageFs.find(ctx).getRootDir(), path.replace('\\', '/'))
+        },
+        "A" to { _, container, path ->
+            var out: File? = null
+            for (drive in Container.drivesIterator(container.drives)) {
+                if (drive[0] == "A") {
+                    out = File(drive[1], path.replace('\\', '/'))
+                    break
+                }
+            }
+            out
+        },
+    )
+
+    /** Directory + exe (Windows path) -> args. Only entries whose exe exists on host are added. */
+    private val vcRedistMap: Map<String, String> = mapOf(
+        "A:\\_CommonRedist\\MSVC2013\\vcredist_x86.exe" to "/install /passive /norestart",
+        "A:\\_CommonRedist\\MSVC2015\\VC_redist.x86.exe" to "/install /passive /norestart",
+        "A:\\_CommonRedist\\MSVC2017\\VC_redist.x86.exe" to "/install /passive /norestart",
+        "A:\\_CommonRedist\\MSVC2019\\VC_redist.x86.exe" to "/install /passive /norestart",
+        "A:\\_CommonRedist\\MSVC2015_x64\\VC_redist.x64.exe" to "/install /passive /norestart",
+        "A:\\_CommonRedist\\MSVC2017_x64\\VC_redist.x64.exe" to "/install /passive /norestart",
+        "A:\\_CommonRedist\\MSVC2019_x64\\VC_redist.x64.exe" to "/install /passive /norestart",
+        // "A:\\_CommonRedist\\DirectX\\DXSETUP.exe" to "/silent",
+    )
+
+    override fun appliesTo(container: Container, appId: String, gameSource: GameSource): Boolean = true
+
+    override fun getChainFragments(
+        context: Context,
+        appId: String,
+        container: Container,
+        gameSource: GameSource,
+    ): List<String> {
+        val parts = mutableListOf<String>()
+        for ((winPath, args) in vcRedistMap) {
+            if (winPath.length < 4 || winPath[1] != ':' || winPath[2] != '\\') continue
+            val driveLetter = winPath.substring(0, 1)
+            val rest = winPath.substring(3)
+            val lastSep = rest.lastIndexOf('\\')
+            if (lastSep < 0) continue
+            val dirPath = rest.substring(0, lastSep)
+            val exeName = rest.substring(lastSep + 1)
+            val resolveDir = driveMap[driveLetter] ?: continue
+            val dir = resolveDir(context, container, dirPath) ?: continue
+            if (!File(dir, exeName).isFile) continue
+            parts.add("$winPath $args")
+        }
+        return parts
+    }
+}


### PR DESCRIPTION
Moving prelaunch steps to be included in the launch command will actually install them and do ALL registry keys stuff that it should (IN GLIBC).

This will fix (in GLIBC):
- Scriptinterpreter will set all the keys that it should.
- VC redist distributables being installed on launch & correctly set their keys in the container registry.
- Side-effect: Bethesda game fixes are no longer needed for GOG. script interpreter will now set those keys correctly.

Todos:
- CMD has to be called to run multiple executables. So when scriptinterpreter or VC redist installs are needed, a command prompt is shown (dunno if that's an issue. But I'd thought i'd mention it at least).
- VC redist installers will run, but will set no registry keys on BIONIC.
- Scriptinterpreter will throw an error on BIONIC.


**Important note, I know we already have installDependencies for Steam, but that's currently also  broken. We can move those into the same prelaunch step so they will also auto run.**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs VC++ redistributables and the GOG script interpreter automatically before game launch by building a single cmd /c chain that runs in the same Wine session. This reduces missing DLL errors and ensures GOG setup/registry steps run correctly.

- **New Features**
  - VC Redist step: detects installers under A:\_CommonRedist (resolves A:/Z: to host), covers common MSVC versions, and adds passive installs only if the exe exists.
  - GOG script interpreter: contributes per-product command parts; creates and uses _CommonRedist/ISI/rootdir symlink so /DIR and /supportDir point to the game root.

- **Refactors**
  - Chain-based flow: PreLaunchStep.getChainFragments and PreLaunchSteps.buildChain; XServerScreen wraps launch commands via maybeWrapWithPreLaunchChain so steps run in the same Wine session across GOG, Epic, Amazon, Steamless, and Custom launches.
  - Removed GOGService.runScriptInterpreterIfNeeded in favor of GOGManager.getScriptInterpreterPartsForLaunch; symlink creation moved to redist download.

<sup>Written for commit 91f4133483cf15d8145c24c6f24724e05d95fef2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







