### PR TITLE
Fix L2/R2 being triggered as buttons instead of axis

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
@@ -71,7 +71,7 @@ class PhysicalControllerHandler(
                         return true
                     }
                     val offset = if (event.action == KeyEvent.ACTION_DOWN &&
-                        (event.keyCode == KeyEvent.KEYCODE_BUTTON_L2 || event.keyCode == KeyEvent.KEYCODE_BUTTON_R2)
+                        (controllerBinding.binding == Binding.GAMEPAD_BUTTON_L2 || controllerBinding.binding == Binding.GAMEPAD_BUTTON_R2)
                     ) 1f else 0f
                     handleInputEvent(controllerBinding.binding, event.action == KeyEvent.ACTION_DOWN, offset)
                     return true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes L2/R2 being treated as digital buttons. Triggers now use MotionEvent axes when available, preventing full-press spikes and enabling analog input.

- **Bug Fixes**
  - Detect trigger axes via InputDevice motion ranges (LTRIGGER/RTRIGGER or BRAKE/GAS), including gamepad/joystick sources.
  - Ignore L2/R2 KeyEvent when axes exist; use analog values from MotionEvent instead.
  - For digital-only controllers, set trigger offset to 1.0 on down and 0 on up; pressed state follows the analog value (> 0).

<sup>Written for commit 83bced181bbb20c6e97a4261081b6a357b4a1f07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved physical controller support for L2/R2 triggers when devices emit both key and motion events: the system now prefers analog trigger values when available, prevents duplicate events, and updates pressed/triggered state consistently across input types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->