### PR TITLE
issue #572 if a image or capsule banner is missing, display game icon…

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryAppItem.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryAppItem.kt
@@ -266,19 +266,16 @@ internal fun AppItem(
 
                             GameSource.STEAM -> {
                                 if (paneType == PaneType.GRID_CAPSULE) {
-                                    appInfo.capsuleImageUrl to appInfo.clientIconUrl
-                                } else {
-                                    // try header first, fall back to hero image from library assets
-                                    val fallback = if (appInfo.heroImageUrl.isNotEmpty()) appInfo.heroImageUrl else appInfo.clientIconUrl
-                                    appInfo.headerImageUrl to fallback
-                                }
-                            }
+            appInfo.capsuleImageUrl = appInfo.clientIconUrl
+        } else if (appInfo.heroImageUrl.isNotEmpty()) {
+            appInfo.headerImageUrl = appInfo.heroImageUrl
+        } else {
+            appInfo.headerImageUrl = appInfo.clientIconUrl
+        }
                         }
                     }
 var imageUrl by remember(primaryUrl, imageRefreshCounter) { mutableStateOf(primaryUrl) }
-                    // Reset alpha and hideText when image URL changes (e.g., when new images are fetched)
-                    LaunchedEffect(imageUrl) {
-                        if (paneType != PaneType.LIST) {
+         var imageUrl by remember(primaryUrl, imageRefreshCounter) { mutableStateOf(primaryUrl) }           
                             hideText = true
                             alpha = 1f
                         }


### PR DESCRIPTION
… as fallback

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the game’s client icon when capsule, header, or hero images are missing, so Library tiles never appear blank. Addresses issue #572.

- **Bug Fixes**
  - Added client icon fallback for GRID_CAPSULE and GRID_HERO when preferred images (SteamGridDB/local/header/capsule) are missing.
  - Steam: header now falls back to hero, then to client icon; capsule falls back to client icon.
  - GOG/Epic/Amazon: iconHash now falls back to the client icon.

<sup>Written for commit 9b43124dbce3e9b3bf401eb1c61d5842824ac121. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image fallback logic across library views to reduce missing or blank artwork.
  * Custom games now consistently show client-provided icons as secondary/fallback images in grid and list layouts.
  * Better fallback handling for Steam: header, capsule, and hero images now prefer sensible alternatives when originals are unavailable.
  * Unified fallback behavior for GOG, Epic, and Amazon titles so client icons appear when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->