### PR TITLE
feat: make suspend persist on controller edit

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -335,6 +335,7 @@ fun XServerScreen(
     var showPhysicalControllerDialog by remember { mutableStateOf(false) }
     var isOverlayPaused by remember { mutableStateOf(false) }
     var keyboardRequestedFromOverlay by remember { mutableStateOf(false) }
+    var keepPausedForEditor by remember { mutableStateOf(false) }
 
     fun startExitWatchForUnmappedGameWindow(window: Window) {
         val winHandler = xServerView?.getxServer()?.winHandler ?: return
@@ -497,6 +498,7 @@ fun XServerScreen(
 
                         NavigationDialog.ACTION_EDIT_CONTROLS -> {
                             PostHog.capture(event = "edit_controls_in_game")
+                            keepPausedForEditor = true
 
                             // Get or create profile for this container
                             val manager = PluviaApp.inputControlsManager ?: InputControlsManager(context)
@@ -571,6 +573,7 @@ fun XServerScreen(
 
                         NavigationDialog.ACTION_EDIT_PHYSICAL_CONTROLLER -> {
                             PostHog.capture(event = "edit_physical_controller_from_menu")
+                            keepPausedForEditor = true
                             showPhysicalControllerDialog = true
                         }
 
@@ -602,7 +605,7 @@ fun XServerScreen(
                 imeInputReceiver?.hideKeyboard()
             }
             keyboardRequestedFromOverlay = false
-            if (PluviaApp.isOverlayPaused) {
+            if (PluviaApp.isOverlayPaused && !keepPausedForEditor) {
                 PluviaApp.xEnvironment?.onResume()
                 isOverlayPaused = false
                 PluviaApp.isOverlayPaused = false
@@ -1235,6 +1238,12 @@ fun XServerScreen(
                     PluviaApp.inputControlsView?.post {
                         PluviaApp.inputControlsView?.invalidate()
                     }
+                    keepPausedForEditor = false
+                    if (PluviaApp.isOverlayPaused) {
+                        PluviaApp.xEnvironment?.onResume()
+                        isOverlayPaused = false
+                        PluviaApp.isOverlayPaused = false
+                    }
                 },
                 onClose = {
                     // Restore element positions from snapshot (cancel behavior)
@@ -1254,6 +1263,12 @@ fun XServerScreen(
                         PluviaApp.inputControlsView?.profile?.loadElements(PluviaApp.inputControlsView)
                         PluviaApp.inputControlsView?.profile?.save()
                         PluviaApp.inputControlsView?.invalidate()
+                    }
+                    keepPausedForEditor = false
+                    if (PluviaApp.isOverlayPaused) {
+                        PluviaApp.xEnvironment?.onResume()
+                        isOverlayPaused = false
+                        PluviaApp.isOverlayPaused = false
                     }
                 },
                 onDuplicate = { id ->
@@ -1357,7 +1372,15 @@ fun XServerScreen(
 
         if (profile != null) {
             androidx.compose.ui.window.Dialog(
-                onDismissRequest = { showPhysicalControllerDialog = false }
+                onDismissRequest = {
+                    showPhysicalControllerDialog = false
+                    keepPausedForEditor = false
+                    if (PluviaApp.isOverlayPaused) {
+                        PluviaApp.xEnvironment?.onResume()
+                        isOverlayPaused = false
+                        PluviaApp.isOverlayPaused = false
+                    }
+                }
             ) {
                 androidx.compose.foundation.layout.Box(
                     modifier = Modifier
@@ -1366,7 +1389,15 @@ fun XServerScreen(
                 ) {
                     app.gamenative.ui.component.dialog.PhysicalControllerConfigSection(
                         profile = profile,
-                        onDismiss = { showPhysicalControllerDialog = false },
+                        onDismiss = {
+                            showPhysicalControllerDialog = false
+                            keepPausedForEditor = false
+                            if (PluviaApp.isOverlayPaused) {
+                                PluviaApp.xEnvironment?.onResume()
+                                isOverlayPaused = false
+                                PluviaApp.isOverlayPaused = false
+                            }
+                        },
                         onSave = {
                             // Ensure controllersLoaded is true before saving
                             // (addController sets the flag even if controller already exists)
@@ -1386,6 +1417,12 @@ fun XServerScreen(
                             }
                             physicalControllerHandler?.setProfile(profile)
                             showPhysicalControllerDialog = false
+                            keepPausedForEditor = false
+                            if (PluviaApp.isOverlayPaused) {
+                                PluviaApp.xEnvironment?.onResume()
+                                isOverlayPaused = false
+                                PluviaApp.isOverlayPaused = false
+                            }
                         }
                     )
                 }


### PR DESCRIPTION
makes game stay suspended when edit on screen controls view is up, so sockpuppet stops dying.

verified other cases where we do not want suspend to persist do not regress: invoke keyboard (primary or ext screen like thor), show/hide controller states, invoke overlay and dismiss while in already suspended state of edit controller overlay does not resume in undesired way.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the game suspended while editing on-screen or physical controller settings so gameplay doesn’t resume unexpectedly. The game resumes only after the editor is closed, saved, or dismissed.

- **New Features**
  - Added a flag to persist suspension during control editors (on-screen and physical).
  - Resume is triggered only on editor close/save/dismiss; other flows (keyboard, overlay toggle) remain unchanged.

<sup>Written for commit 4c1c38dc7eeaf24a8693e49b99da31bfac37b2ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed overlay pause state management when using the in-game editor. The overlay now properly maintains its paused state while editing controls or settings and correctly resumes when you exit the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->