### PR TITLE
fix: collect all mouse movement data

### DIFF
--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -701,19 +701,22 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
     @Override // android.view.View.OnCapturedPointerListener
     public boolean onCapturedPointer(View view, MotionEvent event) {
-        if (event.getAction() == 2) {
-            float dx = event.getX() * this.sensitivity;
-            if (Math.abs(dx) > 6.0f) {
-                dx *= CURSOR_ACCELERATION;
+        if (event.getAction() == MotionEvent.ACTION_MOVE) {
+            float dx = 0f;
+            float dy = 0f;
+
+            int historySize = event.getHistorySize();
+            for (int i = 0; i < historySize; i++) {
+                dx += event.getHistoricalX(i);
+                dy += event.getHistoricalY(i);
             }
-            float dy = event.getY() * this.sensitivity;
-            if (Math.abs(dy) > 6.0f) {
-                dy *= CURSOR_ACCELERATION;
-            }
+
+            dx += event.getX();
+            dy += event.getY();
             this.xServer.injectPointerMoveDelta(Mathf.roundPoint(dx), Mathf.roundPoint(dy));
             return true;
         }
-        event.setSource(event.getSource() | 8194);
+        event.setSource(event.getSource() | InputDevice.SOURCE_MOUSE);
         return onExternalMouseEvent(event);
     }
 


### PR DESCRIPTION
Collect all mouse movement instead of just the last delta
This is a fix required for wireless USB mouse to work correctly inside the container

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collects all mouse movement during ACTION_MOVE (history + current) to prevent lost deltas. Fixes choppy or unresponsive movement for wireless USB mice inside the container.

- **Bug Fixes**
  - Sum MotionEvent historical X/Y with the current sample and inject the full delta.
  - Replace hardcoded source (8194) with InputDevice.SOURCE_MOUSE.

<sup>Written for commit 4c82ecccfc5d1ae860c14b3af3d5ed5d0efa8d38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touchpad pointer movement handling with better delta accumulation for smoother and more accurate cursor tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->