### PR TITLE
feat: handheld auto-configuration for plug-and-play gaming

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -927,6 +927,13 @@ object PrefManager {
         get() = getPref(APP_LANGUAGE, "")
         set(value) = setPref(APP_LANGUAGE, value)
 
+    // Tracks which device profile has been applied (tier + SoC).
+    // Prevents overwriting user-customized settings on subsequent app launches.
+    private val DEVICE_PROFILE_KEY = stringPreferencesKey("device_profile_key")
+    var deviceProfileKey: String
+        get() = getPref(DEVICE_PROFILE_KEY, "")
+        set(value) = setPref(DEVICE_PROFILE_KEY, value)
+
     // auto-apply known config from BestConfigService on first container creation
     private val AUTO_APPLY_KNOWN_CONFIG = booleanPreferencesKey("auto_apply_known_config")
     var autoApplyKnownConfig: Boolean

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -40,34 +40,10 @@ object ContainerUtils {
     )
 
     fun setContainerDefaults(context: Context) {
-        // Override default driver and DXVK version based on Turnip capability
-        if (GPUInformation.isTurnipCapable(context)) {
-            DefaultVersion.VARIANT = Container.BIONIC
-            DefaultVersion.WINE_VERSION = "proton-9.0-arm64ec"
-            DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
-            DefaultVersion.DXVK = if (GPUInformation.isAdreno6xx(context)) "1.11.1-sarek" else "2.4.1-gplasync"
-            DefaultVersion.VKD3D = "2.14.1"
-            DefaultVersion.WRAPPER = "turnip26.0.0_R8"
-            DefaultVersion.STEAM_TYPE = Container.STEAM_TYPE_NORMAL
-            DefaultVersion.ASYNC_CACHE = "1"
-        } else if (GPUInformation.isAdreno8Elite(context)) {
-            DefaultVersion.VARIANT = Container.BIONIC
-            DefaultVersion.WINE_VERSION = "proton-9.0-arm64ec"
-            DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
-            DefaultVersion.DXVK = "2.4.1-gplasync"
-            DefaultVersion.VKD3D = "2.14.1"
-            DefaultVersion.WRAPPER = "Turnip_Gen8_V23"
-            DefaultVersion.STEAM_TYPE = Container.STEAM_TYPE_NORMAL
-            DefaultVersion.ASYNC_CACHE = "1"
-        } else {
-            DefaultVersion.VARIANT = Container.BIONIC
-            DefaultVersion.WINE_VERSION = "proton-9.0-arm64ec"
-            DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
-            DefaultVersion.DXVK = "async-1.10.3"
-            DefaultVersion.VKD3D = "2.14.1"
-            DefaultVersion.STEAM_TYPE = Container.STEAM_TYPE_LIGHT
-            DefaultVersion.ASYNC_CACHE = "0"
-        }
+        // Detect device hardware and apply optimal configuration profile.
+        // Handles gaming handhelds (AYN Odin, AYANEO, Retroid, GPD) and
+        // all other Android devices with tier-based GPU/SoC detection.
+        HandheldProfileManager.detectAndApply(context)
     }
 
     fun getGPUCards(context: Context): Map<Int, GpuInfo> {

--- a/app/src/main/java/app/gamenative/utils/HandheldProfileManager.kt
+++ b/app/src/main/java/app/gamenative/utils/HandheldProfileManager.kt
@@ -1,0 +1,305 @@
+package app.gamenative.utils
+
+import android.content.Context
+import android.os.Build
+import app.gamenative.PrefManager
+import com.winlator.box86_64.Box86_64Preset
+import com.winlator.container.Container
+import com.winlator.core.DefaultVersion
+import com.winlator.core.GPUInformation
+import com.winlator.fexcore.FEXCorePreset
+import timber.log.Timber
+
+/**
+ * Auto-configuration for Android gaming handhelds and devices.
+ * Detects device hardware (SoC, GPU, model) and applies optimal Wine/emulation
+ * defaults so games from Steam, GOG, and Epic launch with minimal user configuration.
+ *
+ * Device tiers:
+ *  FLAGSHIP_ELITE  - SD 8 Elite / 8 Gen 3, Adreno 830+
+ *  FLAGSHIP        - SD 8 Gen 2 / 8 Gen 1, Adreno 730-750
+ *  HIGH            - SD 7xx / 888 / 870, Adreno 710-732
+ *  MID             - SD 865 / 6xx series, Adreno 610-660
+ *  LOW             - Non-Adreno (Mali, PowerVR, etc.)
+ */
+object HandheldProfileManager {
+
+    private const val TAG = "HandheldProfile"
+
+    enum class DeviceTier {
+        FLAGSHIP_ELITE,
+        FLAGSHIP,
+        HIGH,
+        MID,
+        LOW,
+    }
+
+    data class DeviceProfile(
+        val tier: DeviceTier,
+        val name: String,
+        // DefaultVersion overrides (set every launch - volatile statics)
+        val variant: String = Container.BIONIC,
+        val wineVersion: String = "proton-9.0-arm64ec",
+        val graphicsDriver: String = "Wrapper",
+        val wrapper: String,
+        val dxvk: String,
+        val vkd3d: String = "2.14.1",
+        val steamType: String = Container.STEAM_TYPE_NORMAL,
+        val asyncCache: String = "1",
+        // PrefManager overrides (set once per device - persisted)
+        val emulator: String = "FEXCore",
+        val fexcorePreset: String = FEXCorePreset.INTERMEDIATE,
+        val fexcoreTSOMode: String = "Fast",
+        val fexcoreX87Mode: String = "Fast",
+        val fexcoreMultiBlock: String = "Disabled",
+        val box64Preset: String = Box86_64Preset.COMPATIBILITY,
+        val box86Preset: String = Box86_64Preset.COMPATIBILITY,
+        val screenSize: String = "1280x720",
+        val videoMemorySize: String = "2048",
+        val startupSelection: Int = Container.STARTUP_SELECTION_AGGRESSIVE.toInt(),
+    )
+
+    // SoC model identifiers (Build.SOC_MODEL, API 31+) mapped to device tier.
+    // Covers Snapdragon, some Dimensity. Checked with contains() for flexibility.
+    private val SOC_TIERS = linkedMapOf(
+        // --- Snapdragon 8 Elite / 8 Gen 3 ---
+        "SM8750" to DeviceTier.FLAGSHIP_ELITE,   // SD 8 Elite
+        "SM8650" to DeviceTier.FLAGSHIP_ELITE,   // SD 8 Gen 3
+        "pineapple" to DeviceTier.FLAGSHIP_ELITE, // SD 8 Gen 3 codename
+        "SG8375" to DeviceTier.FLAGSHIP_ELITE,   // SD G3x Gen 3 (gaming)
+        // --- Snapdragon 8 Gen 2 / 8 Gen 1 ---
+        "SM8550" to DeviceTier.FLAGSHIP,          // SD 8 Gen 2
+        "kalama" to DeviceTier.FLAGSHIP,          // SD 8 Gen 2 codename
+        "SM8475" to DeviceTier.FLAGSHIP,          // SD 8+ Gen 1
+        "SM8450" to DeviceTier.FLAGSHIP,          // SD 8 Gen 1
+        "taro" to DeviceTier.FLAGSHIP,            // SD 8 Gen 1 codename
+        "SG8275" to DeviceTier.FLAGSHIP,          // SD G3x Gen 2 (gaming)
+        // --- Snapdragon 7xx / 888 / 870 ---
+        "SM7675" to DeviceTier.HIGH,              // SD 7+ Gen 3
+        "SM7550" to DeviceTier.HIGH,              // SD 7 Gen 3
+        "SM7435" to DeviceTier.HIGH,              // SD 7s Gen 2
+        "SM8350" to DeviceTier.HIGH,              // SD 888
+        "lahaina" to DeviceTier.HIGH,             // SD 888 codename
+        // --- Snapdragon 865 / 860 / 855 ---
+        "kona" to DeviceTier.MID,                 // SD 865 codename
+        "msmnile" to DeviceTier.MID,              // SD 855 codename
+        "SM8250" to DeviceTier.MID,               // SD 870/865
+        "SM8150" to DeviceTier.MID,               // SD 855
+    )
+
+    // Known gaming handheld manufacturers -> model prefix -> friendly name.
+    // Used for logging and future per-device overrides.
+    private val KNOWN_HANDHELDS = mapOf(
+        "ayn" to listOf(
+            "Odin 3" to "AYN Odin 3",
+            "Odin2 Max" to "AYN Odin 2 Max",
+            "Odin2 Mini" to "AYN Odin 2 Mini",
+            "Odin2" to "AYN Odin 2",
+        ),
+        "ayaneo" to listOf(
+            "POCKET S2" to "AYANEO Pocket S2",
+            "POCKET EVO" to "AYANEO Pocket EVO",
+            "POCKET MICRO" to "AYANEO Pocket Micro",
+            "POCKET S" to "AYANEO Pocket S",
+        ),
+        "retroid" to listOf(
+            "Pocket 5" to "Retroid Pocket 5",
+            "Pocket Flip 2" to "Retroid Pocket Flip 2",
+            "Pocket Mini" to "Retroid Pocket Mini",
+            "Pocket 4 Pro" to "Retroid Pocket 4 Pro",
+            "Pocket 4" to "Retroid Pocket 4",
+        ),
+        "gpd" to listOf(
+            "XP3" to "GPD XP3",
+            "XP2" to "GPD XP2",
+            "XP Plus" to "GPD XP Plus",
+        ),
+    )
+
+    /**
+     * Detects the device hardware and applies the optimal configuration profile.
+     * Called from [ContainerUtils.setContainerDefaults] on every app launch.
+     *
+     * - DefaultVersion statics are always updated (they reset on process death).
+     * - PrefManager settings are only written on first detection for a given device,
+     *   so user customizations made in the UI are preserved across restarts.
+     */
+    fun detectAndApply(context: Context) {
+        val tier = detectDeviceTier(context)
+        val profile = buildProfile(tier, context)
+        val handheldName = detectHandheldName()
+        val label = handheldName ?: profile.name
+
+        // Always set volatile DefaultVersion statics
+        applyDefaultVersion(profile)
+
+        // Only set PrefManager defaults once per device to avoid overwriting user settings.
+        // The key encodes the tier + SoC so a device change triggers re-application.
+        val soc = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) Build.SOC_MODEL else "unknown"
+        val profileKey = "${tier.name}_${soc}"
+        if (PrefManager.deviceProfileKey != profileKey) {
+            applyPrefManagerDefaults(profile)
+            PrefManager.deviceProfileKey = profileKey
+            Timber.tag(TAG).i("First-time profile applied: $label (tier=$tier, soc=$soc)")
+        } else {
+            Timber.tag(TAG).d("Profile already applied for: $label (tier=$tier)")
+        }
+    }
+
+    /**
+     * Detects device tier. Priority: SoC model (API 31+) > GPU renderer string.
+     */
+    private fun detectDeviceTier(context: Context): DeviceTier {
+        // 1. SoC model matching (most reliable)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val soc = Build.SOC_MODEL
+            if (!soc.isNullOrEmpty()) {
+                for ((pattern, tier) in SOC_TIERS) {
+                    if (soc.contains(pattern, ignoreCase = true)) {
+                        Timber.tag(TAG).d("SoC match: $soc contains '$pattern' -> $tier")
+                        return tier
+                    }
+                }
+            }
+        }
+
+        // 2. GPU renderer fallback
+        return when {
+            GPUInformation.isAdreno8Elite(context) -> DeviceTier.FLAGSHIP_ELITE
+            GPUInformation.isTurnipCapable(context) && !GPUInformation.isAdreno6xx(context)
+                && !GPUInformation.isAdreno710_720_732(context) -> DeviceTier.FLAGSHIP
+            GPUInformation.isAdreno710_720_732(context) -> DeviceTier.HIGH
+            GPUInformation.isAdreno6xx(context) -> DeviceTier.MID
+            GPUInformation.isTurnipCapable(context) -> DeviceTier.MID
+            else -> DeviceTier.LOW
+        }
+    }
+
+    /**
+     * Checks if this device is a known gaming handheld by manufacturer + model.
+     */
+    private fun detectHandheldName(): String? {
+        val mfr = Build.MANUFACTURER?.lowercase() ?: return null
+        val model = Build.MODEL ?: return null
+        val entries = KNOWN_HANDHELDS[mfr] ?: return null
+        for ((prefix, name) in entries) {
+            if (model.startsWith(prefix, ignoreCase = true)) {
+                return name
+            }
+        }
+        return null
+    }
+
+    /**
+     * Builds the optimal [DeviceProfile] for the given [DeviceTier].
+     * GPU-specific adjustments (e.g. DXVK version for Adreno 710/720/732) are applied here.
+     */
+    private fun buildProfile(tier: DeviceTier, context: Context): DeviceProfile = when (tier) {
+        DeviceTier.FLAGSHIP_ELITE -> DeviceProfile(
+            tier = tier,
+            name = "Flagship Elite (8 Elite / 8 Gen 3)",
+            wrapper = "Turnip_Gen8_V23",
+            dxvk = "2.4.1-gplasync",
+            steamType = Container.STEAM_TYPE_NORMAL,
+            fexcorePreset = FEXCorePreset.PERFORMANCE,
+            fexcoreMultiBlock = "Enabled",
+            box64Preset = Box86_64Preset.PERFORMANCE,
+            box86Preset = Box86_64Preset.PERFORMANCE,
+            screenSize = "1280x720",
+            videoMemorySize = "4096",
+            startupSelection = Container.STARTUP_SELECTION_AGGRESSIVE.toInt(),
+        )
+        DeviceTier.FLAGSHIP -> DeviceProfile(
+            tier = tier,
+            name = "Flagship (8 Gen 2 / 8 Gen 1)",
+            wrapper = "turnip26.0.0_R8",
+            dxvk = "2.4.1-gplasync",
+            steamType = Container.STEAM_TYPE_NORMAL,
+            fexcorePreset = FEXCorePreset.INTERMEDIATE,
+            fexcoreMultiBlock = "Enabled",
+            box64Preset = Box86_64Preset.INTERMEDIATE,
+            box86Preset = Box86_64Preset.INTERMEDIATE,
+            screenSize = "1280x720",
+            videoMemorySize = "3072",
+            startupSelection = Container.STARTUP_SELECTION_AGGRESSIVE.toInt(),
+        )
+        DeviceTier.HIGH -> DeviceProfile(
+            tier = tier,
+            name = "High (7xx / 888 / 870)",
+            wrapper = "turnip26.0.0_R8",
+            // Adreno 6xx and 710/720/732 GPUs benefit from older DXVK for stability.
+            // SD 888 (SoC=HIGH) has Adreno 660 (6xx), so check actual GPU not just tier.
+            dxvk = if (GPUInformation.isAdreno6xx(context) || GPUInformation.isAdreno710_720_732(context))
+                "1.11.1-sarek" else "2.4.1-gplasync",
+            steamType = Container.STEAM_TYPE_LIGHT,
+            fexcorePreset = FEXCorePreset.INTERMEDIATE,
+            fexcoreMultiBlock = "Disabled",
+            box64Preset = Box86_64Preset.COMPATIBILITY,
+            box86Preset = Box86_64Preset.COMPATIBILITY,
+            screenSize = "1280x720",
+            videoMemorySize = "2048",
+            startupSelection = Container.STARTUP_SELECTION_ESSENTIAL.toInt(),
+        )
+        DeviceTier.MID -> DeviceProfile(
+            tier = tier,
+            name = "Mid (6xx / 865)",
+            wrapper = "turnip26.0.0_R8",
+            dxvk = "1.11.1-sarek",
+            steamType = Container.STEAM_TYPE_LIGHT,
+            fexcorePreset = FEXCorePreset.COMPATIBILITY,
+            fexcoreMultiBlock = "Disabled",
+            box64Preset = Box86_64Preset.COMPATIBILITY,
+            box86Preset = Box86_64Preset.COMPATIBILITY,
+            screenSize = "960x540",
+            videoMemorySize = "2048",
+            startupSelection = Container.STARTUP_SELECTION_ESSENTIAL.toInt(),
+        )
+        DeviceTier.LOW -> DeviceProfile(
+            tier = tier,
+            name = "Low (Non-Adreno)",
+            wrapper = "System",
+            dxvk = "async-1.10.3",
+            asyncCache = "0",
+            steamType = Container.STEAM_TYPE_LIGHT,
+            fexcorePreset = FEXCorePreset.COMPATIBILITY,
+            fexcoreMultiBlock = "Disabled",
+            box64Preset = Box86_64Preset.STABILITY,
+            box86Preset = Box86_64Preset.STABILITY,
+            screenSize = "960x540",
+            videoMemorySize = "1024",
+            startupSelection = Container.STARTUP_SELECTION_NORMAL.toInt(),
+        )
+    }
+
+    /**
+     * Sets DefaultVersion statics. These are volatile (reset on process death)
+     * and must be applied on every app launch before any Container class usage.
+     */
+    private fun applyDefaultVersion(profile: DeviceProfile) {
+        DefaultVersion.VARIANT = profile.variant
+        DefaultVersion.WINE_VERSION = profile.wineVersion
+        DefaultVersion.DEFAULT_GRAPHICS_DRIVER = profile.graphicsDriver
+        DefaultVersion.DXVK = profile.dxvk
+        DefaultVersion.VKD3D = profile.vkd3d
+        DefaultVersion.WRAPPER = profile.wrapper
+        DefaultVersion.STEAM_TYPE = profile.steamType
+        DefaultVersion.ASYNC_CACHE = profile.asyncCache
+    }
+
+    /**
+     * Sets PrefManager defaults for emulation settings not covered by DefaultVersion.
+     * Only called once per device (guarded by [PrefManager.deviceProfileKey]).
+     */
+    private fun applyPrefManagerDefaults(profile: DeviceProfile) {
+        PrefManager.emulator = profile.emulator
+        PrefManager.fexcorePreset = profile.fexcorePreset
+        PrefManager.fexcoreTSOMode = profile.fexcoreTSOMode
+        PrefManager.fexcoreX87Mode = profile.fexcoreX87Mode
+        PrefManager.fexcoreMultiBlock = profile.fexcoreMultiBlock
+        PrefManager.box64Preset = profile.box64Preset
+        PrefManager.box86Preset = profile.box86Preset
+        PrefManager.screenSize = profile.screenSize
+        PrefManager.videoMemorySize = profile.videoMemorySize
+        PrefManager.startupSelection = profile.startupSelection
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the 3-branch GPU if/else in `setContainerDefaults()` with a 5-tier device detection system that auto-configures optimal Wine/emulation settings
- Detects device hardware via `Build.SOC_MODEL` (API 31+) with GPU renderer fallback, covering Snapdragon 8 Elite through 855 and non-Adreno devices
- Identifies known gaming handhelds (AYN Odin, AYANEO Pocket, Retroid Pocket, GPD XP) by manufacturer/model

## Device Tiers

| Tier | Devices | Key Settings |
|------|---------|-------------|
| FLAGSHIP_ELITE | SD 8 Elite, 8 Gen 3, G3x Gen 3 | Turnip Gen8, DXVK 2.4.1, FEXCore PERFORMANCE, MultiBlock on, 4096MB VRAM |
| FLAGSHIP | SD 8 Gen 2, 8 Gen 1, G3x Gen 2 | Turnip 26.0, DXVK 2.4.1, FEXCore INTERMEDIATE, MultiBlock on, 3072MB |
| HIGH | SD 7xx, 888, 870 | Turnip 26.0, DXVK auto (sarek for 6xx/710-732), FEXCore INTERMEDIATE |
| MID | SD 865, Adreno 6xx | Turnip 26.0, DXVK sarek, FEXCore COMPATIBILITY, 960x540 |
| LOW | Non-Adreno (Mali, etc.) | System driver, async DXVK, Box64 STABILITY, 960x540 |

## How It Works
1. `HandheldProfileManager.detectAndApply()` runs in `MainActivity.onCreate()` via `setContainerDefaults()`
2. `DefaultVersion.*` statics are always set (volatile, needed every launch)
3. `PrefManager.*` emulation defaults (presets, screen size, VRAM) are only written once per device via a `deviceProfileKey` guard — user customizations are preserved across restarts
4. DXVK version selection is GPU-aware regardless of tier (SD 888 with Adreno 660 gets sarek)

## Files Changed
- **New**: `HandheldProfileManager.kt` — device detection, profile building, configuration application
- **Modified**: `ContainerUtils.kt` — delegates `setContainerDefaults()` to HandheldProfileManager
- **Modified**: `PrefManager.kt` — adds `deviceProfileKey` to track applied profile

## Test plan
- [ ] Verify FLAGSHIP_ELITE tier on SD 8 Elite device (AYN Odin 3 / AYANEO Pocket S2)
- [ ] Verify FLAGSHIP tier on SD 8 Gen 2 device (AYN Odin 2)
- [ ] Verify MID tier on SD 865 device (Retroid Pocket 5)
- [ ] Verify LOW tier on non-Adreno device
- [ ] Confirm user settings persist after app restart (deviceProfileKey guard)
- [ ] Confirm DefaultVersion statics are refreshed on each launch
- [ ] Launch a Steam/GOG/Epic game on each tier — should work without manual config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-configures Android gaming handhelds by detecting SoC/GPU and applying optimal Turnip/DXVK/FEXCore presets. Replaces the old 3-branch GPU logic with a 5-tier system for plug-and-play game launching.

- **New Features**
  - 5-tier profiles: FLAGSHIP_ELITE, FLAGSHIP, HIGH, MID, LOW with tuned Wine, DXVK, driver, VRAM, and resolution.
  - SoC-based detection via Build.SOC_MODEL (API 31+) with GPU fallback; recognizes AYN, AYANEO, Retroid, GPD models.
  - GPU-aware DXVK selection (uses sarek for Adreno 6xx and 710/720/732).
  - PrefManager.deviceProfileKey to apply defaults once per device and preserve user tweaks.
  - ContainerUtils.setContainerDefaults now delegates to HandheldProfileManager.
  - Added HandheldProfileManager.kt; updated PrefManager.kt and ContainerUtils.kt.

<sup>Written for commit 5f35b264ba42612721a2db10cb120e0549d63d85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Intelligent device detection now automatically configures emulation and graphics settings based on your device's processor tier and hardware capabilities.
  * User settings are now preserved across app launches, preventing automatic reconfigurations from overwriting your customizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->