### PR TITLE
fix: prevent full login from popping on disconnect of steam while gam…

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -298,14 +298,21 @@ fun PluviaMain(
                 }
 
                 MainViewModel.MainUiEvent.OnLoggedOut -> {
-                    // Clear persisted route so next login starts fresh from Home
-                    viewModel.clearPersistedRoute()
-                    // Pop stack and go back to login
-                    navController.popBackStack(
-                        route = PluviaScreen.LoginUser.route,
-                        inclusive = false,
-                        saveState = false,
-                    )
+                    val hasActiveGameSession = SteamService.keepAlive || PluviaApp.xEnvironment != null
+                    if (hasActiveGameSession) {
+                        Timber.tag("PluviaMain").w(
+                            "Received logout while game session is active; deferring navigation to login",
+                        )
+                    } else {
+                        // Clear persisted route so next login starts fresh from Home
+                        viewModel.clearPersistedRoute()
+                        // Pop stack and go back to login
+                        navController.popBackStack(
+                            route = PluviaScreen.LoginUser.route,
+                            inclusive = false,
+                            saveState = false,
+                        )
+                    }
                 }
 
                 is MainViewModel.MainUiEvent.OnLogonEnded -> {
@@ -487,7 +494,10 @@ fun PluviaMain(
 
             // Handle navigation when already logged in (e.g., app resumed with active session)
             // Only navigate if currently on LoginUser screen to avoid disrupting user's current view
-            if (PlatformAuthUtils.isSignedInToAnyPlatform(context) && !SteamService.keepAlive) {
+            if (PlatformAuthUtils.isSignedInToAnyPlatform(context) &&
+                !SteamService.keepAlive &&
+                PluviaApp.xEnvironment == null
+            ) {
                 val baseRoute = viewModel.getPersistedRoute() ?: PluviaScreen.Home.route
                 val targetRoute = if (SteamService.isLoggedIn) {
                     baseRoute
@@ -1020,7 +1030,11 @@ fun PluviaMain(
             }
         }
 
+        val hasRestorableGameSession =
+            (SteamService.keepAlive || PluviaApp.xEnvironment != null) && state.launchedAppId.isNotBlank()
+
         val startDestination = when {
+            hasRestorableGameSession -> PluviaScreen.XServer.route
             SteamService.isLoggedIn -> PluviaScreen.Home.route + "?offline=false"
             GOGService.hasStoredCredentials(context) ||
                 EpicService.hasStoredCredentials(context) ||

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -431,6 +431,9 @@ class MainViewModel @Inject constructor(
     }
 
     fun launchApp(context: Context, appId: String) {
+        // Keep SteamService alive while a game session is active.
+        SteamService.keepAlive = true
+
         // Show booting splash before launching the app
         viewModelScope.launch {
             setShowBootingSplash(true)
@@ -625,6 +628,9 @@ class MainViewModel @Inject constructor(
     }
 
     fun onGameLaunchError(error: String) {
+        // Launch failed, so this is not an active game session.
+        SteamService.keepAlive = false
+
         viewModelScope.launch {
             // Hide the splash screen if it's still showing
             bootingSplashTimeoutJob?.cancel()


### PR DESCRIPTION
…e running

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the login screen from interrupting active game sessions when Steam disconnects. Adds session-aware navigation to defer logout and resume the running game.

- **Bug Fixes**
  - Defer logout navigation when a game session is active (SteamService.keepAlive or xEnvironment).
  - Set keepAlive on app launch; reset on launch error.
  - Only auto-leave Login screen if signed in and no active/restorable session (!keepAlive and xEnvironment == null).
  - Start at XServer when a restorable session exists (session present and launchedAppId set).

<sup>Written for commit f1493c218f66aafc59ef7c7ec7bc6a808dbc74c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

