### PR TITLE
fix: remain connected to SteamService and solve for login page game smother

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -298,6 +298,10 @@ fun PluviaMain(
                 }
 
                 MainViewModel.MainUiEvent.OnLoggedOut -> {
+                    if (SteamService.keepAlive) {
+                        return@collect
+                    }
+
                     // Clear persisted route so next login starts fresh from Home
                     viewModel.clearPersistedRoute()
                     // Pop stack and go back to login
@@ -1020,13 +1024,15 @@ fun PluviaMain(
             }
         }
 
-        val startDestination = when {
-            SteamService.isLoggedIn -> PluviaScreen.Home.route + "?offline=false"
-            GOGService.hasStoredCredentials(context) ||
-                EpicService.hasStoredCredentials(context) ||
-                AmazonService.hasStoredCredentials(context) ->
-                PluviaScreen.Home.route + "?offline=true"
-            else -> PluviaScreen.LoginUser.route
+        val startDestination = remember {
+            when {
+                SteamService.isLoggedIn -> PluviaScreen.Home.route + "?offline=false"
+                GOGService.hasStoredCredentials(context) ||
+                    EpicService.hasStoredCredentials(context) ||
+                    AmazonService.hasStoredCredentials(context) ->
+                    PluviaScreen.Home.route + "?offline=true"
+                else -> PluviaScreen.LoginUser.route
+            }
         }
 
         NavHost(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keep SteamService connected during keep-alive and prevent login screen flicker. We skip logout handling when keepAlive is true and memoize the start destination for stable navigation.

- **Bug Fixes**
  - Ignore MainUiEvent.OnLoggedOut when SteamService.keepAlive is true to avoid unintended disconnects.
  - Wrap startDestination in remember to stop recompute-induced navigation flicker on the login screen.

<sup>Written for commit 597a217af7e02a77124ddd98a18c8dcba9e53010. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where logout was occurring incorrectly when the connection should have been maintained.

* **Performance**
  * Optimized app startup navigation logic to improve recomposition efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->