### PR TITLE
Revert "fix: remain connected to SteamService and solve for login page game smother"

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -298,10 +298,6 @@ fun PluviaMain(
                 }
 
                 MainViewModel.MainUiEvent.OnLoggedOut -> {
-                    if (SteamService.keepAlive) {
-                        return@collect
-                    }
-
                     // Clear persisted route so next login starts fresh from Home
                     viewModel.clearPersistedRoute()
                     // Pop stack and go back to login
@@ -1024,15 +1020,13 @@ fun PluviaMain(
             }
         }
 
-        val startDestination = remember {
-            when {
-                SteamService.isLoggedIn -> PluviaScreen.Home.route + "?offline=false"
-                GOGService.hasStoredCredentials(context) ||
-                    EpicService.hasStoredCredentials(context) ||
-                    AmazonService.hasStoredCredentials(context) ->
-                    PluviaScreen.Home.route + "?offline=true"
-                else -> PluviaScreen.LoginUser.route
-            }
+        val startDestination = when {
+            SteamService.isLoggedIn -> PluviaScreen.Home.route + "?offline=false"
+            GOGService.hasStoredCredentials(context) ||
+                EpicService.hasStoredCredentials(context) ||
+                AmazonService.hasStoredCredentials(context) ->
+                PluviaScreen.Home.route + "?offline=true"
+            else -> PluviaScreen.LoginUser.route
         }
 
         NavHost(


### PR DESCRIPTION
Reverts utkarshdalal/GameNative#677

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Steam keep-alive change to restore the expected logout flow and correct initial routing. Users now fully log out, and the start screen matches current auth/offline state.

- **Bug Fixes**
  - Always process logout: clear persisted route and navigate to Login (removed keepAlive guard).
  - Compute startDestination without remember so it updates with current login or stored credentials.

<sup>Written for commit 8b8e3672d0b8458fd118557e68a3ffcd7676eba3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed logout flow to properly clear persisted navigation state and return to login screen.
  * Improved app navigation state handling during screen recomposition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->