### PR TITLE
refactor: share sync policy across stores

### DIFF
--- a/app/src/main/java/app/gamenative/service/ServiceSyncPolicy.kt
+++ b/app/src/main/java/app/gamenative/service/ServiceSyncPolicy.kt
@@ -1,0 +1,45 @@
+package app.gamenative.service
+
+object ServiceSyncPolicy {
+
+    fun shouldSyncOnColdStart(
+        hasPerformedInitialSync: Boolean,
+        lastSyncTimestamp: Long,
+        syncThrottleMillis: Long,
+        now: Long = System.currentTimeMillis(),
+    ): Boolean {
+        if (!hasPerformedInitialSync) return true
+        return now - lastSyncTimestamp >= syncThrottleMillis
+    }
+
+    fun shouldSyncForAction(
+        action: String?,
+        manualSyncAction: String,
+        autoSyncAction: String,
+        hasPerformedInitialSync: Boolean,
+        lastSyncTimestamp: Long,
+        syncThrottleMillis: Long,
+        now: Long = System.currentTimeMillis(),
+    ): Boolean {
+        return when (action) {
+            manualSyncAction -> true
+            autoSyncAction -> true
+            null -> shouldSyncOnColdStart(
+                hasPerformedInitialSync = hasPerformedInitialSync,
+                lastSyncTimestamp = lastSyncTimestamp,
+                syncThrottleMillis = syncThrottleMillis,
+                now = now,
+            )
+            else -> false
+        }
+    }
+
+    fun remainingThrottleMinutes(
+        lastSyncTimestamp: Long,
+        syncThrottleMillis: Long,
+        now: Long = System.currentTimeMillis(),
+    ): Long {
+        val remainingMs = (lastSyncTimestamp + syncThrottleMillis - now).coerceAtLeast(0L)
+        return remainingMs / 1000 / 60
+    }
+}

--- a/app/src/main/java/app/gamenative/service/amazon/AmazonService.kt
+++ b/app/src/main/java/app/gamenative/service/amazon/AmazonService.kt
@@ -13,6 +13,7 @@ import app.gamenative.db.dao.AmazonGameDao
 import app.gamenative.enums.Marker
 import app.gamenative.events.AndroidEvent
 import app.gamenative.service.NotificationHelper
+import app.gamenative.service.ServiceSyncPolicy
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.ExecutableSelectionUtils
 import app.gamenative.utils.MarkerUtils
@@ -109,24 +110,24 @@ class AmazonService : Service() {
             }
 
             val intent = Intent(context, AmazonService::class.java)
+            val shouldSync = ServiceSyncPolicy.shouldSyncOnColdStart(
+                hasPerformedInitialSync = hasPerformedInitialSync,
+                lastSyncTimestamp = lastSyncTimestamp,
+                syncThrottleMillis = SYNC_THROTTLE_MILLIS,
+            )
 
-            // First-time start: always sync without throttle
-            if (!hasPerformedInitialSync) {
-                Timber.i("[Amazon] First-time start — starting service with initial sync")
+            if (shouldSync) {
                 intent.action = ACTION_SYNC_LIBRARY
-                context.startForegroundService(intent)
-                return
-            }
-
-            // Subsequent starts: check throttle for sync
-            val now = System.currentTimeMillis()
-            val timeSinceLastSync = now - lastSyncTimestamp
-
-            if (timeSinceLastSync >= SYNC_THROTTLE_MILLIS) {
-                Timber.i("[Amazon] Starting service with automatic sync (throttle passed)")
-                intent.action = ACTION_SYNC_LIBRARY
+                if (!hasPerformedInitialSync) {
+                    Timber.i("[Amazon] First-time start — starting service with initial sync")
+                } else {
+                    Timber.i("[Amazon] Starting service with automatic sync (throttle passed)")
+                }
             } else {
-                val remainingMinutes = (SYNC_THROTTLE_MILLIS - timeSinceLastSync) / 1000 / 60
+                val remainingMinutes = ServiceSyncPolicy.remainingThrottleMinutes(
+                    lastSyncTimestamp = lastSyncTimestamp,
+                    syncThrottleMillis = SYNC_THROTTLE_MILLIS,
+                )
                 Timber.i("[Amazon] Starting service without sync — throttled (${remainingMinutes}min remaining)")
             }
             context.startForegroundService(intent)
@@ -775,30 +776,29 @@ class AmazonService : Service() {
         val notification = notificationHelper.createForegroundNotification("Connected")
         startForeground(1, notification)
 
-        val shouldSync = when (intent?.action) {
-            ACTION_MANUAL_SYNC -> {
-                Timber.i("[Amazon] Manual sync requested — bypassing throttle")
-                true
-            }
-            ACTION_SYNC_LIBRARY -> {
-                Timber.i("[Amazon] Automatic sync requested")
-                true
-            }
+        val now = System.currentTimeMillis()
+        val shouldSync = ServiceSyncPolicy.shouldSyncForAction(
+            action = intent?.action,
+            manualSyncAction = ACTION_MANUAL_SYNC,
+            autoSyncAction = ACTION_SYNC_LIBRARY,
+            hasPerformedInitialSync = hasPerformedInitialSync,
+            lastSyncTimestamp = lastSyncTimestamp,
+            syncThrottleMillis = SYNC_THROTTLE_MILLIS,
+            now = now,
+        )
+
+        when (intent?.action) {
+            ACTION_MANUAL_SYNC -> Timber.i("[Amazon] Manual sync requested — bypassing throttle")
+            ACTION_SYNC_LIBRARY -> Timber.i("[Amazon] Automatic sync requested")
             null -> {
-                // Service restarted by Android (START_STICKY)
-                val timeSinceLastSync = System.currentTimeMillis() - lastSyncTimestamp
-                val shouldResync = !hasPerformedInitialSync || timeSinceLastSync >= SYNC_THROTTLE_MILLIS
-                if (shouldResync) {
+                val timeSinceLastSync = now - lastSyncTimestamp
+                if (shouldSync) {
                     Timber.i("[Amazon] Service restarted by Android — performing sync (initial=$hasPerformedInitialSync, elapsed=${timeSinceLastSync}ms)")
                 } else {
                     Timber.d("[Amazon] Service restarted by Android — skipping sync (throttled)")
                 }
-                shouldResync
             }
-            else -> {
-                Timber.d("[Amazon] Service started without sync action")
-                false
-            }
+            else -> Timber.d("[Amazon] Service started without sync action")
         }
 
         if (shouldSync) {

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -16,6 +16,7 @@ import app.gamenative.events.AndroidEvent
 import app.gamenative.PluviaApp
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.service.NotificationHelper
+import app.gamenative.service.ServiceSyncPolicy
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
@@ -49,33 +50,31 @@ class EpicService : Service() {
         fun start(context: Context) {
 
             Timber.tag("EPIC").d("Starting service...")
-            // If already running, do nothing
             if (isRunning) {
                 Timber.tag("EPIC").d("[EpicService] Service already running, skipping start")
                 return
             }
 
-            // First-time start: always sync without throttle
-            if (!hasPerformedInitialSync) {
-                Timber.tag("EPIC").i("[EpicService] First-time start - starting service with initial sync")
-                val intent = Intent(context, EpicService::class.java)
-                intent.action = ACTION_SYNC_LIBRARY
-                context.startForegroundService(intent)
-                return
-            }
-
-            // Subsequent starts: always start service, but check throttle for sync
-            val now = System.currentTimeMillis()
-            val timeSinceLastSync = now - lastSyncTimestamp
-
             val intent = Intent(context, EpicService::class.java)
-            if (timeSinceLastSync >= SYNC_THROTTLE_MILLIS) {
-                Timber.tag("EPIC").i("[EpicService] Starting service with automatic sync (throttle passed)")
+            val shouldSync = ServiceSyncPolicy.shouldSyncOnColdStart(
+                hasPerformedInitialSync = hasPerformedInitialSync,
+                lastSyncTimestamp = lastSyncTimestamp,
+                syncThrottleMillis = SYNC_THROTTLE_MILLIS,
+            )
+
+            if (shouldSync) {
                 intent.action = ACTION_SYNC_LIBRARY
+                if (!hasPerformedInitialSync) {
+                    Timber.tag("EPIC").i("[EpicService] First-time start - starting service with initial sync")
+                } else {
+                    Timber.tag("EPIC").i("[EpicService] Starting service with automatic sync (throttle passed)")
+                }
             } else {
-                val remainingMinutes = (SYNC_THROTTLE_MILLIS - timeSinceLastSync) / 1000 / 60
+                val remainingMinutes = ServiceSyncPolicy.remainingThrottleMinutes(
+                    lastSyncTimestamp = lastSyncTimestamp,
+                    syncThrottleMillis = SYNC_THROTTLE_MILLIS,
+                )
                 Timber.tag("EPIC").i("Starting service without sync - throttled (${remainingMinutes}min remaining)")
-                // Start service without sync action
             }
             context.startForegroundService(intent)
         }
@@ -505,38 +504,29 @@ class EpicService : Service() {
         val notification = notificationHelper.createForegroundNotification("Connected")
         startForeground(1, notification)
 
-        // Determine if we should sync based on the action
-        val shouldSync = when (intent?.action) {
-            ACTION_MANUAL_SYNC -> {
-                Timber.tag("EPIC").i("Manual sync requested - bypassing throttle")
-                true
-            }
+        val now = System.currentTimeMillis()
+        val shouldSync = ServiceSyncPolicy.shouldSyncForAction(
+            action = intent?.action,
+            manualSyncAction = ACTION_MANUAL_SYNC,
+            autoSyncAction = ACTION_SYNC_LIBRARY,
+            hasPerformedInitialSync = hasPerformedInitialSync,
+            lastSyncTimestamp = lastSyncTimestamp,
+            syncThrottleMillis = SYNC_THROTTLE_MILLIS,
+            now = now,
+        )
 
-            ACTION_SYNC_LIBRARY -> {
-                Timber.tag("EPIC").i("Automatic sync requested")
-                true
-            }
-
+        when (intent?.action) {
+            ACTION_MANUAL_SYNC -> Timber.tag("EPIC").i("Manual sync requested - bypassing throttle")
+            ACTION_SYNC_LIBRARY -> Timber.tag("EPIC").i("Automatic sync requested")
             null -> {
-                // Service restarted by Android with null intent (START_STICKY behavior)
-                // Only sync if we haven't done initial sync yet, or if it's been a while
-                val timeSinceLastSync = System.currentTimeMillis() - lastSyncTimestamp
-                val shouldResync = !hasPerformedInitialSync || timeSinceLastSync >= SYNC_THROTTLE_MILLIS
-
-                if (shouldResync) {
+                val timeSinceLastSync = now - lastSyncTimestamp
+                if (shouldSync) {
                     Timber.tag("EPIC").i("Service restarted by Android - performing sync (hasPerformedInitialSync=$hasPerformedInitialSync, timeSinceLastSync=${timeSinceLastSync}ms)")
-                    true
                 } else {
                     Timber.tag("EPIC").d("Service restarted by Android - skipping sync (throttled)")
-                    false
                 }
             }
-
-            else -> {
-                // Service started without sync action (e.g., just to keep it alive)
-                Timber.tag("EPIC").d(" Service started without sync action")
-                false
-            }
+            else -> Timber.tag("EPIC").d(" Service started without sync action")
         }
 
         // Start background library sync if requested

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -12,6 +12,7 @@ import app.gamenative.data.LibraryItem
 import app.gamenative.events.AndroidEvent
 import app.gamenative.PluviaApp
 import app.gamenative.service.NotificationHelper
+import app.gamenative.service.ServiceSyncPolicy
 import app.gamenative.utils.ContainerUtils
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
@@ -56,33 +57,31 @@ class GOGService : Service() {
             get() = instance != null
 
         fun start(context: Context) {
-            // If already running, do nothing
             if (isRunning) {
                 Timber.d("[GOGService] Service already running, skipping start")
                 return
             }
 
-            // First-time start: always sync without throttle
-            if (!hasPerformedInitialSync) {
-                Timber.i("[GOGService] First-time start - starting service with initial sync")
-                val intent = Intent(context, GOGService::class.java)
-                intent.action = ACTION_SYNC_LIBRARY
-                context.startForegroundService(intent)
-                return
-            }
-
-            // Subsequent starts: always start service, but check throttle for sync
-            val now = System.currentTimeMillis()
-            val timeSinceLastSync = now - lastSyncTimestamp
-
             val intent = Intent(context, GOGService::class.java)
-            if (timeSinceLastSync >= SYNC_THROTTLE_MILLIS) {
-                Timber.i("[GOGService] Starting service with automatic sync (throttle passed)")
+            val shouldSync = ServiceSyncPolicy.shouldSyncOnColdStart(
+                hasPerformedInitialSync = hasPerformedInitialSync,
+                lastSyncTimestamp = lastSyncTimestamp,
+                syncThrottleMillis = SYNC_THROTTLE_MILLIS,
+            )
+
+            if (shouldSync) {
                 intent.action = ACTION_SYNC_LIBRARY
+                if (!hasPerformedInitialSync) {
+                    Timber.i("[GOGService] First-time start - starting service with initial sync")
+                } else {
+                    Timber.i("[GOGService] Starting service with automatic sync (throttle passed)")
+                }
             } else {
-                val remainingMinutes = (SYNC_THROTTLE_MILLIS - timeSinceLastSync) / 1000 / 60
+                val remainingMinutes = ServiceSyncPolicy.remainingThrottleMinutes(
+                    lastSyncTimestamp = lastSyncTimestamp,
+                    syncThrottleMillis = SYNC_THROTTLE_MILLIS,
+                )
                 Timber.d("[GOGService] Starting service without sync - throttled (${remainingMinutes}min remaining)")
-                // Start service without sync action
             }
             context.startForegroundService(intent)
         }
@@ -588,38 +587,29 @@ class GOGService : Service() {
         val notification = notificationHelper.createForegroundNotification("Connected")
         startForeground(1, notification)
 
-        // Determine if we should sync based on the action
-        val shouldSync = when (intent?.action) {
-            ACTION_MANUAL_SYNC -> {
-                Timber.i("[GOGService] Manual sync requested - bypassing throttle")
-                true
-            }
+        val now = System.currentTimeMillis()
+        val shouldSync = ServiceSyncPolicy.shouldSyncForAction(
+            action = intent?.action,
+            manualSyncAction = ACTION_MANUAL_SYNC,
+            autoSyncAction = ACTION_SYNC_LIBRARY,
+            hasPerformedInitialSync = hasPerformedInitialSync,
+            lastSyncTimestamp = lastSyncTimestamp,
+            syncThrottleMillis = SYNC_THROTTLE_MILLIS,
+            now = now,
+        )
 
-            ACTION_SYNC_LIBRARY -> {
-                Timber.i("[GOGService] Automatic sync requested")
-                true
-            }
-
+        when (intent?.action) {
+            ACTION_MANUAL_SYNC -> Timber.i("[GOGService] Manual sync requested - bypassing throttle")
+            ACTION_SYNC_LIBRARY -> Timber.i("[GOGService] Automatic sync requested")
             null -> {
-                // Service restarted by Android with null intent (START_STICKY behavior)
-                // Only sync if we haven't done initial sync yet, or if it's been a while
-                val timeSinceLastSync = System.currentTimeMillis() - lastSyncTimestamp
-                val shouldResync = !hasPerformedInitialSync || timeSinceLastSync >= SYNC_THROTTLE_MILLIS
-
-                if (shouldResync) {
+                val timeSinceLastSync = now - lastSyncTimestamp
+                if (shouldSync) {
                     Timber.i("[GOGService] Service restarted by Android - performing sync (hasPerformedInitialSync=$hasPerformedInitialSync, timeSinceLastSync=${timeSinceLastSync}ms)")
-                    true
                 } else {
                     Timber.d("[GOGService] Service restarted by Android - skipping sync (throttled)")
-                    false
                 }
             }
-
-            else -> {
-                // Service started without sync action (e.g., just to keep it alive)
-                Timber.d("[GOGService] Service started without sync action")
-                false
-            }
+            else -> Timber.d("[GOGService] Service started without sync action")
         }
 
         // Start background library sync if requested


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralized sync decision logic into a shared ServiceSyncPolicy to remove duplication and keep Amazon, Epic, and GOG services consistent. This preserves behavior for initial/manual/auto sync and throttle while simplifying maintenance.

- **Refactors**
  - Added ServiceSyncPolicy with shouldSyncOnColdStart, shouldSyncForAction, and remainingThrottleMinutes.
  - Updated AmazonService, EpicService, and GOGService to use the policy on start and when handling actions.
  - Replaced inline throttle checks with shared helpers and aligned logging for manual/auto/cold-start cases.
  - No functional changes intended; existing throttle and initial sync behavior is preserved.

<sup>Written for commit 6a548afdf5b213015a227173c5a8777bad954c7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized synchronization throttling logic across all services for more consistent and predictable sync behavior.
  * Improved handling of manual and automatic sync timing to ensure reliable cold-start and restart operations.
  * Enhanced sync decision-making to better balance user-initiated syncs with automatic background synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->