### PR TITLE
fix: keep xserver session pinned and throttle reconnects

### DIFF
--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -32,6 +32,8 @@ import io.ktor.client.plugins.HttpTimeout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -114,7 +116,14 @@ class PluviaApp : SplitCompatApplication() {
         internal var onDestinationChangedListener: NavChangedListener? = null
 
         // TODO: find a way to make this saveable, this is terrible (leak that memory baby)
-        internal var xEnvironment: XEnvironment? = null
+        private val _xEnvironmentFlow = MutableStateFlow<XEnvironment?>(null)
+        internal val xEnvironmentFlow = _xEnvironmentFlow.asStateFlow()
+        internal var xEnvironment: XEnvironment?
+            get() = _xEnvironmentFlow.value
+            set(value) {
+                _xEnvironmentFlow.value = value
+            }
+
         internal var xServerView: XServerView? = null
         var inputControlsView: InputControlsView? = null
         var inputControlsManager: InputControlsManager? = null

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -354,10 +354,18 @@ class SteamService : Service(), IChallengeUrlChanged {
             }
         }
 
+        private val _keepAliveFlow = MutableStateFlow(false)
+
+        @JvmStatic
+        val keepAliveFlow = _keepAliveFlow.asStateFlow()
+
         // Track whether a game is currently running to prevent premature service stop
         @JvmStatic
-        @Volatile
-        var keepAlive: Boolean = false
+        var keepAlive: Boolean
+            get() = _keepAliveFlow.value
+            set(value) {
+                _keepAliveFlow.value = value
+            }
 
         @Volatile
         var isImporting: Boolean = false
@@ -2639,10 +2647,25 @@ class SteamService : Service(), IChallengeUrlChanged {
         // Register callback for Wi-Fi connectivity
         networkCallback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
-                Timber.d("Wifi available")
-                isWifiConnected = true
-                scheduleReconnectIfEligible("network available", network)
+                val caps = connectivityManager.getNetworkCapabilities(network)
+                val isWifiOrEthernet = caps?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true ||
+                    caps?.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) == true
+                val isCellular = caps?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
+
+                isWifiConnected = isWifiOrEthernet
+
+                Timber.d(
+                    "Network available: wifiOrEthernet=%s cellular=%s validated=%s",
+                    isWifiOrEthernet,
+                    isCellular,
+                    caps?.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) == true,
+                )
+
+                if (isWifiOrEthernet) {
+                    scheduleReconnectIfEligible("network available", network, caps)
+                }
             }
+
             override fun onCapabilitiesChanged(
                 network: Network,
                 caps: NetworkCapabilities,
@@ -2847,7 +2870,6 @@ class SteamService : Service(), IChallengeUrlChanged {
                     return@withLock false
                 }
 
-                retryAttempt = 0
                 true
             }
 
@@ -2878,6 +2900,11 @@ class SteamService : Service(), IChallengeUrlChanged {
                 }
 
                 if (reconnectJob?.isActive == true) {
+                    return@withLock
+                }
+
+                if (connectJob?.isActive == true) {
+                    Timber.d("Reconnect skipped - connect attempt already in progress")
                     return@withLock
                 }
 
@@ -2964,6 +2991,7 @@ class SteamService : Service(), IChallengeUrlChanged {
         scope.launch(Dispatchers.Default) {
             val runningJob = coroutineContext[Job] ?: return@launch
             var shouldConnect = false
+            var shouldScheduleReconnectAfterCleanup = false
 
             reconnectMutex.withLock {
                 if (connectJob?.isActive == true) {
@@ -2996,14 +3024,37 @@ class SteamService : Service(), IChallengeUrlChanged {
                 delay(5000)
 
                 if (!isConnected) {
+                    shouldScheduleReconnectAfterCleanup = true
                     Timber.w("Failed to connect to Steam, marking endpoint bad and force disconnecting")
 
-                    try {
-                        client.servers.tryMark(client.currentEndpoint, PROTOCOL_TYPES, ServerQuality.BAD)
-                    } catch (e: NullPointerException) {
-                        // I don't care
-                    } catch (e: Exception) {
-                        Timber.e(e, "Failed to mark endpoint as bad:")
+                    val endpoint = client.currentEndpoint
+                    val servers = client.servers
+
+                    if (endpoint == null || servers == null) {
+                        Timber.e(
+                            "Cannot mark endpoint as bad (endpoint=%s, serversNull=%s, protocolTypes=%s)",
+                            endpoint,
+                            servers == null,
+                            PROTOCOL_TYPES,
+                        )
+                    } else {
+                        try {
+                            servers.tryMark(endpoint, PROTOCOL_TYPES, ServerQuality.BAD)
+                        } catch (e: NullPointerException) {
+                            Timber.e(
+                                e,
+                                "NPE while marking endpoint as bad (endpoint=%s, protocolTypes=%s)",
+                                endpoint,
+                                PROTOCOL_TYPES,
+                            )
+                        } catch (e: Exception) {
+                            Timber.e(
+                                e,
+                                "Failed to mark endpoint as bad (endpoint=%s, protocolTypes=%s)",
+                                endpoint,
+                                PROTOCOL_TYPES,
+                            )
+                        }
                     }
 
                     try {
@@ -3015,14 +3066,18 @@ class SteamService : Service(), IChallengeUrlChanged {
                     }
                 }
             } catch (e: Exception) {
-                Timber.e(e, "connectToSteam failed; scheduling reconnect")
-                scheduleReconnect()
+                Timber.e(e, "connectToSteam failed; reconnect will be scheduled after connect job cleanup")
+                shouldScheduleReconnectAfterCleanup = true
             } finally {
                 reconnectMutex.withLock {
                     if (connectJob == runningJob) {
                         connectJob = null
                     }
                 }
+            }
+
+            if (shouldScheduleReconnectAfterCleanup && !isStopping) {
+                scheduleReconnect()
             }
         }
     }

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
@@ -99,6 +98,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -221,7 +221,9 @@ fun PluviaMain(
     var openContainerConfigForAppId by rememberSaveable { mutableStateOf<String?>(null) }
 
     val isGameSessionActive by remember {
-        snapshotFlow { SteamService.keepAlive && PluviaApp.xEnvironment != null }
+        SteamService.keepAliveFlow.combine(PluviaApp.xEnvironmentFlow) { keepAlive, xEnvironment ->
+            keepAlive && xEnvironment != null
+        }
     }.collectAsState(initial = SteamService.keepAlive && PluviaApp.xEnvironment != null)
     var pendingLogoutRedirect by rememberSaveable { mutableStateOf(false) }
 
@@ -321,6 +323,9 @@ fun PluviaMain(
                     )
                     if (!popped) {
                         navController.navigate(PluviaScreen.LoginUser.route) {
+                            popUpTo(navController.graph.startDestinationId) {
+                                inclusive = true
+                            }
                             launchSingleTop = true
                         }
                     }
@@ -427,6 +432,9 @@ fun PluviaMain(
             )
             if (!popped) {
                 navController.navigate(PluviaScreen.LoginUser.route) {
+                    popUpTo(navController.graph.startDestinationId) {
+                        inclusive = true
+                    }
                     launchSingleTop = true
                 }
             }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -173,6 +174,19 @@ private val isExiting = AtomicBoolean(false)
 
 private const val UNHANDLED_MOTION_LOG_THROTTLE_MS = 300L
 private val unhandledMotionLogTimestamps = ConcurrentHashMap<String, Long>()
+
+private fun clearUnhandledMotionLogTimestampsForOwner(ownerId: String) {
+    val ownerPrefix = "$ownerId:"
+    val keysToRemove = unhandledMotionLogTimestamps.keys.filter { it.startsWith(ownerPrefix) }
+    keysToRemove.forEach { unhandledMotionLogTimestamps.remove(it) }
+    if (keysToRemove.isNotEmpty()) {
+        Timber.d(
+            "XServerScreen[%s] cleared %d unhandled motion log keys",
+            ownerId,
+            keysToRemove.size,
+        )
+    }
+}
 
 private const val EXIT_PROCESS_TIMEOUT_MS = 30_000L
 private const val EXIT_PROCESS_POLL_INTERVAL_MS = 1_000L
@@ -610,14 +624,18 @@ fun XServerScreen(
         navDialog.show()
     }
 
-    DisposableEffect(container, backActionOwnerId, registerBackAction, gameBack) {
+    val currentGameBack = rememberUpdatedState(gameBack)
+    DisposableEffect(container, backActionOwnerId, registerBackAction) {
         Timber.d("XServerScreen[%s] registering back action", backActionOwnerId)
-        registerBackAction(backActionOwnerId, gameBack)
+        registerBackAction(backActionOwnerId) {
+            currentGameBack.value.invoke()
+        }
         onDispose {
             Timber.d("XServerScreen[%s] leaving, clearing back action", backActionOwnerId)
             imeInputReceiver?.hideKeyboard()
             imeInputReceiver = null
             registerBackAction(backActionOwnerId, null)
+            clearUnhandledMotionLogTimestampsForOwner(backActionOwnerId)
         }   // reset when screen leaves
     }
 
@@ -716,6 +734,7 @@ fun XServerScreen(
             PluviaApp.events.off<AndroidEvent.GuestProgramTerminated, Unit>(onGuestProgramTerminated)
             PluviaApp.events.off<SteamEvent.ForceCloseApp, Unit>(onForceCloseApp)
             ProcessHelper.removeDebugCallback(debugCallback)
+            clearUnhandledMotionLogTimestampsForOwner(backActionOwnerId)
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the XServer route during active gameplay and hardens Steam reconnects with validated-network gating, synchronized backoff, and strict job control to stop thrashing. Session state now drives navigation via flows for smoother logout and route restoration.

- **Bug Fixes**
  - Synchronized reconnects with a mutex and distinct reconnect/connect jobs; cancels jobs on service stop/clear; resets retries on successful connect.
  - Reconnects only on validated internet (Wi‑Fi/Ethernet/Cellular) with exponential backoff and jitter (1s–30s); scheduled on network available/validated and deferred when not validated; retries cap at 20 (service stays alive if keepAlive).
  - XServer routing: pin and auto-restore to XServer when a session is active; persist startDestination; defer logout redirects until the session ends; mark bad Steam endpoints and force‑disconnect if connect stalls.

- **Refactors**
  - Added StateFlow for keepAlive and XEnvironment to drive session reactivity in UI/navigation.
  - Back action now uses ownerId; XServerScreen safely registers/unregisters listeners and throttles unhandled motion logs per owner; added targeted gamepad key/motion logs.

<sup>Written for commit 01cffa6e4f1d4ac45a5b5010debed3c467eb2d4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More robust Steam connectivity: scheduled, validated reconnects with exponential backoff to reduce disruptions during network changes.
  * Navigation resilience: improved start-destination and route restoration when game sessions become active.
  * Logout flow: deferred/safer logout handling while a game session is running to avoid abrupt exits.
  * Input & lifecycle diagnostics: richer logging and owner-aware back-action handling for more reliable back/navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->