### PR TITLE
feat(ui/ux): update xserver quick menu to align with new UI

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -291,7 +291,6 @@ private fun QuickMenuItemRow(
                     Modifier.focusRequester(focusRequester)
                 } else Modifier
             )
-            .focusable(enabled = isEnabled, interactionSource = interactionSource)
             .selectable(
                 selected = isFocused,
                 enabled = isEnabled,

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -412,7 +412,7 @@ fun XServerScreen(
             imeInputReceiver?.hideKeyboard()
         }
         keyboardRequestedFromOverlay = false
-        if (PluviaApp.isOverlayPaused) {
+        if (PluviaApp.isOverlayPaused && !keepPausedForEditor) {
             PluviaApp.xEnvironment?.onResume()
             isOverlayPaused = false
             PluviaApp.isOverlayPaused = false
@@ -475,6 +475,7 @@ fun XServerScreen(
 
             QuickMenuAction.EDIT_CONTROLS -> {
                 PostHog.capture(event = "edit_controls_in_game")
+                keepPausedForEditor = true
 
                 // Get or create profile for this container
                 val manager = PluviaApp.inputControlsManager ?: InputControlsManager(context)
@@ -549,6 +550,7 @@ fun XServerScreen(
 
             QuickMenuAction.EDIT_PHYSICAL_CONTROLLER -> {
                 PostHog.capture(event = "edit_physical_controller_from_menu")
+                keepPausedForEditor = true
                 showPhysicalControllerDialog = true
             }
 


### PR DESCRIPTION
- rolls in most of the ui reworks to quick menu from #395, adding controller focus, preserving suspend and resume of game proc, generally bringing in line with current master
<img width="1824" height="1013" alt="image" src="https://github.com/user-attachments/assets/8364158a-a13c-4e81-b20d-963381233ec7" />





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the in-game back menu with a left-side QuickMenu panel that supports controller-first navigation and correctly routes gamepad input to the menu. Cleanly pauses/resumes the game; keyboard behavior stays the same.

- **New Features**
  - Replaced NavigationDialog with a Compose QuickMenu in XServerScreen.
  - Gamepad-driven focus/selection; Compose consumes button and motion input while the menu is open with more reliable first-item focus.
  - Pauses game/audio while visible and resumes on dismiss; back closes the menu if already open.
  - Menu actions: toggle keyboard, show/hide input controls, edit controls (auto-creates a profile when needed), edit physical controller (shown only when a controller is connected), and exit game.
  - UI: left-side slide-in/out with rounded right corners; removed bold on focused text to prevent wrapping.

- **Bug Fixes**
  - Fixed gamepad button routing and pause/resume logic while the sidebar is open and on dismiss.

<sup>Written for commit 2ff602fdc5bc4cd6d4105e4c802a957d9bebccf4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick Menu integrated into the main screen for streamlined access to keyboard, input settings, and profiles
  * Back button now dismisses the Quick Menu and routes navigation through it when open

* **Improvements**
  * Refined menu entrance/exit animations and alignment for smoother presentation
  * More reliable focus handling with retry logic for quicker keyboard/gamepad navigation
  * Simplified menu typography for consistent item appearance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->