### PR TITLE
Remove unreachable code in validateComponentVersions

### DIFF
--- a/app/src/main/java/app/gamenative/utils/BestConfigService.kt
+++ b/app/src/main/java/app/gamenative/utils/BestConfigService.kt
@@ -325,7 +325,6 @@ object BestConfigService {
             if (version.isNotEmpty() && !ManifestComponentHelper.versionExists(version, availableDxvk)) {
                 Timber.tag("BestConfigService").w("DXVK version $version not found, updating to PrefManager default")
                 return "DXVK $version"
-                filteredJson.put("dxwrapperConfig", PrefManager.dxWrapperConfig)
             }
         }
 
@@ -336,7 +335,6 @@ object BestConfigService {
             if (version.isNotEmpty() && !ManifestComponentHelper.versionExists(version, availableVkd3d)) {
                 Timber.tag("BestConfigService").w("VKD3D version $version not found, updating to PrefManager default")
                 return "VKD3D $version"
-                filteredJson.put("dxwrapperConfig", PrefManager.dxWrapperConfig)
             }
         }
 
@@ -353,7 +351,6 @@ object BestConfigService {
             if (!ManifestComponentHelper.versionExists(box64Version, box64VersionsToCheck)) {
                 Timber.tag("BestConfigService").w("Box64 version $box64Version not found in $containerVariant variant entries, updating to PrefManager default")
                 return "Box64 $box64Version"
-                filteredJson.put("box64Version", PrefManager.box64Version)
             }
         }
 
@@ -369,7 +366,6 @@ object BestConfigService {
         if (fexcoreVersion.isNotEmpty() && !ManifestComponentHelper.versionExists(fexcoreVersion, availableFexcore)) {
             Timber.tag("BestConfigService").w("FEXCore version $fexcoreVersion not found, updating to PrefManager default")
             return "FEXCore $fexcoreVersion"
-            filteredJson.put("fexcoreVersion", PrefManager.fexcoreVersion)
         }
 
         // Validate Wine/Proton version (check separately based on container variant)
@@ -385,7 +381,6 @@ object BestConfigService {
             if (!ManifestComponentHelper.versionExists(wineVersion, wineVersionsToCheck)) {
                 Timber.tag("BestConfigService").w("Wine version $wineVersion not found in $containerVariant variant entries, updating to PrefManager default")
                 return "Wine $wineVersion"
-                filteredJson.put("wineVersion", PrefManager.wineVersion)
             }
         }
 
@@ -411,7 +406,6 @@ object BestConfigService {
             if (preset == null) {
                 Timber.tag("BestConfigService").w("Box64 preset $box64Preset not found, updating to PrefManager default")
                 return "Box64 preset $box64Preset"
-                filteredJson.put("box64Preset", PrefManager.box64Preset)
             }
         }
 
@@ -422,7 +416,6 @@ object BestConfigService {
             if (preset == null) {
                 Timber.tag("BestConfigService").w("FEXCore preset $fexcorePreset not found, updating to PrefManager default")
                 return "FEXCore preset $fexcorePreset"
-                filteredJson.put("fexcorePreset", PrefManager.fexcorePreset)
             }
         }
 


### PR DESCRIPTION
Seven `filteredJson.put()` calls sit after `return` statements in `validateComponentVersions()` and never execute. The log messages already say "updating to PrefManager default" but the updates don't actually happen.

The caller (`parseConfigToContainerData`) returns an empty map when validation fails anyway, so these mutations would have no effect even if they ran. Removing them to avoid confusion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed seven unreachable filteredJson.put() calls in validateComponentVersions that were placed after return statements. They never ran, and the caller discards results on validation failure, so removing them simplifies the code and avoids misleading logs.

<sup>Written for commit 3c3509cc226bbf47d823107afebce89ae007524d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Validation logic no longer mutates configuration values on failure; it returns explicit substitution text instead of applying silent defaults. Downstream code will no longer observe previously injected default values, yielding clearer and more predictable validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->