### PR TITLE
fix(): Remove UE assets from game queries for Epic.

### DIFF
--- a/app/src/main/java/app/gamenative/db/dao/EpicGameDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/EpicGameDao.kt
@@ -49,7 +49,8 @@ interface EpicGameDao {
     @Query("SELECT * FROM epic_games WHERE app_name = :appName")
     suspend fun getByAppName(appName: String): EpicGame?
 
-    @Query("SELECT * FROM epic_games WHERE is_dlc = 0 AND namespace != 'ue' ORDER BY title ASC")
+    // Note: '89efe5924d3d467c839449ab6ab52e7f' and 'ue' are the namespaces for Unreal Engine software/assets.
+    @Query("SELECT * FROM epic_games WHERE is_dlc = 0 AND namespace != 'ue' AND namespace != '89efe5924d3d467c839449ab6ab52e7f' ORDER BY title ASC")
     fun getAll(): Flow<List<EpicGame>>
 
     @Query("SELECT * FROM epic_games WHERE is_installed = :isInstalled ORDER BY title ASC")
@@ -61,7 +62,7 @@ interface EpicGameDao {
     @Query("SELECT * FROM epic_games WHERE base_game_app_name IS NOT NULL AND is_dlc = 1")
     fun getAllDlcTitles(): Flow<List<EpicGame>>
 
-    @Query("SELECT * FROM epic_games WHERE is_dlc = 0 AND namespace != 'ue' AND title LIKE '%' || :searchQuery || '%' ORDER BY title ASC")
+    @Query("SELECT * FROM epic_games WHERE is_dlc = 0 AND namespace != 'ue' AND namespace != '89efe5924d3d467c839449ab6ab52e7f' AND title LIKE '%' || :searchQuery || '%' ORDER BY title ASC")
     fun searchByTitle(searchQuery: String): Flow<List<EpicGame>>
 
     // Only delete non-installed games from DB - Need to preserve any currently installed games.


### PR DESCRIPTION
Epic had changed the namespace for a subset of the UE assets in a change recently. 

Since filtering on namespace is the only reliable way, I've updated our query to ignore them like we did with the 'ue' namespace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude Unreal Engine assets from Epic game lists and search so UE tools don’t appear as games. Filters out both 'ue' and the new '89efe5924d3d467c839449ab6ab52e7f' namespace.

- **Bug Fixes**
  - Updated getAll to ignore UE namespaces for non-DLC titles.
  - Updated searchByTitle to apply the same UE namespace filter.

<sup>Written for commit 5d069389eb2adade26dd6dc56d4650b2639284b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved game filtering to properly exclude certain Unreal Engine content from search results and game listings, ensuring more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->