### PR TITLE
refactor: remove Supabase integration

### DIFF
--- a/.github/workflows/app-release-signed.yml
+++ b/.github/workflows/app-release-signed.yml
@@ -64,8 +64,6 @@ jobs:
         POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}
         POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
         STEAMGRIDDB_API_KEY=${{ secrets.STEAMGRIDDB_API_KEY }}
-        SUPABASE_URL=${{ secrets.SUPABASE_URL }}
-        SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}
         EOF
 
     - name: Install Android SDK Build Tools

--- a/.github/workflows/pluvia-pr-check.yml
+++ b/.github/workflows/pluvia-pr-check.yml
@@ -28,8 +28,6 @@ jobs:
           cat <<EOF > local.properties
           POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
-          SUPABASE_URL=${{ secrets.SUPABASE_URL }}
-          SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}
           EOF
       - name: Inject dummy credentials
         if: github.event.pull_request.head.repo.full_name != github.repository
@@ -37,8 +35,6 @@ jobs:
           cat <<EOF > local.properties
           POSTHOG_API_KEY=dummy
           POSTHOG_HOST=https://us.i.posthog.com
-          SUPABASE_URL=https://dummy.supabase.co
-          SUPABASE_KEY=dummy
           EOF
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -60,8 +60,6 @@ jobs:
           cat <<EOF > local.properties
           POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
-          SUPABASE_URL=${{ secrets.SUPABASE_URL }}
-          SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}
           EOF
 
       - name: Install Android SDK Build Tools

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,10 +24,6 @@ val keystoreProperties: Properties? = if (keystorePropertiesFile.exists()) {
 val posthogApiKey: String = project.findProperty("POSTHOG_API_KEY") as String? ?: System.getenv("POSTHOG_API_KEY") ?: ""
 val posthogHost: String = project.findProperty("POSTHOG_HOST") as String? ?: System.getenv("POSTHOG_HOST") ?: "https://us.i.posthog.com"
 
-// Add Supabase URL and key as build-time variables
-val supabaseUrl: String = project.findProperty("SUPABASE_URL") as String? ?: System.getenv("SUPABASE_URL") ?: "https://your-project.supabase.co"
-val supabaseKey: String = project.findProperty("SUPABASE_KEY") as String? ?: System.getenv("SUPABASE_KEY") ?: ""
-
 room {
     schemaDirectory("$projectDir/schemas")
 }
@@ -65,8 +61,6 @@ android {
 
         buildConfigField("String", "POSTHOG_API_KEY", "\"${secret("POSTHOG_API_KEY")}\"")
         buildConfigField("String", "POSTHOG_HOST",  "\"${secret("POSTHOG_HOST")}\"")
-        buildConfigField("String", "SUPABASE_URL",  "\"${secret("SUPABASE_URL")}\"")
-        buildConfigField("String", "SUPABASE_KEY",  "\"${secret("SUPABASE_KEY")}\"")
         buildConfigField("String", "STEAMGRIDDB_API_KEY", "\"${secret("STEAMGRIDDB_API_KEY")}\"")
         buildConfigField("String", "CLOUD_PROJECT_NUMBER", "\"${secret("CLOUD_PROJECT_NUMBER")}\"")
         val iconValue = "@mipmap/ic_launcher"
@@ -287,15 +281,6 @@ dependencies {
 
     // Add PostHog Android SDK dependency
     implementation("com.posthog:posthog-android:3.8.0")
-
-    // 1) import the platform – it pins *every* Supabase + Ktor module
-    implementation(platform("io.github.jan-tennert.supabase:bom:3.1.4"))
-
-    // 2) add whichever supabase-kt modules you actually use
-    implementation("io.github.jan-tennert.supabase:postgrest-kt")   // PostgREST
-    implementation("io.github.jan-tennert.supabase:realtime-kt")
-
-    implementation("io.ktor:ktor-client-android:3.1.3")
 
     implementation("com.auth0.android:jwtdecode:2.0.2")
 }

--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -1,7 +1,6 @@
 package app.gamenative
 
 import android.os.StrictMode
-import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.navigation.NavController
 import app.gamenative.db.dao.AmazonGameDao
 import app.gamenative.db.dao.GOGGameDao
@@ -27,13 +26,6 @@ import com.winlator.widget.XServerView
 import com.winlator.xenvironment.XEnvironment
 import dagger.hilt.android.HiltAndroidApp
 
-// Supabase imports
-import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.annotations.SupabaseInternal
-import io.github.jan.supabase.createSupabaseClient
-import io.github.jan.supabase.postgrest.Postgrest
-import io.github.jan.supabase.network.supabaseApi
-import io.ktor.client.plugins.HttpTimeout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -108,14 +100,6 @@ class PluviaApp : SplitCompatApplication() {
 
         PlayIntegrity.warmUp(this)
 
-        // Initialize Supabase client
-        try {
-            initSupabase()
-            Timber.d("Supabase client initialized with URL: ${BuildConfig.SUPABASE_URL}")
-        } catch (e: Exception) {
-            Timber.e(e, "Failed to initialize Supabase client: ${e.message}")
-            e.printStackTrace()
-        }
     }
 
     /**
@@ -198,37 +182,5 @@ class PluviaApp : SplitCompatApplication() {
         @JvmField
         var isOverlayPaused: Boolean = false
 
-        // Supabase client for game feedback
-        lateinit var supabase: SupabaseClient
-            private set
-
-        fun isSupabaseInitialized(): Boolean = ::supabase.isInitialized
-
-        // Initialize Supabase client
-        @OptIn(SupabaseInternal::class)
-        fun initSupabase() {
-            Timber.d("Initializing Supabase client with URL: ${BuildConfig.SUPABASE_URL}")
-            if (BuildConfig.SUPABASE_URL.isBlank() || BuildConfig.SUPABASE_KEY.isBlank()) {
-                Timber.e("Invalid Supabase URL or key - URL: ${BuildConfig.SUPABASE_URL}, key empty: ${BuildConfig.SUPABASE_KEY.isBlank()}")
-                throw IllegalStateException("Supabase URL or key is empty")
-            }
-
-            supabase = createSupabaseClient(
-                supabaseUrl = BuildConfig.SUPABASE_URL,
-                supabaseKey = BuildConfig.SUPABASE_KEY
-            ) {
-                Timber.d("Configuring Supabase client")
-                httpConfig {
-                    Timber.d("Setting up HTTP timeouts")
-                    install(HttpTimeout) {
-                        requestTimeoutMillis = 30_000   // overall call
-                        connectTimeoutMillis = 15_000   // TCP handshake / TLS
-                        socketTimeoutMillis  = 30_000   // idle socket
-                    }
-                }
-                install(Postgrest)
-                Timber.d("Postgrest plugin installed")
-            }
-        }
     }
 }

--- a/app/src/main/java/app/gamenative/api/ApiResult.kt
+++ b/app/src/main/java/app/gamenative/api/ApiResult.kt
@@ -1,0 +1,7 @@
+package app.gamenative.api
+
+sealed class ApiResult<out T> {
+    data class Success<T>(val data: T) : ApiResult<T>()
+    data class HttpError(val code: Int, val message: String) : ApiResult<Nothing>()
+    data class NetworkError(val exception: Exception) : ApiResult<Nothing>()
+}

--- a/app/src/main/java/app/gamenative/api/GameNativeApi.kt
+++ b/app/src/main/java/app/gamenative/api/GameNativeApi.kt
@@ -1,0 +1,77 @@
+package app.gamenative.api
+
+import app.gamenative.BuildConfig
+import app.gamenative.utils.PlayIntegrity
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import timber.log.Timber
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+object GameNativeApi {
+
+    val BASE_URL: String =
+        if (BuildConfig.DEBUG) "http://10.0.2.2:8787" else "https://api.gamenative.app"
+
+    val httpClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .build()
+    }
+
+    inline fun <T> executeRequest(request: Request, parser: (String) -> T): ApiResult<T> {
+        return try {
+            val response = httpClient.newCall(request).execute()
+            val body = response.body?.string() ?: ""
+
+            if (!response.isSuccessful) {
+                val message = try {
+                    val json = JSONObject(body)
+                    json.optJSONObject("error")?.optString("message") ?: body
+                } catch (_: Exception) {
+                    body
+                }
+                Timber.tag("GameNativeApi").w("HTTP ${response.code}: $message")
+                return ApiResult.HttpError(response.code, message)
+            }
+
+            ApiResult.Success(parser(body))
+        } catch (e: IOException) {
+            Timber.tag("GameNativeApi").e(e, "Network error: ${e.message}")
+            ApiResult.NetworkError(e)
+        } catch (e: Exception) {
+            Timber.tag("GameNativeApi").e(e, "Unexpected error: ${e.message}")
+            ApiResult.NetworkError(e)
+        }
+    }
+
+    suspend fun buildPostRequest(url: String, body: JSONObject): Request {
+        val mediaType = "application/json".toMediaType()
+        val bodyString = body.toString()
+        val requestBody = bodyString.toRequestBody(mediaType)
+
+        val integrityToken = PlayIntegrity.requestToken(bodyString.toByteArray())
+
+        val builder = Request.Builder()
+            .url(url)
+            .post(requestBody)
+            .header("Content-Type", "application/json")
+
+        if (integrityToken != null) {
+            builder.header("X-Integrity-Token", integrityToken)
+        }
+
+        return builder.build()
+    }
+
+    fun buildGetRequest(url: String): Request {
+        return Request.Builder()
+            .url(url)
+            .get()
+            .build()
+    }
+}

--- a/app/src/main/java/app/gamenative/api/GameRunApi.kt
+++ b/app/src/main/java/app/gamenative/api/GameRunApi.kt
@@ -1,0 +1,56 @@
+package app.gamenative.api
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+
+object GameRunApi {
+
+    data class GameRunResponse(val id: Long?, val created: Boolean)
+
+    suspend fun submit(
+        gameName: String,
+        deviceModel: String,
+        deviceManufacturer: String,
+        gpuName: String,
+        socName: String?,
+        androidVersion: String,
+        appVersion: String,
+        configs: JSONObject,
+        rating: Int,
+        tags: List<String>,
+        notes: String?,
+        avgFps: Float?,
+        sessionLengthSec: Int?,
+    ): ApiResult<GameRunResponse> = withContext(Dispatchers.IO) {
+        val body = JSONObject().apply {
+            put("gameName", gameName)
+            put("deviceModel", deviceModel)
+            put("deviceManufacturer", deviceManufacturer)
+            put("gpuName", gpuName)
+            put("socName", socName)
+            put("androidVersion", androidVersion)
+            put("appVersion", appVersion)
+            put("configs", configs)
+            put("rating", rating)
+            put("tags", JSONArray(tags))
+            put("notes", notes)
+            if (avgFps != null) put("avgFps", avgFps.toDouble()) else put("avgFps", JSONObject.NULL)
+            if (sessionLengthSec != null) put("sessionLengthSec", sessionLengthSec) else put("sessionLengthSec", JSONObject.NULL)
+        }
+
+        val request = GameNativeApi.buildPostRequest(
+            "${GameNativeApi.BASE_URL}/api/game-run",
+            body,
+        )
+
+        GameNativeApi.executeRequest(request) { responseBody ->
+            val json = JSONObject(responseBody)
+            GameRunResponse(
+                id = if (json.isNull("id")) null else json.optLong("id"),
+                created = json.optBoolean("created", false),
+            )
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/api/SupportersApi.kt
+++ b/app/src/main/java/app/gamenative/api/SupportersApi.kt
@@ -1,0 +1,29 @@
+package app.gamenative.api
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+object SupportersApi {
+
+    data class Supporter(val name: String?, val oneOff: Boolean?, val total: Double?)
+
+    suspend fun fetch(): ApiResult<List<Supporter>> = withContext(Dispatchers.IO) {
+        val request = GameNativeApi.buildGetRequest(
+            "${GameNativeApi.BASE_URL}/api/supporters",
+        )
+
+        GameNativeApi.executeRequest(request) { responseBody ->
+            val json = JSONObject(responseBody)
+            val array = json.getJSONArray("supporters")
+            (0 until array.length()).map { i ->
+                val item = array.getJSONObject(i)
+                Supporter(
+                    name = if (item.isNull("name")) null else item.optString("name"),
+                    oneOff = if (item.isNull("oneOff")) null else item.optBoolean("oneOff"),
+                    total = if (item.isNull("total")) null else item.optDouble("total"),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -966,7 +966,7 @@ fun PluviaMain(
                     val appId = feedbackState.appId
                     Timber.d("GameFeedback: Got appId=$appId")
 
-                    // Submit feedback to Supabase
+                    // Submit feedback via worker API
                     Timber.d("GameFeedback: Starting coroutine for submission")
                     viewModel.viewModelScope.launch {
                         Timber.d("GameFeedback: Inside coroutine scope")
@@ -974,7 +974,6 @@ fun PluviaMain(
                             Timber.d("GameFeedback: Calling submitGameFeedback with rating=${feedbackState.rating}")
                             val result = GameFeedbackUtils.submitGameFeedback(
                                 context = context,
-                                supabase = PluviaApp.supabase,
                                 appId = appId,
                                 rating = feedbackState.rating,
                                 tags = feedbackState.selectedTags.toList(),

--- a/app/src/main/java/app/gamenative/ui/component/dialog/SupportersDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/SupportersDialog.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import app.gamenative.PluviaApp
 import app.gamenative.R
 import app.gamenative.utils.KofiSupporter
 import app.gamenative.utils.fetchKofiSupporters
@@ -52,15 +51,10 @@ fun SupportersDialog(
         isLoading = true
         hasError = false
         try {
-            // Check if supabase is initialized before accessing
-            if (PluviaApp.isSupabaseInitialized()) {
-                val data = withContext(Dispatchers.IO) {
-                    fetchKofiSupporters(PluviaApp.supabase)
-                }
-                supporters = data
-            } else {
-                hasError = true
+            val data = withContext(Dispatchers.IO) {
+                fetchKofiSupporters()
             }
+            supporters = data
         } catch (e: Exception) {
             hasError = true
         }

--- a/app/src/main/java/app/gamenative/utils/GameFeedbackUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/GameFeedbackUtils.kt
@@ -3,74 +3,45 @@ package app.gamenative.utils
 import android.content.Context
 import android.os.Build
 import app.gamenative.BuildConfig
+import app.gamenative.api.ApiResult
+import app.gamenative.api.GameRunApi
 import app.gamenative.data.GameSource
 import app.gamenative.service.SteamService
 import app.gamenative.service.amazon.AmazonService
 import app.gamenative.service.epic.EpicService
 import app.gamenative.service.gog.GOGService
-import app.gamenative.utils.CustomGameScanner
-import com.winlator.container.Container
-import com.winlator.core.FileUtils
 import com.winlator.core.GPUInformation
-import com.winlator.xenvironment.ImageFs
-import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.postgrest.from
-import io.github.jan.supabase.postgrest.query.Columns
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonObject
 import org.json.JSONObject
-
 import timber.log.Timber
-import java.io.File
 
 object GameFeedbackUtils {
 
-
-    @Serializable
-    data class GameRunInsert(
-        @SerialName("game_id") val gameId: Long,
-        @SerialName("device_id") val deviceId: Long,
-        @SerialName("app_version_id") val appVersionId: Long,
-        val configs: JsonObject,
-        val rating: Int,
-        val tags: List<String> = emptyList(),
-        val notes: String? = null,
-        @SerialName("avg_fps") val avgFps: Float? = null,
-        @SerialName("session_length_sec") val sessionLengthSec: Int? = null,
-    )
-
-
-    /** Submit game feedback to Supabase. */
     suspend fun submitGameFeedback(
         context: Context,
-        supabase: SupabaseClient,
         appId: String,
         rating: Int,
         tags: List<String>,
         notes: String?,
-    ) = withContext(Dispatchers.IO) {
+    ): Boolean = withContext(Dispatchers.IO) {
         Timber.d("GameFeedbackUtils: Starting submitGameFeedback method with rating=$rating")
         try {
             val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
             val gameId = ContainerUtils.extractGameIdFromContainerId(appId)
             val container = ContainerUtils.getContainer(context, appId)
-            val configJson = Json.parseToJsonElement(container.containerJson).jsonObject
+            val configJson = JSONObject(container.containerJson)
             Timber.d("config string is: " + container.containerJson)
             Timber.d("configJson: $configJson")
+
             // Get the game name from container or use a fallback
-            val gameName = when(gameSource) {
+            val gameName = when (gameSource) {
                 GameSource.CUSTOM_GAME -> {
                     val folderPath = CustomGameScanner.findCustomGameById(gameId) ?: ""
-                    if(folderPath.isNotEmpty()){
+                    if (folderPath.isNotEmpty()) {
                         val game = CustomGameScanner.createLibraryItemFromFolder(folderPath)
                         game?.name ?: ""
-                    }
-                    else {
+                    } else {
                         ""
                     }
                 }
@@ -96,15 +67,11 @@ object GameFeedbackUtils {
                 }
             }
 
-            if(gameName.isEmpty()){
+            if (gameName.isEmpty()) {
                 Timber.e("SubmitGameFeedback: Could not get game name for appId $appId")
                 return@withContext false
             }
             Timber.d("GameFeedbackUtils: Game name: $gameName")
-
-            // Get device model
-            val deviceModel = HardwareUtils.getMachineName()
-            Timber.d("GameFeedbackUtils: Device model: $deviceModel")
 
             // Get GPU info if available
             val gpu = try {
@@ -114,8 +81,7 @@ object GameFeedbackUtils {
                 gpuInfo
             } catch (e: Exception) {
                 Timber.e(e, "GameFeedbackUtils: Failed to get GPU info: ${e.message}")
-                e.printStackTrace()
-                "Unknown GPU"  // Provide a default value instead of null
+                "Unknown GPU"
             }
 
             // Get SOC identifier
@@ -125,7 +91,6 @@ object GameFeedbackUtils {
                 socName
             } catch (e: Exception) {
                 Timber.e(e, "GameFeedbackUtils: Failed to get SOC info: ${e.message}")
-                e.printStackTrace()
                 null
             }
 
@@ -157,143 +122,41 @@ object GameFeedbackUtils {
                 }
             } else null
 
-            // Log the submission
-            Timber.i("GameFeedbackUtils: Submitting game feedback: game=$gameName, device=$deviceModel, rating=$rating, tags=${tags.joinToString()}, avgFps=$avgFps, sessionLengthSec=$sessionLengthSec")
+            Timber.i("GameFeedbackUtils: Submitting game feedback: game=$gameName, device=${Build.MODEL}, rating=$rating, tags=${tags.joinToString()}, avgFps=$avgFps, sessionLengthSec=$sessionLengthSec")
 
-            // Submit to Supabase
-            try {
-                Timber.d("GameFeedbackUtils: About to call logRun on supabase client")
-                supabase.logRun(
-                    gameName = gameName,
-                    deviceModel = deviceModel,
-                    gpu = gpu,
-                    soc = soc,
-                    androidVer = androidVer,
-                    appVersion = appVersion,
-                    configs = configJson,
-                    rating = rating,
-                    tags = tags,
-                    notes = notes,
-                    avgFps = avgFps,
-                    sessionLengthSec = sessionLengthSec,
-                )
-                Timber.i("GameFeedbackUtils: Game feedback submitted successfully")
-                true
-            } catch (e: Exception) {
-                Timber.e(e, "GameFeedbackUtils: Exception during Supabase submission: ${e.message}")
-                e.printStackTrace()
-                false
+            val result = GameRunApi.submit(
+                gameName = gameName,
+                deviceModel = Build.MODEL,
+                deviceManufacturer = Build.MANUFACTURER,
+                gpuName = gpu,
+                socName = soc,
+                androidVersion = androidVer,
+                appVersion = appVersion,
+                configs = configJson,
+                rating = rating,
+                tags = tags,
+                notes = notes,
+                avgFps = avgFps,
+                sessionLengthSec = sessionLengthSec,
+            )
+
+            when (result) {
+                is ApiResult.Success -> {
+                    Timber.i("GameFeedbackUtils: Game feedback submitted successfully (id=${result.data.id})")
+                    true
+                }
+                is ApiResult.HttpError -> {
+                    Timber.e("GameFeedbackUtils: HTTP error ${result.code}: ${result.message}")
+                    false
+                }
+                is ApiResult.NetworkError -> {
+                    Timber.e(result.exception, "GameFeedbackUtils: Network error during submission")
+                    false
+                }
             }
         } catch (e: Exception) {
             Timber.e(e, "GameFeedbackUtils: Failed to prepare game feedback: ${e.message}")
-            e.printStackTrace()
             false
-        }
-    }
-
-    @Serializable private data class IdRow(val id: Long)
-
-    /** Helper extension that writes a game run record to Supabase. */
-    suspend fun SupabaseClient.logRun(
-        gameName: String,
-        deviceModel: String,
-        gpu: String? = null,
-        soc: String? = null,
-        androidVer: String? = null,
-        appVersion: String,
-        configs: JsonObject,
-        rating: Int,
-        tags: List<String> = emptyList(),
-        notes: String? = null,
-        avgFps: Float? = null,
-        sessionLengthSec: Int? = null,
-    ) {
-        Timber.d("GameFeedbackUtils.logRun: Starting with game=$gameName, rating=$rating")
-
-        try {
-            // Create game or get its ID
-            Timber.d("GameFeedbackUtils.logRun: Creating/getting game record for: $gameName")
-            val gameData = mapOf("name" to gameName)
-            val gameId = try {
-                val result = from("games")
-                    .upsert(listOf(gameData)) {
-                        onConflict="name"
-                        select(columns = Columns.list("id"))
-                    }
-                    .decodeSingle<IdRow>()
-                Timber.d("GameFeedbackUtils.logRun: Game upsert successful, id: ${result.id}")
-                result.id
-            } catch (e: Exception) {
-                Timber.e(e, "GameFeedbackUtils.logRun: Failed to upsert game: ${e.message}")
-                throw e
-            }
-
-            // Create device or get its ID
-            Timber.d("GameFeedbackUtils.logRun: Creating/getting device record")
-            val deviceData = buildMap {
-                put("model", deviceModel)
-                put("gpu", gpu ?: "")
-                if (soc != null) {
-                    put("soc", soc)
-                }
-                put("android_ver", androidVer ?: "")
-            }
-            val deviceId = try {
-                val result = from("devices")
-                    .upsert(listOf(deviceData)) {
-                        onConflict="model,gpu,android_ver"
-                        select(columns = Columns.list("id"))
-                    }
-                    .decodeSingle<IdRow>()
-                Timber.d("GameFeedbackUtils.logRun: Device upsert successful, id: ${result.id}")
-                result.id
-            } catch (e: Exception) {
-                Timber.e(e, "GameFeedbackUtils.logRun: Failed to upsert device: ${e.message}")
-                throw e
-            }
-
-            // Create app version or get its ID
-            Timber.d("GameFeedbackUtils.logRun: Creating/getting app version record for: $appVersion")
-            val appVersionData = mapOf("semver" to appVersion)
-            val appVersionId = try {
-                val result = from("app_versions")
-                    .upsert(listOf(appVersionData)) {
-                        onConflict="semver"
-                        select(columns = Columns.list("id"))
-                    }
-                    .decodeSingle<IdRow>()
-                Timber.d("GameFeedbackUtils.logRun: App version upsert successful, id: ${result.id}")
-                result.id
-            } catch (e: Exception) {
-                Timber.e(e, "GameFeedbackUtils.logRun: Failed to upsert app version: ${e.message}")
-                throw e
-            }
-
-            // Create the game run record
-            Timber.d("GameFeedbackUtils.logRun: Creating game run record with gameId: $gameId, deviceId: $deviceId, appVersionId: $appVersionId")
-            try {
-                val run = GameRunInsert(
-                    gameId = gameId,
-                    deviceId = deviceId,
-                    appVersionId = appVersionId,
-                    configs = configs,
-                    rating = rating,
-                    tags = tags,
-                    notes = notes,
-                    avgFps = avgFps,
-                    sessionLengthSec = sessionLengthSec,
-                )
-
-                from("game_runs").insert(run)
-                Timber.d("GameFeedbackUtils.logRun: Game run record created successfully")
-            } catch (e: Exception) {
-                Timber.e(e, "GameFeedbackUtils.logRun: Failed to create game run record: ${e.message}")
-                throw e
-            }
-        } catch (e: Exception) {
-            Timber.e(e, "GameFeedbackUtils.logRun: Error in logRun: ${e.message}")
-            e.printStackTrace()
-            throw e
         }
     }
 }

--- a/app/src/main/java/app/gamenative/utils/SupportersUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SupportersUtils.kt
@@ -1,34 +1,30 @@
 package app.gamenative.utils
 
-import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.postgrest.from
-import io.github.jan.supabase.postgrest.query.Columns
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import app.gamenative.api.ApiResult
+import app.gamenative.api.SupportersApi
 import timber.log.Timber
 
-@Serializable
 data class KofiSupporter(
-    @SerialName("Name") val name: String? = null,
-    @SerialName("OneOff") val oneOff: Boolean? = null,
-    @SerialName("Total") val total: Double? = null,
+    val name: String? = null,
+    val oneOff: Boolean? = null,
+    val total: Double? = null,
 )
 
 /**
- * Fetch supporters from Supabase `kofi_supporters` table.
- * Only fetches fields needed for display.
+ * Fetch supporters from the worker API.
  */
-suspend fun fetchKofiSupporters(supabase: SupabaseClient): List<KofiSupporter> {
-    return try {
-        Timber.d("Fetching Ko-fi supporters from Supabase")
-        supabase
-            .from("kofi_supporters")
-            .select(columns = Columns.list("Name", "OneOff", "Total"))
-            .decodeList<KofiSupporter>()
-    } catch (e: Exception) {
-        Timber.e(e, "Failed to fetch Ko-fi supporters: ${e.message}")
-        emptyList()
+suspend fun fetchKofiSupporters(): List<KofiSupporter> {
+    return when (val result = SupportersApi.fetch()) {
+        is ApiResult.Success -> result.data.map {
+            KofiSupporter(name = it.name, oneOff = it.oneOff, total = it.total)
+        }
+        is ApiResult.HttpError -> {
+            Timber.e("Failed to fetch Ko-fi supporters: HTTP ${result.code} ${result.message}")
+            emptyList()
+        }
+        is ApiResult.NetworkError -> {
+            Timber.e(result.exception, "Failed to fetch Ko-fi supporters: network error")
+            emptyList()
+        }
     }
 }
-
-


### PR DESCRIPTION
remove Supabase integration and update game feedback submission to use new API

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Supabase integration and migrated feedback submission and supporters fetching to the GameNative worker API with Play Integrity attestation. Added a small OkHttp-based API layer and cleaned up build/workflows.

- **New Features**
  - OkHttp API layer (ApiResult, GameNativeApi) with Play Integrity tokens on POST requests.
  - GameRunApi.submit for feedback and SupportersApi.fetch for supporters.

- **Refactors**
  - Deleted Supabase client/init, buildConfig fields, dependencies, and CI secrets.
  - Updated GameFeedbackUtils, SupportersUtils, SupportersDialog, and PluviaMain to use the new APIs.

<sup>Written for commit 0c471c8f21021edf3a1d389690cdba8bf017565b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Feedback submission now routes through the app's worker API with unified result handling for clearer success/failure and improved reliability.
  * Supporters list retrieval switched to the worker API with robust HTTP/network error handling and safer fallbacks.
  * Streamlined app startup by removing an unnecessary background initialization path, slightly improving launch performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->