### PR TITLE
Adds function to case insensitively resolve cloud save path

### DIFF
--- a/app/src/main/java/app/gamenative/service/epic/EpicCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicCloudSavesManager.kt
@@ -1199,17 +1199,17 @@ object EpicCloudSavesManager {
             "{appname}" to game.appName,
         )
 
-        val appDataPath = "C:/users/$user/AppData/Local"
-        val appDataRoamingPath = "C:/users/$user/AppData/Roaming"
-        val documentsPath = "C:/users/$user/Documents"
-        val savedGamesPath = "C:/users/$user/Saved Games"
+        val appDataPath = File(winePrefix, "drive_c/users/$user/AppData/Local").absolutePath
+        val appDataRoamingPath = File(winePrefix, "drive_c/users/$user/AppData/Roaming").absolutePath
+        val documentsPath = File(winePrefix, "drive_c/users/$user/Documents").absolutePath
+        val savedGamesPath = File(winePrefix, "drive_c/users/$user/Saved Games").absolutePath
 
         pathVars["{appdata}"] = appDataPath
         pathVars["{localappdata}"] = appDataPath       // Windows %LocalAppData% — same as AppData/Local
         pathVars["{roamingappdata}"] = appDataRoamingPath // Windows %AppData% (Roaming)
         pathVars["{userdir}"] = documentsPath
         pathVars["{usersavedgames}"] = savedGamesPath
-        pathVars["{userprofile}"] = "C:/users/$user"
+        pathVars["{userprofile}"] = File(winePrefix, "drive_c/users/$user").absolutePath
 
         // Normalize path separators first
         var resolvedPath = cloudSaveFolder.replace("\\", "/")
@@ -1246,7 +1246,7 @@ object EpicCloudSavesManager {
             }
         }
 
-        val resolvedWinePath: String = windowsToWinePath(winePrefix, normalizedParts.joinToString("/")) ?: return null
+        val resolvedWinePath: String = resolveCaseInsensitivity(normalizedParts.joinToString("/"))
         val finalPath = File(resolvedWinePath)
 
         // Check subdirectories for save files
@@ -1295,19 +1295,10 @@ object EpicCloudSavesManager {
         return actualPath
     }
 
-    // Resolve a Windows path against a wine prefix path case insensitively
-    private fun windowsToWinePath(winePrefix:String, windowsPath: String): String? {
-        val pathParts = windowsPath.replace("\\", "/").split("/").toMutableList()
-        val drive = pathParts[0]
-
-        if (drive.length != 2 || !drive.endsWith(":")) {
-            Timber.tag("Epic").w("[Cloud Saves] Could not resolve drive; aborting")
-            return null
-        }
-
-        pathParts[0] = "drive_" + pathParts[0][0]
-
-        var currentPath = Path(winePrefix)
+    // Resolve a path case insensitively if there's no direct casing match
+    private fun resolveCaseInsensitivity(path: String): String {
+        val pathParts = path.replace("\\", "/").split("/")
+        var currentPath = Path("/")
 
         for (segment in pathParts) {
             // If we're at a place where the current path doesn't exist,


### PR DESCRIPTION
Enter the Gungeon has an odd cloud save location of {appdata}/../locallow/Dodge Roll/Enter the Gungeon/ and the current code did not have handling to account for "locallow" being an already existing directory with a different casing. This resulting in two directories in that path and EtG was not able to read the saved game. I'm currently resolving the entire path case insensitively against the file system since it's a more invasive change to ensure that installdir isn't broken as it doesn't follow the same basic structure as the other paths.

There is no clean upgrade path for broken saved games though. Once the duplicate folder has been made, the direct casing condition will be satisfied and will always pick the wrong one. The fix in that case is to open the container and delete the offending duplicate and then resync manually.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Epic cloud save path resolution on Wine with case-insensitive, per-segment matching and correct Wine prefix mapping. Also resolves full path strings (including {installdir}) to prevent duplicate folders and broken lookups.

- **Bug Fixes**
  - Added resolveCaseInsensitivity() to map Windows-style paths into the Wine prefix by matching each segment case-insensitively.
  - Resolve the entire path string (e.g., "{appdata}/../LocalLow/..." and "{installdir}/...") so mixed casing doesn’t create a second "locallow" and saves are found.

<sup>Written for commit fc9804459e98ea2801f78b988b7dbb07ee7a1c05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



