### PR TITLE
fix: wrap AndroidView in key(isPortrait) to fix portrait layout on landscape phones

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1215,13 +1215,13 @@ fun XServerScreen(
             windowModificationListener = null
         },
     )
+        }
 
         // Floating toolbar for edit mode (always visible in edit mode)
         if (isEditMode && areControlsVisible) {
             EditModeToolbar(
                 onAdd = {
-     
-        }               if (PluviaApp.inputControlsView?.addElement() == true) {
+                    if (PluviaApp.inputControlsView?.addElement() == true) {
                         // Element was added, refresh the view
                         PluviaApp.inputControlsView?.invalidate()
                     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect portrait layout on landscape phones by wrapping AndroidView in key(isPortrait) so the view recreates on orientation changes. Also prevent a WindowManager listener leak by tracking and removing the OnWindowModificationListener on recreate and release, and fix a misplaced key() closing brace/onAdd lambda to ensure correct scoping.

<sup>Written for commit 9bb187655599d964eb3bbcc1f208e9e58b1f4c06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orientation handling so the native view reliably recreates and the UI refreshes.
  * Prevented duplicate window-listener registrations by ensuring previous listeners are removed.
  * Ensured window listeners are cleaned up when the native view is released.

* **Style**
  * Minor layout/formatting adjustment to an edit toolbar action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->