### PR TITLE
fix: release pointer capture when container exits

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2586,6 +2586,7 @@ private fun exit(winHandler: WinHandler?, environment: XEnvironment?, frameRatin
         container.saveData()
     }
 
+    PluviaApp.touchpadView?.releasePointerCapture()
     winHandler?.stop()
     environment?.stopEnvironmentComponents()
     SteamService.keepAlive = false


### PR DESCRIPTION
fix mouse being invisible after exiting container
no need to check if a pointer is captured to begin with, calling releasePointerCapture does nothing if that's the case, per documentation (https://developer.android.com/reference/android/view/View#releasePointerCapture())

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release pointer capture when the XServer container exits to prevent the mouse cursor from staying invisible after closing the container.

- **Bug Fixes**
  - Always call touchpadView.releasePointerCapture() in exit(); it's a safe no-op if nothing is captured.

<sup>Written for commit fb049ea4083e1376a5a6ee66f8e800e770585312. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured touchpad pointer capture is properly released when the application exits, preventing potential pointer input issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->