### PR TITLE
feat: Add new manifest attribute to ensure app is classified as a game

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         android:largeHeap="true"
         android:theme="@style/Theme.Pluvia"
         android:allowAudioPlaybackCapture="true"
+        android:appCategory="game"
         tools:targetApi="29">
         <!--
          android:windowSoftInputMode must always be in the activity block.


### PR DESCRIPTION
### Rationale

The app wasn’t marked as a game, which caused recognition issues on newer Android versions. This is particularly important on Samsung devices, where system features like Game Launcher depend on the app category to detect games correctly.

### What Changed

Set the app category to `game` in the Android manifest.

### Impact

No change to core functionality. The app is now properly recognized as a game, especially on Samsung devices, enabling game-specific system features and optimizations. Sorting in the dashboard might change, which could potentially confuse the user at first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark the app as a game by setting android:appCategory="game" in AndroidManifest.xml. This ensures proper classification on Android (including Samsung Game Launcher) and enables game-specific system features; no functional changes, but the app may appear under Games and sorting may change.

<sup>Written for commit b1725e86745da06b86dc330942386822bcf62fb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app metadata to properly categorize the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->