### PR TITLE
fix(): Update library navigation so that it persists the user's place in the library

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -305,6 +305,8 @@ private fun LibraryScreenContent(
     var wasOptionsPanelOpen by remember { mutableStateOf(false) }
     // Keep a stable reference to the selected item so detail view doesn't disappear during list refresh/pagination.
     var selectedLibraryItem by remember { mutableStateOf<LibraryItem?>(null) }
+    // Persist index for keeping the user's place in the library view
+    var lastSelectedAppIndex by remember { mutableIntStateOf(0) }
     val filterFabExpanded by remember { derivedStateOf { listState.firstVisibleItemIndex == 0 } }
 
     // Dialog state for add custom game prompt
@@ -396,7 +398,10 @@ private fun LibraryScreenContent(
             // Brief delay to let the UI settle after transition
             kotlinx.coroutines.delay(100)
             // Restore focus to content area
+            // Also now persists the target index to keep track of where user left off.
             if (state.appInfoList.isNotEmpty()) {
+                gridFocusTargetListIndex = lastSelectedAppIndex
+                    .coerceIn(0, state.appInfoList.lastIndex)
                 requestGridFocusOrDefer()
             } else {
                 requestRootFocusSafe()
@@ -791,6 +796,7 @@ private fun LibraryScreenContent(
                     onNavigate = { appId ->
                         selectedAppId = appId
                         selectedLibraryItem = state.appInfoList.find { it.appId == appId }
+                        lastSelectedAppIndex = selectedLibraryItem?.index ?: listState.firstVisibleItemIndex
                     },
                     onRefresh = onRefresh,
                     modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
This fixes an issue where the index wasn't being persisted. 

Quick thoughts for people, when changing tab, do we want the tabIndex to reset?

Draft for now, just to double-verify that this is not just a replicate fix. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the user's place in the Library grid so the view no longer jumps to the top. When returning, focus restores to the last selected app based on the tracked index.

<sup>Written for commit deb3f0ab42398e82ce093af84e434a52cf22baf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The library grid now persists your position when navigating between the list and item details, automatically returning you to your previously selected item for a seamless browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->