### PR TITLE
fix: handle SOURCE_TOUCHPAD events

### DIFF
--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -1241,6 +1241,9 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
     @Override // android.view.View.OnCapturedPointerListener
     public boolean onCapturedPointer(View view, MotionEvent event) {
+        if (event.isFromSource(InputDevice.SOURCE_TOUCHPAD)) {
+            return handleTouchpadEvent(event);
+        }
         if (event.getAction() == MotionEvent.ACTION_MOVE) {
             float dx = 0f;
             float dy = 0f;


### PR DESCRIPTION
trackpad support broke when we switched to relative mouse movement

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle SOURCE_TOUCHPAD MotionEvent in TouchpadView.onCapturedPointer. We now delegate these events to handleTouchpadEvent, restoring trackpad support after the switch to relative mouse movement.

<sup>Written for commit 129f5f89889631f1d5060d34e59c2c92ade22bfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where touchpad input was not being processed correctly by implementing dedicated handling for touchpad events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->