### PR TITLE
added back allowed orientations, only for landscape and reverse lands…

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/OrientationDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/OrientationDialog.kt
@@ -62,7 +62,7 @@ fun OrientationDialog(
         },
         text = {
             Column {
-                Orientation.entries.dropLast(1).forEach { orientation ->
+                arrayOf(Orientation.LANDSCAPE, Orientation.REVERSE_LANDSCAPE).forEach { orientation ->
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Checkbox(
                             checked = currentSettings.contains(orientation),

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -436,7 +436,7 @@ class MainViewModel @Inject constructor(
         // Show booting splash before launching the app
         viewModelScope.launch {
             setShowBootingSplash(true)
-            PluviaApp.events.emit(AndroidEvent.SetAllowedOrientation(EnumSet.of(Orientation.LANDSCAPE)))
+            PluviaApp.events.emit(AndroidEvent.SetAllowedOrientation(PrefManager.allowedOrientation))
 
             val apiJob = viewModelScope.async(Dispatchers.IO) {
                 val container = ContainerUtils.getOrCreateContainer(context, appId)

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupEmulation.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupEmulation.kt
@@ -16,7 +16,7 @@ import app.gamenative.R
 import app.gamenative.ui.component.dialog.Box64PresetsDialog
 import app.gamenative.ui.component.dialog.ContainerConfigDialog
 import app.gamenative.ui.component.dialog.FEXCorePresetsDialog
-
+import app.gamenative.ui.component.dialog.OrientationDialog
 import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.ui.theme.settingsTileColors
 import app.gamenative.ui.theme.settingsTileColorsAlt
@@ -30,7 +30,13 @@ fun SettingsGroupEmulation() {
     SettingsGroup(
     ) {
         var showConfigDialog by rememberSaveable { mutableStateOf(false) }
+        var showOrientationDialog by rememberSaveable { mutableStateOf(false) }
         var showBox64PresetsDialog by rememberSaveable { mutableStateOf(false) }
+
+        OrientationDialog(
+            openDialog = showOrientationDialog,
+            onDismiss = { showOrientationDialog = false },
+        )
 
         ContainerConfigDialog(
             visible = showConfigDialog,
@@ -71,6 +77,13 @@ fun SettingsGroupEmulation() {
         if (showWineProtonManager) {
             WineProtonManagerDialog(open = showWineProtonManager, onDismiss = { showWineProtonManager = false })
         }
+
+        SettingsMenuLink(
+            colors = settingsTileColors(),
+            title = { Text(text = stringResource(R.string.settings_emulation_orientations_title)) },
+            subtitle = { Text(text = stringResource(R.string.settings_emulation_orientations_subtitle)) },
+            onClick = { showOrientationDialog = true },
+        )
 
         SettingsMenuLink(
             colors = settingsTileColors(),

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -260,7 +260,7 @@ fun XServerScreen(
     PluviaApp.events.emit(
         AndroidEvent.SetAllowedOrientation(
             if (container.isPortraitMode) EnumSet.of(Orientation.PORTRAIT)
-            else EnumSet.of(Orientation.LANDSCAPE)
+            else PrefManager.allowedOrientation,
         ),
     )
 


### PR DESCRIPTION
…cape

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored orientation controls and limited them to Landscape and Reverse Landscape. Added an Emulation settings option to pick allowed orientations and applied it on app launch and in XServer.

- **New Features**
  - Orientation dialog now shows only Landscape and Reverse Landscape.
  - New “Orientations” tile in Emulation settings opens the dialog.
  - MainViewModel and XServerScreen read PrefManager.allowedOrientation; portrait mode still forces Portrait.

<sup>Written for commit 3ae7bfe9eaea9b95684f37dbf483198447e3d60f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added orientation settings in the settings menu for users to customize screen orientation behavior
  * Screen orientation handling now respects user preferences instead of applying fixed defaults across the app
  * Updated available orientation modes to Landscape and Reverse Landscape

<!-- end of auto-generated comment: release notes by coderabbit.ai -->