### PR TITLE
fix(): remove trim for passwords to fix trailing spaces in some user passwords

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2288,7 +2288,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                 instance!!.steamClient?.let { steamClient ->
                     val authDetails = AuthSessionDetails().apply {
                         this.username = username.trim()
-                        this.password = password.trim()
+                        this.password = password // Not trimming as some passwords have leading spaces.
                         this.persistentSession = rememberSession
                         this.authenticator = authenticator
                         this.deviceFriendlyName = SteamUtils.getMachineName(instance!!)


### PR DESCRIPTION
This PR just removes the trimming of leading spaces for passwords as it breaks for some users who have trailing spaces on purpose.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop trimming passwords in SteamService so whitespace is preserved, fixing login failures for users whose passwords include leading or trailing spaces.

<sup>Written for commit d43bf4364802584317d267a466bd572d664ef4af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed password authentication to properly preserve leading and trailing spaces, allowing users with such characters in their password to log in successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->