### PR TITLE
fix(): trim game search

### DIFF
--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -354,6 +354,7 @@ class LibraryViewModel @Inject constructor(
 
             val currentState = _state.value
             val currentFilter = AppFilter.getAppType(currentState.appInfoSortType)
+            val normalizedQuery = currentState.searchQuery.trim()
 
             // Fetch download directory apps once on IO thread and cache as a HashSet for O(1) lookups
             val downloadDirectoryApps = DownloadService.getDownloadDirectoryApps()
@@ -388,9 +389,8 @@ class LibraryViewModel @Inject constructor(
                     }
                 }
                 .filter { item ->
-                    val trimmedQuery = currentState.searchQuery.trim()
-                    if (trimmedQuery.isNotEmpty()) {
-                        item.name.contains(trimmedQuery, ignoreCase = true)
+                    if (normalizedQuery.isNotEmpty()) {
+                        item.name.contains(normalizedQuery, ignoreCase = true)
                     } else {
                         true
                     }
@@ -450,8 +450,8 @@ class LibraryViewModel @Inject constructor(
             val filteredGOGGames = gogGameList
                 .asSequence()
                 .filter { game ->
-                    if (currentState.searchQuery.isNotEmpty()) {
-                        game.title.contains(currentState.searchQuery, ignoreCase = true)
+                    if (normalizedQuery.isNotEmpty()) {
+                        game.title.contains(normalizedQuery, ignoreCase = true)
                     } else {
                         true
                     }
@@ -485,8 +485,8 @@ class LibraryViewModel @Inject constructor(
             val filteredEpicGames = epicGameList
                 .asSequence()
                 .filter { game ->
-                    if (currentState.searchQuery.isNotEmpty()) {
-                        game.title.contains(currentState.searchQuery, ignoreCase = true)
+                    if (normalizedQuery.isNotEmpty()) {
+                        game.title.contains(normalizedQuery, ignoreCase = true)
                     } else {
                         true
                     }
@@ -520,8 +520,8 @@ class LibraryViewModel @Inject constructor(
             val filteredAmazonGames = amazonGameList
                 .asSequence()
                 .filter { game ->
-                    if (currentState.searchQuery.isNotEmpty()) {
-                        game.title.contains(currentState.searchQuery, ignoreCase = true)
+                    if (normalizedQuery.isNotEmpty()) {
+                        game.title.contains(normalizedQuery, ignoreCase = true)
                     } else {
                         true
                     }
@@ -557,7 +557,7 @@ class LibraryViewModel @Inject constructor(
             val amazonInstalledCount = filteredAmazonGames.count { it.isInstalled }
             // Save game counts for skeleton loaders (only when not searching, to get accurate counts)
             // This needs to happen before filtering by source, so we save the total counts
-            if (currentState.searchQuery.isEmpty()) {
+            if (normalizedQuery.isEmpty()) {
                 PrefManager.customGamesCount = customGameItems.size
                 PrefManager.steamGamesCount = filteredSteamApps.size
                 PrefManager.gogGamesCount = filteredGOGGames.size


### PR DESCRIPTION
Fixing a small issue where accidently pressing space will give back 0 results for games. 

Just a small UX enhancements for those of us who are really bad for adding an extra space by default.

Example:

Current functionality searching for "Borderlands 2 " will reveal no results.

This fix will allow it so that we trim automatically so that it will now give back Borderlands 2 correctly.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim whitespace from library search queries in `LibraryViewModel`. The normalized query is used across all store filters and count logic so trailing spaces no longer hide results.

<sup>Written for commit 6a34eee25dbeec93422995330411b2fb57872b8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search now ignores leading/trailing spaces so whitespace-only queries no longer hide results.
  * Store and custom filters (Steam, GOG, Epic, Amazon, custom library) correctly apply trimmed queries.
  * Counts/state updates tied to an empty trimmed query, preventing unintended saves when query contains only spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->