### PR TITLE
fix: Reduces search time for steam_api[64].dll.orig

### DIFF
--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -739,7 +739,11 @@ object SteamUtils {
         val (files, directories) = file.walkTopDown().maxDepth(1).partition { it.isFile }
 
         val steamApi = files.firstOrNull {
-            it.toPath().name.startsWith("steam_api", true) && it.toPath().name.endsWith(".dll", true)
+            it.toPath().name.startsWith("steam_api", true)
+            && (
+                it.toPath().name.endsWith(".dll", true)
+                || it.toPath().name.endsWith(".dll.orig", true)
+            )
         }
 
         if (steamApi != null)


### PR DESCRIPTION
## Why was this done

Container load times (and game boot times) seemed to scale according to the number of files on the game folder.

Upon further investigation using the game `Rain World` as an example, the function `putBackSteamDlls` was taking up to 4 minutes to run from external storage. This happened because the game itself had around 31 thousand game files and no `steam_api[64].dll.orig` to be found.

So the game traversed all directories, read all files, for nothing to be found.

The proposed solution that I gave to this question was, first, looking for the `steam_api[64].dll` and, then, looking for the `.orig` for replacing. So, the original search goes to a depth of 10, however the replacement only uses a depth of 1.

The first attempt of implementing this didn't involve the creation of the method `findSteamApiDllPath` at all, however, upon debugging, another problem was clear: the traversal of `walkTopDown` on an exFAT filesystem.

Because the folders were always returned first, the `FileTreeWalker` always accessed them first in depth and then searching for the actual files, which completely missed the point and required a custom implementation.

## What was done

- Changed the `putBackSteamDlls` method to first find the `steam_api[64].dll` (that I'd assume all steam games have) and search for the `.orig` file second
- After finding the root directory of the dll, a simple depth 1 search would be required
- Kept the old logic to minimize PR size
- Created the `findSteamApiDllRootFile` helper function to search for the root directory

## Results

`Rain World` boot time reduced from ~4 minutes to under 15 seconds on a Retroid Pocket G2

## ATTENTION AND FURTHER TESTING

Since I had to reinstall GN to be able to deploy and debug, this deleted all my installed games and I only tested with RW.

Further testing would be greatly appreciated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces container and game boot times by first locating steam_api/steam_api64.dll, then scanning only that directory for .orig files. Keeps the DLL root search comprehensive (depth 10) while avoiding full-folder scans; Rain World drops from ~4 minutes to <15 seconds.

- **Bug Fixes**
  - Updated putBackSteamDlls to find `steam_api*.dll` or `.dll.orig` first, then search depth 1 in its parent for `*.orig`; case-insensitive; warns and exits if no DLL is found.
  - Added findSteamApiDllRootFile to traverse files before directories (handles exFAT quirks) and search up to depth 10 to match prior coverage.

<sup>Written for commit 26e95c452317f1fd159945c238694796f8ef3b9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Steam API DLLs to better handle varied directory layouts.
  * Safer restoration: aborts when the DLL location cannot be found to avoid partial restores.
  * Scoped restoration to the discovered DLL directory to reduce unintended file traversal and limit impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->