### PR TITLE
Added language support for Epic (also shrinks game sizes)

### DIFF
--- a/app/src/main/java/app/gamenative/service/epic/EpicConstants.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicConstants.kt
@@ -11,6 +11,55 @@ import timber.log.Timber
  * Constants for Epic Games Store integration
  */
 object EpicConstants {
+
+    /** Container language value for "required only" (no optional language tags). Same key as [PrefManager.containerLanguage]. */
+    const val EPIC_FALLBACK_CONTAINER_LANGUAGE = "english"
+
+    /**
+     * Maps container language (same values as GOG/Steam container language) to Epic manifest install tag names.
+     * Used to download required + selected language files. Keys match [PrefManager.containerLanguage].
+     * Each value lists tag names/codes that may appear in manifests (e.g. "German" or "de-DE"). Same codes as GOG where applicable.
+     */
+    internal val CONTAINER_LANGUAGE_TO_EPIC_INSTALL_TAGS: Map<String, List<String>> = mapOf(
+        "arabic" to listOf("Arabic", "ar"),
+        "bulgarian" to listOf("Bulgarian", "bg-BG", "bg"),
+        "schinese" to listOf("Chinese", "ChineseSimplified", "zh-Hans", "zh_Hans", "zh"),
+        "tchinese" to listOf("ChineseTraditional", "zh-Hant", "zh_Hant"),
+        "czech" to listOf("Czech", "cs-CZ", "cs"),
+        "danish" to listOf("Danish", "da-DK", "da"),
+        "dutch" to listOf("Dutch", "nl-NL", "nl"),
+        "english" to listOf("English", "en-US", "en"),
+        "finnish" to listOf("Finnish", "fi-FI", "fi"),
+        "french" to listOf("French", "fr-FR", "fr"),
+        "german" to listOf("German", "de-DE", "de"),
+        "greek" to listOf("Greek", "el-GR", "el"),
+        "hungarian" to listOf("Hungarian", "hu-HU", "hu"),
+        "italian" to listOf("Italian", "it-IT", "it"),
+        "japanese" to listOf("Japanese", "ja-JP", "ja"),
+        "koreana" to listOf("Korean", "ko-KR", "ko"),
+        "norwegian" to listOf("Norwegian", "nb-NO", "no"),
+        "polish" to listOf("Polish", "pl-PL", "pl"),
+        "portuguese" to listOf("Portuguese", "pt-PT", "pt"),
+        "brazilian" to listOf("PortugueseBrazilian", "Brazilian", "pt-BR", "br"),
+        "romanian" to listOf("Romanian", "ro-RO", "ro"),
+        "russian" to listOf("Russian", "ru-RU", "ru"),
+        "spanish" to listOf("Spanish", "es-ES", "es"),
+        "latam" to listOf("SpanishLatinAmerica", "Latam", "es-MX", "es_mx"),
+        "swedish" to listOf("Swedish", "sv-SE", "sv"),
+        "thai" to listOf("Thai", "th-TH", "th"),
+        "turkish" to listOf("Turkish", "tr-TR", "tr"),
+        "ukrainian" to listOf("Ukrainian", "uk-UA", "uk"),
+        "vietnamese" to listOf("Vietnamese", "vi-VN", "vi"),
+    )
+
+    /**
+     * Maps container language name to Epic manifest install tags to include (in addition to required files).
+     * Uses the same container language values as GOG. Returns empty list for unknown → required-only is always used as fallback.
+     */
+    fun containerLanguageToEpicInstallTags(containerLanguage: String): List<String> =
+        CONTAINER_LANGUAGE_TO_EPIC_INSTALL_TAGS[containerLanguage.lowercase()]
+            ?: CONTAINER_LANGUAGE_TO_EPIC_INSTALL_TAGS.getValue(EPIC_FALLBACK_CONTAINER_LANGUAGE)
+
     //! OAuth Configuration - Using Legendary's official credentials (Do not worry, these are hard-coded and not sensitive.)
     const val EPIC_CLIENT_ID = "34a02cf8f4414e29b15921876da36f9a"
     const val EPIC_CLIENT_SECRET = "daafbccc737745039dffe53d94fc76cf"

--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -7,6 +7,7 @@ import app.gamenative.enums.Marker
 import app.gamenative.utils.MarkerUtils
 import app.gamenative.data.EpicGame
 import app.gamenative.service.epic.manifest.EpicManifest
+import app.gamenative.service.epic.manifest.ManifestUtils
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.nio.ByteBuffer
@@ -61,6 +62,9 @@ class EpicDownloadManager @Inject constructor(
      * @param game Epic game to download
      * @param installPath Directory where game will be installed
      * @param downloadInfo Progress tracker
+     * @param containerLanguage Container language (e.g. "english", "german"). Same as GOG/Steam; used to select install tags so the correct language files are downloaded.
+     * @param dlcIds Optional DLC game IDs to include
+     * @param commonRedistDir Optional directory for common redistributables
      * @return Result indicating success or failure
      */
     suspend fun downloadGame(
@@ -68,7 +72,7 @@ class EpicDownloadManager @Inject constructor(
         game: EpicGame,
         installPath: String,
         downloadInfo: DownloadInfo,
-        language: String = "en-US",
+        containerLanguage: String = EpicConstants.EPIC_FALLBACK_CONTAINER_LANGUAGE,
         dlcIds: List<Int>,
         commonRedistDir: File? = null,
     ): Result<Unit> = withContext(Dispatchers.IO) {
@@ -127,17 +131,30 @@ class EpicDownloadManager @Inject constructor(
             // Parse manifest binary to get chunks and files
             val manifest = EpicManifest.readAll(manifestData.manifestBytes)
 
-            // Extract chunk and file data from parsed manifest
-            val chunkDataList = manifest.chunkDataList
-                ?: return@withContext Result.failure(Exception("No chunk data in manifest"))
-            val fileManifestList = manifest.fileManifestList
-                ?: return@withContext Result.failure(Exception("No file manifest in manifest"))
+            // Use container language (same as GOG) to select install tags: required + optional language files.
+            val selectedTags = EpicConstants.containerLanguageToEpicInstallTags(containerLanguage)
+            val files = ManifestUtils.getFilesForSelectedInstallTags(manifest, selectedTags)
+            val chunks = ManifestUtils.getRequiredChunksForFileList(manifest, files)
 
-            val chunks = chunkDataList.elements
-            val files = fileManifestList.elements
+            if (selectedTags.isNotEmpty()) {
+                Timber.tag("Epic").i("Container language '$containerLanguage' -> install tags: ${selectedTags.joinToString()}")
+            }
+
             val chunkDir = manifest.getChunkDir()
 
-            // Calculate total download size including DLCs (use compressed size for download tracking)
+            if (chunks.isEmpty()) {
+                return@withContext Result.failure(Exception("No chunk data in manifest"))
+            }
+            if (files.isEmpty()) {
+                val msg = if (selectedTags.isNotEmpty()) {
+                    "No files found for the selected language. This game may not support this language."
+                } else {
+                    "No file manifest in manifest"
+                }
+                return@withContext Result.failure(Exception(msg))
+            }
+
+            // Calculate total download size including DLCs
             var totalDownloadSize = chunks.sumOf { it.fileSize }
             var totalInstalledSize = chunks.sumOf { it.windowSize.toLong() }
             val baseGameSize = totalDownloadSize

--- a/app/src/main/java/app/gamenative/service/epic/EpicManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicManager.kt
@@ -951,9 +951,8 @@ class EpicManager @Inject constructor(
             // Parse with Kotlin parser
             val manifest = app.gamenative.service.epic.manifest.EpicManifest.readAll(manifestData.manifestBytes)
 
-            // Calculate install size
-            val installSize = manifest.fileManifestList?.elements?.sumOf { it.fileSize } ?: 0L
-            val downloadSize = app.gamenative.service.epic.manifest.ManifestUtils.getTotalDownloadSize(manifest)
+            // Required-only sizes for detail page display (download uses container language via getSizesForSelectedInstallTags elsewhere).
+            val (downloadSize, installSize) = app.gamenative.service.epic.manifest.ManifestUtils.getSizesForSelectedInstallTags(manifest, emptyList())
             Timber.tag("Epic").d(
                 "Manifest stats for $appName: version=${manifest.version}, featureLevel=${manifest.meta?.featureLevel}, " +
                     "buildVersion=${manifest.meta?.buildVersion}, buildId=${manifest.meta?.buildId}",

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -346,7 +346,7 @@ class EpicService : Service() {
                 ?: EpicManager.ManifestSizes(installSize = 0L, downloadSize = 0L)
         }
 
-        fun downloadGame(context: Context, appId: Int, dlcGameIds: List<Int>, installPath: String): Result<DownloadInfo> {
+        fun downloadGame(context: Context, appId: Int, dlcGameIds: List<Int>, installPath: String, containerLanguage: String): Result<DownloadInfo> {
             val instance = getInstance() ?: return Result.failure(Exception("Service not available"))
 
             val game = runBlocking { instance.epicManager.getGameById(appId) }
@@ -380,7 +380,7 @@ class EpicService : Service() {
                         game,
                         installPath,
                         downloadInfo,
-                        "en-US",
+                        containerLanguage,
                         dlcGameIds,
                         commonRedistDir,
                     )

--- a/app/src/main/java/app/gamenative/service/epic/manifest/ManifestUtils.kt
+++ b/app/src/main/java/app/gamenative/service/epic/manifest/ManifestUtils.kt
@@ -41,17 +41,34 @@ object ManifestUtils {
     }
 
     /**
+     * Get list of files that are part of the default/required install.
+     * Epic manifests list all files including optional (e.g. language packs). Files with
+     * no install tags are typically always installed; files with tags are optional.
+     */
+    fun getRequiredInstallFiles(manifest: EpicManifest): List<FileManifest> {
+        val all = manifest.fileManifestList?.elements ?: return emptyList()
+        val required = all.filter { it.installTags.isEmpty() }
+        return if (required.isEmpty()) all else required
+    }
+
+    /**
      * Get list of all unique chunks referenced by files
      */
     fun getRequiredChunks(manifest: EpicManifest): List<ChunkInfo> {
+        return getRequiredChunksForFileList(manifest, manifest.fileManifestList?.elements ?: emptyList())
+    }
+
+    /**
+     * Get unique chunks referenced by the given file list
+     */
+    fun getRequiredChunksForFileList(manifest: EpicManifest, files: List<FileManifest>): List<ChunkInfo> {
         val chunkGuids = mutableSetOf<String>()
         val chunks = mutableListOf<ChunkInfo>()
 
-        manifest.fileManifestList?.elements?.forEach { file ->
+        files.forEach { file ->
             file.chunkParts.forEach { part ->
                 val guidStr = part.guidStr
                 if (chunkGuids.add(guidStr)) {
-                    // Find the chunk info for this GUID
                     manifest.chunkDataList?.getChunkByGuid(guidStr)?.let { chunk ->
                         chunks.add(chunk)
                     }
@@ -86,17 +103,29 @@ object ManifestUtils {
     }
 
     /**
-     * Calculate total download size for manifest
+     * Calculate total download size for manifest (all files).
      */
     fun getTotalDownloadSize(manifest: EpicManifest): Long {
         return getRequiredChunks(manifest).sumOf { it.fileSize }
     }
 
     /**
-     * Calculate total installed size for manifest
+     * Calculate total installed size for manifest (all files).
      */
     fun getTotalInstalledSize(manifest: EpicManifest): Long {
         return manifest.fileManifestList?.elements?.sumOf { it.fileSize } ?: 0L
+    }
+
+    /**
+     * Calculate download and install size for the given install tags (required + selectedTags).
+     * Use emptyList() for required-only. Same logic as download uses.
+     */
+    fun getSizesForSelectedInstallTags(manifest: EpicManifest, selectedTags: List<String>): Pair<Long, Long> {
+        val files = getFilesForSelectedInstallTags(manifest, selectedTags)
+        val installSize = files.sumOf { it.fileSize }
+        val chunks = getRequiredChunksForFileList(manifest, files)
+        val downloadSize = chunks.sumOf { it.fileSize }
+        return downloadSize to installSize
     }
 
     /**
@@ -114,12 +143,28 @@ object ManifestUtils {
     }
 
     /**
-     * Get files matching install tags
+     * Get files matching install tags (optional content only; does not include required).
      */
     fun getFilesWithTags(manifest: EpicManifest, tags: List<String>): List<FileManifest> {
         return manifest.fileManifestList?.elements?.filter { file ->
             tags.any { tag -> file.installTags.contains(tag) }
         } ?: emptyList()
+    }
+
+    /**
+     * Get the file list to download when the user selects optional install tags (e.g. languages).
+     * Returns required (no-tag) files plus any file that has at least one of [selectedTags].
+     * So: base game + selected optional content (e.g. German + French = required + German files + French files).
+     * Use this when building the download set for "required + these tags" (like Legendary/Heroic).
+     */
+    fun getFilesForSelectedInstallTags(manifest: EpicManifest, selectedTags: List<String>): List<FileManifest> {
+        val all = manifest.fileManifestList?.elements ?: return emptyList()
+        if (selectedTags.isEmpty()) return getRequiredInstallFiles(manifest)
+        val withLanguage = all.filter { file ->
+            file.installTags.isEmpty() || file.installTags.any { it in selectedTags }
+        }
+        // If selected language matched no files (e.g. manifest uses "de" not "German"), fall back to required-only
+        return if (withLanguage.isEmpty()) getRequiredInstallFiles(manifest) else withLanguage
     }
 
     /**

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
@@ -391,9 +391,10 @@ class EpicAppScreen : BaseAppScreen() {
                 SnackbarManager.show(message)
 
                 // Start download - EpicService will handle monitoring, database updates, verification, and events
-                // Pass the selected DLC IDs (excluding the base game)
+                // Pass the selected DLC IDs (excluding the base game). Use container language for install-tag selection.
                 val dlcIds = selectedGameIds.filter { it != libraryItem.gameId }
-                val result = EpicService.downloadGame(context, libraryItem.gameId, dlcIds, installPath)
+                val containerData = loadContainerData(context, libraryItem)
+                val result = EpicService.downloadGame(context, libraryItem.gameId, dlcIds, installPath, containerData.language)
 
                 if (result.isSuccess) {
                     Timber.tag(TAG).i("Epic game download started successfully: ${libraryItem.gameId}")


### PR DESCRIPTION
Currently it downloads all files with all tags.. Only files with "no tags" are required. And language specific files would be located under a "language" tag. So implemented that.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds language-aware downloads for Epic. We now install required files plus the selected container language to cut download/install sizes and match the GOG/Steam language setting.

- **New Features**
  - Map container languages to Epic install tags (e.g., german → ["German", "de-DE", "de"]; includes schinese/tchinese/latam, etc.).
  - Download only required files + selected language tags; clear errors if none found.
  - Fallbacks: unknown language → English tags; if no tag matches → required-only.
  - UI passes container language to the service; service and download manager apply it.
  - Manifest utils add helpers to pick files/chunks and compute sizes for selected tags.
  - Game details show sizes for required-only content.

<sup>Written for commit 9805f4c6c0b4258c89f8847ea27fe5938157bc82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language-to-install-tag mapping and a fallback language so installs can pick tag-specific content.
  * Tag-aware manifest selection to compute download and install sizes for selected language tags.

* **Improvements**
  * UI now passes container language through the download flow so installs respect container language.
  * Size calculations unified using tag-aware logic.

* **Bug Fixes**
  * Better validation and clearer error messages when manifest chunks or files are missing for selected tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->