### PR TITLE
Fix app crash in race condition in DownloadInfo ETA by snapshotting speed samples

### DIFF
--- a/app/src/main/java/app/gamenative/data/DownloadInfo.kt
+++ b/app/src/main/java/app/gamenative/data/DownloadInfo.kt
@@ -199,12 +199,16 @@ data class DownloadInfo(
         if (bytesDownloaded >= totalExpectedBytes) return null
 
         val now = System.currentTimeMillis()
-        trimOldSamples(now, windowSeconds * 1000L)
 
-        if (speedSamples.size < 2) return null
+        // Snapshot via toTypedArray().toList() so we never call toList() on the COWAL
+        // when it's empty (which can crash), and we get a consistent view so another
+        // thread can't shrink the list between our size check and first()/last().
+        val cutoff = now - windowSeconds * 1000L
+        val samples = speedSamples.toTypedArray().filter { it.timeMs >= cutoff }.toList()
+        if (samples.size < 2) return null
 
-        val first = speedSamples.first()
-        val last = speedSamples.last()
+        val first = samples.first()
+        val last = samples.last()
         val elapsedMs = last.timeMs - first.timeMs
         if (elapsedMs <= 0L) return null
 


### PR DESCRIPTION
Cause:
speedSamples is a CopyOnWriteArrayList updated from the download thread (e.g. in addSpeedSample → trimOldSamples). The UI thread was calling getEstimatedTimeRemaining(), which did:

trimOldSamples(...)
if (speedSamples.size < 2) return null
speedSamples.first() then speedSamples.last()
Between step 2 and 3 another thread could change the list. So size could be 61789 when checked, then the list could shrink to 61788 elements, and Kotlin’s last() would still do get(61788) (because it had computed lastIndex = size - 1 = 61788), causing ArrayIndexOutOfBoundsException: length=61788; index=61788.

Fix:
Take a single snapshot and use it for both the size check and the first/last reads:

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition in DownloadInfo ETA by snapshotting and filtering speed samples before reading. Prevents intermittent ArrayIndexOutOfBoundsException and avoids toList() on an empty COWAL.

- **Bug Fixes**
  - Snapshot with speedSamples.toTypedArray().filter { it.timeMs >= cutoff }.toList() and use it for size and first/last.
  - Replace trimOldSamples() with a read-only cutoff filter to avoid concurrent list changes during reads.

<sup>Written for commit 69db58e3efc38b6e63358eed6e77ac68b946e841. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download time remaining estimates for greater consistency and accuracy during active downloads, reducing incorrect or missing ETA displays and preventing crashes from concurrent update issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->