### PR TITLE
Fix/cpu affinity empty selection crash

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/settings/SettingsCPUList.kt
+++ b/app/src/main/java/app/gamenative/ui/component/settings/SettingsCPUList.kt
@@ -46,9 +46,11 @@ fun SettingsCPUList(
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 for (cpu in 0 until Runtime.getRuntime().availableProcessors()) {
+                    val isLastSelectedCpu = cpuAffinity.size == 1 && cpuAffinity.contains(cpu)
                     Column {
                         Checkbox(
                             checked = cpuAffinity.contains(cpu),
+                            enabled = enabled && !isLastSelectedCpu,
                             onCheckedChange = {
                                 val newAffinity = if (it) {
                                     (cpuAffinity + cpu).sorted()


### PR DESCRIPTION
https://discord.com/channels/1378308569287622737/1480266813458612286

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent a crash when CPU affinity becomes empty by sanitizing input and enforcing at least one selected CPU. Also disable the checkbox for the last selected CPU to avoid ending up with an empty set.

- **Bug Fixes**
  - Parse CPU affinity with `mapNotNull { it.toIntOrNull() }` to ignore invalid/empty entries.
  - Block deselecting the last CPU and disable its checkbox when it's the only selection.

<sup>Written for commit 10a28b78b7f92a633b5e4e833825f4a5bbf71506. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU affinity configuration parsing to robustly handle and filter out non-numeric or invalid entries.
  * Enhanced the CPU selection interface to prevent deselection of the last remaining CPU, ensuring a valid configuration is always maintained in settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->