### PR TITLE
Fix resume bug for steam downloads

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -538,13 +538,15 @@ internal fun AppScreenContent(
             ?: remember { mutableStateOf<String?>(null) }
     )
     val downloadingLabel = stringResource(R.string.downloading)
-    val downloadTimeLeftText = remember(displayInfo.appId, downloadProgress, downloadInfo, downloadStatusMessage) {
+    val downloadTimeLeftText = remember(displayInfo.appId, downloadProgress, downloadInfo, isDownloading, downloadStatusMessage) {
         val etaMs = downloadInfo?.getEstimatedTimeRemaining()
         if (etaMs != null && etaMs > 0L) {
             val totalSeconds = etaMs / 1000
             val minutesLeft = totalSeconds / 60
             val secondsPart = totalSeconds % 60
             "${minutesLeft}m ${secondsPart}s left"
+        } else if (isDownloading && downloadProgress >= 1f) {
+            "Unpacking..."
         } else if (downloadProgress in 0f..1f && downloadProgress < 1f) {
             downloadStatusMessage?.takeUnless { it.isBlank() } ?: ""
         } else {

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -499,8 +499,9 @@ class SteamAppScreen : BaseAppScreen() {
     }
 
     override fun isDownloading(context: Context, libraryItem: LibraryItem): Boolean {
-        val downloadInfo = SteamService.getAppDownloadInfo(libraryItem.gameId)
-        return downloadInfo != null && (downloadInfo.getProgress() ?: 0f) < 1f
+        val gameId = libraryItem.gameId
+        return SteamService.getAppDownloadInfo(gameId) != null
+            && !SteamService.isAppInstalled(gameId)
     }
 
     override fun getDownloadProgress(context: Context, libraryItem: LibraryItem): Float {
@@ -629,7 +630,6 @@ class SteamAppScreen : BaseAppScreen() {
                 ),
             )
         } else if (SteamService.hasPartialDownload(gameId)) {
-            // Resume incomplete download
             CoroutineScope(Dispatchers.IO).launch {
                 SteamService.downloadApp(gameId)
             }
@@ -650,10 +650,11 @@ class SteamAppScreen : BaseAppScreen() {
     override fun onPauseResumeClick(context: Context, libraryItem: LibraryItem) {
         val gameId = libraryItem.gameId
         val downloadInfo = SteamService.getAppDownloadInfo(gameId)
-        val isDownloading = downloadInfo != null && (downloadInfo.getProgress() ?: 0f) < 1f
 
-        if (isDownloading) {
-            downloadInfo?.cancel()
+        if (downloadInfo != null) {
+            if (!SteamService.isAppInstalled(gameId)) {
+                downloadInfo.cancel()
+            }
         } else {
             CoroutineScope(Dispatchers.IO).launch {
                 SteamService.downloadApp(gameId)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Steam download resume/pause detection so ongoing installs aren’t cancelled or re-downloaded. Also improves the status text to reflect the unpacking phase at 100% progress.

- **Bug Fixes**
  - `isDownloading` now returns true when `SteamService.getAppDownloadInfo(gameId)` exists and the app isn’t installed.
  - Pause/Resume: only cancels when a download is in progress and the app isn’t installed; otherwise starts the download.
  - Time-left label now shows “Unpacking...” when progress reaches 100% but install isn’t finished, and recomputes when `isDownloading` changes.

<sup>Written for commit 35c426581aa699a4a0f8d78e41d705c2f0d1432a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Download status now displays "Unpacking..." message when reaching 100% completion.

* **Bug Fixes**
  * Improved download state detection accuracy.
  * Fixed pause/resume download functionality to work correctly under refined conditions.
  * Enhanced real-time updates to download progress display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->