### PR TITLE
Fix Steam WebSocket idle disconnects

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -239,6 +239,7 @@ class SteamService : Service(), IChallengeUrlChanged {
     )
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var reconnectJob: Job? = null
 
     private val onEndProcess: (AndroidEvent.EndProcess) -> Unit = {
         Companion.stop()
@@ -2690,9 +2691,10 @@ class SteamService : Service(), IChallengeUrlChanged {
                 it.withConnectionTimeout(60000L)
                 it.withHttpClient(
                     OkHttpClient.Builder()
-                        .connectTimeout(10, TimeUnit.SECONDS) // Time to establish connection
-                        .readTimeout(60, TimeUnit.SECONDS) // Max inactivity between reads
-                        .writeTimeout(30, TimeUnit.SECONDS) // Time for writes
+                        .connectTimeout(10, TimeUnit.SECONDS)
+                        .readTimeout(60, TimeUnit.SECONDS)
+                        .writeTimeout(30, TimeUnit.SECONDS)
+                        .pingInterval(15, TimeUnit.SECONDS) // keep WebSocket alive during idle
                         .build(),
                 )
             }
@@ -2847,6 +2849,7 @@ class SteamService : Service(), IChallengeUrlChanged {
         _unifiedFriends?.close()
         _unifiedFriends = null
 
+        reconnectJob?.cancel()
         isStopping = false
         retryAttempt = 0
 
@@ -2872,6 +2875,7 @@ class SteamService : Service(), IChallengeUrlChanged {
     private fun onConnected(callback: ConnectedCallback) {
         Timber.i("Connected to Steam")
 
+        reconnectJob?.cancel()
         retryAttempt = 0
         isConnected = true
 
@@ -2898,14 +2902,17 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         if (!isStopping && retryAttempt < MAX_RETRY_ATTEMPTS) {
             retryAttempt++
+            val backoffMs = (1000L * minOf(1 shl (retryAttempt - 1), 60)).coerceAtMost(60_000L)
 
-            Timber.w("Attempting to reconnect (retry $retryAttempt)")
+            Timber.w("Attempting to reconnect (retry $retryAttempt) after ${backoffMs}ms")
 
-            // isLoggingOut = false
             val event = SteamEvent.RemotelyDisconnected
             PluviaApp.events.emit(event)
 
-            connectToSteam()
+            reconnectJob = scope.launch {
+                delay(backoffMs)
+                if (isRunning && !isStopping) connectToSteam()
+            }
         } else {
             val event = SteamEvent.Disconnected
             PluviaApp.events.emit(event)


### PR DESCRIPTION
Fixes #770

## Summary
- Add 15s WebSocket ping interval to OkHttp client to keep connection alive during idle
- Add exponential backoff (1s..60s) to reconnection attempts instead of immediate retry

## Test plan
- [ ] Leave app idle for extended period, verify connection stays alive
- [ ] Kill network, verify reconnect attempts are spaced with increasing delays
- [ ] Verify normal connect/disconnect/login flow still works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #770. Prevents Steam WebSocket idle disconnects with a 15s ping and adds exponential reconnect backoff (1s–60s) to avoid rapid retries.

- **Bug Fixes**
  - Keep-alive: set `OkHttpClient.pingInterval(15s)` for the Steam WebSocket.
  - Reconnect: exponential backoff (1s→60s) via scheduled coroutine with delay logging; cancels any pending reconnect on connect/stop to avoid overlaps; normal connect/disconnect/login flows unchanged.

<sup>Written for commit 84a1383e831c8922356efa0f0b898ca9651992b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection stability by adding periodic keepalive pings to prevent idle disconnects.
  * Implemented scheduled exponential backoff for reconnection attempts to reduce repeated immediate retries.
  * Ensured pending reconnect attempts are canceled during shutdown to prevent leaks and unintended reconnects.
  * Enhanced retry logging to show backoff durations for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->