### PR TITLE
Fix crash on empty depot list (#729)

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/GameManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GameManagerDialog.kt
@@ -141,7 +141,8 @@ fun GameManagerDialog(
         allDownloadableApps.sortBy { it.first }
 
         // Add Base Game
-        allDownloadableApps.add(0, Pair(gameId, downloadableDepots.toSortedMap().values.first()))
+        val baseDepot = downloadableDepots.values.firstOrNull { it.dlcAppId == INVALID_APP_ID } ?: return@LaunchedEffect
+        allDownloadableApps.add(0, Pair(gameId, baseDepot))
         selectedAppIds[gameId] = true
         enabledAppIds[gameId] = false
     }


### PR DESCRIPTION
Fixes #729

## Summary
- `GameManagerDialog` calls `.first()` on depot list without checking empty, crashes with `NoSuchElementException` when a game returns 0 downloadable depots
- Fix: use `.firstOrNull()` and bail out of the `LaunchedEffect` if no depots

## Test plan
- [ ] Trigger a download when Steam returns 0 depots, verify no crash
- [ ] Verify normal games with depots still download correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent a crash in GameManagerDialog when a game has no downloadable depots or lacks a base depot. Use firstOrNull to pick the base depot (dlcAppId == INVALID_APP_ID) and return early in LaunchedEffect, so empty/missing depots don’t crash and normal downloads still work.

<sup>Written for commit 4c1a567d19bdb727c2aebc8db63cc4ff2f2a6201. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the game manager dialog when no base game depot is available. The dialog now safely checks for an eligible base depot, skips insertion if none exists, and—when present—ensures the base game is placed at the start of the downloadable apps list to preserve expected ordering and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->