### PR TITLE
fix: set ExeRunDir to game root in ColdClientLoader.ini

### DIFF
--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -339,6 +339,7 @@ object SteamUtils {
         val gameName = getAppDirName(getAppInfoOf(steamAppId))
         val executablePath = container.executablePath.replace("/", "\\")
         val exePath = "steamapps\\common\\$gameName\\$executablePath"
+        val exeRunDir = "steamapps\\common\\$gameName"
         val exeCommandLine = container.execArgs
         val iniFile = File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/ColdClientLoader.ini")
         iniFile.parentFile?.mkdirs()
@@ -362,7 +363,7 @@ object SteamUtils {
                 [SteamClient]
 
                 Exe=$exePath
-                ExeRunDir=
+                ExeRunDir=$exeRunDir
                 ExeCommandLine=$exeCommandLine
                 AppId=$steamAppId
 


### PR DESCRIPTION
Since the initial ColdClientLoader implementation (77c8e155), ExeRunDir has been left empty. When empty, ColdClientLoader defaults the working directory to the executable's parent directory. This is fine for games whose exe sits at the game root, but breaks games like New Star GP where the exe lives in a subdirectory (e.g. release/NSGP.exe).

Steam itself always launches games with the working directory set to the game install root, not the exe's subdirectory. New Star GP stores its save file (UserData.txt) in the game install root, and its UFS config declares it there too. The game opens UserData.txt as a relative path, so when CWD is release/ instead of the game root, the file is never found and progress cannot be loaded.

Setting ExeRunDir=steamapps\common\<gameName> matches Steam's behaviour and fixes cloud save loading for any game whose executable is not at the root of the install directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set ExeRunDir in `ColdClientLoader.ini` to the game install root (`steamapps\common\<gameName>`) using the actual install folder name from `getAppDirName()`. This matches Steam’s working directory and fixes cloud save loading for New Star GP and other games with executables in subfolders.

<sup>Written for commit 657ea54167b8589e0f403f192a44588d17cb0b32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated Steam client INI files now populate the game's runtime directory from the Steam installation path.
  * The runtime directory field is no longer left empty for installed games, improving launch configuration accuracy and reducing manual edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->