### PR TITLE
fix: resume immediately when opening keyboard in manual suspend mode

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -476,9 +476,14 @@ fun XServerScreen(
         if (!keyboardRequestedFromOverlay) {
             imeInputReceiver?.hideKeyboard()
         }
+        val resumeImmediatelyForKeyboard = keyboardRequestedFromOverlay && manualResumeMode
         keyboardRequestedFromOverlay = false
         if (!keepPausedForEditor) {
-            resumeIfAllowedAfterOverlay()
+            if (resumeImmediatelyForKeyboard) {
+                forceResumeIfSuspended()
+            } else {
+                resumeIfAllowedAfterOverlay()
+            }
         }
         showQuickMenu = false
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Resume the app immediately when the keyboard is opened from the overlay in manual suspend mode, so input works and the session doesn’t stay paused.

<sup>Written for commit 8f60d1726fdc4f9079b72085ccfc543a7088a4d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app resume behavior when dismissing overlay menus with keyboard interaction in manual resume mode, ensuring faster and more responsive resumption in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->