### PR TITLE
Reextracted steps to separate files

### DIFF
--- a/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
@@ -18,40 +18,12 @@ import java.io.File
  * so importing a container config won't incorrectly skip pre-install steps.
  */
 object PreInstallSteps {
-
-    /** Windows path -> installer args, checked against host filesystem to see which exist. */
-    private val vcRedistMap: Map<String, String> = mapOf(
-        "A:\\_CommonRedist\\vcredist\\2005\\vcredist_x86.exe" to "/Q",
-        "A:\\_CommonRedist\\vcredist\\2005\\vcredist_x64.exe" to "/Q",
-        "A:\\_CommonRedist\\vcredist\\2008\\vcredist_x86.exe" to "/qb!",
-        "A:\\_CommonRedist\\vcredist\\2008\\vcredist_x64.exe" to "/qb!",
-        "A:\\_CommonRedist\\vcredist\\2010\\vcredist_x86.exe" to "/passive /norestart",
-        "A:\\_CommonRedist\\vcredist\\2010\\vcredist_x64.exe" to "/passive /norestart",
-        "A:\\_CommonRedist\\vcredist\\2012\\vcredist_x86.exe" to "/passive /norestart",
-        "A:\\_CommonRedist\\vcredist\\2012\\vcredist_x64.exe" to "/passive /norestart",
-        "A:\\_CommonRedist\\vcredist\\2013\\vcredist_x86.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\vcredist\\2013\\vcredist_x64.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\vcredist\\2015\\vc_redist.x86.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\vcredist\\2015\\vc_redist.x64.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\vcredist\\2017\\vc_redist.x86.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\vcredist\\2017\\vc_redist.x64.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\vcredist\\2019\\vc_redist.x86.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\vcredist\\2019\\vc_redist.x64.exe" to "/install /passive /norestart",
-        "A:\\redist\\vcredist_x86.exe" to "",
-        "A:\\redist\\vcredist_x64.exe" to "",
-        "A:\\_CommonRedist\\MSVC2013\\vcredist_x86.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\MSVC2013_x64\\vcredist_x64.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\MSVC2015\\VC_redist.x86.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\MSVC2015_x64\\VC_redist.x64.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\MSVC2017\\VC_redist.x86.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\MSVC2017_x64\\VC_redist.x64.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\MSVC2019\\VC_redist.x86.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\MSVC2019_x64\\VC_redist.x64.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\VC_redist.x86.exe" to "/install /passive /norestart",
-        "A:\\_CommonRedist\\VC_redist.x64.exe" to "/install /passive /norestart",
+    private val steps: List<PreInstallStep> = listOf(
+        VcRedistStep,
+        GogScriptInterpreterStep,
     )
 
-    private val allMarkers = listOf(Marker.VCREDIST_INSTALLED, Marker.GOG_SCRIPT_INSTALLED)
+    private val allMarkers = steps.map { it.marker }.distinct()
 
     /**
      * Returns a list of guest executable commands for pre-install steps. Each entry is a
@@ -71,18 +43,22 @@ object PreInstallSteps {
 
         val commands = mutableListOf<String>()
 
-        if (!MarkerUtils.hasMarker(gameDirPath, Marker.VCREDIST_INSTALLED)) {
-            buildVcRedistCommand(gameDir)?.let {
-                commands.add(wrapAsGuestExecutable(it, screenInfo))
-            }
-        }
-
-        if (gameSource == GameSource.GOG &&
-            container.containerVariant.equals(Container.GLIBC) &&
-            !MarkerUtils.hasMarker(gameDirPath, Marker.GOG_SCRIPT_INSTALLED)
-        ) {
-            buildGogScriptCommand(appId)?.let {
-                commands.add(wrapAsGuestExecutable(it, screenInfo))
+        for (step in steps) {
+            if (step.appliesTo(
+                    container = container,
+                    gameSource = gameSource,
+                    gameDirPath = gameDirPath,
+                )
+            ) {
+                step.buildCommand(
+                    container = container,
+                    appId = appId,
+                    gameSource = gameSource,
+                    gameDir = gameDir,
+                    gameDirPath = gameDirPath,
+                )?.let { cmd ->
+                    commands.add(wrapAsGuestExecutable(cmd, screenInfo))
+                }
             }
         }
 
@@ -106,26 +82,6 @@ object PreInstallSteps {
     private fun wrapAsGuestExecutable(cmdChain: String, screenInfo: String): String {
         val wrapped = "winhandler.exe cmd /c \"$cmdChain & taskkill /F /IM explorer.exe\""
         return "wine explorer /desktop=shell,$screenInfo $wrapped"
-    }
-
-    private fun buildVcRedistCommand(gameDir: File): String? {
-        val parts = mutableListOf<String>()
-        for ((winPath, args) in vcRedistMap) {
-            if (winPath.length < 4 || winPath[1] != ':' || winPath[2] != '\\') continue
-            val rest = winPath.substring(3)
-            val lastSep = rest.lastIndexOf('\\')
-            if (lastSep < 0) continue
-            val hostFile = File(gameDir, rest.replace('\\', '/'))
-            if (!hostFile.isFile) continue
-            parts.add(if (args.isEmpty()) winPath else "$winPath $args")
-        }
-        return if (parts.isEmpty()) null else parts.joinToString(" & ")
-    }
-
-    private fun buildGogScriptCommand(appId: String): String? {
-        val parts = GOGService.getInstance()?.gogManager
-            ?.getScriptInterpreterPartsForLaunch(appId) ?: return null
-        return if (parts.isEmpty()) null else parts.joinToString(" & ")
     }
 
     private fun getGameDir(container: Container): File? {

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/GogScriptInterpreterStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/GogScriptInterpreterStep.kt
@@ -1,0 +1,33 @@
+package app.gamenative.utils
+
+import app.gamenative.data.GameSource
+import app.gamenative.enums.Marker
+import app.gamenative.service.gog.GOGService
+import com.winlator.container.Container
+import java.io.File
+
+object GogScriptInterpreterStep : PreInstallStep {
+    override val marker: Marker = Marker.GOG_SCRIPT_INSTALLED
+
+    override fun appliesTo(
+        container: Container,
+        gameSource: GameSource,
+        gameDirPath: String,
+    ): Boolean {
+        return gameSource == GameSource.GOG &&
+            container.containerVariant.equals(Container.GLIBC) &&
+            !MarkerUtils.hasMarker(gameDirPath, Marker.GOG_SCRIPT_INSTALLED)
+    }
+
+    override fun buildCommand(
+        container: Container,
+        appId: String,
+        gameSource: GameSource,
+        gameDir: File,
+        gameDirPath: String,
+    ): String? {
+        val parts = GOGService.getInstance()?.gogManager
+            ?.getScriptInterpreterPartsForLaunch(appId) ?: return null
+        return if (parts.isEmpty()) null else parts.joinToString(" & ")
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/PreInstallStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/PreInstallStep.kt
@@ -1,0 +1,24 @@
+package app.gamenative.utils
+
+import app.gamenative.data.GameSource
+import app.gamenative.enums.Marker
+import com.winlator.container.Container
+import java.io.File
+
+interface PreInstallStep {
+    val marker: Marker
+
+    fun appliesTo(
+        container: Container,
+        gameSource: GameSource,
+        gameDirPath: String,
+    ): Boolean
+
+    fun buildCommand(
+        container: Container,
+        appId: String,
+        gameSource: GameSource,
+        gameDir: File,
+        gameDirPath: String,
+    ): String?
+}

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/VcRedistStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/VcRedistStep.kt
@@ -1,0 +1,71 @@
+package app.gamenative.utils
+
+import app.gamenative.enums.Marker
+import app.gamenative.data.GameSource
+import com.winlator.container.Container
+import java.io.File
+
+/** Windows path -> installer args, checked against host filesystem to see which exist. */
+private val vcRedistMap: Map<String, String> = mapOf(
+    "A:\\_CommonRedist\\vcredist\\2005\\vcredist_x86.exe" to "/Q",
+    "A:\\_CommonRedist\\vcredist\\2005\\vcredist_x64.exe" to "/Q",
+    "A:\\_CommonRedist\\vcredist\\2008\\vcredist_x86.exe" to "/qb!",
+    "A:\\_CommonRedist\\vcredist\\2008\\vcredist_x64.exe" to "/qb!",
+    "A:\\_CommonRedist\\vcredist\\2010\\vcredist_x86.exe" to "/passive /norestart",
+    "A:\\_CommonRedist\\vcredist\\2010\\vcredist_x64.exe" to "/passive /norestart",
+    "A:\\_CommonRedist\\vcredist\\2012\\vcredist_x86.exe" to "/passive /norestart",
+    "A:\\_CommonRedist\\vcredist\\2012\\vcredist_x64.exe" to "/passive /norestart",
+    "A:\\_CommonRedist\\vcredist\\2013\\vcredist_x86.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\vcredist\\2013\\vcredist_x64.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\vcredist\\2015\\vc_redist.x86.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\vcredist\\2015\\vc_redist.x64.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\vcredist\\2017\\vc_redist.x86.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\vcredist\\2017\\vc_redist_x64\\vc_redist.x64.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\vcredist\\2019\\vc_redist.x86.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\vcredist\\2019\\vc_redist.x64.exe" to "/install /passive /norestart",
+    "A:\\redist\\vcredist_x86.exe" to "",
+    "A:\\redist\\vcredist_x64.exe" to "",
+    "A:\\_CommonRedist\\MSVC2013\\vcredist_x86.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\MSVC2013_x64\\vcredist_x64.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\MSVC2015\\VC_redist.x86.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\MSVC2015_x64\\VC_redist.x64.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\MSVC2017\\VC_redist.x86.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\MSVC2017_x64\\VC_redist.x64.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\MSVC2019\\VC_redist.x86.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\MSVC2019_x64\\VC_redist.x64.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\VC_redist.x86.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\VC_redist.x64.exe" to "/install /passive /norestart",
+)
+
+object VcRedistStep : PreInstallStep {
+    override val marker: Marker = Marker.VCREDIST_INSTALLED
+
+    override fun appliesTo(
+        container: Container,
+        gameSource: GameSource,
+        gameDirPath: String,
+    ): Boolean {
+        return !MarkerUtils.hasMarker(gameDirPath, Marker.VCREDIST_INSTALLED)
+    }
+
+    override fun buildCommand(
+        container: Container,
+        appId: String,
+        gameSource: GameSource,
+        gameDir: File,
+        gameDirPath: String,
+    ): String? {
+        val parts = mutableListOf<String>()
+        for ((winPath, args) in vcRedistMap) {
+            if (winPath.length < 4 || winPath[1] != ':' || winPath[2] != '\\') continue
+            val rest = winPath.substring(3)
+            val lastSep = rest.lastIndexOf('\\')
+            if (lastSep < 0) continue
+            val hostFile = File(gameDir, rest.replace('\\', '/'))
+            if (!hostFile.isFile) continue
+            parts.add(if (args.isEmpty()) winPath else "$winPath $args")
+        }
+        return if (parts.isEmpty()) null else parts.joinToString(" & ")
+    }
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored pre-install steps into modular classes. Extracted VC++ Redistributable and GOG script interpreter logic to make steps easier to add and maintain.

- **Refactors**
  - Added `PreInstallStep` interface with `marker`, `appliesTo`, and `buildCommand`.
  - Extracted `VcRedistStep` and `GogScriptInterpreterStep` into separate files.
  - `PreInstallSteps` now iterates a `steps` list and derives markers from steps.
  - Moved VC++ redistributable path map into `VcRedistStep` and updated it (added 2017 x64 variant).
  - Preserved command wrapping with the virtual desktop.

<sup>Written for commit 0c3777c45503c31a9615dbcc066cc1fc59ace298. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

