### PR TITLE
Fix: scan all external volumes for installed games

### DIFF
--- a/app/src/main/java/app/gamenative/service/DownloadService.kt
+++ b/app/src/main/java/app/gamenative/service/DownloadService.kt
@@ -1,6 +1,7 @@
 package app.gamenative.service
 
 import android.content.Context
+import android.os.Environment
 import app.gamenative.utils.StorageUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -24,12 +25,23 @@ object DownloadService {
             field = value
         }
 
+    // all mounted non-primary external volumes (SD cards, USB), discovered at init
+    var externalVolumePaths: List<String> = emptyList()
+        private set
+
     fun populateDownloadService(context: Context) {
         baseDataDirPath = context.dataDir.path
         baseCacheDirPath = context.cacheDir.path
         // Prefer the parent of external files dir (Android/data/<package>) so we can create siblings of /files
         val extFiles = context.getExternalFilesDir(null)
         baseExternalAppDirPath = extFiles?.parentFile?.path ?: ""
+
+        val sm = context.getSystemService(android.os.storage.StorageManager::class.java)
+        externalVolumePaths = context.getExternalFilesDirs(null)
+            .filterNotNull()
+            .filter { Environment.getExternalStorageState(it) == Environment.MEDIA_MOUNTED }
+            .filter { sm.getStorageVolume(it)?.isPrimary != true }
+            .map { it.absolutePath }
     }
 
     fun getDownloadDirectoryApps (): MutableList<String> {
@@ -41,11 +53,15 @@ object DownloadService {
         if (lastUpdateTime < (time - 5 * 1000) || lastUpdateTime > time) {
             lastUpdateTime = time
 
-            // For now, grab parent directories from SteamService
-            val subDir = getSubdirectories(SteamService.internalAppInstallPath)
-            subDir += getSubdirectories(SteamService.externalAppInstallPath)
+            // scan internal + all mounted external volumes, deduplicate across volumes
+            val dirs = mutableSetOf<String>()
+            dirs += getSubdirectories(SteamService.internalAppInstallPath)
+            for (volPath in externalVolumePaths) {
+                val extInstallPath = java.nio.file.Paths.get(volPath, "Steam", "steamapps", "common").toString()
+                dirs += getSubdirectories(extInstallPath)
+            }
 
-            downloadDirectoryApps = subDir
+            downloadDirectoryApps = dirs.toMutableList()
         }
 
         return downloadDirectoryApps ?: mutableListOf()


### PR DESCRIPTION
## Summary
- Games on external storage (SD/USB) were invisible when "Write to external storage" toggle was off
- Root cause: discovery scanned `externalStoragePath` pref which is cleared when toggle is off (broken since original implementation in #93)
- Fix: discover all mounted non-primary volumes at init, scan all of them regardless of toggle state
- Also fixes multi-volume setups (SD + USB)

## Test plan
- [ ] Install a game with external storage enabled
- [ ] Disable the toggle — game should remain visible
- [ ] Re-enable — still visible
- [ ] Test with multiple external volumes if possible

Fixes #776

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scan all mounted external SD/USB volumes for installed games so titles remain visible when the external storage toggle is off, including multi-volume setups. Fixes #776.

- **Bug Fixes**
  - Discover mounted, non-primary volumes at init and store their paths.
  - Scan internal and each volume’s Steam/steamapps/common and de-dupe results, no longer relying on the cleared `externalStoragePath` pref.

<sup>Written for commit 4381c478337648b14754e9585a949703ee34749a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scans external storage volumes (SD cards, USB drives) in addition to internal storage to discover installed games and apps.
  * Includes common game directories (e.g., Steam installs) on each volume and deduplicates duplicates across volumes for clearer results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->