### PR TITLE
Add physx preinstall step

### DIFF
--- a/app/src/main/java/app/gamenative/enums/Marker.kt
+++ b/app/src/main/java/app/gamenative/enums/Marker.kt
@@ -8,4 +8,5 @@ enum class Marker(val fileName: String ) {
     STEAM_COLDCLIENT_USED(".steam_coldclient_used"),
     VCREDIST_INSTALLED(".vcredist_installed"),
     GOG_SCRIPT_INSTALLED(".gog_script_installed"),
+    PHYSX_INSTALLED(".physx_installed"),
 }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2841,29 +2841,6 @@ private fun installOpenAL(context: RedistContext) {
     }
 }
 
-private fun installPhysX(context: RedistContext) {
-    val physxDir = File(context.commonRedistDir, "PhysX")
-    if (physxDir.exists() && physxDir.isDirectory()) {
-        physxDir.walkTopDown()
-            .filter { it.isFile && it.name.startsWith("PhysX", ignoreCase = true) &&
-                        it.name.endsWith(".msi", ignoreCase = true) }
-            .forEach { msiFile ->
-                try {
-                    val relativePath = msiFile.relativeTo(context.commonRedistDir).path.replace('/', '\\')
-                    val drive = context.driveLetter
-                    val winePath = "$drive:\\_CommonRedist\\$relativePath"
-                    PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Installing PhysX..."))
-                    Timber.i("Installing PhysX: $winePath")
-                    val cmd = "wine msiexec /i $winePath /quiet /norestart && wineserver -k"
-                    val output = context.guestProgramLauncherComponent.execShellCommand(cmd)
-                    Timber.i("PhysX installation output: $output")
-                } catch (e: Exception) {
-                    Timber.e(e, "Failed to install PhysX ${msiFile.name}")
-                }
-            }
-    }
-}
-
 private fun installXNAFramework(context: RedistContext) {
     val xnaDir = File(context.commonRedistDir, "xnafx")
     if (xnaDir.exists() && xnaDir.isDirectory()) {
@@ -2922,7 +2899,6 @@ private fun installRedistributables(
         }
 
         installOpenAL(redistContext)
-        installPhysX(redistContext)
         installXNAFramework(redistContext)
 
         Timber.tag("installRedist").i("Finished checking for redistributables")

--- a/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
@@ -26,6 +26,7 @@ object PreInstallSteps {
 
     private val steps: List<PreInstallStep> = listOf(
         VcRedistStep,
+        PhysXStep,
         GogScriptInterpreterStep,
     )
 

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/PhysXStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/PhysXStep.kt
@@ -1,0 +1,69 @@
+package app.gamenative.utils
+
+import app.gamenative.data.GameSource
+import app.gamenative.enums.Marker
+import com.winlator.container.Container
+import java.io.File
+import timber.log.Timber
+
+object PhysXStep : PreInstallStep {
+    override val marker: Marker = Marker.PHYSX_INSTALLED
+
+    override fun appliesTo(
+        container: Container,
+        gameSource: GameSource,
+        gameDirPath: String,
+    ): Boolean {
+        return !MarkerUtils.hasMarker(gameDirPath, Marker.PHYSX_INSTALLED)
+    }
+
+    override fun buildCommand(
+        container: Container,
+        appId: String,
+        gameSource: GameSource,
+        gameDir: File,
+        gameDirPath: String,
+    ): String? {
+        val searchDirs = listOf(
+            File(gameDirPath, "_CommonRedist/PhysX"),
+            File(gameDirPath, "redist"),
+            File(gameDirPath, "Redist"),
+        ).filter { it.exists() && it.isDirectory }
+
+        if (searchDirs.isEmpty()) {
+            Timber.tag("PhysXStep").i("No PhysX search directories found for game at $gameDirPath")
+            return null
+        }
+
+        val parts = mutableListOf<String>()
+
+        for (dir in searchDirs) {
+            Timber.tag("PhysXStep").i("Searching for PhysX installers under ${dir.absolutePath}")
+            dir.walkTopDown()
+                .filter { file ->
+                    file.isFile &&
+                        file.name.startsWith("PhysX", ignoreCase = true) &&
+                        (file.name.endsWith(".msi", ignoreCase = true) ||
+                            file.name.endsWith(".exe", ignoreCase = true))
+                }
+                .forEach { installerFile ->
+                    val relativePath = installerFile
+                        .relativeTo(gameDir)
+                        .path
+                        .replace('/', '\\')
+                    val winePath = "A:\\$relativePath"
+                    Timber.tag("PhysXStep").i("Queued PhysX installer: $winePath")
+
+                    val command =
+                        if (installerFile.name.endsWith(".msi", ignoreCase = true)) {
+                            "msiexec /i $winePath /quiet /norestart"
+                        } else {
+                            "$winePath /quiet /norestart"
+                        }
+                    parts.add(command)
+                }
+        }
+
+        return if (parts.isEmpty()) null else parts.joinToString(" & ")
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a preinstall framework that runs VC++ redistributables, PhysX, and the GOG script interpreter before game launch, using per-step markers to avoid repeat installs. Steps run in the same Wine session, show a booting splash, and reset when the container variant changes.

- **New Features**
  - PhysX preinstall: dedicated step that scans `_CommonRedist/PhysX`, `redist`, and `Redist` for `PhysX*.msi`/`.exe` and runs them silently.
  - VC++ redistributables: auto-detects common installers and runs them silently.
  - GOG script interpreter: GLIBC-only, creates `ISI/rootdir` symlink, and chains required products into the launch.

- **Refactors**
  - Added `PHYSX_INSTALLED` marker and included `PhysXStep` in `PreInstallSteps`.
  - Removed inline PhysX installer from `XServerScreen`.

<sup>Written for commit 87ed21065877c5273bc88040f9d8e9c972b93f69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized PhysX redistributable installation handling to execute during pre-installation steps instead of during display server initialization, improving the installation sequence and architecture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->