### PR TITLE
Added openAL preinstall step

### DIFF
--- a/app/src/main/java/app/gamenative/enums/Marker.kt
+++ b/app/src/main/java/app/gamenative/enums/Marker.kt
@@ -9,4 +9,5 @@ enum class Marker(val fileName: String ) {
     VCREDIST_INSTALLED(".vcredist_installed"),
     GOG_SCRIPT_INSTALLED(".gog_script_installed"),
     PHYSX_INSTALLED(".physx_installed"),
+    OPENAL_INSTALLED(".openal_installed"),
 }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2809,37 +2809,7 @@ private fun getRedistDirectory(
     }
 
     return RedistContext(commonRedistDir, driveLetter, guestProgramLauncherComponent)
-}
-
-/**
- * Installs OpenAL redistributables (oalinst.exe) (https://www.openal.org/)
- * Helps with 3D audio implementations between 2001-2010
- */
-private fun installOpenAL(context: RedistContext) {
-    val openalDir = File(context.commonRedistDir, "OpenAL")
-    if (!openalDir.exists() || !openalDir.isDirectory()) return
-
-    val openalInstaller = openalDir.walkTopDown()
-        .filter { it.isFile &&
-            (it.name.equals("oalinst.exe", ignoreCase = true) ||
-             it.name.startsWith("OpenAL", ignoreCase = true)) &&
-            it.name.endsWith(".exe", ignoreCase = true) }
-        .firstOrNull()
-
-    openalInstaller?.let { exeFile ->
-        try {
-            val relativePath = exeFile.relativeTo(context.commonRedistDir).path.replace('/', '\\')
-            val winePath = "${context.driveLetter}:\\_CommonRedist\\$relativePath"
-            PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Installing OpenAL..."))
-            Timber.i("Installing OpenAL: $winePath")
-            val cmd = "wine $winePath /s && wineserver -k"
-            val output = context.guestProgramLauncherComponent.execShellCommand(cmd)
-            Timber.i("OpenAL installation output: $output")
-        } catch (e: Exception) {
-            Timber.e(e, "Failed to install OpenAL ${exeFile.name}")
         }
-    }
-}
 
 private fun installXNAFramework(context: RedistContext) {
     val xnaDir = File(context.commonRedistDir, "xnafx")
@@ -2898,7 +2868,6 @@ private fun installRedistributables(
             return
         }
 
-        installOpenAL(redistContext)
         installXNAFramework(redistContext)
 
         Timber.tag("installRedist").i("Finished checking for redistributables")

--- a/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
@@ -27,6 +27,7 @@ object PreInstallSteps {
     private val steps: List<PreInstallStep> = listOf(
         VcRedistStep,
         PhysXStep,
+        OpenALStep,
         GogScriptInterpreterStep,
     )
 

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/OpenALStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/OpenALStep.kt
@@ -1,0 +1,65 @@
+package app.gamenative.utils
+
+import app.gamenative.data.GameSource
+import app.gamenative.enums.Marker
+import com.winlator.container.Container
+import java.io.File
+import timber.log.Timber
+
+object OpenALStep : PreInstallStep {
+    override val marker: Marker = Marker.OPENAL_INSTALLED
+
+    override fun appliesTo(
+        container: Container,
+        gameSource: GameSource,
+        gameDirPath: String,
+    ): Boolean {
+        return !MarkerUtils.hasMarker(gameDirPath, Marker.OPENAL_INSTALLED)
+    }
+
+    override fun buildCommand(
+        container: Container,
+        appId: String,
+        gameSource: GameSource,
+        gameDir: File,
+        gameDirPath: String,
+    ): String? {
+        val searchDirs = listOf(
+            File(gameDirPath, "_CommonRedist/OpenAL"),
+            File(gameDirPath, "redist"),
+            File(gameDirPath, "Redist"),
+        ).filter { it.exists() && it.isDirectory }
+
+        if (searchDirs.isEmpty()) {
+            Timber.tag("OpenALStep").i("No OpenAL search directories found for game at $gameDirPath")
+            return null
+        }
+
+        val parts = mutableListOf<String>()
+
+        for (dir in searchDirs) {
+            Timber.tag("OpenALStep").i("Searching for OpenAL installers under ${dir.absolutePath}")
+            dir.walkTopDown()
+                .filter { file ->
+                    file.isFile &&
+                        (file.name.equals("oalinst.exe", ignoreCase = true) ||
+                            file.name.startsWith("OpenAL", ignoreCase = true)) &&
+                        file.name.endsWith(".exe", ignoreCase = true)
+                }
+                .forEach { exeFile ->
+                    val relativePath = exeFile
+                        .relativeTo(gameDir)
+                        .path
+                        .replace('/', '\\')
+                    val winePath = "A:\\$relativePath"
+                    Timber.tag("OpenALStep").i("Queued OpenAL installer: $winePath")
+
+                    val command = "$winePath /s"
+                    parts.add(command)
+                }
+        }
+
+        return if (parts.isEmpty()) null else parts.joinToString(" & ")
+    }
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add pre-install steps for VC++ Redistributables, PhysX, OpenAL, and the GOG script interpreter to run before first launch, reducing setup errors and black screens. Steps run in a Wine desktop session with clear splash messages and are skipped on future launches via marker files.

- **New Features**
  - Added `OpenALStep` and `PhysXStep` to `PreInstallSteps`; auto-detect installers in `_CommonRedist/OpenAL`, `redist`, or `Redist` and run silently (quiet flags for `.exe`, `msiexec` for `.msi`).
  - Track completion with new markers (`.physx_installed`, `.openal_installed`) alongside existing markers; reset when the container variant changes.
  - GOG: create `ISI\rootdir` symlink and run the script interpreter only on `glibc` containers.

- **Refactors**
  - Removed inline OpenAL/PhysX installer logic from `XServerScreen`; installs now run as pre-install steps before the game.
  - `PreInstallSteps` chains steps and now includes `OpenALStep`; `GOGManager` returns interpreter command; removed `GOGService.runScriptInterpreterIfNeeded`. Launchers stop auto-emitting "Launching game..."; `MainViewModel` handles the booting splash.

<sup>Written for commit af71e6d82ff1bcfc0d4c6828b5e5babc3c8cef52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized OpenAL installation handling into a dedicated pre-installation step with automatic detection of installers in game directories and installation status tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->