### PR TITLE
Fix child account seeing all family games

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -1014,6 +1014,25 @@ object PrefManager {
             setPref(CUSTOM_GAMES_COUNT, value)
         }
 
+    // cached parental control allowed app IDs, comma-separated ("[]" = empty set, "" = null/unset)
+    private val PARENTAL_ALLOWED_APP_IDS = stringPreferencesKey("parental_allowed_app_ids")
+    var parentalAllowedAppIds: Set<Int>?
+        get() {
+            val raw = getPref(PARENTAL_ALLOWED_APP_IDS, "")
+            return when {
+                raw.isEmpty() -> null
+                raw == "[]" -> emptySet()
+                else -> raw.split(',').mapNotNull { it.toIntOrNull() }.toSet()
+            }
+        }
+        set(value) {
+            setPref(PARENTAL_ALLOWED_APP_IDS, when (value) {
+                null -> ""
+                emptySet<Int>() -> "[]"
+                else -> value.joinToString(",")
+            })
+        }
+
     private val STEAM_GAMES_COUNT = intPreferencesKey("steam_games_count")
     var steamGamesCount: Int
         get() = getPref(STEAM_GAMES_COUNT, 0)

--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -1026,9 +1026,9 @@ object PrefManager {
             }
         }
         set(value) {
-            setPref(PARENTAL_ALLOWED_APP_IDS, when (value) {
-                null -> ""
-                emptySet<Int>() -> "[]"
+            setPref(PARENTAL_ALLOWED_APP_IDS, when {
+                value == null -> ""
+                value.isEmpty() -> "[]"
                 else -> value.joinToString(",")
             })
         }

--- a/app/src/main/java/app/gamenative/events/AndroidEvent.kt
+++ b/app/src/main/java/app/gamenative/events/AndroidEvent.kt
@@ -25,6 +25,7 @@ interface AndroidEvent<T> : Event<T> {
     data class LibraryInstallStatusChanged(val appId: Int) : AndroidEvent<Unit>
     data class CustomGameImagesFetched(val appId: String) : AndroidEvent<Unit>
     data object RecommendationToggleChanged : AndroidEvent<Unit>
+    data object AllowedAppsLoaded : AndroidEvent<Unit>
     data class GOGAuthCodeReceived(val authCode: String) : AndroidEvent<Unit>
     data class EpicAuthCodeReceived(val authCode: String) : AndroidEvent<Unit>
     data object ServiceReady : AndroidEvent<Unit>

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -74,7 +74,9 @@ import `in`.dragonbra.javasteam.enums.EResult
 import `in`.dragonbra.javasteam.networking.steam3.ProtocolTypes
 import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientObjects.ECloudPendingRemoteOperation
 import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesFamilygroupsSteamclient
+import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesParentalSteamclient
 import `in`.dragonbra.javasteam.rpc.service.FamilyGroups
+import `in`.dragonbra.javasteam.rpc.service.Parental
 import `in`.dragonbra.javasteam.steam.authentication.AuthPollResult
 import `in`.dragonbra.javasteam.steam.authentication.AuthSessionDetails
 import `in`.dragonbra.javasteam.steam.authentication.AuthenticationException
@@ -239,6 +241,7 @@ class SteamService : Service(), IChallengeUrlChanged {
     private var _steamCloud: SteamCloud? = null
     private var _steamUserStats: SteamUserStats? = null
     private var _steamFamilyGroups: FamilyGroups? = null
+    private var _steamParental: Parental? = null
 
     private var _loginResult: LoginResult = LoginResult.Failed
 
@@ -271,6 +274,17 @@ class SteamService : Service(), IChallengeUrlChanged {
 
     // The current shared family group the logged in user is joined to.
     private var familyGroupMembers: ArrayList<Int> = arrayListOf()
+
+    sealed class ParentalState {
+        data object Loading : ParentalState()
+        data object Unrestricted : ParentalState()
+        data class Restricted(val allowedAppIds: Set<Int>) : ParentalState()
+    }
+
+    @Volatile
+    private var parentalState: ParentalState = PrefManager.parentalAllowedAppIds.let { cached ->
+        if (cached != null) ParentalState.Restricted(cached) else ParentalState.Loading
+    }
 
     private val appTokens: ConcurrentHashMap<Int, Long> = ConcurrentHashMap()
 
@@ -501,6 +515,9 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         val familyMembers: List<Int>
             get() = instance?.familyGroupMembers ?: emptyList()
+
+        val parentalControlState: ParentalState
+            get() = instance?.parentalState ?: ParentalState.Loading
 
         val isLoginInProgress: Boolean
             get() = instance?._loginResult == LoginResult.InProgress
@@ -3332,6 +3349,7 @@ class SteamService : Service(), IChallengeUrlChanged {
 
             _unifiedFriends = SteamUnifiedFriends(this)
             _steamFamilyGroups = steamClient!!.getHandler<SteamUnifiedMessages>()!!.createService<FamilyGroups>()
+            _steamParental = steamClient!!.getHandler<SteamUnifiedMessages>()!!.createService<Parental>()
 
             // subscribe to the callbacks we are interested in
             with(callbackSubscriptions) {
@@ -3469,6 +3487,11 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         _unifiedFriends?.close()
         _unifiedFriends = null
+        _steamFamilyGroups = null
+        _steamParental = null
+
+        familyGroupMembers.clear()
+        parentalState = ParentalState.Loading
 
         reconnectJob?.cancel()
         isStopping = false
@@ -3603,6 +3626,42 @@ class SteamService : Service(), IChallengeUrlChanged {
                                 familyGroupMembers.add(accountID)
                             }
                         }
+
+                    }
+                }
+
+                // fetch parental controls to restrict visible games
+                scope.launch {
+                    val sessionSteamId = steamClient?.steamID ?: return@launch
+                    val request = SteammessagesParentalSteamclient.CParental_GetParentalSettings_Request.newBuilder().apply {
+                        steamid = sessionSteamId.convertToUInt64()
+                    }.build()
+
+                    _steamParental!!.getParentalSettings(request).await().let {
+                        // verify session is still the same after await
+                        if (steamClient?.steamID != sessionSteamId) return@launch
+
+                        if (it.result != EResult.OK) {
+                            Timber.w("Failed to load parental settings.")
+                            return@launch
+                        }
+
+                        val settings = it.body.settings
+                        if (!settings.isEnabled) {
+                            Timber.i("Parental controls not enabled.")
+                            parentalState = ParentalState.Unrestricted
+                            PrefManager.parentalAllowedAppIds = null
+                        } else {
+                            val allowed = (settings.applistBaseList + settings.applistCustomList)
+                                .filter { app -> app.isAllowed }
+                                .map { app -> app.appid }
+                                .toSet()
+
+                            parentalState = ParentalState.Restricted(allowed)
+                            PrefManager.parentalAllowedAppIds = allowed
+                            Timber.i("Parental controls: ${allowed.size} allowed apps.")
+                        }
+                        PluviaApp.events.emit(AndroidEvent.AllowedAppsLoaded)
                     }
                 }
 

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -80,6 +80,10 @@ class LibraryViewModel @Inject constructor(
         onFilterApps(paginationCurrentPage)
     }
 
+    private val onAllowedAppsLoaded: (AndroidEvent.AllowedAppsLoaded) -> Unit = {
+        onFilterApps(paginationCurrentPage)
+    }
+
     private val onCustomGameImagesFetched: (AndroidEvent.CustomGameImagesFetched) -> Unit = {
         // Increment refresh counter and refresh the library list to pick up newly fetched images
         _state.update { it.copy(imageRefreshCounter = it.imageRefreshCounter + 1) }
@@ -187,6 +191,7 @@ class LibraryViewModel @Inject constructor(
         PluviaApp.events.on<AndroidEvent.LibraryInstallStatusChanged, Unit>(onInstallStatusChanged)
         PluviaApp.events.on<AndroidEvent.CustomGameImagesFetched, Unit>(onCustomGameImagesFetched)
         PluviaApp.events.on<AndroidEvent.RecommendationToggleChanged, Unit>(onRecommendationToggleChanged)
+        PluviaApp.events.on<AndroidEvent.AllowedAppsLoaded, Unit>(onAllowedAppsLoaded)
 
         viewModelScope.launch(Dispatchers.IO) {
             cachedRecommendation = RecommendationRepository.getCurrentRecommendation(context)
@@ -201,6 +206,7 @@ class LibraryViewModel @Inject constructor(
         PluviaApp.events.off<AndroidEvent.LibraryInstallStatusChanged, Unit>(onInstallStatusChanged)
         PluviaApp.events.off<AndroidEvent.CustomGameImagesFetched, Unit>(onCustomGameImagesFetched)
         PluviaApp.events.off<AndroidEvent.RecommendationToggleChanged, Unit>(onRecommendationToggleChanged)
+        PluviaApp.events.off<AndroidEvent.AllowedAppsLoaded, Unit>(onAllowedAppsLoaded)
         super.onCleared()
     }
 
@@ -399,6 +405,14 @@ class LibraryViewModel @Inject constructor(
                 return status == GameCompatibilityStatus.COMPATIBLE || status == GameCompatibilityStatus.GPU_COMPATIBLE
             }
 
+            // Filter Steam apps first (no pagination yet)
+            // Note: Don't sort individual lists - we'll sort the combined list for consistent ordering
+            val allowedApps = when (val state = SteamService.parentalControlState) {
+                is SteamService.ParentalState.Restricted -> state.allowedAppIds
+                is SteamService.ParentalState.Loading -> PrefManager.parentalAllowedAppIds
+                is SteamService.ParentalState.Unrestricted -> null
+            }
+
             val steamFilteredBeforeCompatibility: List<SteamApp> = appList
                 .asSequence()
                 .filter { item ->
@@ -409,11 +423,15 @@ class LibraryViewModel @Inject constructor(
                         } ?: emptyList()
                     }.let { owners ->
                         if (owners.isEmpty()) {
-                            true // no owner info ⇒ don’t filter the item out
+                            true // no owner info ⇒ don't filter the item out
                         } else {
                             owners.any { item.ownerAccountId.contains(it) }
                         }
                     }
+                }
+                .filter { item ->
+                    // parental controls: null = unrestricted, non-null = only allowed apps
+                    allowedApps?.contains(item.id) ?: true
                 }
                 .filter { item ->
                     currentFilter.any { item.type == it }


### PR DESCRIPTION
## Description
enforce Steam Family parental controls so child accounts only see parent-approved games. fetch parental settings via `Parental.getParentalSettings()` on login and filter library to only allowed apps.

- cache allowed app IDs in PrefManager for offline enforcement
- emit `AllowedAppsLoaded` event to re-filter library when parental data arrives async
- clean up parental/family state on disconnect

closes #787.

## Recording
n/a — filtering behavior, no new UI elements

## Test plan
- [ ] Log in with child account in Steam Family — should only see parent-allowed games
- [ ] Log in with non-child account — should see all owned/shared games as before
- [ ] Log in with child account, kill app, restart offline — cached restrictions still apply
- [ ] Log out and log in as different user — no stale restrictions carry over

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parental controls: the app now fetches Steam parental restrictions, caches allowed app IDs locally, and enforces them in the library so only approved apps are shown when restricted.
  * Library updates automatically apply parental rules when restrictions are loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->