### PR TITLE
fix: show Steam sign-in in menu after logout

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/components/SystemMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/SystemMenu.kt
@@ -592,7 +592,7 @@ fun SystemMenu(
 
                         Spacer(modifier = Modifier.height(16.dp))
 
-                        if (isOffline) {
+                        if (isOffline || !SteamService.isLoggedIn) {
                             val goOnlineLabelRes = if (!SteamService.isLoggedIn) {
                                 R.string.steam_sign_in
                             } else {


### PR DESCRIPTION
Fixes #789

## Summary
- When Steam is logged out, burger menu now shows "Sign in to Steam" instead of "Sign out of Steam"
- One-line fix: `if (isOffline)` → `if (isOffline || !SteamService.isLoggedIn)` in SystemMenu

## Test plan
- [ ] Log into Steam, verify menu shows "Go offline" + "Sign out of Steam"
- [ ] Sign out of Steam, verify menu shows "Sign in to Steam"
- [ ] Tap "Sign in to Steam", verify it navigates to login screen
- [ ] Go offline, verify menu still shows correct label based on login state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the System menu label after Steam logout: the burger menu now shows "Sign in to Steam" instead of "Sign out of Steam" when not logged in.

- **Bug Fixes**
  - In `SystemMenu`, changed the condition to `if (isOffline || !SteamService.isLoggedIn)` to show the sign-in option when logged out while preserving offline behavior.

<sup>Written for commit f16aaadf95a07441361c2014261dc2739e8e410b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved System Menu to display online access options when the user is offline or not logged in.
  * Updated button labels to clearly differentiate between sign-in and go-online actions based on user state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->