### PR TITLE
fix: preserve steam cloud sync state across auth loss

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2452,26 +2452,28 @@ class SteamService : Service(), IChallengeUrlChanged {
 
                 isLoggingOut = true
 
-                performLogOffDuties()
+                performLogOffDuties(clearCloudSyncState = true)
 
                 val steamUser = instance!!._steamUser!!
                 steamUser.logOff()
             }
         }
 
-        private fun clearUserData() {
+        private fun clearUserData(clearCloudSyncState: Boolean = false) {
             PrefManager.clearPreferences()
 
-            clearDatabase()
+            clearDatabase(clearCloudSyncState = clearCloudSyncState)
         }
 
-        fun clearDatabase() {
+        fun clearDatabase(clearCloudSyncState: Boolean = false) {
             with(instance!!) {
                 scope.launch {
                     db.withTransaction {
                         appDao.deleteAll()
-                        changeNumbersDao.deleteAll()
-                        fileChangeListsDao.deleteAll()
+                        if (clearCloudSyncState) {
+                            changeNumbersDao.deleteAll()
+                            fileChangeListsDao.deleteAll()
+                        }
                         licenseDao.deleteAll()
                         encryptedAppTicketDao.deleteAll()
                         downloadingAppInfoDao.deleteAll()
@@ -2480,10 +2482,10 @@ class SteamService : Service(), IChallengeUrlChanged {
             }
         }
 
-        private fun performLogOffDuties() {
+        private fun performLogOffDuties(clearCloudSyncState: Boolean = false) {
             val username = PrefManager.username
 
-            clearUserData()
+            clearUserData(clearCloudSyncState = clearCloudSyncState)
 
             val event = SteamEvent.LoggedOut(username)
             PluviaApp.events.emit(event)
@@ -2987,7 +2989,11 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         notificationHelper.notify("Disconnected...")
 
-        if (isLoggingOut || callback.result == EResult.LogonSessionReplaced) {
+        if (isLoggingOut) {
+            performLogOffDuties(clearCloudSyncState = true)
+
+            scope.launch { stop() }
+        } else if (callback.result == EResult.LogonSessionReplaced) {
             performLogOffDuties()
 
             scope.launch { stop() }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves Steam Cloud sync state when authentication is lost and only clears it on explicit logout or when a different account signs in. This avoids unnecessary cloud resyncs for the same user.

- **Bug Fixes**
  - Added `clearCloudSyncState` flag to `performLogOffDuties`, `clearUserData`, and `clearDatabase` to conditionally delete cloud tables (`changeNumbersDao`, `fileChangeListsDao`).
  - On manual logout, always pass `clearCloudSyncState = true`; on `LogonSessionReplaced`, preserve cloud state.
  - Reconciles a preserved account marker in `SharedPreferences` on login to keep state for the same user and clear it on account switch.

<sup>Written for commit 9a7ad795aaf925a62efbde98ac112d45cec25d59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined logout behavior to explicitly clear cloud synchronization data, ensuring improved data consistency during user session termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->