### PR TITLE
fix: preserve steam state on unexpected session replacement

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2987,9 +2987,21 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         notificationHelper.notify("Disconnected...")
 
-        if (isLoggingOut || callback.result == EResult.LogonSessionReplaced) {
+        if (isLoggingOut) {
             performLogOffDuties()
 
+            scope.launch { stop() }
+        } else if (callback.result == EResult.LogonSessionReplaced) {
+            // Treat unexpected session replacement as a disconnect, not a full logout.
+            // Preserving cached credentials, library data, and cloud sync metadata lets us
+            // reconnect later without wiping the user's Steam library or save sync baseline.
+            Timber.w(
+                "Steam session was replaced unexpectedly; preserving cached credentials, library, and cloud sync metadata",
+            )
+
+            // Make sure the UI leaves the connected state even if the transport already
+            // dropped before stop() can trigger the normal onDisconnected callback.
+            PluviaApp.events.emit(SteamEvent.Disconnected)
             scope.launch { stop() }
         } else if (callback.result == EResult.LoggedInElsewhere) {
             // received when a client runs an app and wants to forcibly close another


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents save and library loss when a Steam session is unexpectedly replaced. We now treat session replacement as a disconnect, preserve cached credentials/library/cloud-sync metadata, and ensure the UI leaves the connected state.

- **Bug Fixes**
  - Do not run logout cleanup on session replacement; preserve cached credentials, library data, and cloud sync metadata.
  - Emit a Disconnected event so the UI updates even if the transport already dropped.
  - Keep explicit logout behavior unchanged (runs cleanup and stops).

<sup>Written for commit 83f310d51e3f236abdadc06cb81eee9b6518f10b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session disconnection handling to properly distinguish between explicit logouts and forced session disconnections, ensuring the UI consistently reflects the connection state while preserving user data, cached content, and synchronization information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->