### PR TITLE
fix: preserve steam state on unexpected session replacement

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2987,9 +2987,16 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         notificationHelper.notify("Disconnected...")
 
-        if (isLoggingOut || callback.result == EResult.LogonSessionReplaced) {
+        if (isLoggingOut) {
             performLogOffDuties()
 
+            scope.launch { stop() }
+        } else if (callback.result == EResult.LogonSessionReplaced) {
+            Timber.w(
+                "Steam session was replaced unexpectedly; preserving cached credentials, library, and cloud sync metadata",
+            )
+
+            PluviaApp.events.emit(SteamEvent.Disconnected)
             scope.launch { stop() }
         } else if (callback.result == EResult.LoggedInElsewhere) {
             // received when a client runs an app and wants to forcibly close another


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves cached Steam state on unexpected session replacement to avoid save loss and unnecessary sign-outs. On `EResult.LogonSessionReplaced`, we now emit a disconnect event and stop the service without running logoff cleanup.

- **Bug Fixes**
  - Split handling for `isLoggingOut` vs `LogonSessionReplaced`; only run `performLogOffDuties` on real logout.
  - On session replacement, keep cached credentials/library/cloud sync metadata, emit `SteamEvent.Disconnected`, and stop the service gracefully.

<sup>Written for commit 2bebae485a6ed9882ce9c18e66c689817dfd2a14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Steam session handling when your session is replaced (e.g., logged in elsewhere). The app now properly detects and cleanly handles these disconnection scenarios, ensuring the service stops appropriately without attempting unnecessary operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->