### PR TITLE
Rabbit fixes

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1945,7 +1945,7 @@ private fun setupXEnvironment(
         )
     }
 
-    var preInstallCommands: List<String> = emptyList()
+    var preInstallCommands: List<PreInstallSteps.PreInstallCommand> = emptyList()
     var gameExecutable = ""
 
     if (container != null) {
@@ -1972,10 +1972,14 @@ private fun setupXEnvironment(
             getWineStartCommand(context, appId, container, bootToContainer, testGraphics, appLaunchInfo, envVars, guestProgramLauncherComponent, gameSource) +
             (if (container.execArgs.isNotEmpty()) " " + container.execArgs else "")
         preInstallCommands = PreInstallSteps.getPreInstallCommands(
-            container, appId, gameSource, xServer.screenInfo.toString(), containerVariantChanged,
+            container,
+            appId,
+            gameSource,
+            xServer.screenInfo.toString(),
+            containerVariantChanged,
         )
         guestProgramLauncherComponent.guestExecutable =
-            preInstallCommands.firstOrNull() ?: gameExecutable
+            preInstallCommands.firstOrNull()?.executable ?: gameExecutable
         guestProgramLauncherComponent.isWoW64Mode = wow64Mode
         // Set steam type for selecting appropriate box64rc
         guestProgramLauncherComponent.setSteamType(container.getSteamType())
@@ -2089,20 +2093,20 @@ private fun setupXEnvironment(
         if (status != 0) {
             Timber.e("Guest program terminated with status: $status")
             onGameLaunchError?.invoke("Game terminated with error status: $status")
-            navigateBack()
         }
         PluviaApp.events.emit(AndroidEvent.GuestProgramTerminated)
     }
 
-    fun chainPreInstallSteps(remaining: List<String>) {
+    fun chainPreInstallSteps(remaining: List<PreInstallSteps.PreInstallCommand>) {
         if (remaining.isEmpty()) {
             guestProgramLauncherComponent.setGuestExecutable(gameExecutable)
             guestProgramLauncherComponent.setTerminationCallback(gameTerminationCallback)
             return
         }
-        guestProgramLauncherComponent.setGuestExecutable(remaining.first())
+        guestProgramLauncherComponent.setGuestExecutable(remaining.first().executable)
         guestProgramLauncherComponent.setTerminationCallback { _ ->
-            PreInstallSteps.markAllDone(container)
+            val current = remaining.first()
+            PreInstallSteps.markStepDone(container, current.marker)
             guestProgramLauncherComponent.setPreUnpack(null)
             try {
                 guestProgramLauncherComponent.execShellCommand("wineserver -k")

--- a/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
@@ -11,13 +11,19 @@ import java.io.File
  * as Wine guest programs before the game launches. These installers require wine explorer
  * and cannot be run via execShellCommand.
  *
- * Each returned command is a complete guest executable string for one Wine session.
- * The caller chains them via termination callbacks, launching the game after the last one.
+ * Each returned entry contains the marker and complete guest executable string for one
+ * Wine session. The caller chains them via termination callbacks and persists markers
+ * per-step as they complete.
  *
  * Completion is tracked via marker files in the game directory (not container config),
  * so importing a container config won't incorrectly skip pre-install steps.
  */
 object PreInstallSteps {
+    data class PreInstallCommand(
+        val marker: Marker,
+        val executable: String,
+    )
+
     private val steps: List<PreInstallStep> = listOf(
         VcRedistStep,
         GogScriptInterpreterStep,
@@ -26,7 +32,7 @@ object PreInstallSteps {
     private val allMarkers = steps.map { it.marker }.distinct()
 
     /**
-     * Returns a list of guest executable commands for pre-install steps. Each entry is a
+     * Returns a list of pre-install commands (marker + guest executable). Each entry is a
      * separate Wine session. Returns empty list if nothing needs installing.
      */
     fun getPreInstallCommands(
@@ -35,13 +41,13 @@ object PreInstallSteps {
         gameSource: GameSource,
         screenInfo: String,
         containerVariantChanged: Boolean,
-    ): List<String> {
+    ): List<PreInstallCommand> {
         val gameDir = getGameDir(container) ?: return emptyList()
         val gameDirPath = gameDir.absolutePath
 
         if (containerVariantChanged) resetMarkers(gameDirPath)
 
-        val commands = mutableListOf<String>()
+        val commands = mutableListOf<PreInstallCommand>()
 
         for (step in steps) {
             if (step.appliesTo(
@@ -57,7 +63,12 @@ object PreInstallSteps {
                     gameDir = gameDir,
                     gameDirPath = gameDirPath,
                 )?.let { cmd ->
-                    commands.add(wrapAsGuestExecutable(cmd, screenInfo))
+                    commands.add(
+                        PreInstallCommand(
+                            marker = step.marker,
+                            executable = wrapAsGuestExecutable(cmd, screenInfo),
+                        ),
+                    )
                 }
             }
         }
@@ -73,6 +84,12 @@ object PreInstallSteps {
         }
     }
 
+    fun markStepDone(container: Container, marker: Marker) {
+        val gameDir = getGameDir(container) ?: return
+        val gameDirPath = gameDir.absolutePath
+        MarkerUtils.addMarker(gameDirPath, marker)
+    }
+
     private fun resetMarkers(gameDirPath: String) {
         for (marker in allMarkers) {
             MarkerUtils.removeMarker(gameDirPath, marker)
@@ -80,7 +97,7 @@ object PreInstallSteps {
     }
 
     private fun wrapAsGuestExecutable(cmdChain: String, screenInfo: String): String {
-        val wrapped = "winhandler.exe cmd /c \"$cmdChain & taskkill /F /IM explorer.exe\""
+        val wrapped = "winhandler.exe cmd /c \"$cmdChain & taskkill /F /IM explorer.exe & wineserver -k\""
         return "wine explorer /desktop=shell,$screenInfo $wrapped"
     }
 


### PR DESCRIPTION
- mark done per step instead of all after first step
- removed navigateback
- reinstated wineserver -k

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the pre-install flow by tracking completion per step and cleaning up Wine after each step. Also stops navigating back on guest program errors to keep users on the same screen.

- **Bug Fixes**
  - Track and persist completion per step via new `PreInstallCommand(marker, executable)` to avoid skipping remaining steps.
  - Clean up Wine after each step by running `wineserver -k` (in the wrapped command and on termination) to prevent hanging sessions.
  - On guest program error, do not navigate back; stay on the XServer screen while still logging and emitting the termination event.

<sup>Written for commit 5a78ed3f862557e133033d2dcc9facdc96384919. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

