### PR TITLE
Added XNAFrameworks step

### DIFF
--- a/app/src/main/java/app/gamenative/enums/Marker.kt
+++ b/app/src/main/java/app/gamenative/enums/Marker.kt
@@ -10,4 +10,5 @@ enum class Marker(val fileName: String ) {
     GOG_SCRIPT_INSTALLED(".gog_script_installed"),
     PHYSX_INSTALLED(".physx_installed"),
     OPENAL_INSTALLED(".openal_installed"),
+    XNA_INSTALLED(".xna_installed"),
 }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2809,29 +2809,6 @@ private fun getRedistDirectory(
     }
 
     return RedistContext(commonRedistDir, driveLetter, guestProgramLauncherComponent)
-        }
-
-private fun installXNAFramework(context: RedistContext) {
-    val xnaDir = File(context.commonRedistDir, "xnafx")
-    if (xnaDir.exists() && xnaDir.isDirectory()) {
-        xnaDir.walkTopDown()
-            .filter { it.isFile && it.name.startsWith("xna", ignoreCase = true) &&
-                        it.name.endsWith(".msi", ignoreCase = true) }
-            .forEach { msiFile ->
-                try {
-                    val relativePath = msiFile.relativeTo(context.commonRedistDir).path.replace('/', '\\')
-                    val drive = context.driveLetter
-                    val winePath = "$drive:\\_CommonRedist\\$relativePath"
-                    PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Installing XNA Framework..."))
-                    Timber.i("Installing XNA: $winePath")
-                    val cmd = "wine msiexec /i $winePath /quiet /norestart && wineserver -k"
-                    val output = context.guestProgramLauncherComponent.execShellCommand(cmd)
-                    Timber.i("XNA installation output: $output")
-                } catch (e: Exception) {
-                    Timber.e(e, "Failed to install XNA ${msiFile.name}")
-                }
-            }
-    }
 }
 
 /**
@@ -2867,8 +2844,6 @@ private fun installRedistributables(
             Timber.tag("installRedist").i("Could not set up redistributable context, skipping installation")
             return
         }
-
-        installXNAFramework(redistContext)
 
         Timber.tag("installRedist").i("Finished checking for redistributables")
     } catch (e: Exception) {

--- a/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
@@ -28,6 +28,7 @@ object PreInstallSteps {
         VcRedistStep,
         PhysXStep,
         OpenALStep,
+        XnaFrameworkStep,
         GogScriptInterpreterStep,
     )
 

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/XnaFrameworkStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/XnaFrameworkStep.kt
@@ -1,0 +1,64 @@
+package app.gamenative.utils
+
+import app.gamenative.data.GameSource
+import app.gamenative.enums.Marker
+import com.winlator.container.Container
+import java.io.File
+import timber.log.Timber
+
+object XnaFrameworkStep : PreInstallStep {
+    override val marker: Marker = Marker.XNA_INSTALLED
+
+    override fun appliesTo(
+        container: Container,
+        gameSource: GameSource,
+        gameDirPath: String,
+    ): Boolean {
+        return !MarkerUtils.hasMarker(gameDirPath, Marker.XNA_INSTALLED)
+    }
+
+    override fun buildCommand(
+        container: Container,
+        appId: String,
+        gameSource: GameSource,
+        gameDir: File,
+        gameDirPath: String,
+    ): String? {
+        val searchDirs = listOf(
+            File(gameDirPath, "_CommonRedist/xnafx"),
+            File(gameDirPath, "redist"),
+            File(gameDirPath, "Redist"),
+        ).filter { it.exists() && it.isDirectory }
+
+        if (searchDirs.isEmpty()) {
+            Timber.tag("XnaFrameworkStep").i("No XNA Framework search directories found for game at $gameDirPath")
+            return null
+        }
+
+        val parts = mutableListOf<String>()
+
+        for (dir in searchDirs) {
+            Timber.tag("XnaFrameworkStep").i("Searching for XNA installers under ${dir.absolutePath}")
+            dir.walkTopDown()
+                .filter { file ->
+                    file.isFile &&
+                        file.name.startsWith("xna", ignoreCase = true) &&
+                        file.name.endsWith(".msi", ignoreCase = true)
+                }
+                .forEach { msiFile ->
+                    val relativePath = msiFile
+                        .relativeTo(gameDir)
+                        .path
+                        .replace('/', '\\')
+                    val winePath = "A:\\$relativePath"
+                    Timber.tag("XnaFrameworkStep").i("Queued XNA installer: $winePath")
+
+                    val command = "msiexec /i $winePath /quiet /norestart"
+                    parts.add(command)
+                }
+        }
+
+        return if (parts.isEmpty()) null else parts.joinToString(" & ")
+    }
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a dedicated pre-install step to detect and install Microsoft XNA Framework redistributables from game folders. Removes the inline XNA installer from the X server screen and adds a marker to prevent repeat installs.

- New Features
  - Added XnaFrameworkStep that scans _CommonRedist/xnafx, redist, and Redist for xna*.msi and builds quiet msiexec commands (Wine path A:\...).
  - Introduced XNA_INSTALLED marker to skip when already installed.
  - Removed the legacy installXNAFramework() and its call from XServerScreen; installation now runs via PreInstallSteps.

<sup>Written for commit b2e1332ce2ede6f476b7ab2eeb4ef137447f302c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized XNA Framework installation handling to operate within the pre-installation steps system for improved installation management and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->