### PR TITLE
fix: reject config with missing components, show dialog with apply-anyway option

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.core.net.toUri
 import app.gamenative.PluviaApp
 import app.gamenative.R
@@ -170,6 +171,26 @@ abstract class BaseAppScreen {
 
         fun shouldImportConfig(appId: String): Boolean {
             return importConfigRequests[appId] == true
+        }
+
+        // missing components that prevent config from being applied
+        data class MissingComponentsState(
+            val components: List<String>,
+            val onApplyAnyway: (() -> Unit)? = null,
+        )
+
+        private val missingComponentsDialogStates = mutableStateMapOf<String, MissingComponentsState>()
+
+        fun showMissingComponentsDialog(appId: String, components: List<String>, onApplyAnyway: (() -> Unit)? = null) {
+            missingComponentsDialogStates[appId] = MissingComponentsState(components, onApplyAnyway)
+        }
+
+        fun hideMissingComponentsDialog(appId: String) {
+            missingComponentsDialogStates.remove(appId)
+        }
+
+        fun getMissingComponentsState(appId: String): MissingComponentsState? {
+            return missingComponentsDialogStates[appId]
         }
 
         fun showKnownConfigInstallState(gameId: Int, state: KnownConfigInstallState) {
@@ -640,17 +661,44 @@ abstract class BaseAppScreen {
             )
             if (!installsOk) return
 
+            val appId = libraryItem.appId
+            val configJson = bestConfig.bestConfig
+            val matchType = bestConfig.matchType
+
             val parsedConfig = BestConfigService.parseConfigToContainerData(
                 context = context,
-                configJson = bestConfig.bestConfig,
-                matchType = bestConfig.matchType,
+                configJson = configJson,
+                matchType = matchType,
                 applyKnownConfig = true,
                 storeMatch = bestConfig.matchedStore.equals(libraryItem.gameSource.name, ignoreCase = true),
             )
-            val missingContentDescription = BestConfigService.consumeLastMissingContentDescription()
+            val missingComponents = BestConfigService.consumeLastMissingComponents()
 
-            if (parsedConfig != null && parsedConfig.isNotEmpty()) {
-                val container = ContainerUtils.getOrCreateContainer(context, libraryItem.appId)
+            if (missingComponents.isNotEmpty()) {
+                showMissingComponentsDialog(appId, missingComponents) {
+                    // "apply anyway" — re-parse with defaults replacing missing components
+                    uiScope.launch(Dispatchers.IO) {
+                        try {
+                            val forced = BestConfigService.parseConfigToContainerData(
+                                context, configJson, matchType, true, forceApply = true,
+                            )
+                            if (forced != null && forced.isNotEmpty()) {
+                                val c = ContainerUtils.getOrCreateContainer(context, appId)
+                                val cd = ContainerUtils.toContainerData(c)
+                                val updated = ContainerUtils.applyBestConfigMapToContainerData(cd, forced)
+                                ContainerUtils.applyToContainer(context, c, updated)
+                                SnackbarManager.show(context.getString(R.string.best_config_applied_with_defaults))
+                            } else {
+                                SnackbarManager.show(context.getString(R.string.best_config_known_config_invalid))
+                            }
+                        } catch (e: Exception) {
+                            Timber.w(e, "Failed to force-apply config: ${e.message}")
+                            SnackbarManager.show(context.getString(R.string.best_config_apply_failed, e.message ?: "Unknown error"))
+                        }
+                    }
+                }
+            } else if (parsedConfig != null && parsedConfig.isNotEmpty()) {
+                val container = ContainerUtils.getOrCreateContainer(context, appId)
                 val currentData = ContainerUtils.toContainerData(container)
                 val updatedData = ContainerUtils.applyBestConfigMapToContainerData(
                     currentData,
@@ -659,12 +707,7 @@ abstract class BaseAppScreen {
                 ContainerUtils.applyToContainer(context, container, updatedData)
                 SnackbarManager.show(context.getString(R.string.best_config_applied_successfully))
             } else {
-                val message = if (missingContentDescription != null) {
-                    context.getString(R.string.best_config_missing_content, missingContentDescription)
-                } else {
-                    context.getString(R.string.best_config_known_config_invalid)
-                }
-                SnackbarManager.show(message)
+                SnackbarManager.show(context.getString(R.string.best_config_known_config_invalid))
             }
         } catch (e: CancellationException) {
             throw e
@@ -1058,6 +1101,44 @@ abstract class BaseAppScreen {
                 context.getString(R.string.working)
             },
         )
+
+        // missing components dialog — shown when config can't be applied
+        val missingState = getMissingComponentsState(appId)
+        if (missingState != null) {
+            AlertDialog(
+                onDismissRequest = {
+                    hideMissingComponentsDialog(appId)
+                },
+                title = { Text(stringResource(R.string.best_config_missing_components_title)) },
+                text = {
+                    Text(
+                        text = stringResource(
+                            R.string.best_config_missing_components_message,
+                            missingState.components.joinToString("\n"),
+                        ),
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = {
+                        hideMissingComponentsDialog(appId)
+                    }) {
+                        Text(stringResource(R.string.ok))
+                    }
+                },
+                dismissButton = if (missingState.onApplyAnyway != null) {
+                    {
+                        TextButton(onClick = {
+                            hideMissingComponentsDialog(appId)
+                            missingState.onApplyAnyway.invoke()
+                        }) {
+                            Text(stringResource(R.string.best_config_apply_anyway))
+                        }
+                    }
+                } else {
+                    null
+                },
+            )
+        }
 
         // Render any additional dialogs
         AdditionalDialogs(libraryItem, onDismiss = {}, onEditContainer = onEditContainer, onBack = onBack)

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -680,7 +680,9 @@ abstract class BaseAppScreen {
                     uiScope.launch(Dispatchers.IO) {
                         try {
                             val forced = BestConfigService.parseConfigToContainerData(
-                                context, configJson, matchType, true, forceApply = true,
+                                context, configJson, matchType, true,
+                                storeMatch = bestConfig.matchedStore.equals(libraryItem.gameSource.name, ignoreCase = true),
+                                forceApply = true,
                             )
                             if (forced != null && forced.isNotEmpty()) {
                                 val c = ContainerUtils.getOrCreateContainer(context, appId)

--- a/app/src/main/java/app/gamenative/ui/util/ContainerConfigTransfer.kt
+++ b/app/src/main/java/app/gamenative/ui/util/ContainerConfigTransfer.kt
@@ -3,6 +3,7 @@ package app.gamenative.ui.util
 import android.content.Context
 import android.net.Uri
 import app.gamenative.R
+import app.gamenative.ui.screen.library.appscreen.BaseAppScreen
 import app.gamenative.ui.util.SnackbarManager
 import app.gamenative.utils.BestConfigService
 import app.gamenative.utils.ContainerUtils
@@ -10,7 +11,9 @@ import app.gamenative.utils.ManifestInstaller
 import java.io.IOException
 import kotlin.text.Charsets
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -97,10 +100,55 @@ object ContainerConfigTransfer {
                 applyKnownConfig = true,
             ) ?: emptyMap()
 
+            val missingComponents = BestConfigService.consumeLastMissingComponents()
             if (bestConfigMap.isEmpty()) {
-                SnackbarManager.show(
-                    context.getString(R.string.best_config_known_config_invalid),
-                )
+                if (missingComponents.isNotEmpty()) {
+                    BaseAppScreen.showMissingComponentsDialog(appId, missingComponents) {
+                        // "apply anyway" — re-parse with defaults, install manifest entries, apply
+                        CoroutineScope(Dispatchers.IO).launch {
+                            try {
+                                val forced = BestConfigService.parseConfigToContainerData(
+                                    context, configJson, matchType, true, forceApply = true,
+                                ) ?: emptyMap()
+                                if (forced.isEmpty()) {
+                                    SnackbarManager.show(context.getString(R.string.best_config_known_config_invalid))
+                                    return@launch
+                                }
+
+                                val requests = BestConfigService.resolveMissingManifestInstallRequests(
+                                    context, configJson, matchType,
+                                )
+                                for (request in requests) {
+                                    val result = ManifestInstaller.installManifestEntry(
+                                        context = context,
+                                        entry = request.entry,
+                                        isDriver = request.isDriver,
+                                        contentType = request.contentType,
+                                        onProgress = { _ -> },
+                                    )
+                                    if (!result.success) {
+                                        SnackbarManager.show(result.message)
+                                        return@launch
+                                    }
+                                }
+
+                                val container = ContainerUtils.getOrCreateContainer(context, appId)
+                                val currentData = ContainerUtils.toContainerData(container)
+                                val updatedData = ContainerUtils.applyBestConfigMapToContainerData(currentData, forced)
+                                ContainerUtils.applyToContainer(context, container, updatedData)
+                                SnackbarManager.show(context.getString(R.string.best_config_applied_with_defaults))
+                            } catch (e: Exception) {
+                                SnackbarManager.show(
+                                    context.getString(R.string.best_config_apply_failed, e.message ?: "Unknown error"),
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    SnackbarManager.show(
+                        context.getString(R.string.best_config_known_config_invalid),
+                    )
+                }
                 return false
             }
 

--- a/app/src/main/java/app/gamenative/utils/BestConfigService.kt
+++ b/app/src/main/java/app/gamenative/utils/BestConfigService.kt
@@ -7,6 +7,7 @@ import app.gamenative.R
 import com.winlator.box86_64.Box86_64PresetManager
 import com.winlator.container.Container
 import com.winlator.container.ContainerData
+import com.winlator.core.DefaultVersion
 import com.winlator.contents.ContentProfile
 import com.winlator.fexcore.FEXCorePresetManager
 import com.winlator.core.KeyValueSet
@@ -34,12 +35,12 @@ object BestConfigService {
     // In-memory cache keyed by "${gameName}_${gpuName}"
     private val cache = ConcurrentHashMap<String, BestConfigResponse>()
 
-    // Last missing content description from validation (e.g. "DXVK 1.10.3")
-    private var lastMissingContentDescription: String? = null
+    // unavailable components from last config validation
+    private var lastMissingComponents: List<String> = emptyList()
 
-    fun consumeLastMissingContentDescription(): String? {
-        val result = lastMissingContentDescription
-        lastMissingContentDescription = null
+    fun consumeLastMissingComponents(): List<String> {
+        val result = lastMissingComponents
+        lastMissingComponents = emptyList()
         return result
     }
     /**
@@ -203,10 +204,10 @@ object BestConfigService {
 
     /**
      * Validates component versions in the filtered JSON.
-     * Returns a human-readable description of the first missing component (e.g. "DXVK 1.10.3"),
-     * or null if all referenced versions exist.
+     * Returns list of human-readable descriptions of missing/unavailable components.
      */
-    private suspend fun validateComponentVersions(context: Context, filteredJson: JSONObject): String? {
+    private suspend fun validateComponentVersions(context: Context, filteredJson: JSONObject): List<String> {
+        val missing = mutableListOf<String>()
         // Get resource arrays (same as ContainerConfigDialog)
         val dxvkVersions = context.resources.getStringArray(R.array.dxvk_version_entries).toList()
         val vkd3dVersions = context.resources.getStringArray(R.array.vkd3d_version_entries).toList()
@@ -316,9 +317,8 @@ object BestConfigService {
             val kvs = KeyValueSet(dxwrapperConfig)
             val version = kvs.get("version")
             if (version.isNotEmpty() && !ManifestComponentHelper.versionExists(version, availableDxvk)) {
-                Timber.tag("BestConfigService").w("DXVK version $version not found, updating to PrefManager default")
-                return "DXVK $version"
-                filteredJson.put("dxwrapperConfig", PrefManager.dxWrapperConfig)
+                Timber.tag("BestConfigService").w("DXVK version $version not found")
+                missing.add("DXVK $version")
             }
         }
 
@@ -327,9 +327,8 @@ object BestConfigService {
             val kvs = KeyValueSet(dxwrapperConfig)
             val version = kvs.get("vkd3dVersion")
             if (version.isNotEmpty() && !ManifestComponentHelper.versionExists(version, availableVkd3d)) {
-                Timber.tag("BestConfigService").w("VKD3D version $version not found, updating to PrefManager default")
-                return "VKD3D $version"
-                filteredJson.put("dxwrapperConfig", PrefManager.dxWrapperConfig)
+                Timber.tag("BestConfigService").w("VKD3D version $version not found")
+                missing.add("VKD3D $version")
             }
         }
 
@@ -344,25 +343,23 @@ object BestConfigService {
                 }
             }
             if (!ManifestComponentHelper.versionExists(box64Version, box64VersionsToCheck)) {
-                Timber.tag("BestConfigService").w("Box64 version $box64Version not found in $containerVariant variant entries, updating to PrefManager default")
-                return "Box64 $box64Version"
-                filteredJson.put("box64Version", PrefManager.box64Version)
+                Timber.tag("BestConfigService").w("Box64 version $box64Version not found in $containerVariant variant")
+                missing.add("Box64 $box64Version")
             }
         }
 
         // Validate WoWBox64 version (if wineVersion contains arm64ec)
         if (wineVersion.contains("arm64ec", ignoreCase = true)) {
             if (box64Version.isNotEmpty() && !ManifestComponentHelper.versionExists(box64Version, availableWowBox64) && emulator != "FEXCore") {
-                Timber.tag("BestConfigService").w("WoWBox64 version $box64Version not found, updating to PrefManager default")
-                return "WoWBox64 $box64Version"
+                Timber.tag("BestConfigService").w("WoWBox64 version $box64Version not found")
+                missing.add("WoWBox64 $box64Version")
             }
         }
 
         // Validate FEXCore version
         if (fexcoreVersion.isNotEmpty() && !ManifestComponentHelper.versionExists(fexcoreVersion, availableFexcore)) {
-            Timber.tag("BestConfigService").w("FEXCore version $fexcoreVersion not found, updating to PrefManager default")
-            return "FEXCore $fexcoreVersion"
-            filteredJson.put("fexcoreVersion", PrefManager.fexcoreVersion)
+            Timber.tag("BestConfigService").w("FEXCore version $fexcoreVersion not found")
+            missing.add("FEXCore $fexcoreVersion")
         }
 
         // Validate Wine/Proton version (check separately based on container variant)
@@ -376,9 +373,8 @@ object BestConfigService {
                 }
             }
             if (!ManifestComponentHelper.versionExists(wineVersion, wineVersionsToCheck)) {
-                Timber.tag("BestConfigService").w("Wine version $wineVersion not found in $containerVariant variant entries, updating to PrefManager default")
-                return "Wine $wineVersion"
-                filteredJson.put("wineVersion", PrefManager.wineVersion)
+                Timber.tag("BestConfigService").w("Wine version $wineVersion not found in $containerVariant variant")
+                missing.add("Wine $wineVersion")
             }
         }
 
@@ -393,8 +389,8 @@ object BestConfigService {
             val driverVersion = configMap["version"] ?: ""
             if (driverVersion.isNotEmpty() && !ManifestComponentHelper.versionExists(driverVersion, availableDrivers)) {
                 Timber.tag("BestConfigService")
-                    .w("Graphics driver version $driverVersion not found for $containerVariant variant, updating to PrefManager default")
-                return "Graphics driver $driverVersion"
+                    .w("Graphics driver version $driverVersion not found for $containerVariant variant")
+                missing.add("Graphics driver $driverVersion")
             }
         }
 
@@ -402,9 +398,8 @@ object BestConfigService {
         if (box64Preset.isNotEmpty()) {
             val preset = Box86_64PresetManager.getPreset("box64", context, box64Preset)
             if (preset == null) {
-                Timber.tag("BestConfigService").w("Box64 preset $box64Preset not found, updating to PrefManager default")
-                return "Box64 preset $box64Preset"
-                filteredJson.put("box64Preset", PrefManager.box64Preset)
+                Timber.tag("BestConfigService").w("Box64 preset $box64Preset not found")
+                missing.add("Box64 preset $box64Preset")
             }
         }
 
@@ -413,13 +408,12 @@ object BestConfigService {
         if (fexcorePreset.isNotEmpty()) {
             val preset = FEXCorePresetManager.getPreset(context, fexcorePreset)
             if (preset == null) {
-                Timber.tag("BestConfigService").w("FEXCore preset $fexcorePreset not found, updating to PrefManager default")
-                return "FEXCore preset $fexcorePreset"
-                filteredJson.put("fexcorePreset", PrefManager.fexcorePreset)
+                Timber.tag("BestConfigService").w("FEXCore preset $fexcorePreset not found")
+                missing.add("FEXCore preset $fexcorePreset")
             }
         }
 
-        return null
+        return missing
     }
 
     suspend fun resolveMissingManifestInstallRequests(
@@ -634,9 +628,49 @@ object BestConfigService {
     }
 
     /**
+     * Replace missing component versions in filteredJson with defaults so config can still be applied.
+     */
+    private fun replaceWithDefaults(filteredJson: JSONObject, missing: List<String>) {
+        for (entry in missing) {
+            when {
+                entry.startsWith("DXVK ") -> {
+                    val kvs = KeyValueSet(filteredJson.optString("dxwrapperConfig", ""))
+                    kvs.put("version", DefaultVersion.DXVK)
+                    filteredJson.put("dxwrapperConfig", kvs.toString())
+                }
+                entry.startsWith("VKD3D ") -> {
+                    val kvs = KeyValueSet(filteredJson.optString("dxwrapperConfig", ""))
+                    kvs.put("vkd3dVersion", DefaultVersion.VKD3D)
+                    filteredJson.put("dxwrapperConfig", kvs.toString())
+                }
+                entry.startsWith("Box64 preset ") -> {
+                    filteredJson.put("box64Preset", PrefManager.box64Preset)
+                }
+                entry.startsWith("FEXCore preset ") -> {
+                    filteredJson.put("fexcorePreset", PrefManager.fexcorePreset)
+                }
+                entry.startsWith("Box64 ") || entry.startsWith("WoWBox64 ") -> {
+                    filteredJson.put("box64Version", DefaultVersion.BOX64)
+                }
+                entry.startsWith("FEXCore ") -> {
+                    filteredJson.put("fexcoreVersion", DefaultVersion.FEXCORE)
+                }
+                entry.startsWith("Wine ") -> {
+                    filteredJson.put("wineVersion", DefaultVersion.WINE_VERSION)
+                }
+                entry.startsWith("Graphics driver ") -> {
+                    filteredJson.put("graphicsDriverConfig", PrefManager.graphicsDriverConfig)
+                    filteredJson.put("graphicsDriverVersion", PrefManager.graphicsDriverVersion)
+                }
+            }
+        }
+    }
+
+    /**
      * Parses bestConfig JSON into a map of fields to update.
      * First parses values (using PrefManager defaults for validation), then validates component versions.
      * Returns map with only fields present in config (no defaults), or empty map if validation fails.
+     * When forceApply is true, missing components are replaced with defaults instead of rejecting.
      */
     suspend fun parseConfigToContainerData(
         context: Context,
@@ -644,6 +678,7 @@ object BestConfigService {
         matchType: String,
         applyKnownConfig: Boolean,
         storeMatch: Boolean = true,
+        forceApply: Boolean = false,
     ): Map<String, Any?>? {
         try {
             val originalJson = JSONObject(configJson.toString())
@@ -712,12 +747,15 @@ object BestConfigService {
                 val filteredConfig = filterConfigByMatchType(updatedConfigJson, matchType, storeMatch)
                 val filteredJson = JSONObject(filteredConfig.toString())
 
-                // Step 2: Validate component versions against resource arrays
-                val missingContent = validateComponentVersions(context, filteredJson)
-                if (missingContent != null) {
-                    lastMissingContentDescription = missingContent
-                    Timber.tag("BestConfigService").w("Component version validation failed for: $missingContent, returning empty map")
-                    return mapOf()
+                // Step 2: check for unavailable component versions
+                lastMissingComponents = validateComponentVersions(context, filteredJson)
+                if (lastMissingComponents.isNotEmpty()) {
+                    if (!forceApply) {
+                        Timber.tag("BestConfigService").w("Config rejected: missing components: ${lastMissingComponents.joinToString(", ")}")
+                        return mapOf()
+                    }
+                    Timber.tag("BestConfigService").w("Force-applying config, replacing missing components with defaults: ${lastMissingComponents.joinToString(", ")}")
+                    replaceWithDefaults(filteredJson, lastMissingComponents)
                 }
 
                 // Step 3: Build map with only fields present in filteredJson (not defaults)

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -928,11 +928,14 @@
 
     <!-- Best Config Toast Messages -->
     <string name="best_config_applied_successfully">Konfiguration anvendt med succes</string>
+    <string name="best_config_missing_components_title">Konfiguration ikke anvendt</string>
+    <string name="best_config_missing_components_message">Følgende nødvendige komponenter er ikke tilgængelige på denne enhed:\n\n%1$s\n\nInstaller de manglende komponenter og prøv igen.</string>
     <string name="best_config_known_config_invalid">Kendt konfiguration ugyldig</string>
     <string name="best_config_no_config_available">Ingen bedste konfiguration tilgængelig for dette spil</string>
     <string name="best_config_fetch_failed">Kunne ikke hente konfiguration. Kontrollér din netværksforbindelse.</string>
+    <string name="best_config_apply_anyway">Anvend alligevel</string>
+    <string name="best_config_applied_with_defaults">Konfiguration anvendt, manglende komponenter erstattet med standardværdier</string>
     <string name="best_config_apply_failed">Kunne ikke anvende konfiguration: %s</string>
-    <string name="best_config_missing_content">%s mangler</string>
     <string name="import_config">Importér konfiguration</string>
     <string name="export_config">Eksportér konfiguration</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1043,11 +1043,14 @@
     <string name="best_config_compatibility_unknown">Keine bekannte Konfiguration</string>
     <!-- Best Config Toast Messages -->
     <string name="best_config_applied_successfully">Konfiguration erfolgreich übernommen</string>
+    <string name="best_config_missing_components_title">Konfiguration nicht angewendet</string>
+    <string name="best_config_missing_components_message">Die folgenden erforderlichen Komponenten sind auf diesem Gerät nicht verfügbar:\n\n%1$s\n\nInstallieren Sie die fehlenden Komponenten und versuchen Sie es erneut.</string>
     <string name="best_config_known_config_invalid">Bekannte Konfiguration ungültig</string>
     <string name="best_config_no_config_available">Keine optimale Konfiguration verfügbar</string>
     <string name="best_config_fetch_failed">Konfiguration konnte nicht abgerufen werden. Bitte überprüfen Sie Ihre Netzwerkverbindung.</string>
+    <string name="best_config_apply_anyway">Trotzdem anwenden</string>
+    <string name="best_config_applied_with_defaults">Konfiguration angewendet, fehlende Komponenten durch Standardwerte ersetzt</string>
     <string name="best_config_apply_failed">Konfiguration konnte nicht übernommen werden: %s</string>
-    <string name="best_config_missing_content">%s fehlt</string>
     <string name="import_config">Konfiguration importieren</string>
     <string name="export_config">Konfiguration exportieren</string>
     <string name="library_app_type">App-Typ</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1117,11 +1117,14 @@
 
     <!-- Best Config Toast Messages -->
     <string name="best_config_applied_successfully">La mejor configuración se ha aplicado correctamente.</string>
+    <string name="best_config_missing_components_title">Configuración no aplicada</string>
+    <string name="best_config_missing_components_message">Los siguientes componentes requeridos no están disponibles en este dispositivo:\n\n%1$s\n\nInstale los componentes faltantes e intente nuevamente.</string>
     <string name="best_config_known_config_invalid">La configuración conocida es inválida.</string>
     <string name="best_config_no_config_available">No hay una mejor configuración disponible para este juego.</string>
     <string name="best_config_fetch_failed">Error al obtener la configuración. Compruebe su conexión de red.</string>
+    <string name="best_config_apply_anyway">Aplicar de todos modos</string>
+    <string name="best_config_applied_with_defaults">Configuración aplicada, componentes faltantes reemplazados por valores predeterminados</string>
     <string name="best_config_apply_failed">Error al aplicar la configuración: %s.</string>
-    <string name="best_config_missing_content">Falta %s.</string>
     <string name="import_config">Importar configuración</string>
     <string name="export_config">Exportar configuración</string>
     <string name="library_app_type">Tipo de aplicación</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1101,11 +1101,14 @@
 
     <!-- Best Config Toast Messages -->
     <string name="best_config_applied_successfully">Configuration appliquée avec succès</string>
+    <string name="best_config_missing_components_title">Configuration non appliquée</string>
+    <string name="best_config_missing_components_message">Les composants requis suivants ne sont pas disponibles sur cet appareil :\n\n%1$s\n\nInstallez les composants manquants et réessayez.</string>
     <string name="best_config_known_config_invalid">Configuration connue invalide</string>
     <string name="best_config_no_config_available">Aucune meilleure configuration disponible pour ce jeu</string>
     <string name="best_config_fetch_failed">Échec de la récupération de la configuration. Vérifiez votre connexion réseau.</string>
+    <string name="best_config_apply_anyway">Appliquer quand même</string>
+    <string name="best_config_applied_with_defaults">Configuration appliquée, composants manquants remplacés par les valeurs par défaut</string>
     <string name="best_config_apply_failed">Échec de l\'application de la configuration : %s</string>
-    <string name="best_config_missing_content">%s manquant</string>
     <string name="import_config">Importer la configuration</string>
     <string name="export_config">Exporter la configuration</string>
     <string name="library_app_type">Type d\'app</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1097,11 +1097,14 @@
 
     <!-- Best Config Toast Messages -->
     <string name="best_config_applied_successfully">Config applicata con successo</string>
+    <string name="best_config_missing_components_title">Configurazione non applicata</string>
+    <string name="best_config_missing_components_message">I seguenti componenti necessari non sono disponibili su questo dispositivo:\n\n%1$s\n\nInstalla i componenti mancanti e riprova.</string>
     <string name="best_config_known_config_invalid">Config nota non valida</string>
     <string name="best_config_no_config_available">Nessuna miglior config disponibile per questo gioco</string>
     <string name="best_config_fetch_failed">Impossibile recuperare la configurazione. Controlla la connessione di rete.</string>
+    <string name="best_config_apply_anyway">Applica comunque</string>
+    <string name="best_config_applied_with_defaults">Configurazione applicata, componenti mancanti sostituiti con valori predefiniti</string>
     <string name="best_config_apply_failed">Impossibile applicare config: %s</string>
-    <string name="best_config_missing_content">%s mancante</string>
     <string name="import_config">Importa configurazione</string>
     <string name="export_config">Esporta configurazione</string>
     <string name="library_app_type">Tipo App</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1115,11 +1115,14 @@
 
     <!-- Best Config Toast Messages -->
     <string name="best_config_applied_successfully">설정이 성공적으로 적용되었습니다</string>
+    <string name="best_config_missing_components_title">구성이 적용되지 않음</string>
+    <string name="best_config_missing_components_message">이 장치에서 다음 필수 구성 요소를 사용할 수 없습니다:\n\n%1$s\n\n누락된 구성 요소를 설치하고 다시 시도하세요.</string>
     <string name="best_config_known_config_invalid">알려진 설정이 유효하지 않음</string>
     <string name="best_config_no_config_available">이 게임에 사용 가능한 최적 설정이 없습니다</string>
     <string name="best_config_fetch_failed">설정을 가져오지 못했습니다. 네트워크 연결을 확인하세요.</string>
+    <string name="best_config_apply_anyway">그래도 적용</string>
+    <string name="best_config_applied_with_defaults">구성이 적용되었습니다. 누락된 구성 요소가 기본값으로 대체되었습니다</string>
     <string name="best_config_apply_failed">설정 적용 실패: %s</string>
-    <string name="best_config_missing_content">%s 누락됨</string>
     <string name="import_config">설정 가져오기</string>
     <string name="export_config">설정 내보내기</string>
     <string name="library_app_type">앱 유형</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1114,11 +1114,14 @@
 
     <!-- Best Config Toast Messages -->
     <string name="best_config_applied_successfully">Konfiguracja zastosowana pomyślnie</string>
+    <string name="best_config_missing_components_title">Konfiguracja nie została zastosowana</string>
+    <string name="best_config_missing_components_message">Następujące wymagane komponenty nie są dostępne na tym urządzeniu:\n\n%1$s\n\nZainstaluj brakujące komponenty i spróbuj ponownie.</string>
     <string name="best_config_known_config_invalid">Znana konfiguracja jest nieprawidłowa</string>
     <string name="best_config_no_config_available">Brak najlepszej konfiguracji dla tej gry</string>
     <string name="best_config_fetch_failed">Nie udało się pobrać konfiguracji. Sprawdź połączenie sieciowe.</string>
+    <string name="best_config_apply_anyway">Zastosuj mimo to</string>
+    <string name="best_config_applied_with_defaults">Konfiguracja zastosowana, brakujące komponenty zastąpione wartościami domyślnymi</string>
     <string name="best_config_apply_failed">Nie udało się zastosować konfiguracji: %s</string>
-    <string name="best_config_missing_content">Brak %s</string>
     <string name="import_config">Importuj konfigurację</string>
     <string name="export_config">Eksportuj konfigurację</string>
     <string name="library_app_type">Typ aplikacji</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -928,11 +928,14 @@
 
     <!-- Best Config Toast Messages -->
     <string name="best_config_applied_successfully">Config aplicada com sucesso</string>
+    <string name="best_config_missing_components_title">Configuração não aplicada</string>
+    <string name="best_config_missing_components_message">Os seguintes componentes necessários não estão disponíveis neste dispositivo:\n\n%1$s\n\nInstale os componentes ausentes e tente novamente.</string>
     <string name="best_config_known_config_invalid">Config conhecida inválida</string>
     <string name="best_config_no_config_available">Nenhuma melhor config disponível para este jogo</string>
     <string name="best_config_fetch_failed">Falha ao obter a configuração. Verifique sua conexão de rede.</string>
+    <string name="best_config_apply_anyway">Aplicar mesmo assim</string>
+    <string name="best_config_applied_with_defaults">Configuração aplicada, componentes ausentes substituídos por padrões</string>
     <string name="best_config_apply_failed">Falha ao aplicar config: %s</string>
-    <string name="best_config_missing_content">%s ausente</string>
     <string name="import_config">Importar configuração</string>
     <string name="export_config">Exportar configuração</string>
 

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1105,11 +1105,14 @@
 
 	<!-- Best Config Toast Messages -->
 	<string name="best_config_applied_successfully">Configurația a fost aplicată cu succes</string>
+	<string name="best_config_missing_components_title">Configurația nu a fost aplicată</string>
+	<string name="best_config_missing_components_message">Următoarele componente necesare nu sunt disponibile pe acest dispozitiv:\n\n%1$s\n\nInstalați componentele lipsă și încercați din nou.</string>
 	<string name="best_config_known_config_invalid">Config cunoscut invalid</string>
 	<string name="best_config_no_config_available">Nu există o configurație optimă pentru acest joc</string>
 	<string name="best_config_fetch_failed">Nu s-a putut obține configurația. Verificați conexiunea la rețea.</string>
+	<string name="best_config_apply_anyway">Aplică oricum</string>
+	<string name="best_config_applied_with_defaults">Configurație aplicată, componentele lipsă înlocuite cu valori implicite</string>
 	<string name="best_config_apply_failed">Aplicarea configurației a eșuat: %s</string>
-	<string name="best_config_missing_content">%s lipsește</string>
 	<string name="import_config">Importă configurarea</string>
 	<string name="export_config">Exportă configurarea</string>
 	<string name="library_app_type">Tip aplicație</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -104,11 +104,14 @@
     <string name="bcn_emulation">Эмуляция BCn</string>
     <string name="bcn_emulation_type">Тип эмуляции BCn</string>
     <string name="best_config_applied_successfully">Конфигурация успешно применена</string>
+    <string name="best_config_applied_with_defaults">Конфигурация применена, отсутствующие компоненты заменены значениями по умолчанию</string>
+    <string name="best_config_apply_anyway">Применить всё равно</string>
     <string name="best_config_apply_failed">Ошибка применения конфигурации: %s</string>
     <string name="best_config_exact_gpu_match">Известная конфигурация работает на вашем GPU</string>
     <string name="best_config_fallback_match">Известная конфигурация может работать на вашем GPU</string>
     <string name="best_config_known_config_invalid">Известная конфигурация невалидна</string>
-    <string name="best_config_missing_content">%s отсутствует</string>
+    <string name="best_config_missing_components_message">Следующие необходимые компоненты недоступны на этом устройстве:\n\n%1$s\n\nУстановите недостающие компоненты и повторите попытку.</string>
+    <string name="best_config_missing_components_title">Конфигурация не применена</string>
     <string name="best_config_no_config_available">Нет доступной лучшей конфигурации для этой игры</string>
     <string name="best_config_fetch_failed">Не удалось получить конфигурацию. Проверьте сетевое подключение.</string>
     <string name="bind_button">Привязать: %1$s</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1100,11 +1100,14 @@
 
     <!-- Best Config Toast Messages -->
     <string name="best_config_applied_successfully">Конфігурацію успішно застосовано</string>
+    <string name="best_config_missing_components_title">Конфігурацію не застосовано</string>
+    <string name="best_config_missing_components_message">Наступні необхідні компоненти недоступні на цьому пристрої:\n\n%1$s\n\nВстановіть відсутні компоненти та спробуйте знову.</string>
     <string name="best_config_known_config_invalid">Відома конфігурація недійсна</string>
     <string name="best_config_no_config_available">Немає доступної найкращої конфігурації для цієї гри</string>
     <string name="best_config_fetch_failed">Не вдалося отримати конфігурацію. Перевірте підключення до мережі.</string>
+    <string name="best_config_apply_anyway">Застосувати все одно</string>
+    <string name="best_config_applied_with_defaults">Конфігурацію застосовано, відсутні компоненти замінено значеннями за замовчуванням</string>
     <string name="best_config_apply_failed">Не вдалося застосувати конфігурацію: %s</string>
-    <string name="best_config_missing_content">%s відсутній</string>
     <string name="import_config">Імпортувати конфігурацію</string>
     <string name="export_config">Експортувати конфігурацію</string>
     <string name="library_app_type">Тип застосунку</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1092,11 +1092,14 @@
 
     <!-- 最佳配置提示消息 -->
     <string name="best_config_applied_successfully">配置已成功应用</string>
+    <string name="best_config_missing_components_title">配置未应用</string>
+    <string name="best_config_missing_components_message">此设备上以下必需组件不可用：\n\n%1$s\n\n请安装缺失的组件后重试。</string>
     <string name="best_config_known_config_invalid">已知配置无效</string>
     <string name="best_config_no_config_available">此游戏没有可用的最佳配置</string>
     <string name="best_config_fetch_failed">获取配置失败，请检查网络连接。</string>
+    <string name="best_config_apply_anyway">仍然应用</string>
+    <string name="best_config_applied_with_defaults">配置已应用，缺失组件已替换为默认值</string>
     <string name="best_config_apply_failed">应用配置失败：%s</string>
-    <string name="best_config_missing_content">%s 缺失</string>
     <string name="import_config">导入配置</string>
     <string name="export_config">导出配置</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1095,11 +1095,14 @@
 
     <!-- Best Config Toast Messages -->
     <string name="best_config_applied_successfully">配置已成功套用</string>
+    <string name="best_config_missing_components_title">設定未套用</string>
+    <string name="best_config_missing_components_message">此裝置上以下必要元件無法使用：\n\n%1$s\n\n請安裝缺少的元件後重試。</string>
     <string name="best_config_known_config_invalid">已知配置無效</string>
     <string name="best_config_no_config_available">此遊戲沒有可用的最佳配置</string>
     <string name="best_config_fetch_failed">無法取得配置，請檢查網路連線。</string>
+    <string name="best_config_apply_anyway">仍然套用</string>
+    <string name="best_config_applied_with_defaults">設定已套用，缺少的元件已替換為預設值</string>
     <string name="best_config_apply_failed">套用配置失敗: %s</string>
-    <string name="best_config_missing_content">%s 缺少</string>
     <string name="import_config">匯入設定</string>
     <string name="export_config">匯出設定</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1154,7 +1154,10 @@
     <string name="best_config_no_config_available">No best config available for this game</string>
     <string name="best_config_fetch_failed">Failed to fetch config. Please check your network connection.</string>
     <string name="best_config_apply_failed">Failed to apply config: %s</string>
-    <string name="best_config_missing_content">%s missing</string>
+    <string name="best_config_missing_components_title">Config not applied</string>
+    <string name="best_config_missing_components_message">The following required components are not available:\n\n%1$s</string>
+    <string name="best_config_apply_anyway">Apply anyway</string>
+    <string name="best_config_applied_with_defaults">Config applied with missing components replaced by defaults</string>
     <string name="import_config">Import config</string>
     <string name="export_config">Export config</string>
     <string name="library_app_type">App Type</string>


### PR DESCRIPTION
## Description
validate ALL component versions before deciding, instead of failing on the first. when components are missing, show an AlertDialog listing everything rather than silently applying defaults. "Apply anyway" button replaces missing versions with defaults and applies. removed dead fallback-to-defaults code (old `filteredJson.put()` calls were unreachable).

closes #800.

## Recording
<img width="1920" height="1080" alt="Screenshot_20260404-140237" src="https://github.com/user-attachments/assets/b2672427-98cf-4b0a-8d73-7a922f328357" />

## Test plan
- [ ] Import/apply a config referencing unavailable DXVK/Wine/Box64 versions — dialog should list all missing
- [ ] Dismiss the dialog and verify no config changes were made
- [ ] Click "Apply anyway" — config applied with defaults, confirmation snackbar shown
- [ ] Import/apply a valid config — should apply normally with success snackbar
- [ ] Unit tests pass (`BestConfigServiceTest`)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.