### PR TITLE
Fix dpad ordinality on dpad that allows opposing directions to be pressed simultaneously

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
@@ -244,28 +244,24 @@ class PhysicalControllerHandler(
                         }
                         Binding.GAMEPAD_DPAD_UP  -> {
                             state.dpad[0] = isActionDown
-
                             if(isActionDown) {
                                 state.dpad[Binding.GAMEPAD_DPAD_DOWN.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal ] = false
                             }
                         }
                         Binding.GAMEPAD_DPAD_DOWN -> {
                             state.dpad[binding.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal] = isActionDown
-
                             if(isActionDown) {
                                 state.dpad[0] = false
                             }
                         }
                        Binding.GAMEPAD_DPAD_LEFT -> {
                             state.dpad[binding.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal] = isActionDown
-
-                          if(isActionDown) {
+                            if(isActionDown) {
                               state.dpad[Binding.GAMEPAD_DPAD_RIGHT.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal ] = false
                           }
                         }
                         Binding.GAMEPAD_DPAD_RIGHT -> {
                             state.dpad[binding.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal] = isActionDown
-
                             if(isActionDown) {
                                 state.dpad[Binding.GAMEPAD_DPAD_LEFT.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal ] = false
                             }


### PR DESCRIPTION
issue: https://github.com/utkarshdalal/GameNative/issues/804

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes D-pad lock-ups by enforcing ordinality: pressing Up/Down or Left/Right now clears the opposite direction. This handles controllers that can report opposing D-pad presses at the same time.

- **Bug Fixes**
  - Updated `PhysicalControllerHandler` so each D-pad press releases its opposite (Up vs Down, Left vs Right).
  - Prevents stuck inputs on “mushy” D-pads and matches expected single-direction behavior.

<sup>Written for commit 03e3adcb0840d97bdb94620cc40e44e62f904da2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refined physical controller input handling logic to enhance directional input precision and responsiveness for gamepad users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->