### PR TITLE
fix: update action shows Resume instead of download progress

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -469,9 +469,8 @@ class SteamAppScreen : BaseAppScreen() {
     }
 
     override fun isDownloading(context: Context, libraryItem: LibraryItem): Boolean {
-        val gameId = libraryItem.gameId
-        return SteamService.getAppDownloadInfo(gameId) != null
-            && !SteamService.isAppInstalled(gameId)
+        // download job is removed on completion, so non-null means actively downloading
+        return SteamService.getAppDownloadInfo(libraryItem.gameId) != null
     }
 
     override fun getDownloadProgress(context: Context, libraryItem: LibraryItem): Float {
@@ -622,9 +621,7 @@ class SteamAppScreen : BaseAppScreen() {
         val downloadInfo = SteamService.getAppDownloadInfo(gameId)
 
         if (downloadInfo != null) {
-            if (!SteamService.isAppInstalled(gameId)) {
-                downloadInfo.cancel()
-            }
+            downloadInfo.cancel()
         } else {
             CoroutineScope(Dispatchers.IO).launch {
                 SteamService.downloadApp(gameId)


### PR DESCRIPTION
Fixes #807

## Summary
- `isDownloading()` had a `!isAppInstalled` guard (added in #767) that returns false during updates because `DOWNLOAD_COMPLETE_MARKER` already exists — the download job's presence in `downloadJobs` is sufficient since it's removed on completion via `removeDownloadJob`
- Same guard in `onPauseResumeClick` prevented pausing update downloads

## Test plan
- [ ] Install a Steam game, then trigger Update from burger menu — should show Pause button and download progress, not Resume
- [ ] Pause/resume during update should work
- [ ] Fresh install still works (Pause/Resume/completion)
- [ ] Completed download shows Play, not Pause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced download pause and resume functionality for improved reliability.
  * Refined download status detection to more accurately identify ongoing download operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->