### PR TITLE
fix: SD card games unrecoverable when external storage toggle off

### DIFF
--- a/app/src/main/java/app/gamenative/service/DownloadService.kt
+++ b/app/src/main/java/app/gamenative/service/DownloadService.kt
@@ -53,12 +53,10 @@ object DownloadService {
         if (lastUpdateTime < (time - 5 * 1000) || lastUpdateTime > time) {
             lastUpdateTime = time
 
-            // scan internal + all mounted external volumes, deduplicate across volumes
+            // scan all install paths, deduplicate across volumes
             val dirs = mutableSetOf<String>()
-            dirs += getSubdirectories(SteamService.internalAppInstallPath)
-            for (volPath in externalVolumePaths) {
-                val extInstallPath = java.nio.file.Paths.get(volPath, "Steam", "steamapps", "common").toString()
-                dirs += getSubdirectories(extInstallPath)
+            for (installPath in SteamService.allInstallPaths) {
+                dirs += getSubdirectories(installPath)
             }
 
             downloadDirectoryApps = dirs.toMutableList()

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -391,6 +391,22 @@ class SteamService : Service(), IChallengeUrlChanged {
         val externalAppInstallPath: String
             get() = Paths.get(PrefManager.externalStoragePath, "Steam", "steamapps", "common").pathString
 
+        // all install paths: internal + configured external + all mounted volumes
+        val allInstallPaths: List<String>
+            get() {
+                val paths = mutableListOf(internalAppInstallPath)
+                // only include configured external path if it's a real absolute path
+                if (PrefManager.externalStoragePath.isNotBlank()) {
+                    paths += externalAppInstallPath
+                }
+                for (volPath in DownloadService.externalVolumePaths) {
+                    if (volPath.isNotBlank()) {
+                        paths += Paths.get(volPath, "Steam", "steamapps", "common").pathString
+                    }
+                }
+                return paths.distinct()
+            }
+
         private val internalAppStagingPath: String
             get() {
                 return Paths.get(DownloadService.baseDataDirPath, "Steam", "steamapps", "staging").pathString
@@ -741,22 +757,21 @@ class SteamService : Service(), IChallengeUrlChanged {
             val appName = getAppDirName(info)
             val oldName = info?.name.orEmpty()
 
-            // Internal first (legacy installs), external second
-            val internalPath = Paths.get(internalAppInstallPath, appName)
-            if (Files.exists(internalPath)) return internalPath.pathString
-            val internalOld = Paths.get(internalAppInstallPath, oldName)
-            if (oldName.isNotEmpty() && Files.exists(internalOld)) return internalOld.pathString
-
-            val externalPath = Paths.get(externalAppInstallPath, appName)
-            if (Files.exists(externalPath)) return externalPath.pathString
-            val externalOld = Paths.get(externalAppInstallPath, oldName)
-            if (oldName.isNotEmpty() && Files.exists(externalOld)) return externalOld.pathString
-
-            // Nothing on disk yet – default to whatever location you want new installs to use
-            if (PrefManager.useExternalStorage) {
-                return externalPath.pathString
+            // search internal, configured external, and all mounted volumes
+            for (basePath in allInstallPaths) {
+                val path = Paths.get(basePath, appName)
+                if (Files.exists(path)) return path.pathString
+                if (oldName.isNotEmpty()) {
+                    val oldPath = Paths.get(basePath, oldName)
+                    if (Files.exists(oldPath)) return oldPath.pathString
+                }
             }
-            return internalPath.pathString
+
+            // nothing on disk yet — default to preferred install location
+            if (PrefManager.useExternalStorage) {
+                return Paths.get(externalAppInstallPath, appName).pathString
+            }
+            return Paths.get(internalAppInstallPath, appName).pathString
         }
 
         private fun isExecutable(flags: Any): Boolean = when (flags) {


### PR DESCRIPTION
Fixes #808

## Summary
- `getAppDirPath` used `PrefManager.externalStoragePath` which is `""` when toggle is off — games on SD card couldn't be found, making them unplayable/undeletable/unreinstallable
- Add `allInstallPaths` to SteamService (internal + configured external + all mounted volumes) and use it in both `getAppDirPath` and `getDownloadDirectoryApps`, consolidating the volume scanning from #781

## Test plan
- [ ] Install game to SD card, toggle external storage off — game should still show Play, be launchable, and deletable
- [ ] Games on internal storage still work normally
- [ ] New installs default to correct location based on toggle setting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #808 by keeping SD card installs playable and manageable when the external storage toggle is off. We now search all valid install paths and dedupe results.

- **Bug Fixes**
  - Added `allInstallPaths` to `SteamService` (internal, configured external, all mounted volumes) and skip blank paths.
  - Updated `getAppDirPath` to search `allInstallPaths` and default to the preferred location based on the toggle.
  - Updated `DownloadService.getDownloadDirectoryApps` to iterate `SteamService.allInstallPaths`, deduping directory scans.

<sup>Written for commit b924ddd80756e18fe5f6470a8a84cb37ac2375f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Scanning now consolidates all Steam install locations into a single unified pass for simpler discovery.
* **Bug Fixes / Improvements**
  * Improved detection of installed games across internal, external, and mounted volumes.
  * Default/install-path resolution now prefers available external storage when configured, improving placement and discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->