### PR TITLE
Moved image fetching to custom games

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -34,8 +34,6 @@ import app.gamenative.ui.data.AppMenuOption
 import app.gamenative.ui.data.GameDisplayInfo
 import app.gamenative.ui.enums.AppOptionMenuType
 import app.gamenative.utils.ContainerUtils
-import app.gamenative.utils.GameMetadataManager
-import app.gamenative.utils.SteamGridDB
 import app.gamenative.utils.createPinnedShortcut
 import com.winlator.container.ContainerData
 import java.io.File
@@ -388,41 +386,6 @@ abstract class BaseAppScreen {
     }
 
     @Composable
-    private fun getFetchImagesOption(context: Context, libraryItem: LibraryItem): AppMenuOption {
-        return AppMenuOption(
-            optionType = AppOptionMenuType.FetchSteamGridDBImages,
-            onClick = {
-                CoroutineScope(Dispatchers.IO).launch {
-                    try {
-                        val gameName = libraryItem.name
-                        val gameFolderPath = getGameFolderPathForImageFetch(context, libraryItem)
-
-                        if (gameFolderPath != null) {
-                            val folder = File(gameFolderPath)
-                            val appId = libraryItem.gameId
-                            GameMetadataManager.update(
-                                folder = folder,
-                                appId = appId,
-                                steamgriddbFetched = false,
-                            )
-
-                            SteamGridDB.fetchGameImages(gameName, gameFolderPath)
-                            PluviaApp.events.emit(AndroidEvent.CustomGameImagesFetched(libraryItem.appId))
-                            onAfterFetchImages(context, libraryItem, gameFolderPath)
-
-                            SnackbarManager.show(context.getString(R.string.base_app_images_fetched))
-                        } else {
-                            SnackbarManager.show(context.getString(R.string.base_app_game_folder_not_found))
-                        }
-                    } catch (e: Exception) {
-                        SnackbarManager.show(context.getString(R.string.base_app_images_fetch_failed, e.message ?: ""))
-                    }
-                }
-            },
-        )
-    }
-
-    @Composable
     private fun getGetSupportOption(context: Context): AppMenuOption {
         return AppMenuOption(
             optionType = AppOptionMenuType.GetSupport,
@@ -544,7 +507,6 @@ abstract class BaseAppScreen {
 
         // Always available options
         menuOptions.add(getSubmitFeedbackOption(context, libraryItem))
-        menuOptions.add(getFetchImagesOption(context, libraryItem))
         menuOptions.add(getGetSupportOption(context))
 
         // Add any source-specific options

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
@@ -16,19 +16,21 @@ import app.gamenative.events.AndroidEvent
 import app.gamenative.PluviaApp
 import app.gamenative.ui.data.AppMenuOption
 import app.gamenative.ui.data.GameDisplayInfo
+import app.gamenative.ui.enums.AppOptionMenuType
+import app.gamenative.ui.util.SnackbarManager
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.CustomGameScanner
+import app.gamenative.utils.GameMetadataManager
+import app.gamenative.utils.SteamGridDB
 import app.gamenative.utils.StorageUtils
 import com.winlator.container.ContainerData
-import com.winlator.container.ContainerManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.io.File
 import android.net.Uri
-import app.gamenative.ui.enums.AppOptionMenuType
-import app.gamenative.ui.util.SnackbarManager
+import kotlinx.coroutines.CoroutineScope
+import java.io.File
 import timber.log.Timber
 
 /**
@@ -361,8 +363,8 @@ class CustomGameAppScreen : BaseAppScreen() {
         )
     }
 
-    /**
-     * Custom games don't have source-specific menu options beyond what's inherited
+   /**
+     * Custom Game-specific menu options
      */
     @Composable
     override fun getSourceSpecificMenuOptions(
@@ -373,7 +375,47 @@ class CustomGameAppScreen : BaseAppScreen() {
         onClickPlay: (Boolean) -> Unit,
         isInstalled: Boolean
     ): List<AppMenuOption> {
-        return emptyList()
+        val options = mutableListOf<AppMenuOption>()
+
+        // Fetch images from SteamGridDB for Custom Games
+        options.add(getFetchImagesOption(context, libraryItem))
+
+        return options
+    }
+
+    @Composable
+    private fun getFetchImagesOption(context: Context, libraryItem: LibraryItem): AppMenuOption {
+        return AppMenuOption(
+            optionType = AppOptionMenuType.FetchSteamGridDBImages,
+            onClick = {
+                CoroutineScope(Dispatchers.IO).launch {
+                    try {
+                        val gameName = libraryItem.name
+                        val gameFolderPath = getGameFolderPathForImageFetch(context, libraryItem)
+
+                        if (gameFolderPath != null) {
+                            val folder = File(gameFolderPath)
+                            val appId = libraryItem.gameId
+                            GameMetadataManager.update(
+                                folder = folder,
+                                appId = appId,
+                                steamgriddbFetched = false,
+                            )
+
+                            SteamGridDB.fetchGameImages(gameName, gameFolderPath)
+                            PluviaApp.events.emit(AndroidEvent.CustomGameImagesFetched(libraryItem.appId))
+                            onAfterFetchImages(context, libraryItem, gameFolderPath)
+
+                            SnackbarManager.show(context.getString(R.string.base_app_images_fetched))
+                        } else {
+                            SnackbarManager.show(context.getString(R.string.base_app_game_folder_not_found))
+                        }
+                    } catch (e: Exception) {
+                        SnackbarManager.show(context.getString(R.string.base_app_images_fetch_failed, e.message ?: ""))
+                    }
+                }
+            },
+        )
     }
 
     override fun loadContainerData(context: Context, libraryItem: LibraryItem): ContainerData {

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
@@ -583,14 +583,6 @@ class EpicAppScreen : BaseAppScreen() {
         )
     }
 
-    /**
-     * Epic games don't need special image fetching logic like Custom Games
-     * Images come from Epic CDN
-     */
-    override fun getGameFolderPathForImageFetch(context: Context, libraryItem: LibraryItem): String? {
-        return null // Epic uses CDN images, not local files
-    }
-
     override fun observeGameState(
         context: Context,
         libraryItem: LibraryItem,

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -436,9 +436,6 @@ class GOGAppScreen : BaseAppScreen() {
             },
         )
     }
-    override fun getGameFolderPathForImageFetch(context: Context, libraryItem: LibraryItem): String? {
-        return null // GOG Stores full URLs in their database entry.
-    }
 
     override fun observeGameState(
         context: Context,


### PR DESCRIPTION
This feature is available for all platforms but only custom games can successfully use it. Epic and GOG give errors, and Steam already prefetches all images during sync so it has no use for it. We should move it to the CustomAppScreen so the option isn't shown at platforms that shouldn't use it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved SteamGridDB image fetching to Custom Games only to avoid errors on Epic/GOG and redundant work on Steam. The “Fetch SteamGridDB images” action now appears only on Custom Game screens.

- **Refactors**
  - Removed the fetch-images option and logic from BaseAppScreen and its menu.
  - Added a Custom Game-specific menu option in CustomGameAppScreen (updates metadata, downloads images, emits event, shows snackbar).
  - Deleted unused image-fetch path overrides from EpicAppScreen and GOGAppScreen.

<sup>Written for commit e7c1d01fe3cf7b516f7e34b4696abbf4ef239734. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom games now have a dedicated "Fetch SteamGridDB Images" menu option to fetch images and show success/failure notifications.
* **Refactor**
  * Removed the always-available image-fetch option from the main menu.
  * Epic and GOG game screens no longer include special local-image fetch overrides, aligning image handling behavior across sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->