### PR TITLE
feat: Added option to toggle button hints bar

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -948,6 +948,14 @@ object PrefManager {
             setPref(SWAP_FACE_BUTTONS, value)
         }
 
+    // Whether to show the on-screen gamepad hints/action bar in the UI
+    private val SHOW_GAMEPAD_HINTS = booleanPreferencesKey("show_gamepad_hints")
+    var showGamepadHints: Boolean
+        get() = getPref(SHOW_GAMEPAD_HINTS, true)
+        set(value) {
+            setPref(SHOW_GAMEPAD_HINTS, value)
+        }
+
     private val ITEMS_PER_PAGE = intPreferencesKey("items_per_page")
     var itemsPerPage: Int
         get() = getPref(ITEMS_PER_PAGE, 50)

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
@@ -113,6 +113,9 @@ fun SettingsGroupInterface(
     var hideStatusBar by rememberSaveable { mutableStateOf(PrefManager.hideStatusBarWhenNotInGame) }
     var swapFaceButtons by rememberSaveable { mutableStateOf(PrefManager.swapFaceButtons) }
 
+    // Controller/gamepad hints visibility
+    var showGamepadHints by rememberSaveable { mutableStateOf(PrefManager.showGamepadHints) }
+
     // Language selection dialog
     var openLanguageDialog by rememberSaveable { mutableStateOf(false) }
     var showLanguageRestartDialog by rememberSaveable { mutableStateOf(false) }
@@ -271,6 +274,17 @@ fun SettingsGroupInterface(
             onCheckedChange = {
                 warnBeforeExit = it
                 PrefManager.warnBeforeExit = it
+            },
+        )
+
+        SettingsSwitch(
+            colors = settingsTileColorsAlt(),
+            title = { Text(text = stringResource(R.string.settings_interface_show_gamepad_hints_title)) },
+            subtitle = { Text(text = stringResource(R.string.settings_interface_show_gamepad_hints_subtitle)) },
+            state = showGamepadHints,
+            onCheckedChange = { newValue ->
+                showGamepadHints = newValue
+                PrefManager.showGamepadHints = newValue
             },
         )
 

--- a/app/src/main/java/app/gamenative/ui/util/WindowSize.kt
+++ b/app/src/main/java/app/gamenative/ui/util/WindowSize.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import app.gamenative.PrefManager
 
 /**
  * Window width size classes based on Material Design 3 guidelines.
@@ -34,9 +35,11 @@ fun rememberScreenWidthDp(): Int {
     return configuration.screenWidthDp
 }
 
-// TODO: Also consider if a gamepad is actually connected
 @Composable
 fun shouldShowGamepadUI(): Boolean {
+    if (!PrefManager.showGamepadHints) {
+        return false
+    }
     return rememberWindowWidthClass() != WindowWidthClass.COMPACT
 }
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -724,6 +724,8 @@
     <string name="settings_interface_hide_statusbar_subtitle">Skjul Android-statuslinje i spilliste, indstillinger osv. Appen genstarter når den ændres.</string>
     <string name="settings_interface_warn_before_exit_title">Advar før afslutning</string>
     <string name="settings_interface_warn_before_exit_subtitle">Kræver dobbelt tilbagetryk for at afslutte — første tryk viser en advarsel</string>
+    <string name="settings_interface_show_gamepad_hints_title">Vis controller-tip</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">Viser bjælken med controller-knaptip nederst på skærmen</string>
     <string name="settings_interface_icon_style">Ikonstil</string>
     <string name="settings_interface_wifi_only_title">Download kun via Wi-Fi/LAN</string>
     <string name="settings_interface_wifi_only_subtitle">Forhindrer downloads på mobildata</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -863,6 +863,8 @@
     <string name="settings_interface_hide_statusbar_subtitle">Android-Statusleiste in Spieleliste, Einstellungen etc. ausblenden (Neustart nötig).</string>
     <string name="settings_interface_warn_before_exit_title">Vor dem Beenden warnen</string>
     <string name="settings_interface_warn_before_exit_subtitle">Doppeltes Zurückdrücken zum Beenden erforderlich — erstes Drücken zeigt eine Warnung</string>
+    <string name="settings_interface_show_gamepad_hints_title">Controller-Hinweise anzeigen</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">Zeigt die Leiste mit Controller-Tastenhinweisen am unteren Bildschirmrand an</string>
     <string name="settings_interface_icon_style">Iconstil</string>
     <string name="settings_interface_wifi_only_title">Nur über WLAN/LAN herunterladen</string>
     <string name="settings_interface_wifi_only_subtitle">Verhindert Downloads über mobile Daten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -913,6 +913,8 @@
     <string name="settings_interface_hide_statusbar_subtitle">Oculta la barra de estado de Android en la lista de juegos, ajustes, etc. La aplicación se reiniciará al cambiar.</string>
     <string name="settings_interface_warn_before_exit_title">Avisar antes de salir</string>
     <string name="settings_interface_warn_before_exit_subtitle">Requiere pulsar atrás dos veces para salir — la primera muestra un aviso</string>
+    <string name="settings_interface_show_gamepad_hints_title">Mostrar pistas del mando</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">Muestra la barra de pistas de botones del mando en la parte inferior de la pantalla</string>
     <string name="settings_interface_icon_style">Estilo del icono</string>
     <string name="settings_interface_wifi_only_title">Descargar solo por Wi-Fi/LAN</string>
     <string name="settings_interface_wifi_only_subtitle">Evita descargas con datos móviles.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -899,6 +899,8 @@
     <string name="settings_interface_hide_statusbar_subtitle">Masquer la barre d\'état Android dans la liste de jeux, les paramètres, etc. L\'application redémarrera lors du changement.</string>
     <string name="settings_interface_warn_before_exit_title">Avertir avant de quitter</string>
     <string name="settings_interface_warn_before_exit_subtitle">Appui double sur retour requis pour quitter — le premier affiche un avertissement</string>
+    <string name="settings_interface_show_gamepad_hints_title">Afficher les indications de manette</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">Affiche la barre d\'indications des boutons de la manette en bas de l\'écran</string>
     <string name="settings_interface_icon_style">Style d\'icône</string>
     <string name="settings_interface_wifi_only_title">Télécharger uniquement via Wi-Fi/LAN</string>
     <string name="settings_interface_wifi_only_subtitle">Empêcher les téléchargements sur données cellulaires</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -895,6 +895,8 @@
     <string name="settings_interface_hide_statusbar_subtitle">Nascondi barra di stato Android nell\'elenco giochi, impostazioni, ecc. L\'app si riavvierà se modificato.</string>
     <string name="settings_interface_warn_before_exit_title">Avvisa prima di uscire</string>
     <string name="settings_interface_warn_before_exit_subtitle">Richiede doppia pressione di indietro per uscire — la prima mostra un avviso</string>
+    <string name="settings_interface_show_gamepad_hints_title">Mostra suggerimenti del controller</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">Mostra la barra dei suggerimenti dei pulsanti del controller nella parte inferiore dello schermo</string>
     <string name="settings_interface_icon_style">Stile icona</string>
     <string name="settings_interface_wifi_only_title">Scarica solo tramite Wi-Fi/LAN</string>
     <string name="settings_interface_wifi_only_subtitle">Impedisci download su rete cellulare</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -913,6 +913,8 @@
     <string name="settings_interface_hide_statusbar_subtitle">게임 목록, 설정 등에서 Android 상태 표시줄을 숨깁니다. 변경 시 앱이 재시작됩니다.</string>
     <string name="settings_interface_warn_before_exit_title">종료 전 경고</string>
     <string name="settings_interface_warn_before_exit_subtitle">종료하려면 뒤로 두 번 눌러야 합니다 — 첫 번째는 경고를 표시합니다</string>
+    <string name="settings_interface_show_gamepad_hints_title">컨트롤러 힌트 표시</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">화면 하단에 컨트롤러 버튼 힌트 바를 표시합니다</string>
     <string name="settings_interface_icon_style">아이콘 스타일</string>
     <string name="settings_interface_wifi_only_title">Wi-Fi/LAN으로만 다운로드</string>
     <string name="settings_interface_wifi_only_subtitle">셀룰러 데이터로 다운로드 방지</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -912,6 +912,8 @@
     <string name="settings_interface_hide_statusbar_subtitle">Ukryj pasek stanu Androida w liście gier, ustawieniach itp. Aplikacja uruchomi się ponownie po zmianie.</string>
     <string name="settings_interface_warn_before_exit_title">Ostrzegaj przed wyjściem</string>
     <string name="settings_interface_warn_before_exit_subtitle">Wymaga podwójnego naciśnięcia wstecz, aby wyjść — pierwsze naciśnięcie pokazuje ostrzeżenie</string>
+    <string name="settings_interface_show_gamepad_hints_title">Pokazuj podpowiedzi kontrolera</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">Pokazuje pasek podpowiedzi przycisków kontrolera u dołu ekranu</string>
     <string name="settings_interface_icon_style">Styl ikony</string>
     <string name="settings_interface_wifi_only_title">Pobieraj tylko przez Wi-Fi/LAN</string>
     <string name="settings_interface_wifi_only_subtitle">Zapobiegaj pobieraniu przez dane komórkowe</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -724,6 +724,8 @@
     <string name="settings_interface_hide_statusbar_subtitle">Ocultar barra de status do Android na lista de jogos, configurações, etc. O app será reiniciado quando alterado.</string>
     <string name="settings_interface_warn_before_exit_title">Avisar antes de sair</string>
     <string name="settings_interface_warn_before_exit_subtitle">Requer duplo toque em voltar para sair — o primeiro mostra um aviso</string>
+    <string name="settings_interface_show_gamepad_hints_title">Mostrar dicas do controle</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">Mostra a barra de dicas dos botões do controle na parte inferior da tela</string>
     <string name="settings_interface_icon_style">Estilo de ícone</string>
     <string name="settings_interface_wifi_only_title">Baixar apenas por Wi-Fi/LAN</string>
     <string name="settings_interface_wifi_only_subtitle">Impedir downloads usando dados móveis</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -904,6 +904,8 @@
 	<string name="settings_interface_hide_statusbar_subtitle">Ascunde bara de stare Android în lista de jocuri, setări etc. Aplicația se va reporni după modificare.</string>
 	<string name="settings_interface_warn_before_exit_title">Avertizare înainte de ieșire</string>
 	<string name="settings_interface_warn_before_exit_subtitle">Necesită dublu apăsare înapoi pentru a ieși — prima apăsare arată un avertisment</string>
+	<string name="settings_interface_show_gamepad_hints_title">Afișează indicii pentru controler</string>
+	<string name="settings_interface_show_gamepad_hints_subtitle">Afișează bara de indicii pentru butoanele controlerului în partea de jos a ecranului</string>
 	<string name="settings_interface_icon_style">Stil iconițe</string>
 	<string name="settings_interface_wifi_only_title">Descarcă doar prin Wi‑Fi/LAN</string>
 	<string name="settings_interface_wifi_only_subtitle">Previne descărcările pe date mobile</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -990,6 +990,8 @@ https://gamenative.app
     <string name="settings_interface_hide_statusbar_title">Скрыть строку состояния, когда не в игре</string>
     <string name="settings_interface_warn_before_exit_title">Предупреждать перед выходом</string>
     <string name="settings_interface_warn_before_exit_subtitle">Для выхода требуется двойное нажатие назад — первое показывает предупреждение</string>
+    <string name="settings_interface_show_gamepad_hints_title">Показывать подсказки геймпада</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">Показывает панель подсказок кнопок геймпада в нижней части экрана</string>
     <string name="settings_interface_icon_style">Стиль значка</string>
     <string name="settings_interface_no_external_storage">Внешнее хранилище не обнаружено</string>
     <string name="settings_interface_restart_required_title">Требуется перезагрузка</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -898,6 +898,8 @@
     <string name="settings_interface_hide_statusbar_subtitle">Приховує рядок стану Android у списку ігор, налаштуваннях тощо. Застосунок перезапуститься після зміни.</string>
     <string name="settings_interface_warn_before_exit_title">Попереджати перед виходом</string>
     <string name="settings_interface_warn_before_exit_subtitle">Для виходу потрібне подвійне натискання назад — перше показує попередження</string>
+    <string name="settings_interface_show_gamepad_hints_title">Показувати підказки геймпада</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">Показує панель підказок кнопок геймпада внизу екрана</string>
     <string name="settings_interface_icon_style">Стиль значку</string>
     <string name="settings_interface_wifi_only_title">Завантаження тільки через Wi-Fi/LAN</string>
     <string name="settings_interface_wifi_only_subtitle">Запобігає завантаженню через мобільні дані</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -894,6 +894,8 @@
     <string name="settings_interface_hide_statusbar_subtitle">在游戏列表、设置等界面隐藏 Android 状态栏。更改后应用程序将重新启动。</string>
     <string name="settings_interface_warn_before_exit_title">退出前警告</string>
     <string name="settings_interface_warn_before_exit_subtitle">需要双击返回键退出——第一次按下显示警告</string>
+    <string name="settings_interface_show_gamepad_hints_title">显示手柄提示</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">在屏幕底部显示手柄按键提示栏</string>
     <string name="settings_interface_wifi_only_title">仅限通过 Wi-Fi/LAN 下载</string>
     <string name="settings_interface_wifi_only_subtitle">禁止使用移动数据下载</string>
     <string name="settings_interface_external_storage_title">写入外部存储设备</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -896,6 +896,8 @@
     <string name="settings_interface_hide_statusbar_subtitle">在遊戲清單、設定等介面隱藏 Android 狀態列。變更後應用程式將重新啟動。</string>
     <string name="settings_interface_warn_before_exit_title">退出前警告</string>
     <string name="settings_interface_warn_before_exit_subtitle">需要雙擊返回鍵退出——第一次按下顯示警告</string>
+    <string name="settings_interface_show_gamepad_hints_title">顯示手把提示</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">在螢幕底部顯示手把按鍵提示列</string>
     <string name="settings_interface_wifi_only_title">僅限透過 Wi-Fi/LAN 下載</string>
     <string name="settings_interface_wifi_only_subtitle">禁止使用行動數據下載</string>
     <string name="settings_interface_external_storage_title">寫入外部儲存裝置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -889,6 +889,8 @@
     <string name="settings_interface_swap_face_buttons_subtitle">Swap A↔B and X↔Y button icons</string>
     <string name="settings_interface_warn_before_exit_title">Warn before exiting</string>
     <string name="settings_interface_warn_before_exit_subtitle">Require double back press to exit — first press shows a warning</string>
+    <string name="settings_interface_show_gamepad_hints_title">Show controller hints</string>
+    <string name="settings_interface_show_gamepad_hints_subtitle">Show the controller button hints bar at the bottom of the screen</string>
     <string name="settings_interface_icon_style">Icon style</string>
     <string name="settings_interface_wifi_only_title">Download only over Wi-Fi/LAN</string>
     <string name="settings_interface_wifi_only_subtitle">Prevent downloads on cellular data</string>


### PR DESCRIPTION
1. Not all users use a controller.
2. Not all users using a controller actually want the button hints bar since it's all doable from the UI and it can feel bloated (IMO, I don't use it).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a toggle in Interface settings to show or hide the controller button hints bar. When off, the bar is hidden everywhere; when on, it only shows on non-compact screens.

- **New Features**
  - New persisted preference `PrefManager.showGamepadHints` (`show_gamepad_hints`, default on).
  - "Show controller hints" switch in Interface settings with localized title/subtitle.
  - `shouldShowGamepadUI()` checks the pref and only enables the bar on non-compact screens.

<sup>Written for commit 22cdb5ca0fd62fb2a73e12605087d57ad3e3997b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New toggle in Settings → Interface to show or hide controller (gamepad) hints.
  * Two localized strings added for the toggle's title and subtitle.
  * The toggle persists immediately so the UI remembers the user's choice.

* **Changes**
  * When the toggle is off, controller hint UI is suppressed regardless of window size; default is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->