### PR TITLE
feat: Added force cloud sync for GOG + made toasts consistent across platforms

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
@@ -546,7 +546,7 @@ class EpicAppScreen : BaseAppScreen() {
                         val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
                         scope.launch {
                             try {
-                                SnackbarManager.show(context.getString(R.string.epic_cloud_sync_starting))
+                                SnackbarManager.show(context.getString(R.string.library_cloud_sync_starting))
 
                                 val result = withContext(Dispatchers.IO) {
                                     EpicCloudSavesManager.syncCloudSaves(
@@ -557,11 +557,20 @@ class EpicAppScreen : BaseAppScreen() {
                                 }
 
                                 SnackbarManager.show(
-                                    if (result) context.getString(R.string.epic_cloud_sync_success) else context.getString(R.string.epic_cloud_sync_failed),
+                                    if (result) {
+                                        context.getString(R.string.library_cloud_sync_success)
+                                    } else {
+                                        context.getString(R.string.library_cloud_sync_failed)
+                                    },
                                 )
                             } catch (e: Exception) {
                                 Timber.tag(TAG).e(e, "[Cloud Saves] Sync failed")
-                                SnackbarManager.show(context.getString(R.string.epic_cloud_sync_error, e.message ?: ""))
+                                SnackbarManager.show(
+                                    context.getString(
+                                        R.string.library_cloud_sync_error,
+                                        e.message ?: "",
+                                    ),
+                                )
                             }
                         }
                     },

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -29,6 +29,7 @@ import com.winlator.container.ContainerData
 import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import app.gamenative.ui.util.SnackbarManager
@@ -77,6 +78,44 @@ class GOGAppScreen : BaseAppScreen() {
                 bytes >= mb -> String.format(Locale.US, "%.1f MB", bytes / mb)
                 bytes >= kb -> String.format(Locale.US, "%.1f KB", bytes / kb)
                 else -> "$bytes B"
+            }
+        }
+
+        internal suspend fun forceCloudSync(
+            context: Context,
+            appId: String,
+            syncCloudSaves: suspend (Context, String, String) -> Boolean = { syncContext, syncAppId, preferredAction ->
+                GOGService.syncCloudSaves(
+                    context = syncContext,
+                    appId = syncAppId,
+                    preferredAction = preferredAction,
+                )
+            },
+            showSnackbar: (String) -> Unit = SnackbarManager::show,
+            logError: (Throwable) -> Unit = { error ->
+                Timber.tag(TAG).e(error, "[Cloud Saves] Sync failed")
+            },
+        ) {
+            try {
+                showSnackbar(context.getString(R.string.library_cloud_sync_starting))
+
+                val result = withContext(Dispatchers.IO) {
+                    syncCloudSaves(context, appId, "auto")
+                }
+
+                if (result) {
+                    showSnackbar(context.getString(R.string.library_cloud_sync_success))
+                } else {
+                    showSnackbar(context.getString(R.string.library_cloud_sync_failed))
+                }
+            } catch (e: Exception) {
+                logError(e)
+                showSnackbar(
+                    context.getString(
+                        R.string.library_cloud_sync_error,
+                        e.message ?: "",
+                    ),
+                )
             }
         }
     }
@@ -446,7 +485,9 @@ class GOGAppScreen : BaseAppScreen() {
             return emptyList()
         }
 
-        return listOf(
+        val options = mutableListOf<AppMenuOption>()
+
+        options.add(
             AppMenuOption(
                 optionType = AppOptionMenuType.VerifyFiles,
                 onClick = {
@@ -464,6 +505,23 @@ class GOGAppScreen : BaseAppScreen() {
                 },
             ),
         )
+
+        options.add(
+            AppMenuOption(
+                optionType = AppOptionMenuType.ForceCloudSync,
+                onClick = {
+                    val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+                    scope.launch {
+                        forceCloudSync(
+                            context = context,
+                            appId = libraryItem.appId,
+                        )
+                    }
+                },
+            ),
+        )
+
+        return options
     }
 
     /**

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -756,6 +756,8 @@ class SteamAppScreen : BaseAppScreen() {
                         properties = mapOf("game_name" to appInfo.name),
                     )
                     CoroutineScope(Dispatchers.IO).launch {
+                        SnackbarManager.show(context.getString(R.string.library_cloud_sync_starting))
+
                         val steamId = SteamService.userSteamId
                         if (steamId == null) {
                             SnackbarManager.show(context.getString(R.string.steam_not_logged_in))
@@ -776,17 +778,17 @@ class SteamAppScreen : BaseAppScreen() {
 
                         when (syncResult.syncResult) {
                             SyncResult.Success -> {
-                                SnackbarManager.show(context.getString(R.string.steam_cloud_sync_success))
+                                SnackbarManager.show(context.getString(R.string.library_cloud_sync_success))
                             }
 
                             SyncResult.UpToDate -> {
-                                SnackbarManager.show(context.getString(R.string.steam_cloud_sync_up_to_date))
+                                SnackbarManager.show(context.getString(R.string.library_cloud_sync_up_to_date))
                             }
 
                             else -> {
                                 SnackbarManager.show(
                                     context.getString(
-                                        R.string.steam_cloud_sync_failed,
+                                        R.string.library_cloud_sync_error,
                                         syncResult.syncResult,
                                     ),
                                 )

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -30,10 +30,6 @@
     <string name="gog_install_confirmation_message">Appen der installeres har følgende pladskrav. Vil du fortsætte?\n\n\tDownload-størrelse: %1$s\n\tTilgængelig plads: %2$s</string>
     <string name="epic_cancel_download_message">Er du sikker på, at du vil annullere download af appen?</string>
     <string name="epic_delete_download_message">Slet alle downloadede data for dette spil?</string>
-    <string name="epic_cloud_sync_starting">Starter synkronisering af cloud-gemmer…</string>
-    <string name="epic_cloud_sync_success">Cloud-gemmer synkroniseret med succes</string>
-    <string name="epic_cloud_sync_failed">Synkronisering af cloud-gemmer mislykkedes</string>
-    <string name="epic_cloud_sync_error">Fejl ved synkronisering af cloud-gemmer: %1$s</string>
     <string name="epic_uninstall_failed">Afinstallation mislykkedes: %1$s</string>
     <string name="epic_uninstall_error">Afinstallationsfejl: %1$s</string>
     <string name="download_prompt_title">Installér app</string>
@@ -792,9 +788,11 @@
     <string name="library_export_cancelled">Eksport annulleret</string>
     <string name="library_shortcut_created">Genvej oprettet</string>
     <string name="library_failed_to_create_shortcut">Kunne ikke oprette genvej: %s</string>
+    <string name="library_cloud_sync_starting">Starter synkronisering af cloud-gemmer…</string>
     <string name="library_cloud_sync_success">Sky-synkronisering fuldført</string>
     <string name="library_cloud_sync_up_to_date">Gemfiler er allerede opdaterede</string>
-    <string name="library_cloud_sync_failed">Sky-synkronisering fejlede: %s</string>
+    <string name="library_cloud_sync_failed">Sky-synkronisering fejlede</string>
+    <string name="library_cloud_sync_error">Fejl ved synkronisering af cloud-gemmer: %1$s</string>
 
     <!-- TODO: Manual review - LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Internet påkrævet for installation</string>
@@ -1076,9 +1074,6 @@
     <string name="steam_verify_files_message">Sørg venligst for, at dine gemfiler er uploadet til skyen eller sikkerhedskopieret før verificering, da de ellers kan blive overskrevet.</string>
     <string name="steam_update_title">Opdatering</string>
     <string name="steam_update_message">Sørg venligst for, at dine gemfiler er uploadet til skyen eller sikkerhedskopieret før opdatering, da de ellers kan blive overskrevet.</string>
-    <string name="steam_cloud_sync_success">Sky-synkronisering fuldført</string>
-    <string name="steam_cloud_sync_up_to_date">Gemfiler er allerede opdaterede</string>
-    <string name="steam_cloud_sync_failed">Sky-synkronisering fejlede: %s</string>
     <string name="steam_storage_permission_required">Lagertilladelse påkrævet</string>
     <string name="steam_container_reset_success">Container nulstillet til standard</string>
     <string name="steam_imagefs_installed">ImageFS installeret. Prøv at redigere container igen.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -28,9 +28,6 @@
     <string name="steam_verify_files_message">Stelle bitte sicher, dass deine Spielstände vorher in die Cloud hochgeladen oder gesichert wurden, da sie sonst überschrieben werden können.</string>
     <string name="steam_update_title">Aktualisieren</string>
     <string name="steam_update_message">Stelle sicher, dass deine Speicherstände vor dem Aktualisieren in der Cloud gesichert oder gebackupt sind, um ein Überschreiben zu verhindern.</string>
-    <string name="steam_cloud_sync_success">Cloud-Synchronisierung erfolgreich abgeschlossen</string>
-    <string name="steam_cloud_sync_up_to_date">Spielstände sind bereits aktuell</string>
-    <string name="steam_cloud_sync_failed">Cloud-Synchronisierung fehlgeschlagen: %s</string>
     <string name="steam_not_logged_in">Du musst bei Steam angemeldet sein, um diese Funktion zu nutzen</string>
     <string name="steam_storage_permission_required">Speicherberechtigung erforderlich</string>
     <string name="steam_container_reset_success">Container auf Werkseinstellungen zurückgesetzt</string>
@@ -54,10 +51,6 @@
     <string name="steam_never">Nie</string>
     <string name="epic_cancel_download_message">Möchten Sie den Download der App wirklich abbrechen?</string>
     <string name="epic_delete_download_message">Alle heruntergeladenen Daten für dieses Spiel löschen?</string>
-    <string name="epic_cloud_sync_starting">Starte Cloud-Speicherstand-Synchronisation…</string>
-    <string name="epic_cloud_sync_success">Cloud-Spielstände erfolgreich synchronisiert</string>
-    <string name="epic_cloud_sync_failed">Cloud-Spielstand-Synchronisation fehlgeschlagen</string>
-    <string name="epic_cloud_sync_error">Fehler bei Cloud-Spielstand-Synchronisation: %1$s</string>
     <string name="epic_uninstall_failed">Deinstallation fehlgeschlagen: %1$s</string>
     <string name="epic_uninstall_error">Deinstallationsfehler: %1$s</string>
     <string name="steam_continue">Weiter</string>
@@ -925,9 +918,11 @@
     <string name="library_export_cancelled">Export abgebrochen</string>
     <string name="library_shortcut_created">Verknüpfung erstellt</string>
     <string name="library_failed_to_create_shortcut">Verknüpfung konnte nicht erstellt werden: %s</string>
+    <string name="library_cloud_sync_starting">Cloud-Synchronisierung wird gestartet…</string>
     <string name="library_cloud_sync_success">Cloud-Synchronisierung erfolgreich</string>
     <string name="library_cloud_sync_up_to_date">Spielstände sind aktuell</string>
-    <string name="library_cloud_sync_failed">Cloud-Synchronisierung fehlgeschlagen: %s</string>
+    <string name="library_cloud_sync_failed">Cloud-Synchronisierung fehlgeschlagen</string>
+    <string name="library_cloud_sync_error">Cloud-Synchronisierungsfehler: %1$s</string>
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Internetverbindung erforderlich</string>
     <string name="library_wifi_only_enabled">Installieren nur über WLAN/LAN aktiviert</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -29,9 +29,6 @@
     <string name="steam_verify_files_message">Asegúrate de que tus archivos de guardado están en la nube o respaldados antes de verificar, ya que podrían sobrescribirse.</string>
     <string name="steam_update_title">Actualizar</string>
     <string name="steam_update_message">Asegúrate de que tus archivos de guardado están en la nube o respaldados antes de actualizar, ya que podrían sobrescribirse.</string>
-    <string name="steam_cloud_sync_success">Sincronización con la nube completada con éxito.</string>
-    <string name="steam_cloud_sync_up_to_date">Los archivos de guardado ya están actualizados.</string>
-    <string name="steam_cloud_sync_failed">Fallo en la sincronización con la nube: %s.</string>
     <string name="steam_not_logged_in">Debes iniciar sesión en Steam para usar esta función.</string>
     <string name="steam_storage_permission_required">Se requiere permiso de almacenamiento.</string>
     <string name="steam_container_reset_success">Contenedor restablecido a los valores por defecto.</string>
@@ -67,10 +64,6 @@
     <string name="epic_download_error">Error de descarga: %1$s.</string>
     <string name="epic_cancel_download_message">¿Deseas cancelar la descarga de la aplicación?</string>
     <string name="epic_delete_download_message">¿Deseas eliminar todos los datos descargados de este juego?</string>
-    <string name="epic_cloud_sync_starting">Iniciando sincronización en la nube…</string>
-    <string name="epic_cloud_sync_success">Partidas en la nube sincronizadas correctamente.</string>
-    <string name="epic_cloud_sync_failed">Error al sincronizar con la nube.</string>
-    <string name="epic_cloud_sync_error">Error de sincronización en la nube: %1$s.</string>
     <string name="epic_uninstall_failed">Error al desinstalar: %1$s.</string>
     <string name="epic_uninstall_error">Error de desinstalación: %1$s.</string>
     <string name="steam_never">Nunca</string>
@@ -982,9 +975,11 @@
     <string name="library_export_cancelled">Exportación cancelada.</string>
     <string name="library_shortcut_created">Acceso directo creado.</string>
     <string name="library_failed_to_create_shortcut">Error al crear el acceso directo: %s.</string>
+    <string name="library_cloud_sync_starting">Iniciando sincronización en la nube…</string>
     <string name="library_cloud_sync_success">Sincronización con la nube completada con éxito.</string>
     <string name="library_cloud_sync_up_to_date">Los archivos de guardado ya están actualizados.</string>
-    <string name="library_cloud_sync_failed">Fallo en la sincronización con la nube: %s.</string>
+    <string name="library_cloud_sync_failed">Fallo en la sincronización con la nube.</string>
+    <string name="library_cloud_sync_error">Error de sincronización en la nube: %1$s.</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Necesitas conexión a internet para instalar.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -29,9 +29,6 @@
     <string name="steam_verify_files_message">Veuillez vous assurer que vos sauvegardes sont téléchargées dans le cloud ou sauvegardées avant de vérifier, car elles peuvent être écrasées.</string>
     <string name="steam_update_title">Mettre à jour</string>
     <string name="steam_update_message">Veuillez vous assurer que vos sauvegardes sont téléchargées dans le cloud ou sauvegardées avant de mettre à jour, car elles peuvent être écrasées.</string>
-    <string name="steam_cloud_sync_success">Synchronisation cloud terminée avec succès</string>
-    <string name="steam_cloud_sync_up_to_date">Les fichiers de sauvegarde sont déjà à jour</string>
-    <string name="steam_cloud_sync_failed">Échec de la synchronisation cloud : %s</string>
     <string name="steam_not_logged_in">Vous devez être connecté à Steam pour utiliser cette fonctionnalité</string>
     <string name="steam_storage_permission_required">Autorisation de stockage requise</string>
     <string name="steam_container_reset_success">Conteneur réinitialisé aux paramètres par défaut</string>
@@ -59,10 +56,6 @@
     <string name="steam_never">Jamais</string>
     <string name="epic_cancel_download_message">Êtes-vous sûr de vouloir annuler le téléchargement de l\'application?</string>
     <string name="epic_delete_download_message">Supprimer toutes les données téléchargées pour ce jeu?</string>
-    <string name="epic_cloud_sync_starting">Démarrage de la synchronisation des sauvegardes cloud…</string>
-    <string name="epic_cloud_sync_success">Sauvegardes cloud synchronisées avec succès</string>
-    <string name="epic_cloud_sync_failed">Échec de la synchronisation des sauvegardes cloud</string>
-    <string name="epic_cloud_sync_error">Erreur de synchronisation des sauvegardes cloud: %1$s</string>
     <string name="epic_uninstall_failed">Échec de la désinstallation: %1$s</string>
     <string name="epic_uninstall_error">Erreur de désinstallation: %1$s</string>
     <string name="steam_continue">Continuer</string>
@@ -968,9 +961,11 @@
     <string name="library_export_cancelled">Exportation annulée</string>
     <string name="library_shortcut_created">Raccourci créé</string>
     <string name="library_failed_to_create_shortcut">Échec de la création du raccourci : %s</string>
+    <string name="library_cloud_sync_starting">Démarrage de la synchronisation des sauvegardes cloud…</string>
     <string name="library_cloud_sync_success">Synchronisation cloud terminée avec succès</string>
     <string name="library_cloud_sync_up_to_date">Les fichiers de sauvegarde sont déjà à jour</string>
-    <string name="library_cloud_sync_failed">Échec de la synchronisation cloud : %s</string>
+    <string name="library_cloud_sync_failed">Échec de la synchronisation cloud</string>
+    <string name="library_cloud_sync_error">Erreur de synchronisation des sauvegardes cloud: %1$s</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Connexion internet nécessaire pour installer</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -29,9 +29,6 @@
     <string name="steam_verify_files_message">Assicurati che i tuoi salvataggi siano caricati sul cloud o sottoposti a backup prima della verifica, altrimenti potrebbero essere sovrascritti.</string>
     <string name="steam_update_title">Aggiorna</string>
     <string name="steam_update_message">Assicurati che i tuoi salvataggi siano caricati sul cloud o sottoposti a backup prima dell\'aggiornamento, altrimenti potrebbero essere sovrascritti.</string>
-    <string name="steam_cloud_sync_success">Sincronizzazione cloud completata con successo</string>
-    <string name="steam_cloud_sync_up_to_date">I file di salvataggio sono già aggiornati</string>
-    <string name="steam_cloud_sync_failed">Sincronizzazione cloud fallita: %s</string>
     <string name="steam_not_logged_in">Devi aver effettuato l\'accesso a Steam per utilizzare questa funzione</string>
     <string name="steam_storage_permission_required">Permesso di archiviazione richiesto</string>
     <string name="steam_container_reset_success">Container reimpostato ai valori predefiniti</string>
@@ -59,10 +56,6 @@
     <string name="steam_never">Mai</string>
     <string name="epic_cancel_download_message">Sei sicuro di voler annullare il download dell\'app?</string>
     <string name="epic_delete_download_message">Eliminare tutti i dati scaricati per questo gioco?</string>
-    <string name="epic_cloud_sync_starting">Avvio sincronizzazione salvataggi cloud…</string>
-    <string name="epic_cloud_sync_success">Salvataggi cloud sincronizzati con successo</string>
-    <string name="epic_cloud_sync_failed">Sincronizzazione salvataggi cloud non riuscita</string>
-    <string name="epic_cloud_sync_error">Errore sincronizzazione salvataggi cloud: %1$s</string>
     <string name="epic_uninstall_failed">Disinstallazione non riuscita: %1$s</string>
     <string name="epic_uninstall_error">Errore di disinstallazione: %1$s</string>
     <string name="steam_continue">Continua</string>
@@ -964,9 +957,11 @@
     <string name="library_export_cancelled">Esportazione annullata</string>
     <string name="library_shortcut_created">Scorciatoia creata</string>
     <string name="library_failed_to_create_shortcut">Impossibile creare scorciatoia: %s</string>
+    <string name="library_cloud_sync_starting">Avvio sincronizzazione salvataggi cloud…</string>
     <string name="library_cloud_sync_success">Sincronizzazione cloud completata con successo</string>
     <string name="library_cloud_sync_up_to_date">I file di salvataggio sono già aggiornati</string>
-    <string name="library_cloud_sync_failed">Sincronizzazione cloud fallita: %s</string>
+    <string name="library_cloud_sync_failed">Sincronizzazione cloud fallita</string>
+    <string name="library_cloud_sync_error">Errore sincronizzazione salvataggi cloud: %1$s</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Serve internet per installare</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -29,9 +29,6 @@
     <string name="steam_verify_files_message">검증하기 전에 저장 파일이 클라우드에 업로드되었거나 백업되었는지 확인하세요. 그렇지 않으면 덮어쓰기될 수 있습니다.</string>
     <string name="steam_update_title">업데이트</string>
     <string name="steam_update_message">업데이트하기 전에 저장 파일이 클라우드에 업로드되었거나 백업되었는지 확인하세요. 그렇지 않으면 덮어쓰기될 수 있습니다.</string>
-    <string name="steam_cloud_sync_success">클라우드 동기화가 완료되었습니다</string>
-    <string name="steam_cloud_sync_up_to_date">저장 파일이 이미 최신 상태입니다</string>
-    <string name="steam_cloud_sync_failed">클라우드 동기화 실패: %s</string>
     <string name="steam_not_logged_in">이 기능을 사용하려면 Steam에 로그인해야 합니다</string>
     <string name="steam_storage_permission_required">저장소 권한이 필요합니다</string>
     <string name="steam_container_reset_success">컨테이너가 기본값으로 초기화되었습니다</string>
@@ -67,10 +64,6 @@
     <string name="epic_download_error">다운로드 오류: %1$s</string>
     <string name="epic_cancel_download_message">앱 다운로드를 취소하시겠습니까?</string>
     <string name="epic_delete_download_message">이 게임의 다운로드된 모든 데이터를 삭제하시겠습니까?</string>
-    <string name="epic_cloud_sync_starting">클라우드 저장 파일 동기화 시작…</string>
-    <string name="epic_cloud_sync_success">클라우드 저장 파일 동기화 완료</string>
-    <string name="epic_cloud_sync_failed">클라우드 저장 파일 동기화 실패</string>
-    <string name="epic_cloud_sync_error">클라우드 저장 파일 동기화 오류: %1$s</string>
     <string name="epic_uninstall_failed">제거 실패: %1$s</string>
     <string name="epic_uninstall_error">제거 오류: %1$s</string>
     <string name="steam_never">안 함</string>
@@ -982,9 +975,11 @@
     <string name="library_export_cancelled">내보내기 취소됨</string>
     <string name="library_shortcut_created">바로가기가 생성되었습니다</string>
     <string name="library_failed_to_create_shortcut">바로가기 생성 실패: %s</string>
+    <string name="library_cloud_sync_starting">클라우드 저장 파일 동기화 시작…</string>
     <string name="library_cloud_sync_success">클라우드 동기화가 완료되었습니다</string>
     <string name="library_cloud_sync_up_to_date">저장 파일이 이미 최신 상태입니다</string>
-    <string name="library_cloud_sync_failed">클라우드 동기화 실패: %s</string>
+    <string name="library_cloud_sync_failed">클라우드 동기화 실패</string>
+    <string name="library_cloud_sync_error">클라우드 저장 파일 동기화 오류: %1$s</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">설치하려면 인터넷이 필요합니다</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -29,9 +29,6 @@
     <string name="steam_verify_files_message">Upewnij się, że Twoje zapisy są przesłane do chmury lub utworzono ich kopię zapasową przed weryfikacją, w przeciwnym razie mogą zostać nadpisane.</string>
     <string name="steam_update_title">Aktualizuj</string>
     <string name="steam_update_message">Upewnij się, że Twoje zapisy są przesłane do chmury lub utworzono ich kopię zapasową przed aktualizacją, w przeciwnym razie mogą zostać nadpisane.</string>
-    <string name="steam_cloud_sync_success">Synchronizacja z chmurą zakończona pomyślnie</string>
-    <string name="steam_cloud_sync_up_to_date">Pliki zapisu są już aktualne</string>
-    <string name="steam_cloud_sync_failed">Synchronizacja z chmurą nie powiodła się: %s</string>
     <string name="steam_not_logged_in">Musisz być zalogowany do Steam, aby użyć tej funkcji</string>
     <string name="steam_storage_permission_required">Wymagane uprawnienie do pamięci</string>
     <string name="steam_container_reset_success">Kontener zresetowany do domyślnych</string>
@@ -67,10 +64,6 @@
     <string name="epic_download_error">Błąd pobierania: %1$s</string>
     <string name="epic_cancel_download_message">Czy na pewno chcesz anulować pobieranie aplikacji?</string>
     <string name="epic_delete_download_message">Usunąć wszystkie pobrane dane dla tej gry?</string>
-    <string name="epic_cloud_sync_starting">Rozpoczynanie synchronizacji zapisów w chmurze…</string>
-    <string name="epic_cloud_sync_success">Zapisy w chmurze zsynchronizowane pomyślnie</string>
-    <string name="epic_cloud_sync_failed">Synchronizacja zapisów w chmurze nie powiodła się</string>
-    <string name="epic_cloud_sync_error">Błąd synchronizacji zapisów w chmurze: %1$s</string>
     <string name="epic_uninstall_failed">Odinstalowywanie nie powiodło się: %1$s</string>
     <string name="epic_uninstall_error">Błąd odinstalowywania: %1$s</string>
     <string name="steam_never">Nigdy</string>
@@ -981,9 +974,11 @@
     <string name="library_export_cancelled">Eksport anulowany</string>
     <string name="library_shortcut_created">Utworzono skrót</string>
     <string name="library_failed_to_create_shortcut">Nie udało się utworzyć skrótu: %s</string>
+    <string name="library_cloud_sync_starting">Rozpoczynanie synchronizacji zapisów w chmurze…</string>
     <string name="library_cloud_sync_success">Synchronizacja z chmurą zakończona pomyślnie</string>
     <string name="library_cloud_sync_up_to_date">Pliki zapisu są już aktualne</string>
-    <string name="library_cloud_sync_failed">Synchronizacja z chmurą nie powiodła się: %s</string>
+    <string name="library_cloud_sync_failed">Synchronizacja z chmurą nie powiodła się</string>
+    <string name="library_cloud_sync_error">Błąd synchronizacji zapisów w chmurze: %1$s</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Wymagany internet do instalacji</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -119,10 +119,6 @@
     <string name="title_ubuntufs">Ubuntu FS</string>
     <string name="epic_cancel_download_message">Tem certeza de que deseja cancelar o download do aplicativo?</string>
     <string name="epic_delete_download_message">Excluir todos os dados baixados deste jogo?</string>
-    <string name="epic_cloud_sync_starting">Iniciando sincronização de salvamentos na nuvem…</string>
-    <string name="epic_cloud_sync_success">Salvamentos na nuvem sincronizados com sucesso</string>
-    <string name="epic_cloud_sync_failed">Falha na sincronização de salvamentos na nuvem</string>
-    <string name="epic_cloud_sync_error">Erro na sincronização de salvamentos na nuvem: %1$s</string>
     <string name="epic_uninstall_failed">Falha na desinstalação: %1$s</string>
     <string name="epic_uninstall_error">Erro na desinstalação: %1$s</string>
 
@@ -792,9 +788,11 @@
     <string name="library_export_cancelled">Exportação cancelada</string>
     <string name="library_shortcut_created">Atalho criado</string>
     <string name="library_failed_to_create_shortcut">Falha ao criar atalho: %s</string>
+    <string name="library_cloud_sync_starting">Iniciando sincronização de salvamentos na nuvem…</string>
     <string name="library_cloud_sync_success">Sincronização na nuvem concluída com sucesso</string>
     <string name="library_cloud_sync_up_to_date">Os arquivos de save já estão atualizados</string>
-    <string name="library_cloud_sync_failed">Sincronização na nuvem falhou: %s</string>
+    <string name="library_cloud_sync_failed">Sincronização na nuvem falhou</string>
+    <string name="library_cloud_sync_error">Erro na sincronização de salvamentos na nuvem: %1$s</string>
 
     <!-- TODO: Revisão manual - LibraryAppScreen: Rótulos de UI -->
     <string name="library_need_internet">Internet necessária para instalar</string>
@@ -1076,9 +1074,6 @@
     <string name="steam_verify_files_message">Certifique-se de que seus saves foram enviados para a nuvem ou foram feitos backups antes de verificar, caso contrário, eles podem ser sobrescritos.</string>
     <string name="steam_update_title">Atualização</string>
     <string name="steam_update_message">Certifique-se de que seus saves foram enviados para a nuvem ou foram feitos backups antes de atualizar, caso contrário, eles podem ser sobrescritos.</string>
-    <string name="steam_cloud_sync_success">Sincronização na nuvem concluída com sucesso</string>
-    <string name="steam_cloud_sync_up_to_date">Os arquivos de save já estão atualizados</string>
-    <string name="steam_cloud_sync_failed">Sincronização na nuvem falhou: %s</string>
     <string name="steam_storage_permission_required">Permissão de armazenamento necessária</string>
     <string name="steam_container_reset_success">Contêiner redefinido para padrões</string>
     <string name="steam_imagefs_installed">ImageFS instalado. Por favor, tente editar o contêiner novamente.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -29,9 +29,6 @@
     <string name="steam_verify_files_message">Asigură-te că salvările sunt încărcate în cloud sau copiate în altă parte înainte de verificare, deoarece pot fi suprascrise.</string>
     <string name="steam_update_title">Actualizare</string>
     <string name="steam_update_message">Asigură-te că salvările sunt încărcate în cloud sau copiate în altă parte înainte de actualizare, deoarece pot fi suprascrise.</string>
-    <string name="steam_cloud_sync_success">Sincronizarea cloud s-a încheiat cu succes</string>
-    <string name="steam_cloud_sync_up_to_date">Fișierele de salvare sunt deja actualizate</string>
-    <string name="steam_cloud_sync_failed">Sincronizare cloud eșuată: %s</string>
     <string name="steam_not_logged_in">Trebuie să fii autentificat în Steam pentru a folosi această funcție</string>
     <string name="steam_storage_permission_required">Este necesară permisiunea de stocare</string>
     <string name="steam_container_reset_success">Container resetat la setările implicite</string>
@@ -59,10 +56,6 @@
     <string name="steam_never">Niciodată</string>
     <string name="epic_cancel_download_message">Sigur doriți să anulați descărcarea aplicației?</string>
     <string name="epic_delete_download_message">Ștergeți toate datele descărcate pentru acest joc?</string>
-    <string name="epic_cloud_sync_starting">Se pornește sincronizarea salvărilor din cloud…</string>
-    <string name="epic_cloud_sync_success">Salvările din cloud au fost sincronizate cu succes</string>
-    <string name="epic_cloud_sync_failed">Sincronizarea salvărilor din cloud a eșuat</string>
-    <string name="epic_cloud_sync_error">Eroare la sincronizarea salvărilor din cloud: %1$s</string>
     <string name="epic_uninstall_failed">Dezinstalarea a eșuat: %1$s</string>
     <string name="epic_uninstall_error">Eroare la dezinstalare: %1$s</string>
     <string name="steam_continue">Continuă</string>
@@ -972,9 +965,11 @@
 	<string name="library_export_cancelled">Export anulat</string>
 	<string name="library_shortcut_created">Shortcut creat</string>
 	<string name="library_failed_to_create_shortcut">Nu s-a putut crea shortcut-ul: %s</string>
+	<string name="library_cloud_sync_starting">Se pornește sincronizarea salvărilor din cloud…</string>
 	<string name="library_cloud_sync_success">Sincronizare cloud finalizată cu succes</string>
 	<string name="library_cloud_sync_up_to_date">Fișierele de salvare sunt deja la zi</string>
-	<string name="library_cloud_sync_failed">Sincronizare cloud eșuată: %s</string>
+	<string name="library_cloud_sync_failed">Sincronizare cloud eșuată</string>
+	<string name="library_cloud_sync_error">Eroare la sincronizarea salvărilor din cloud: %1$s</string>
 
 	<!-- LibraryAppScreen: UI Labels -->
 	<string name="library_need_internet">Este necesar internet pentru instalare</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -341,10 +341,6 @@
     <string name="end_process">Завершить процесс</string>
     <string name="environment_variables">Переменные окружения</string>
     <string name="epic_cancel_download_message">Вы уверены, что хотите отменить загрузку приложения?</string>
-    <string name="epic_cloud_sync_error">Ошибка синхронизации облачного сохранения: %1$s</string>
-    <string name="epic_cloud_sync_failed">Ошибка синхронизации облачного сохранения</string>
-    <string name="epic_cloud_sync_starting">Начало синхронизации облачного сохранения…</string>
-    <string name="epic_cloud_sync_success">Облачные сохранения успешно синхронизированы</string>
     <string name="epic_delete_download_message">Удалить все загруженные данные для этой игры?</string>
     <string name="epic_download_error">Ошибка загрузки: %1$s</string>
     <string name="epic_download_failed">Ошибка при запуске загрузки: %1$s</string>
@@ -539,9 +535,11 @@ Ubuntu RootFs - releases.ubuntu.com/focal</string>
     <string name="library_app_status">Статус приложения</string>
     <string name="library_app_type">Тип приложения</string>
     <string name="library_cancel_download_message">Вы уверены, что хотите отменить загрузку приложения?</string>
-    <string name="library_cloud_sync_failed">Ошибка синхронизации облака: %s</string>
+    <string name="library_cloud_sync_starting">Начало синхронизации облака…</string>
     <string name="library_cloud_sync_success">Синхронизация облака завершена успешно</string>
     <string name="library_cloud_sync_up_to_date">Файлы сохранения уже актуальны</string>
+    <string name="library_cloud_sync_failed">Ошибка синхронизации облака</string>
+    <string name="library_cloud_sync_error">Ошибка синхронизации облачного сохранения: %1$s</string>
     <string name="library_compatibility_unknown">Неизвестно</string>
     <string name="library_compatible">Совместимо</string>
     <string name="library_config_title">Конфигурация %s</string>
@@ -1050,9 +1048,6 @@ https://gamenative.app
     <string name="steam_2fa_email">Пожалуйста, введите код аутентификации, отправленный на %s</string>
     <string name="steam_2fa_incorrect">Предыдущий код был неправильным, пожалуйста, попробуйте снова.</string>
     <string name="steam_cancel_download_message">Вы уверены, что хотите отменить загрузку приложения?</string>
-    <string name="steam_cloud_sync_failed">Ошибка синхронизации облака: %s</string>
-    <string name="steam_cloud_sync_success">Синхронизация облака завершена успешно</string>
-    <string name="steam_cloud_sync_up_to_date">Файлы сохранения уже актуальны</string>
     <string name="steam_container_reset_success">Контейнер сброшен на значения по умолчанию</string>
     <string name="steam_continue">Продолжить</string>
     <string name="steam_delete_download_message">Удалить все загруженные данные для этой игры?</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -29,9 +29,6 @@
     <string name="steam_verify_files_message">Будь ласка, переконайтеся, що ваші збереження завантажено у хмару або створено їхню резервну копію перед перевіркою, оскільки інакше вони можуть бути перезаписані.</string>
     <string name="steam_update_title">Оновити</string>
     <string name="steam_update_message">Будь ласка, переконайтеся, що ваші збереження завантажено у хмару або створено їхню резервну копію перед оновленням, оскільки інакше вони можуть бути перезаписані.</string>
-    <string name="steam_cloud_sync_success">Успішна синхронізація з хмарою</string>
-    <string name="steam_cloud_sync_up_to_date">Файли збереження вже актуальні</string>
-    <string name="steam_cloud_sync_failed">Помилка синхронізації з хмарою: %s</string>
     <string name="steam_not_logged_in">Ви повинні увійти в Steam, щоб використовувати цю функцію</string>
     <string name="steam_storage_permission_required">Необхідний дозвіл на доступ до сховища</string>
     <string name="steam_container_reset_success">Контейнер скинуто до стандартних налаштувань</string>
@@ -963,9 +960,11 @@
     <string name="library_export_cancelled">Вивантаження скасовано</string>
     <string name="library_shortcut_created">Створено ярлик</string>
     <string name="library_failed_to_create_shortcut">Помилка створення ярлика: %s</string>
+    <string name="library_cloud_sync_starting">Запуск синхронізації з хмарою…</string>
     <string name="library_cloud_sync_success">Успішна синхронізація з хмарою</string>
     <string name="library_cloud_sync_up_to_date">Файли збереження вже актуальні</string>
-    <string name="library_cloud_sync_failed">Помилка синхронізації з хмарою: %s</string>
+    <string name="library_cloud_sync_failed">Помилка синхронізації з хмарою</string>
+    <string name="library_cloud_sync_error">Помилка синхронізації з хмарою: %1$s</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Потрібне інтернет-з\'єднання для інсталяції</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -29,9 +29,6 @@
     <string name="steam_verify_files_message">验证前请确保存档已上传至云端或已备份，否则存档可能会被覆盖</string>
     <string name="steam_update_title">更新</string>
     <string name="steam_update_message">更新前请确保存档已上传至云端或已备份，否则存档可能会被覆盖</string>
-    <string name="steam_cloud_sync_success">云同步已成功完成</string>
-    <string name="steam_cloud_sync_up_to_date">游戏存档已是最新版本</string>
-    <string name="steam_cloud_sync_failed">云同步失败：%s</string>
     <string name="steam_storage_permission_required">需要存储权限</string>
     <string name="steam_container_reset_success">容器已重置为默认设置</string>
     <string name="steam_imagefs_installed">ImageFS 已安装，请重试编辑容器</string>
@@ -58,10 +55,6 @@
     <string name="steam_never">从不</string>
     <string name="epic_cancel_download_message">确定要取消下载应用程序吗？</string>
     <string name="epic_delete_download_message">删除此游戏的所有已下载数据？</string>
-    <string name="epic_cloud_sync_starting">正在开始云存档同步…</string>
-    <string name="epic_cloud_sync_success">云存档同步成功</string>
-    <string name="epic_cloud_sync_failed">云存档同步失败</string>
-    <string name="epic_cloud_sync_error">云存档同步错误：%1$s</string>
     <string name="epic_uninstall_failed">卸载失败：%1$s</string>
     <string name="epic_uninstall_error">卸载错误：%1$s</string>
     <string name="steam_continue">继续</string>
@@ -961,9 +954,11 @@
     <string name="library_export_cancelled">导出已取消</string>
     <string name="library_shortcut_created">快捷方式已创建</string>
     <string name="library_failed_to_create_shortcut">创建快捷方式失败：%s</string>
-    <string name="library_cloud_sync_success">云同步完成</string>
-    <string name="library_cloud_sync_up_to_date">存档文件已更新至最新版本</string>
-    <string name="library_cloud_sync_failed">云同步失败：%s</string>
+    <string name="library_cloud_sync_starting">正在同步云存档…</string>
+    <string name="library_cloud_sync_success">云存档同步完成</string>
+    <string name="library_cloud_sync_up_to_date">云存档同步已是最新状态</string>
+    <string name="library_cloud_sync_failed">云存档同步失败</string>
+    <string name="library_cloud_sync_error">云存档同步错误：%1$s</string>
 
     <!-- 库应用界面：UI标签 -->
     <string name="library_need_internet">需联网安装</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -29,9 +29,6 @@
     <string name="steam_verify_files_message">請確保您的存檔已上傳至雲端或已備份, 然後再進行驗證, 否則存檔可能會被覆蓋</string>
     <string name="steam_update_title">更新</string>
     <string name="steam_update_message">請確保您的存檔已上傳至雲端或已備份, 然後再進行驗證, 否則存檔可能會被覆蓋</string>
-    <string name="steam_cloud_sync_success">雲端同步已成功完成</string>
-    <string name="steam_cloud_sync_up_to_date">遊戲存檔已是最新版本</string>
-    <string name="steam_cloud_sync_failed">雲端同步失敗: %s</string>
     <string name="steam_storage_permission_required">需要存儲權限</string>
     <string name="steam_container_reset_success">容器重設為預設設定</string>
     <string name="steam_imagefs_installed">已安裝 ImageFS, 請嘗試再次編輯容器</string>
@@ -58,10 +55,6 @@
     <string name="steam_never">從不</string>
     <string name="epic_cancel_download_message">確定要取消下載應用程式嗎？</string>
     <string name="epic_delete_download_message">刪除此遊戲的所有已下載資料？</string>
-    <string name="epic_cloud_sync_starting">正在開始雲端存檔同步…</string>
-    <string name="epic_cloud_sync_success">雲端存檔同步成功</string>
-    <string name="epic_cloud_sync_failed">雲端存檔同步失敗</string>
-    <string name="epic_cloud_sync_error">雲端存檔同步錯誤：%1$s</string>
     <string name="epic_uninstall_failed">解除安裝失敗：%1$s</string>
     <string name="epic_uninstall_error">解除安裝錯誤：%1$s</string>
     <string name="steam_continue">繼續</string>
@@ -964,9 +957,11 @@
     <string name="library_export_cancelled">匯出已取消</string>
     <string name="library_shortcut_created">捷徑已建立</string>
     <string name="library_failed_to_create_shortcut">建立捷徑失敗: %s</string>
+    <string name="library_cloud_sync_starting">正在開始雲端存檔同步…</string>
     <string name="library_cloud_sync_success">雲端同步完成</string>
     <string name="library_cloud_sync_up_to_date">儲存檔案已更新至最新版本</string>
-    <string name="library_cloud_sync_failed">雲端同步失敗: %s</string>
+    <string name="library_cloud_sync_failed">雲端同步失敗</string>
+    <string name="library_cloud_sync_error">雲端存檔同步錯誤：%1$s</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">需連網安裝</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,9 +29,6 @@
     <string name="steam_verify_files_message">Please ensure your saves are uploaded to the cloud or backed up before verifying, as they may be overwritten otherwise.</string>
     <string name="steam_update_title">Update</string>
     <string name="steam_update_message">Please ensure your saves are uploaded to the cloud or backed up before updating, as they may be overwritten otherwise.</string>
-    <string name="steam_cloud_sync_success">Cloud sync completed successfully</string>
-    <string name="steam_cloud_sync_up_to_date">Save files are already up to date</string>
-    <string name="steam_cloud_sync_failed">Cloud sync failed: %s</string>
     <string name="steam_not_logged_in">You must be logged into Steam to use this feature</string>
     <string name="steam_storage_permission_required">Storage permission required</string>
     <string name="steam_container_reset_success">Container reset to defaults</string>
@@ -67,10 +64,6 @@
     <string name="epic_download_error">Download error: %1$s</string>
     <string name="epic_cancel_download_message">Are you sure you want to cancel the download of the app?</string>
     <string name="epic_delete_download_message">Delete all downloaded data for this game?</string>
-    <string name="epic_cloud_sync_starting">Starting cloud save sync…</string>
-    <string name="epic_cloud_sync_success">Cloud saves synced successfully</string>
-    <string name="epic_cloud_sync_failed">Cloud save sync failed</string>
-    <string name="epic_cloud_sync_error">Cloud save sync error: %1$s</string>
     <string name="epic_uninstall_failed">Uninstall failed: %1$s</string>
     <string name="epic_uninstall_error">Uninstall error: %1$s</string>
     <string name="steam_never">Never</string>
@@ -988,9 +981,11 @@
     <string name="library_export_cancelled">Export cancelled</string>
     <string name="library_shortcut_created">Shortcut created</string>
     <string name="library_failed_to_create_shortcut">Failed to create shortcut: %s</string>
+    <string name="library_cloud_sync_starting">Starting cloud save sync…</string>
     <string name="library_cloud_sync_success">Cloud sync completed successfully</string>
     <string name="library_cloud_sync_up_to_date">Save files are already up to date</string>
-    <string name="library_cloud_sync_failed">Cloud sync failed: %s</string>
+    <string name="library_cloud_sync_failed">Cloud sync failed</string>
+    <string name="library_cloud_sync_error">Cloud sync error: %1$s</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Need internet to install</string>

--- a/app/src/test/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreenTest.kt
+++ b/app/src/test/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreenTest.kt
@@ -1,0 +1,82 @@
+package app.gamenative.ui.screen.library.appscreen
+
+import android.content.Context
+import app.gamenative.R
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class GOGAppScreenTest {
+    @Test
+    fun `forceCloudSync shows success messages when sync succeeds`() = runBlocking {
+        val context = mockContext()
+        val messages = mutableListOf<String>()
+        var calledAppId: String? = null
+        var calledPreferredAction: String? = null
+
+        GOGAppScreen.forceCloudSync(
+            context = context,
+            appId = "app-123",
+            syncCloudSaves = { _, appId, preferredAction ->
+                calledAppId = appId
+                calledPreferredAction = preferredAction
+                true
+            },
+            showSnackbar = { messages += it },
+        )
+
+        assertEquals("app-123", calledAppId)
+        assertEquals("auto", calledPreferredAction)
+        assertEquals(listOf("starting", "success"), messages)
+    }
+
+    @Test
+    fun `forceCloudSync shows failure message when sync fails`() = runBlocking {
+        val context = mockContext()
+        val messages = mutableListOf<String>()
+
+        GOGAppScreen.forceCloudSync(
+            context = context,
+            appId = "app-123",
+            syncCloudSaves = { _, _, _ -> false },
+            showSnackbar = { messages += it },
+        )
+
+        assertEquals(listOf("starting", "failed"), messages)
+    }
+
+    @Test
+    fun `forceCloudSync logs and shows error when sync throws`() = runBlocking {
+        val context = mockContext()
+        val messages = mutableListOf<String>()
+        var loggedError: Throwable? = null
+
+        GOGAppScreen.forceCloudSync(
+            context = context,
+            appId = "app-123",
+            syncCloudSaves = { _, _, _ -> throw IllegalStateException("boom") },
+            showSnackbar = { messages += it },
+            logError = { loggedError = it },
+        )
+
+        assertTrue(loggedError is IllegalStateException)
+        assertEquals("boom", loggedError?.message)
+        assertEquals(listOf("starting", "error: boom"), messages)
+    }
+
+    private fun mockContext(): Context {
+        val context = mock<Context>()
+        whenever(context.getString(R.string.library_cloud_sync_starting)).thenReturn("starting")
+        whenever(context.getString(R.string.library_cloud_sync_success)).thenReturn("success")
+        whenever(context.getString(R.string.library_cloud_sync_failed)).thenReturn("failed")
+        whenever(context.getString(eq(R.string.library_cloud_sync_error), any())).thenAnswer {
+            "error: ${it.arguments[1]}"
+        }
+        return context
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GOG “Force Cloud Sync” action and unifies cloud sync toasts across Steam, Epic, and GOG using shared `library_cloud_sync_*` strings. Adds a starting toast, standardizes failed vs. error messages, and hides the cloud icon unless cloud sync is available.

- **New Features**
  - Added GOG “Force Cloud Sync” for installed games via `GOGService.syncCloudSaves`, with starting/success/failed/error snackbars.

- **Refactors**
  - Replaced Steam/Epic toasts with `library_cloud_sync_starting/success/up_to_date/failed/error`; Steam now shows a starting toast.
  - Standardized strings (`library_cloud_sync_failed` non-parameterized, `library_cloud_sync_error` parameterized), removed provider-specific copies across locales, and added tests for `GOGAppScreen.forceCloudSync` (success/failure/error).

<sup>Written for commit 0b19c18992e3bd0e212d4959e28883766530a98b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Force Cloud Sync option for GOG games.

* **Refactor**
  * Consolidated cloud-sync notifications under library-level messages (starting, success/up-to-date, failed, error).
  * Introduced a distinct "starting" notice and a separate parameterized error message; made generic "failed" non-parameterized.
  * Replaced provider-specific Steam/Epic cloud-sync copies with the unified library-scoped strings across locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->