### PR TITLE
Added "compatibility" filter

### DIFF
--- a/app/src/main/java/app/gamenative/ui/enums/AppFilter.kt
+++ b/app/src/main/java/app/gamenative/ui/enums/AppFilter.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.Diversity3
 import androidx.compose.material.icons.filled.InstallMobile
 import androidx.compose.material.icons.filled.VideogameAsset
+import androidx.compose.material.icons.rounded.Verified
 import androidx.compose.ui.graphics.vector.ImageVector
 import app.gamenative.enums.AppType
 import app.gamenative.R
@@ -46,6 +47,11 @@ enum class AppFilter(
         code = 0x20,
         displayText = "Family Sharing",
         icon = Icons.Default.Diversity3,
+    ),
+    COMPATIBLE(
+        code = 0x40,
+        displayText = "Compatible",
+        icon = Icons.Rounded.Verified,
     ),
     // ALPHABETIC(
     //     code = 0x20,

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -360,9 +360,16 @@ class LibraryViewModel @Inject constructor(
             val downloadDirectoryApps = DownloadService.getDownloadDirectoryApps()
             val downloadDirectorySet = downloadDirectoryApps.toHashSet()
 
-            // Filter Steam apps first (no pagination yet)
-            // Note: Don't sort individual lists - we'll sort the combined list for consistent ordering
-            val filteredSteamApps: List<SteamApp> = appList
+            fun passesCompatibleFilter(gameName: String): Boolean {
+                if (!currentState.appInfoSortType.contains(AppFilter.COMPATIBLE)) {
+                    return true
+                }
+                val cached = GameCompatibilityCache.getCached(gameName) ?: return true
+                val status = compatibilityStatusFor(cached)
+                return status == GameCompatibilityStatus.COMPATIBLE || status == GameCompatibilityStatus.GPU_COMPATIBLE
+            }
+
+            val steamFilteredBeforeCompatibility: List<SteamApp> = appList
                 .asSequence()
                 .filter { item ->
                     SteamService.familyMembers.ifEmpty {
@@ -404,6 +411,13 @@ class LibraryViewModel @Inject constructor(
                         true
                     }
                 }
+                .toList()
+
+            // Filter Steam apps first (no pagination yet)
+            // Note: Don't sort individual lists - we'll sort the combined list for consistent ordering
+            val filteredSteamApps: List<SteamApp> = steamFilteredBeforeCompatibility
+                .asSequence()
+                .filter { item -> passesCompatibleFilter(item.name) }
                 .sortedWith(
                     compareByDescending<SteamApp> {
                         downloadDirectorySet.contains(SteamService.getAppDirName(it))
@@ -444,7 +458,9 @@ class LibraryViewModel @Inject constructor(
             } else {
                 emptyList()
             }
-            val customEntries = customGameItems.map { LibraryEntry(it, true) }
+            val customEntries = customGameItems
+                .filter { passesCompatibleFilter(it.name) }
+                .map { LibraryEntry(it, true) }
 
             // Filter GOG games
             val filteredGOGGames = gogGameList
@@ -467,7 +483,9 @@ class LibraryViewModel @Inject constructor(
                 }
                 .toList()
 
-            val gogEntries = filteredGOGGames.map { game ->
+            val gogEntries = filteredGOGGames
+                .filter { passesCompatibleFilter(it.title) }
+                .map { game ->
                 LibraryEntry(
                     item = LibraryItem(
                         index = 0,
@@ -502,7 +520,9 @@ class LibraryViewModel @Inject constructor(
                 }
                 .toList()
 
-            val epicEntries = filteredEpicGames.map { game ->
+            val epicEntries = filteredEpicGames
+                .filter { passesCompatibleFilter(it.title) }
+                .map { game ->
                 LibraryEntry(
                     item = LibraryItem(
                         index = 0,
@@ -537,7 +557,9 @@ class LibraryViewModel @Inject constructor(
                 }
                 .toList()
 
-            val amazonEntries = filteredAmazonGames.map { game ->
+            val amazonEntries = filteredAmazonGames
+                .filter { passesCompatibleFilter(it.title) }
+                .map { game ->
                 LibraryEntry(
                     item = LibraryItem(
                         index = 0,
@@ -559,13 +581,13 @@ class LibraryViewModel @Inject constructor(
             // This needs to happen before filtering by source, so we save the total counts
             if (currentState.searchQuery.isEmpty()) {
                 PrefManager.customGamesCount = customGameItems.size
-                PrefManager.steamGamesCount = filteredSteamApps.size
+                PrefManager.steamGamesCount = steamFilteredBeforeCompatibility.size
                 PrefManager.gogGamesCount = filteredGOGGames.size
                 PrefManager.gogInstalledGamesCount = gogInstalledCount
                 PrefManager.epicGamesCount = filteredEpicGames.size
                 PrefManager.epicInstalledGamesCount = epicInstalledCount
                 PrefManager.amazonInstalledGamesCount = amazonInstalledCount
-                Timber.tag("LibraryViewModel").d("Saved counts - Custom: ${customGameItems.size}, Steam: ${filteredSteamApps.size}, GOG: ${filteredGOGGames.size}, GOG installed: $gogInstalledCount, Epic: ${filteredEpicGames.size}, Epic installed: $epicInstalledCount, Amazon installed: $amazonInstalledCount")
+                Timber.tag("LibraryViewModel").d("Saved counts - Custom: ${customGameItems.size}, Steam: ${steamFilteredBeforeCompatibility.size}, GOG: ${filteredGOGGames.size}, GOG installed: $gogInstalledCount, Epic: ${filteredEpicGames.size}, Epic installed: $epicInstalledCount, Amazon installed: $amazonInstalledCount")
             }
 
             // Compute effective source filters based on current tab
@@ -754,6 +776,10 @@ class LibraryViewModel @Inject constructor(
                 // Update state with newly fetched results
                 if (fetchedResults.isNotEmpty()) {
                     updateCompatibilityState(fetchedResults)
+                    // Re-apply list filtering once new compatibility data is available
+                    if (_state.value.appInfoSortType.contains(AppFilter.COMPATIBLE)) {
+                        onFilterApps(paginationCurrentPage)
+                    }
                 }
             } catch (e: Exception) {
                 Timber.tag("LibraryViewModel").e(e, "Error fetching compatibility data: ${e.message}")
@@ -769,14 +795,7 @@ class LibraryViewModel @Inject constructor(
         results: Map<String, GameCompatibilityService.GameCompatibilityResponse>
     ) {
         val compatibilityMap = results.mapValues { (gameName, response) ->
-            val status = when {
-                response.isNotWorking -> GameCompatibilityStatus.NOT_COMPATIBLE
-                !response.hasBeenTried -> GameCompatibilityStatus.UNKNOWN
-                response.gpuPlayableCount > 0 -> GameCompatibilityStatus.GPU_COMPATIBLE
-                response.totalPlayableCount > 0 -> GameCompatibilityStatus.COMPATIBLE
-                else -> GameCompatibilityStatus.UNKNOWN
-            }
-            status
+            compatibilityStatusFor(response)
         }
 
         // Update state with compatibility map (merge with existing)
@@ -785,6 +804,18 @@ class LibraryViewModel @Inject constructor(
             mergedMap.putAll(compatibilityMap)
             Timber.tag("LibraryViewModel").d("Updated state with ${compatibilityMap.size} compatibility entries, total: ${mergedMap.size}")
             currentState.copy(compatibilityMap = mergedMap)
+        }
+    }
+
+    private fun compatibilityStatusFor(
+        response: GameCompatibilityService.GameCompatibilityResponse,
+    ): GameCompatibilityStatus {
+        return when {
+            response.isNotWorking -> GameCompatibilityStatus.NOT_COMPATIBLE
+            !response.hasBeenTried -> GameCompatibilityStatus.UNKNOWN
+            response.gpuPlayableCount > 0 -> GameCompatibilityStatus.GPU_COMPATIBLE
+            response.totalPlayableCount > 0 -> GameCompatibilityStatus.COMPATIBLE
+            else -> GameCompatibilityStatus.UNKNOWN
         }
     }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryOptionsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryOptionsPanel.kt
@@ -203,7 +203,13 @@ fun LibraryOptionsPanel(
                             verticalArrangement = Arrangement.spacedBy(2.dp)
                         ) {
                             AppFilter.entries.forEach { appFilter ->
-                                if (appFilter.code !in listOf(0x01, 0x20)) {
+                                if (appFilter in listOf(
+                                        AppFilter.GAME,
+                                        AppFilter.APPLICATION,
+                                        AppFilter.TOOL,
+                                        AppFilter.DEMO,
+                                    )
+                                ) {
                                     OptionListItem(
                                         text = appFilter.displayText,
                                         selected = selectedFilters.contains(appFilter),
@@ -226,7 +232,12 @@ fun LibraryOptionsPanel(
                             verticalArrangement = Arrangement.spacedBy(2.dp)
                         ) {
                             AppFilter.entries.forEach { appFilter ->
-                                if (appFilter.code in listOf(0x01, 0x20)) {
+                                if (appFilter in listOf(
+                                        AppFilter.INSTALLED,
+                                        AppFilter.SHARED,
+                                        AppFilter.COMPATIBLE,
+                                    )
+                                ) {
                                     OptionListItem(
                                         text = appFilter.displayText,
                                         selected = selectedFilters.contains(appFilter),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Compatible” library filter to focus your library on playable titles using cached and fetched data. It hides not-working apps and keeps titles known to be compatible, including GPU-compatible.

- **New Features**
  - Added `AppFilter.COMPATIBLE` with a verified icon; applied across Steam, Custom, GOG, Epic, and Amazon via `GameCompatibilityCache` to keep only `COMPATIBLE` or `GPU_COMPATIBLE`.
  - Updated options panel: “Compatible” is grouped with `Installed`/`Shared`; type filters (`Game`/`App`/`Tool`/`Demo`) remain separate.
  - When new compatibility data arrives, the list auto-re-filters if “Compatible” is active.

- **Bug Fixes**
  - Steam totals stay accurate by saving counts before compatibility filtering.

<sup>Written for commit a2ea706fa56c2096807a366106e14c4c55b0173c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Compatible" filter and per-item compatibility status so you can identify compatible apps/games across your library.
  * Library now fetches, caches, and applies compatibility data to listings for more accurate compatibility indicators and counts.

* **UI/UX Improvements**
  * Filter options panel simplified to show only relevant choices, including the new Compatible option, reducing clutter and improving discoverability.
  * Counts and listings update to reflect compatibility-aware filtering for clearer results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->