### PR TITLE
Improve boot splash tip readability on dark displays

### DIFF
--- a/app/src/main/java/app/gamenative/ui/components/BootingSplash.kt
+++ b/app/src/main/java/app/gamenative/ui/components/BootingSplash.kt
@@ -238,7 +238,7 @@ fun BootingSplash(
                                 style = MaterialTheme.typography.bodySmall.copy(
                                     lineHeight = 20.sp,
                                 ),
-                                color = PluviaTheme.colors.borderDefault,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 textAlign = TextAlign.Center,
                                 modifier = Modifier
                                     .fillMaxWidth()


### PR DESCRIPTION
## Summary
- replace the boot splash tip text color with Material 3's onSurfaceVariant
- keep the existing hierarchy while making the gray help text readable on dark and AMOLED displays

Implements the contrast fix requested in #822.

Before:
![Screenshot_20260312_140717_GameNative](https://github.com/user-attachments/assets/c4f28cb3-b545-47aa-be56-3cb394035499)
After:
![Screenshot_20260312_152216_GameNative](https://github.com/user-attachments/assets/15ca23d3-e65e-47de-8bbb-2ab9a0aaa943)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve boot splash tip readability on dark and AMOLED displays by switching the tip text color to Material 3 `onSurfaceVariant` while keeping the existing text hierarchy. Fixes #822.

<sup>Written for commit 9db4f839762ee450932775cb4572a9454b170739. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the tips text color in the boot splash screen for improved visual consistency with the design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->