### PR TITLE
fix: allow intent launches for non-Steam and offline-mode games

### DIFF
--- a/app/src/main/java/app/gamenative/MainActivity.kt
+++ b/app/src/main/java/app/gamenative/MainActivity.kt
@@ -37,6 +37,7 @@ import app.gamenative.service.epic.EpicService
 import app.gamenative.ui.PluviaMain
 import app.gamenative.ui.enums.Orientation
 import app.gamenative.utils.AnimatedPngDecoder
+import app.gamenative.data.GameSource
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.IconDecoder
 import app.gamenative.utils.IntentLaunchManager
@@ -224,10 +225,21 @@ class MainActivity : ComponentActivity() {
                 Timber.d("[IntentLaunch]: Received external launch intent for app ${launchRequest.appId}")
                 wasLaunchedViaExternalIntent = true
 
-                // If already logged in, emit event immediately
-                // Otherwise store for processing after login
-                if (SteamService.isLoggedIn) {
-                    Timber.d("[IntentLaunch]: User already logged in, emitting ExternalGameLaunch event immediately")
+                val gameSource = ContainerUtils.extractGameSourceFromContainerId(launchRequest.appId)
+                val runsWithoutSteam = gameSource == GameSource.STEAM &&
+                    ContainerUtils.hasContainer(this, launchRequest.appId) &&
+                    ContainerUtils.getContainer(this, launchRequest.appId).isSteamOfflineMode()
+
+                // only defer to pending for Steam games that need login;
+                // non-Steam games and Steam-offline-mode games can launch without Steam
+                if (gameSource == GameSource.STEAM && !SteamService.isLoggedIn && !runsWithoutSteam) {
+                    setPendingLaunchRequest(launchRequest)
+                    Timber.d("[IntentLaunch]: Steam game but not logged in, stored pending launch request for app ${launchRequest.appId}")
+                } else {
+                    // clear any stale pending request so it doesn't fire on later login
+                    consumePendingLaunchRequest()
+
+                    Timber.d("[IntentLaunch]: Emitting ExternalGameLaunch event for app ${launchRequest.appId}")
                     lifecycleScope.launch {
                         PluviaApp.events.emit(AndroidEvent.ExternalGameLaunch(launchRequest.appId))
                     }
@@ -236,10 +248,6 @@ class MainActivity : ComponentActivity() {
                     launchRequest.containerConfig?.let { config ->
                         IntentLaunchManager.applyTemporaryConfigOverride(this, launchRequest.appId, config)
                     }
-                } else {
-                    // Store the launch request to be processed after login
-                    setPendingLaunchRequest(launchRequest)
-                    Timber.d("[IntentLaunch]: User not logged in, stored pending launch request for app ${launchRequest.appId}")
                 }
             } else {
                 wasLaunchedViaExternalIntent = false


### PR DESCRIPTION
Closes #833

## Summary
- `handleLaunchIntent()` checked `SteamService.isLoggedIn` for all games, blocking non-Steam and offline-configured Steam games from launching via intent when Steam was offline
- Now only defers to pending launch for Steam games that actually need login; all other sources emit `ExternalGameLaunch` immediately

## Test plan
- [ ] Launch custom game via intent with Steam offline
- [ ] Launch GOG/Epic game via intent with Steam offline
- [ ] Launch Steam game with `steamOfflineMode` via intent with Steam offline
- [ ] Launch Steam game (online mode) via intent with Steam offline — should defer until login
- [ ] Launch any game via intent with Steam online — should work as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix intent launches so non-Steam and Steam offline-mode games can start when Steam is offline. Only Steam games that need login are deferred; others emit `AndroidEvent.ExternalGameLaunch` and clear any stale pending request.

<sup>Written for commit 8dda6b90f8291a8e816f39beeb41e396ff6526bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game launch handling for Steam titles to better allow offline play when Steam auth isn't required.
  * Now defers launches only when Steam login is needed and unavailable; otherwise launches immediately and applies container config overrides.
  * Clears stale pending launch requests and adds clearer logging to indicate deferred vs immediate launches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->