### PR TITLE
fix: skip achievements generation when Steam not logged in

### DIFF
--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -1341,14 +1341,23 @@ object SteamUtils {
     }
 
     fun generateAchievementsFile(dllPath: Path, appId: String) {
+        if (!SteamService.isLoggedIn) {
+            Timber.w("Skipping achievements generation for $appId — Steam not logged in")
+            return
+        }
+
         val steamAppId = ContainerUtils.extractGameIdFromContainerId(appId)
         val settingsDir = dllPath.parent.resolve("steam_settings")
         if (Files.notExists(settingsDir)) {
             Files.createDirectories(settingsDir)
         }
 
-        runBlocking {
-            SteamService.generateAchievements(steamAppId, settingsDir.absolutePathString())
+        try {
+            runBlocking {
+                SteamService.generateAchievements(steamAppId, settingsDir.absolutePathString())
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to generate achievements for $appId")
         }
     }
 }


### PR DESCRIPTION
Closes #834

## Summary
- `generateAchievementsFile` NPEs on `instance!!._steamUser!!` when Steam is offline
- Guard with `SteamService.isLoggedIn` check — achievements can't be fetched from Steam API offline anyway; previous cached files in `steam_settings/` persist from prior online launches

## Test plan
- [ ] Launch Steam game with `steamOfflineMode` while Steam is offline — no crash
- [ ] Launch Steam game online — achievements still generated normally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip achievements generation when Steam isn’t logged in to prevent a null-pointer crash in `generateAchievementsFile`, and keep using cached files in `steam_settings/`. When online, achievements still generate; failures are now caught and logged instead of crashing.

<sup>Written for commit 37d2c1abc446769f5d484373261cac0edee2f158. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added Steam authentication validation to skip achievement generation when not logged in, with a warning log.
  * Improved error handling around achievement generation to log failures instead of allowing crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->