### PR TITLE
fix(): update achievement background for better contrast

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/AchievementOverlay.kt
+++ b/app/src/main/java/app/gamenative/ui/component/AchievementOverlay.kt
@@ -99,9 +99,8 @@ private fun AchievementNotificationContent(notification: AchievementNotification
             Column {
                 Text(
                     text = stringResource(R.string.achievement_unlocked),
-                    style = MaterialTheme.typography.labelSmall,
+                    style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.primary,
-                    fontWeight = FontWeight.Bold,
                 )
                 Text(
                     text = notification.name,


### PR DESCRIPTION
Update the achievement pop-up to have a better contrast and be more "our brand" 

Before:

<img width="453" height="98" alt="image" src="https://github.com/user-attachments/assets/999e7848-29db-4966-84da-cef58cb4d676" />


After: 

<img width="740" height="160" alt="image" src="https://github.com/user-attachments/assets/03dc949f-7d3a-4d67-83c3-563cb8833854" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve achievement pop-up contrast by switching the background to `surfaceContainerLow`, and adjust the title text to `labelLarge` without bold for clearer, brand-aligned readability.

<sup>Written for commit 4e881fd0152ef5a9b0e36eb5e3ce2752596a9e17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated achievement notification appearance: adjusted surface color for improved visual consistency.
  * Increased title typography size and removed bold weight for a subtler header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->