### PR TITLE
feat: Adjust color scheme of the External Display Input

### DIFF
--- a/app/src/main/java/app/gamenative/externaldisplay/ExternalDisplayInputController.kt
+++ b/app/src/main/java/app/gamenative/externaldisplay/ExternalDisplayInputController.kt
@@ -20,8 +20,6 @@ import com.winlator.container.Container
 import com.winlator.widget.TouchpadView
 import com.winlator.xserver.XServer
 
-private const val EXTERNAL_SURFACE_BG_RES: Int = R.color.external_display_surface_background
-private const val EXTERNAL_KEY_BG_RES: Int = R.color.external_display_key_background
 
 class ExternalDisplayInputController(
     private val context: Context,
@@ -155,7 +153,7 @@ private class ExternalInputPresentation(
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT,
                     )
-                    setBackgroundColor(ContextCompat.getColor(context, EXTERNAL_SURFACE_BG_RES))
+                    setBackgroundColor(ContextCompat.getColor(context, R.color.external_display_surface_background))
                     touchpadViewProvider()?.let { primary ->
                         setSimTouchScreen(primary.isSimTouchScreen)
                     }
@@ -168,7 +166,7 @@ private class ExternalInputPresentation(
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT,
                     )
-                    setBackgroundColor(ContextCompat.getColor(context, EXTERNAL_SURFACE_BG_RES))
+                    setBackgroundColor(ContextCompat.getColor(context, R.color.external_display_surface_background))
                 }
 
                 val hintIcon = ImageView(context).apply {
@@ -178,7 +176,7 @@ private class ExternalInputPresentation(
                         gravity = Gravity.CENTER
                     }
                     setImageResource(R.drawable.icon_keyboard)
-                    alpha = 0.35f
+                    setColorFilter(ContextCompat.getColor(context, R.color.external_display_key_color))
                     scaleType = ImageView.ScaleType.FIT_CENTER
                 }
 
@@ -221,7 +219,7 @@ private class HybridInputLayout(
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.MATCH_PARENT,
         )
-        setBackgroundColor(ContextCompat.getColor(context, EXTERNAL_SURFACE_BG_RES))
+        setBackgroundColor(ContextCompat.getColor(context, R.color.external_display_surface_background))
         touchpadViewProvider()?.let { primary ->
             setSimTouchScreen(primary.isSimTouchScreen)
         }
@@ -246,9 +244,10 @@ private class HybridInputLayout(
         }
         background = GradientDrawable().apply {
             shape = GradientDrawable.OVAL
-            setColor(ContextCompat.getColor(context, EXTERNAL_KEY_BG_RES))
+            setColor(ContextCompat.getColor(context, R.color.external_display_key_background))
         }
         setImageResource(R.drawable.icon_keyboard)
+        setColorFilter(ContextCompat.getColor(context, R.color.external_display_key_color))
         scaleType = ImageView.ScaleType.CENTER_INSIDE
         setPadding(marginPx / 2, marginPx / 2, marginPx / 2, marginPx / 2)
         setOnClickListener { toggleKeyboard() }

--- a/app/src/main/java/app/gamenative/externaldisplay/ExternalOnScreenKeyboardView.kt
+++ b/app/src/main/java/app/gamenative/externaldisplay/ExternalOnScreenKeyboardView.kt
@@ -7,7 +7,6 @@ import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.StateListDrawable
 import android.view.Gravity
 import android.view.MotionEvent
-import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
@@ -43,11 +42,12 @@ class ExternalOnScreenKeyboardView(
     private val keyButtons = mutableListOf<KeyButton>()
     private val downKeys = mutableSetOf<XKeycode>()
     private var shiftState: ShiftState = ShiftState.OFF
+
     private val keyboardBackgroundColor: Int = ContextCompat.getColor(context, R.color.external_display_keyboard_background)
     private val keyBackgroundColor: Int = ContextCompat.getColor(context, R.color.external_display_key_background)
     private val keyHighlightColor: Int = ContextCompat.getColor(context, R.color.external_display_key_highlight_background)
-    private val keyHighlightStrongColor: Int =
-        ContextCompat.getColor(context, R.color.external_display_key_highlight_strong_background)
+    private val keyHighlightStrongColor: Int = ContextCompat.getColor(context, R.color.external_display_key_highlight_strong_background)
+    private val keyColor: Int = ContextCompat.getColor(context, R.color.external_display_key_color)
 
     init {
         orientation = VERTICAL
@@ -159,7 +159,7 @@ class ExternalOnScreenKeyboardView(
         keys.forEach { spec ->
             val button = Button(context).apply {
                 isAllCaps = false
-                setTextColor(Color.WHITE)
+                setTextColor(keyColor)
                 setTextSize(16f)
                 typeface = Typeface.DEFAULT_BOLD
                 text = spec.normalLabel

--- a/app/src/main/java/app/gamenative/externaldisplay/SwapInputOverlayView.kt
+++ b/app/src/main/java/app/gamenative/externaldisplay/SwapInputOverlayView.kt
@@ -26,7 +26,7 @@ class SwapInputOverlayView(
             gravity = Gravity.CENTER
         }
         setImageResource(R.drawable.icon_keyboard)
-        alpha = 0.35f
+        setColorFilter(ContextCompat.getColor(context, R.color.external_display_key_color))
         scaleType = ImageView.ScaleType.FIT_CENTER
         visibility = View.GONE
         isClickable = false
@@ -56,6 +56,7 @@ class SwapInputOverlayView(
             setColor(ContextCompat.getColor(context, R.color.external_display_key_background))
         }
         setImageResource(R.drawable.icon_keyboard)
+        setColorFilter(ContextCompat.getColor(context, R.color.external_display_key_color))
         scaleType = ImageView.ScaleType.CENTER_INSIDE
         setPadding(marginPx / 2, marginPx / 2, marginPx / 2, marginPx / 2)
         visibility = View.GONE

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,9 +5,10 @@
     <color name="colorPrimaryDark">#455a64</color>
     <color name="colorAccent">#06B6D4</color>
     <color name="navigation_dialog_item_color">#FAFAFA</color>
-    <color name="external_display_surface_background">#2B2B2B</color>
-    <color name="external_display_keyboard_background">#1F1F1F</color>
-    <color name="external_display_key_background">#3A3A3A</color>
-    <color name="external_display_key_highlight_background">#3D6CC4</color>
-    <color name="external_display_key_highlight_strong_background">#2E5AAC</color>
+    <color name="external_display_surface_background">#000000</color>
+    <color name="external_display_keyboard_background">#000000</color>
+    <color name="external_display_key_background">#161616</color>
+    <color name="external_display_key_highlight_background">#323232</color>
+    <color name="external_display_key_highlight_strong_background">#404040</color>
+    <color name="external_display_key_color">#D9D9D9</color>
 </resources>


### PR DESCRIPTION
As discussed in #497, changed the existing colors of External Display Input to work better on an AMOLED display.

<img width="40%" height="auto" alt="Screenshot_20260206-170654" src="https://github.com/user-attachments/assets/1059df94-a087-40e3-8979-9141d4efdfae" />
<img width="40%" height="auto" alt="Screenshot_20260206-170700" src="https://github.com/user-attachments/assets/50f0280c-b237-46fd-b294-581659e55e4d" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the External Display Input palette for AMOLED: pure-black surfaces/keyboard, darker key backgrounds, softer gray highlights, and a new high-contrast key color for icons and labels. Standardized color usage via `R.color` across controller, keyboard, and overlay; replaced alpha-based icon styling with explicit color tinting.

<sup>Written for commit d45f0bf3b38b865303b9b96afec0023b9e5f3cc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refreshed external keyboard display theme: background and keyboard surfaces updated to darker (near-black) tones for improved contrast.
  * Replaced semi-transparent icon treatments with solid color tints for keyboard hints and toggle, improving legibility.
  * Added a new unified key color resource and adjusted key/background highlight colors for consistent keyboard styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->