### PR TITLE
Add Steam cloud saves browser shortcut

### DIFF
--- a/app/src/main/java/app/gamenative/ui/enums/AppOptionMenuType.kt
+++ b/app/src/main/java/app/gamenative/ui/enums/AppOptionMenuType.kt
@@ -19,6 +19,7 @@ enum class AppOptionMenuType(val text: String) {
     MoveToExternalStorage("Move to external storage"),
     MoveToInternalStorage("Move to internal storage"),
     ForceCloudSync("Force cloud sync"),
+    BrowseOnlineSaves("Browse online saves"),
     ForceDownloadRemote("Force download remote saves"),
     ForceUploadLocal("Force upload local saves"),
     FetchSteamGridDBImages("Fetch game images"),

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -2,6 +2,7 @@ package app.gamenative.ui.screen.library.appscreen
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Environment
@@ -754,15 +755,27 @@ class SteamAppScreen : BaseAppScreen() {
         val appId = libraryItem.appId
         val appInfo = SteamService.getAppInfoOf(gameId) ?: return emptyList()
         val isDownloadInProgress = SteamService.getDownloadingAppInfoOf(gameId) != null
-
-        if (!isInstalled || isDownloadInProgress) {
-            return emptyList()
-        }
-
         val scope = rememberCoroutineScope()
 
-        // Steam-specific options (only when installed)
-        return listOf(
+        val options = mutableListOf<AppMenuOption>(
+            AppMenuOption(
+                AppOptionMenuType.BrowseOnlineSaves,
+                onClick = {
+                    val browserIntent = Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse("https://store.steampowered.com/account/remotestorageapp/?appid=$gameId"),
+                    )
+                    context.startActivity(browserIntent)
+                },
+            ),
+        )
+
+        if (!isInstalled || isDownloadInProgress) {
+            return options
+        }
+
+        // Steam-specific options that only make sense once the game is installed.
+        options += listOf(
             AppMenuOption(
                 AppOptionMenuType.ResetDrm,
                 onClick = {
@@ -902,6 +915,8 @@ class SteamAppScreen : BaseAppScreen() {
                 }
             ),
         )
+
+        return options
     }
 
     override fun loadContainerData(context: Context, libraryItem: LibraryItem): ContainerData {

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/GameOptionsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/GameOptionsPanel.kt
@@ -332,6 +332,7 @@ private fun getIconForOption(type: AppOptionMenuType): ImageVector {
         AppOptionMenuType.MoveToExternalStorage -> Icons.Default.SdStorage
         AppOptionMenuType.MoveToInternalStorage -> Icons.Default.Storage
         AppOptionMenuType.ForceCloudSync -> Icons.Default.Sync
+        AppOptionMenuType.BrowseOnlineSaves -> Icons.AutoMirrored.Filled.OpenInNew
         AppOptionMenuType.ForceDownloadRemote -> Icons.Default.CloudDownload
         AppOptionMenuType.ForceUploadLocal -> Icons.Default.CloudUpload
         AppOptionMenuType.FetchSteamGridDBImages -> Icons.Default.Image
@@ -376,6 +377,7 @@ private fun groupOptions(options: List<AppMenuOption>): Map<OptionCategory, List
 
             // Cloud Saves
             AppOptionMenuType.ForceCloudSync,
+            AppOptionMenuType.BrowseOnlineSaves,
             AppOptionMenuType.ForceDownloadRemote,
             AppOptionMenuType.ForceUploadLocal,
             -> cloudSaves.add(option)


### PR DESCRIPTION
![steam-cloud-link](https://github.com/user-attachments/assets/edf4fefb-d591-4ca9-9c04-d32501b74d11)

simple convenience feature, for steam games, open steam cloud management page in your default browser

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Browse online saves” shortcut for Steam games to open the game’s Steam Cloud page in your default browser. The option is available even if the game isn’t installed.

- **New Features**
  - New “Browse online saves” menu item on Steam game pages opens https://store.steampowered.com/account/remotestorageapp/?appid=<appId>.
  - Placed under the Cloud Saves group with an external-link icon.
  - Shown at all times for Steam titles, including during download or when uninstalled.

<sup>Written for commit c260193c79d31a694d832cf23521951a8a0bff23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Browse Online Saves" menu option to each game, providing direct access to cloud-stored saved games through the store's remote storage interface. This feature is grouped with other cloud save options in the game options panel, making it easy for players to discover and manage their backed-up game saves from one convenient location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->