### PR TITLE
Added app screen gradient so back button stays visible

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -672,7 +672,7 @@ internal fun AppScreenContent(
                     }
                 }
 
-                // Gradient overlay
+                // Gradient overlay (bottom, for title/action bar)
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -682,6 +682,25 @@ internal fun AppScreenContent(
                                     Color.Transparent,
                                     Color.Black.copy(alpha = 0.3f),
                                     Color.Black.copy(alpha = 0.85f),
+                                ),
+                                startY = 0f,
+                                endY = Float.POSITIVE_INFINITY,
+                            ),
+                        ),
+                )
+
+                // Top gradient overlay (so back button is visible on light/white images)
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(120.dp)
+                        .align(Alignment.TopCenter)
+                        .background(
+                            brush = Brush.verticalGradient(
+                                colors = listOf(
+                                    Color.Black.copy(alpha = 0.5f),
+                                    Color.Black.copy(alpha = 0.15f),
+                                    Color.Transparent,
                                 ),
                                 startY = 0f,
                                 endY = Float.POSITIVE_INFINITY,


### PR DESCRIPTION
Added a subtle gradient to make the back button slightly better to see.

Before:
<img width="1374" height="773" alt="image" src="https://github.com/user-attachments/assets/d536a690-e3d3-45ec-beec-46542d84c84c" />
After:
<img width="1374" height="773" alt="image" src="https://github.com/user-attachments/assets/44939f09-6447-4798-bcf4-2f968de5097a" />


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a top gradient overlay to the app screen so the back button stays visible on light/white header images. Improves contrast without changing layout or behavior.

- **Bug Fixes**
  - Added a 120dp top `Brush.verticalGradient` overlay to ensure the back button and status icons remain readable across varied artwork.

<sup>Written for commit f6ee4e52e4134221c3f093935cd1f4dabd596cf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the library screen's hero area to ensure the back button remains clearly visible on light and white background images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->