### PR TITLE
Updated achievement uploading code to not skip achievements.json when…

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2678,30 +2678,38 @@ class SteamService : Service(), IChallengeUrlChanged {
         }
 
         suspend fun syncAchievementsFromGoldberg(context: Context, appId: Int) {
-            val gseSaveDir = getGseSaveDirs(context, appId).firstOrNull { it.isDirectory }
-            if (gseSaveDir == null) {
+            val gseSaveDirs = getGseSaveDirs(context, appId).filter { it.isDirectory }
+            if (gseSaveDirs.isEmpty()) {
                 Timber.d("No GSE save directory found for appId=$appId")
                 return
             }
 
             val unlockedNames = mutableSetOf<String>()
-            val goldbergAchFile = File(gseSaveDir, "achievements.json")
-            if (goldbergAchFile.exists()) {
-                try {
-                    val json = JSONObject(goldbergAchFile.readText(Charsets.UTF_8))
-                    for (name in json.keys()) {
-                        val entry = json.optJSONObject(name) ?: continue
-                        if (entry.optBoolean("earned", false)) {
-                            unlockedNames.add(name)
+            var gseStatsDir: File? = null
+
+            for (gseSaveDir in gseSaveDirs) {
+                val goldbergAchFile = File(gseSaveDir, "achievements.json")
+                if (goldbergAchFile.exists()) {
+                    try {
+                        val json = JSONObject(goldbergAchFile.readText(Charsets.UTF_8))
+                        for (name in json.keys()) {
+                            val entry = json.optJSONObject(name) ?: continue
+                            if (entry.optBoolean("earned", false)) {
+                                unlockedNames.add(name)
+                            }
                         }
+                    } catch (e: Exception) {
+                        Timber.e(e, "Failed to parse Goldberg achievements.json in ${gseSaveDir.absolutePath} for appId=$appId")
                     }
-                } catch (e: Exception) {
-                    Timber.e(e, "Failed to parse Goldberg achievements.json for appId=$appId")
+                }
+
+                val statsDir = File(gseSaveDir, "stats")
+                if (gseStatsDir == null && statsDir.isDirectory && (statsDir.listFiles()?.isNotEmpty() == true)) {
+                    gseStatsDir = statsDir
                 }
             }
 
-            val gseStatsDir = File(gseSaveDir, "stats")
-            val hasStats = gseStatsDir.isDirectory && (gseStatsDir.listFiles()?.isNotEmpty() == true)
+            val hasStats = gseStatsDir != null
 
             if (unlockedNames.isEmpty() && !hasStats) {
                 Timber.d("No earned achievements or stats found in Goldberg output for appId=$appId")
@@ -2715,7 +2723,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             }
 
             Timber.i("Found ${unlockedNames.size} earned achievements and ${if (hasStats) "stats" else "no stats"} for appId=$appId, syncing to Steam")
-            val result = storeAchievementUnlocks(appId, configDirectory, unlockedNames, gseStatsDir)
+            val result = storeAchievementUnlocks(appId, configDirectory, unlockedNames, gseStatsDir ?: gseSaveDirs.first().resolve("stats"))
             result.onSuccess {
                 Timber.i("Successfully synced achievements and stats to Steam for appId=$appId")
             }.onFailure { e ->


### PR DESCRIPTION
… blank directory

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes achievement syncing by scanning all Goldberg save directories instead of only the first, so `achievements.json` isn’t skipped when the first directory is empty.

- **Bug Fixes**
  - Parse `achievements.json` from every GSE save dir and collect all earned achievements.
  - Pick the first non-empty `stats` dir; fall back to the first dir’s `stats` path to keep upload flow working.
  - Improve error logs with the directory path for easier debugging.

<sup>Written for commit 30055dadbd24a2d28e43c3da168b22620382be44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Achievement synchronization now scans all available save locations instead of stopping at the first one, ensuring no achievements are missed across multiple directories
  * Improved reliability with enhanced fallback logic for locating and using statistics directories when primary locations are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->