### PR TITLE
fix: avoid tearing down running sessions on stale launcher exit

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -441,82 +441,101 @@ fun XServerScreen(
         clearOverlayPauseState()
     }
 
-    fun startExitWatchForUnmappedGameWindow(window: Window) {
-        val winHandler = xServerView?.getxServer()?.winHandler ?: return
-        if (exitWatchJob?.isActive == true) return
-        val targetExecutable = extractExecutableBasename(container.executablePath)
-        if (!windowMatchesExecutable(window, targetExecutable)) return
+    suspend fun awaitNoNonEssentialWineProcesses(winHandler: WinHandler, reason: String): Boolean {
+        val allowlist = buildEssentialProcessAllowlist()
+        val previousListener = winHandler.getOnGetProcessInfoListener()
+        val lock = Any()
+        var pendingSnapshot: CompletableDeferred<List<ProcessInfo>?>? = null
+        var currentList = mutableListOf<ProcessInfo>()
+        var expectedCount = 0
 
-        exitWatchJob = CoroutineScope(Dispatchers.IO).launch {
-            val allowlist = buildEssentialProcessAllowlist()
-            val previousListener = winHandler.getOnGetProcessInfoListener()
-            val lock = Any()
-            var pendingSnapshot: CompletableDeferred<List<ProcessInfo>?>? = null
-            var currentList = mutableListOf<ProcessInfo>()
-            var expectedCount = 0
-
-            val listener = OnGetProcessInfoListener { index, count, processInfo ->
-                previousListener?.onGetProcessInfo(index, count, processInfo)
-                synchronized(lock) {
-                    val deferred = pendingSnapshot ?: return@synchronized
-                    if (count == 0 && processInfo == null) {
-                        if (!deferred.isCompleted) deferred.complete(null)
-                        return@synchronized
-                    }
-                    if (index == 0) {
-                        currentList = mutableListOf()
-                        expectedCount = count
-                    }
-                    if (processInfo != null) {
-                        currentList.add(processInfo)
-                    }
-                    if (currentList.size >= expectedCount && !deferred.isCompleted) {
-                        deferred.complete(currentList.toList())
-                    }
+        val listener = OnGetProcessInfoListener { index, count, processInfo ->
+            previousListener?.onGetProcessInfo(index, count, processInfo)
+            synchronized(lock) {
+                val deferred = pendingSnapshot ?: return@synchronized
+                if (count == 0 && processInfo == null) {
+                    if (!deferred.isCompleted) deferred.complete(null)
+                    return@synchronized
                 }
-            }
-
-            winHandler.setOnGetProcessInfoListener(listener)
-            try {
-                val startTime = System.currentTimeMillis()
-                while (System.currentTimeMillis() - startTime < EXIT_PROCESS_TIMEOUT_MS) {
-                    val deferred = CompletableDeferred<List<ProcessInfo>?>()
-                    synchronized(lock) {
-                        pendingSnapshot = deferred
-                    }
-                    winHandler.listProcesses()
-                    val snapshot = withTimeoutOrNull(EXIT_PROCESS_RESPONSE_TIMEOUT_MS) {
-                        deferred.await()
-                    }
-                    if (snapshot != null) {
-                        val hasNonEssential = snapshot.any {
-                            !allowlist.contains(normalizeProcessName(it.name))
-                        }
-                        if (!hasNonEssential) {
-                            withContext(Dispatchers.Main) {
-                                exit(
-                                    winHandler,
-                                    PluviaApp.xEnvironment,
-                                    frameRating,
-                                    currentAppInfo,
-                                    container,
-                                    appId,
-                                    onExit,
-                                    navigateBack,
-                                )
-                            }
-                            break
-                        }
-                    }
-                    delay(EXIT_PROCESS_POLL_INTERVAL_MS)
+                if (index == 0) {
+                    currentList = mutableListOf()
+                    expectedCount = count
                 }
-            } finally {
-                winHandler.setOnGetProcessInfoListener(previousListener)
-                synchronized(lock) {
-                    pendingSnapshot = null
+                if (processInfo != null) {
+                    currentList.add(processInfo)
+                }
+                if (currentList.size >= expectedCount && !deferred.isCompleted) {
+                    deferred.complete(currentList.toList())
                 }
             }
         }
+
+        winHandler.setOnGetProcessInfoListener(listener)
+        try {
+            val startTime = System.currentTimeMillis()
+            while (System.currentTimeMillis() - startTime < EXIT_PROCESS_TIMEOUT_MS) {
+                val deferred = CompletableDeferred<List<ProcessInfo>?>()
+                synchronized(lock) {
+                    pendingSnapshot = deferred
+                }
+                winHandler.listProcesses()
+                val snapshot = withTimeoutOrNull(EXIT_PROCESS_RESPONSE_TIMEOUT_MS) {
+                    deferred.await()
+                }
+                if (snapshot != null) {
+                    val nonEssentialProcesses = snapshot.filter {
+                        !allowlist.contains(normalizeProcessName(it.name))
+                    }
+                    if (nonEssentialProcesses.isEmpty()) {
+                        return true
+                    }
+                    Timber.tag("ExitWatch").d(
+                        "Waiting to exit (%s); non-essential Wine processes still running: %s",
+                        reason,
+                        nonEssentialProcesses.joinToString { "${it.name}(${it.pid})" },
+                    )
+                }
+                delay(EXIT_PROCESS_POLL_INTERVAL_MS)
+            }
+            return false
+        } finally {
+            winHandler.setOnGetProcessInfoListener(previousListener)
+            synchronized(lock) {
+                pendingSnapshot = null
+            }
+        }
+    }
+
+    fun startExitWatch(winHandler: WinHandler, reason: String) {
+        if (isExiting.get()) return
+        if (exitWatchJob?.isActive == true) return
+
+        exitWatchJob = CoroutineScope(Dispatchers.IO).launch {
+            val isSafeToExit = awaitNoNonEssentialWineProcesses(winHandler, reason)
+            if (isSafeToExit) {
+                withContext(Dispatchers.Main) {
+                    exit(
+                        winHandler,
+                        PluviaApp.xEnvironment,
+                        frameRating,
+                        currentAppInfo,
+                        container,
+                        appId,
+                        onExit,
+                        navigateBack,
+                    )
+                }
+            } else {
+                Timber.tag("ExitWatch").w("Timed out waiting for Wine processes to exit after %s", reason)
+            }
+        }
+    }
+
+    fun startExitWatchForUnmappedGameWindow(window: Window) {
+        val winHandler = xServerView?.getxServer()?.winHandler ?: return
+        val targetExecutable = extractExecutableBasename(container.executablePath)
+        if (!windowMatchesExecutable(window, targetExecutable)) return
+        startExitWatch(winHandler, "window unmapped for ${window.className}")
     }
 
     val dismissOverlayMenu: () -> Unit = {
@@ -812,7 +831,13 @@ fun XServerScreen(
         }
         val onGuestProgramTerminated: (AndroidEvent.GuestProgramTerminated) -> Unit = {
             Timber.i("onGuestProgramTerminated")
-            exit(xServerView!!.getxServer().winHandler, PluviaApp.xEnvironment, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+            val winHandler = xServerView?.getxServer()?.winHandler
+            if (winHandler == null) {
+                Timber.w("Guest program terminated but WinHandler is unavailable; exiting immediately")
+                exit(null, PluviaApp.xEnvironment, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+            } else {
+                startExitWatch(winHandler, "guest program terminated")
+            }
         }
         val onForceCloseApp: (SteamEvent.ForceCloseApp) -> Unit = {
             Timber.i("onForceCloseApp")

--- a/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
@@ -64,6 +64,7 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
     private String fexcorePreset = FEXCorePreset.INTERMEDIATE;
     private Callback<Integer> terminationCallback;
     private static final Object lock = new Object();
+    private int launchGeneration = 0;
     private boolean wow64Mode = true;
     private final ContentsManager contentsManager;
     private final ContentProfile wineProfile;
@@ -91,12 +92,13 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
     public void start() {
         synchronized (lock) {
             stop();
+            int currentGeneration = ++launchGeneration;
             if (wineInfo.isArm64EC())
                 extractEmulatorsDlls();
             else
                 extractBox64Files();
             if (preUnpack != null) preUnpack.run();
-            pid = execGuestProgram();
+            pid = execGuestProgram(currentGeneration);
             Log.d("BionicProgramLauncherComponent", "Process " + pid + " started");
             SteamService.setKeepAlive(true);
         }
@@ -105,9 +107,12 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
     @Override
     public void stop() {
         synchronized (lock) {
+            launchGeneration++;
             if (pid != -1) {
-                Process.killProcess(pid);
-                Log.d("BionicProgramLauncherComponent", "Stopped process " + pid);
+                int processToStop = pid;
+                pid = -1;
+                Process.killProcess(processToStop);
+                Log.d("BionicProgramLauncherComponent", "Stopped process " + processToStop);
                 List<ProcessHelper.ProcessInfo> subProcesses = ProcessHelper.listSubProcesses();
                 for (ProcessHelper.ProcessInfo subProcess : subProcesses) {
                     Process.killProcess(subProcess.pid);
@@ -176,7 +181,7 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
         this.workingDir = workingDir;
     }
 
-    private int execGuestProgram() {
+    private int execGuestProgram(final int generation) {
 
         final int MAX_PLAYERS = 1; // old static method
 
@@ -337,8 +342,16 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
         }
 
         return ProcessHelper.exec(command, envVars.toStringArray(), workingDir != null ? workingDir : rootDir, (status) -> {
+            boolean isStaleCallback;
             synchronized (lock) {
-                pid = -1;
+                isStaleCallback = generation != launchGeneration;
+                if (!isStaleCallback) {
+                    pid = -1;
+                }
+            }
+            if (isStaleCallback) {
+                Log.d("BionicProgramLauncherComponent", "Ignoring stale termination callback for generation " + generation + " with status " + status);
+                return;
             }
             if (!environment.isWinetricksRunning()) {
                 SteamService.setKeepAlive(false);
@@ -520,7 +533,10 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
 
     public void restartWineServer() {
         ProcessHelper.terminateAllWineProcesses();
-        pid = execGuestProgram();
+        synchronized (lock) {
+            int currentGeneration = ++launchGeneration;
+            pid = execGuestProgram(currentGeneration);
+        }
         Log.d("BionicProgramLauncherComponent", "Wine restarted successfully");
 
     }

--- a/app/src/main/java/com/winlator/xenvironment/components/GlibcProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/GlibcProgramLauncherComponent.java
@@ -48,6 +48,7 @@ public class GlibcProgramLauncherComponent extends GuestProgramLauncherComponent
     private String steamType = DefaultVersion.STEAM_TYPE;
     private Callback<Integer> terminationCallback;
     private static final Object lock = new Object();
+    private int launchGeneration = 0;
     private boolean wow64Mode = true;
     private final ContentsManager contentsManager;
     private final ContentProfile wineProfile;
@@ -69,10 +70,11 @@ public class GlibcProgramLauncherComponent extends GuestProgramLauncherComponent
         Log.d("GlibcProgramLauncherComponent", "Starting...");
         synchronized (lock) {
             stop();
+            int currentGeneration = ++launchGeneration;
             extractBox64Files();
             copyDefaultBox64RCFile();
             if (preUnpack != null) preUnpack.run();
-            pid = execGuestProgram();
+            pid = execGuestProgram(currentGeneration);
             Log.d("GlibcProgramLauncherComponent", "Process " + pid + " started");
             SteamService.setKeepAlive(true);
         }
@@ -82,10 +84,12 @@ public class GlibcProgramLauncherComponent extends GuestProgramLauncherComponent
     public void stop() {
         Log.d("GlibcProgramLauncherComponent", "Stopping...");
         synchronized (lock) {
+            launchGeneration++;
             if (pid != -1) {
-                Process.killProcess(pid);
-                Log.d("GlibcProgramLauncherComponent", "Stopped process " + pid);
+                int processToStop = pid;
                 pid = -1;
+                Process.killProcess(processToStop);
+                Log.d("GlibcProgramLauncherComponent", "Stopped process " + processToStop);
                 List<ProcessHelper.ProcessInfo> subProcesses = ProcessHelper.listSubProcesses();
                 for (ProcessHelper.ProcessInfo subProcess : subProcesses) {
                     Process.killProcess(subProcess.pid);
@@ -168,7 +172,7 @@ public class GlibcProgramLauncherComponent extends GuestProgramLauncherComponent
         this.workingDir = workingDir;
     }
 
-    private int execGuestProgram() {
+    private int execGuestProgram(final int generation) {
         Context context = environment.getContext();
         ImageFs imageFs = ImageFs.find(context);
         File rootDir = imageFs.getRootDir();
@@ -229,9 +233,17 @@ public class GlibcProgramLauncherComponent extends GuestProgramLauncherComponent
         Log.d("GlibcProgramLauncherComponent", "Final command: " + command);
 
         return ProcessHelper.exec(command, envVars.toStringArray(), workingDir != null ? workingDir : rootDir, (status) -> {
-            Log.d("GlibcProgramLauncherComponent", "Process terminated " + pid + " with status " + status);
+            boolean isStaleCallback;
             synchronized (lock) {
-                pid = -1;
+                isStaleCallback = generation != launchGeneration;
+                if (!isStaleCallback) {
+                    Log.d("GlibcProgramLauncherComponent", "Process terminated " + pid + " with status " + status);
+                    pid = -1;
+                }
+            }
+            if (isStaleCallback) {
+                Log.d("GlibcProgramLauncherComponent", "Ignoring stale termination callback for generation " + generation + " with status " + status);
+                return;
             }
             SteamService.setKeepAlive(false);
             if (terminationCallback != null) terminationCallback.call(status);


### PR DESCRIPTION
https://discord.com/channels/1378308569287622737/1478153403535196342

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents tearing down an active session when a stale launcher process exits. Adds generation checks to launcher components and waits for non-essential Wine processes to stop before exiting.

- **Bug Fixes**
  - Added a generation counter to `BionicProgramLauncherComponent` and `GlibcProgramLauncherComponent` to ignore stale termination callbacks; incremented on start/stop/restart and kill uses a captured pid.
  - Consolidated exit handling in `XServerScreen`: introduced a safe exit watch that polls Wine processes and exits only when only essential processes remain; used for window unmap and guest termination events.
  - Avoids duplicate exits by checking existing exit activity; logs reasons/timeouts; exits immediately only if `WinHandler` is unavailable.

<sup>Written for commit 0aa8349a3ffd8226ac128a65d8e8d6fff2ecbca6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced process shutdown mechanism with improved timeout handling and graceful cleanup.
  * Fixed race conditions that could occur during program restarts and process termination.
  * Improved reliability of background process management during application exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->