### PR TITLE
fix: resume after toggling performance HUD in quick menu

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -364,6 +364,7 @@ fun XServerScreen(
     var elementToEdit by remember { mutableStateOf<com.winlator.inputcontrols.ControlElement?>(null) }
     var showPhysicalControllerDialog by remember { mutableStateOf(false) }
     var keyboardRequestedFromOverlay by remember { mutableStateOf(false) }
+    var performanceHudToggledFromOverlay by remember { mutableStateOf(false) }
     var showQuickMenu by remember { mutableStateOf(false) }
     var hasPhysicalController by remember { mutableStateOf(false) }
     var keepPausedForEditor by remember { mutableStateOf(false) }
@@ -532,9 +533,11 @@ fun XServerScreen(
             imeInputReceiver?.hideKeyboard()
         }
         val resumeImmediatelyForKeyboard = keyboardRequestedFromOverlay && manualResumeMode
+        val resumeImmediatelyForPerformanceHud = performanceHudToggledFromOverlay && manualResumeMode
         keyboardRequestedFromOverlay = false
+        performanceHudToggledFromOverlay = false
         if (!keepPausedForEditor) {
-            if (resumeImmediatelyForKeyboard) {
+            if (resumeImmediatelyForKeyboard || resumeImmediatelyForPerformanceHud) {
                 forceResumeIfSuspended()
             } else {
                 resumeIfAllowedAfterOverlay()
@@ -678,6 +681,7 @@ fun XServerScreen(
             }
 
             QuickMenuAction.PERFORMANCE_HUD -> {
+                performanceHudToggledFromOverlay = true
                 val enabled = performanceHudView == null
                 updatePerformanceHud(enabled)
                 PostHog.capture(
@@ -730,6 +734,7 @@ fun XServerScreen(
         // Suspend game and audio while the navigation overlay is visible.
         pauseForOverlayIfAllowed()
         keyboardRequestedFromOverlay = false
+        performanceHudToggledFromOverlay = false
 
         val controllerManager = ControllerManager.getInstance()
         controllerManager.scanForDevices()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a pause/resume issue when toggling the Performance HUD from the quick menu. The game now resumes immediately in manual resume mode after the toggle.

- **Bug Fixes**
  - Added `performanceHudToggledFromOverlay` to track HUD toggles from the overlay.
  - Resume immediately when the flag is set and manual resume mode is on.
  - Reset the flag after handling and when the overlay opens.

<sup>Written for commit 26cd69aaf9ea1934b2fe7228360d4c28b0c52e74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed overlay behavior when toggling the performance HUD to ensure proper game resumption and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->