### PR TITLE
Add connector context to XConnectorEpoll logs

### DIFF
--- a/app/src/main/java/com/winlator/xconnector/XConnectorEpoll.java
+++ b/app/src/main/java/com/winlator/xconnector/XConnectorEpoll.java
@@ -9,6 +9,7 @@ import java.nio.ByteBuffer;
 public class XConnectorEpoll implements Runnable {
     private static final String TAG = "XConnectorEpoll";
 
+    private final String connectorLabel;
     private final ConnectionHandler connectionHandler;
     private final int epollFd;
     private Thread epollThread;
@@ -46,6 +47,7 @@ public class XConnectorEpoll implements Runnable {
     public XConnectorEpoll(UnixSocketConfig socketConfig, ConnectionHandler connectionHandler, RequestHandler requestHandler) {
         this.connectionHandler = connectionHandler;
         this.requestHandler = requestHandler;
+        this.connectorLabel = socketConfig.path + " [" + connectionHandler.getClass().getSimpleName() + "/" + requestHandler.getClass().getSimpleName() + "]";
         int createAFUnixSocket = createAFUnixSocket(socketConfig.path);
         this.serverFd = createAFUnixSocket;
         if (createAFUnixSocket < 0) {
@@ -70,21 +72,25 @@ public class XConnectorEpoll implements Runnable {
             closeFd(createEpollFd);
             throw new RuntimeException("Failed to add shutdown fd to epoll.");
         }
-        this.epollThread = new Thread(this);
+        this.epollThread = new Thread(this, "XConnectorEpoll:" + this.connectorLabel);
+    }
+
+    private String logPrefix() {
+        return "[" + this.connectorLabel + "]";
     }
 
     public synchronized void start() {
         Thread thread;
         if (!this.running && (thread = this.epollThread) != null) {
             this.running = true;
-            Log.d(TAG, "Starting connector thread");
+            Log.d(TAG, logPrefix() + " Starting connector thread (epollFd=" + this.epollFd + ", serverFd=" + this.serverFd + ", shutdownFd=" + this.shutdownFd + ")");
             thread.start();
         }
     }
 
     public synchronized void stop() {
         if (this.running && this.epollThread != null) {
-            Log.d(TAG, "Stopping connector thread");
+            Log.d(TAG, logPrefix() + " Stopping connector thread (connectedClients=" + this.connectedClients.size() + ")");
             this.running = false;
             requestShutdown();
             while (this.epollThread.isAlive()) {
@@ -102,7 +108,7 @@ public class XConnectorEpoll implements Runnable {
         while (this.running) {
             if (!doEpollIndefinitely(this.epollFd, this.serverFd, !this.multithreadedClients && this.monitorClients)) {
                 if (this.running) {
-                    Log.e(TAG, "epoll loop exited unexpectedly; shutting down all X clients");
+                    Log.e(TAG, logPrefix() + " epoll loop exited unexpectedly; shutting down all X clients (epollFd=" + this.epollFd + ", serverFd=" + this.serverFd + ", shutdownFd=" + this.shutdownFd + ", connectedClients=" + this.connectedClients.size() + ", multithreadedClients=" + this.multithreadedClients + ", monitorClients=" + this.monitorClients + ")");
                 }
                 break;
             }


### PR DESCRIPTION
- add connector identity to XConnectorEpoll logs
- include fd and client-count context in start/stop/failure messages
- keeping this PR logging-only with no behavior changes
for further investigating on https://discord.com/channels/1378308569287622737/1479696127837077606


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced logging and error diagnostics with detailed information for improved troubleshooting and system visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->