### PR TITLE
Overlay: show active state on toggle icons, use per-item accent colors

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -220,6 +220,7 @@ fun QuickMenu(
     performanceHudConfig: PerformanceHudConfig = PerformanceHudConfig(),
     onPerformanceHudConfigChanged: (PerformanceHudConfig) -> Unit = {},
     hasPhysicalController: Boolean = false,
+    activeToggleIds: Set<Int> = emptySet(),
     modifier: Modifier = Modifier,
 ) {
     val exitGameItem = QuickMenuItem(
@@ -502,6 +503,7 @@ fun QuickMenu(
                                             controllerItems.forEachIndexed { index, item ->
                                                 QuickMenuItemRow(
                                                     item = item,
+                                                    isActive = item.id in activeToggleIds,
                                                     onClick = {
                                                         if (onItemSelected(item.id)) {
                                                             onDismiss()
@@ -1486,6 +1488,7 @@ private fun QuickMenuSwitch(
 @Composable
 private fun QuickMenuItemRow(
     item: QuickMenuItem,
+    isActive: Boolean = false,
     onClick: () -> Unit,
     focusRequester: FocusRequester? = null,
     modifier: Modifier = Modifier,
@@ -1564,11 +1567,16 @@ private fun QuickMenuItemRow(
         Box(
             modifier = Modifier
                 .size(40.dp)
+                .then(
+                    if (isActive) {
+                        Modifier.border(BorderStroke(2.dp, accentColor), CircleShape)
+                    } else Modifier
+                )
                 .clip(CircleShape)
                 .background(
                     when {
                         !isEnabled -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
-                        isFocused -> accentColor.copy(alpha = 0.2f)
+                        isFocused || isActive -> accentColor.copy(alpha = 0.2f)
                         else -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
                     },
                 ),
@@ -1579,7 +1587,7 @@ private fun QuickMenuItemRow(
                 contentDescription = null,
                 tint = when {
                     !isEnabled -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = disabledAlpha)
-                    isFocused -> accentColor
+                    isFocused || isActive -> accentColor
                     else -> MaterialTheme.colorScheme.onSurfaceVariant
                 },
                 modifier = Modifier.size(22.dp),

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1981,6 +1981,9 @@ fun XServerScreen(
             performanceHudConfig = performanceHudConfig,
             onPerformanceHudConfigChanged = ::applyPerformanceHudConfig,
             hasPhysicalController = hasPhysicalController,
+            activeToggleIds = buildSet {
+                if (areControlsVisible) add(QuickMenuAction.INPUT_CONTROLS)
+            },
         )
 
         if (manualResumeMode && PluviaApp.isOverlayPaused && !showQuickMenu && !keepPausedForEditor) {


### PR DESCRIPTION
Added a visible indicator when overlay settings are currently enabled.

<img width="1371" height="771" alt="image" src="https://github.com/user-attachments/assets/ecb7b668-b000-41ac-999b-4c7a0fa4045d" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show active state on quick menu toggles with per-item accent colors so you can see what’s on at a glance. Input Controls now reflect their status directly in the quick menu.

- **New Features**
  - `QuickMenu` accepts `activeToggleIds`.
  - `XServerScreen` sets `QuickMenuAction.INPUT_CONTROLS` when controls are visible.
  - Active items use per-item accent: tinted background, icon tint, and a 2dp circular border.

<sup>Written for commit 0c4e1af6942880a78b9ff951f0c49c7e8aa845b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick menu now indicates active toggles (e.g., performance overlay, input controls) and updates with screen state.

* **Style**
  * Improved active-item visuals: circular active border, adjusted icon tint and background alpha, and consistent accent treatment for focused or active items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->