### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
   "items": {
     "driver": [
       {
-        "id": "Turnip_Gen8_V23",
-        "name": "Turnip_Gen8_V23",
+        "id": "Turnip-Gen8-V23",
+        "name": "Turnip-Gen8-V23",
         "url": "https://downloads.gamenative.app/drivers/Turnip_Gen8_V23.zip",
         "variant": "bionic"
       },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the driver `name` in manifest.json from `Turnip_Gen8_V23` to `Turnip-Gen8-V23` to match the `id`, preventing lookup mismatches for the Turnip Gen8 V23 driver.

<sup>Written for commit fef42a17e43e5759faa3e51fce035970a705754e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized a driver identifier to a consistent naming format (replaced underscore with hyphen). No functional changes or behavioral impacts expected; existing connections and IDs remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->