### PR TITLE
Fix cold-launch intent race, add failure feedback

### DIFF
--- a/app/src/main/java/app/gamenative/MainActivity.kt
+++ b/app/src/main/java/app/gamenative/MainActivity.kt
@@ -42,6 +42,7 @@ import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.IconDecoder
 import app.gamenative.utils.IntentLaunchManager
 import app.gamenative.utils.LocaleHelper
+import app.gamenative.ui.util.SnackbarManager
 import com.posthog.PostHog
 import com.skydoves.landscapist.coil.LocalCoilImageLoader
 import com.winlator.core.AppUtils
@@ -246,6 +247,11 @@ class MainActivity : ComponentActivity() {
                     setPendingLaunchRequest(launchRequest)
                     Timber.d("[IntentLaunch]: Stored pending launch request for app ${launchRequest.appId}")
                 }
+            } else if (intent.action == "${BuildConfig.APPLICATION_ID}.LAUNCH_GAME") {
+                // intent matched our action but failed to parse — tell the user
+                wasLaunchedViaExternalIntent = false
+                Timber.w("[IntentLaunch]: parseLaunchIntent returned null for LAUNCH_GAME intent")
+                SnackbarManager.show(getString(R.string.intent_launch_failed))
             }
         } catch (e: Exception) {
             Timber.e(e, "[IntentLaunch]: Failed to handle launch intent")

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -189,9 +189,6 @@ private fun resolveGameAppId(context: Context, appId: String): GameResolutionRes
     )
 }
 
-private fun resolveNotInstalledGameName(appId: String): String {
-    return ContainerUtils.resolveGameName(appId)
-}
 
 /** Steam game that needs login before launch (excludes offline-mode games) */
 private fun needsSteamLogin(context: Context, appId: String): Boolean {
@@ -283,6 +280,7 @@ fun PluviaMain(
             // Steam games needing login will be handled by OnLogonEnded
             if (needsSteamLogin(context, launchRequest.appId)) {
                 MainActivity.setPendingLaunchRequest(launchRequest)
+                SnackbarManager.show(context.getString(R.string.intent_launch_steam_login_required))
             } else {
                 when (val resolution = resolveGameAppId(context, launchRequest.appId)) {
                     is GameResolutionResult.Success -> {
@@ -308,7 +306,7 @@ fun PluviaMain(
                     }
 
                     is GameResolutionResult.NotFound -> {
-                        val appName = resolveNotInstalledGameName(resolution.originalAppId)
+                        val appName = ContainerUtils.resolveGameName(resolution.originalAppId)
                         Timber.w("[PluviaMain]: Game not installed: $appName (${launchRequest.appId})")
                         msgDialogState = MessageDialogState(
                             visible = true,
@@ -367,7 +365,7 @@ fun PluviaMain(
                         }
 
                         is GameResolutionResult.NotFound -> {
-                            val appName = resolveNotInstalledGameName(resolution.originalAppId)
+                            val appName = ContainerUtils.resolveGameName(resolution.originalAppId)
                             Timber.w("[PluviaMain]: Game not installed: $appName (${event.appId})")
                             msgDialogState = MessageDialogState(
                                 visible = true,
@@ -411,7 +409,7 @@ fun PluviaMain(
                                         .i("Processing pending launch request for app ${launchRequest.appId} (user is now logged in)")
                                     when (val resolution = resolveGameAppId(context, launchRequest.appId)) {
                                         is GameResolutionResult.NotFound -> {
-                                            val appName = resolveNotInstalledGameName(resolution.originalAppId)
+                                            val appName = ContainerUtils.resolveGameName(resolution.originalAppId)
                                             Timber.tag("IntentLaunch").w("Game not installed: $appName (${launchRequest.appId})")
                                             msgDialogState = MessageDialogState(
                                                 visible = true,

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -93,6 +93,8 @@
     <string name="content_info">Indholdsinfo</string>
     <string name="game_not_installed_title">Spillet er ikke installeret</string>
     <string name="game_not_installed_message">%s er ikke installeret. Installér spillet før du starter det.</string>
+    <string name="intent_launch_failed">Kunne ikke starte spillet: ugyldig startgenvej</string>
+    <string name="intent_launch_steam_login_required">Steam-login er påkrævet for at starte dette spil</string>
     <string name="game_executable_not_found_title">Kan ikke starte</string>
     <string name="game_executable_not_found">Den eksekverbare fil kunne ikke vælges automatisk. Angiv stien til den eksekverbare fil i containerindstillinger.</string>
     <string name="save_container_settings_title">Gem containerkonfiguration?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -158,6 +158,8 @@
     <string name="content_info">Inhaltsinfo</string>
     <string name="game_not_installed_title">Spiel nicht installiert</string>
     <string name="game_not_installed_message">%s ist nicht installiert. Bitte installiere das Spiel, bevor du es startest.</string>
+    <string name="intent_launch_failed">Spiel konnte nicht gestartet werden: ungültige Startverknüpfung</string>
+    <string name="intent_launch_steam_login_required">Steam-Anmeldung erforderlich, um dieses Spiel zu starten</string>
     <string name="game_executable_not_found_title">Start nicht möglich</string>
     <string name="game_executable_not_found">Die ausführbare Datei konnte nicht automatisch ausgewählt werden. Bitte lege den Pfad in den Containereinstellungen fest.</string>
     <string name="save_container_settings_title">Container-Konfiguration speichern?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -180,6 +180,8 @@
     <string name="content_info">Información de contenido</string>
     <string name="game_not_installed_title">Juego no instalado</string>
     <string name="game_not_installed_message">%s no está instalado. Instala el juego antes de iniciarlo.</string>
+    <string name="intent_launch_failed">No se pudo iniciar el juego: acceso directo de inicio no válido</string>
+    <string name="intent_launch_steam_login_required">Se requiere iniciar sesión en Steam para iniciar este juego</string>
     <string name="game_executable_not_found_title">No se puede iniciar</string>
     <string name="game_executable_not_found">No se pudo seleccionar automáticamente el ejecutable. Establece la ruta en los ajustes del contenedor.</string>
     <string name="save_container_settings_title">Guardar configuración del contenedor</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -165,6 +165,8 @@
     <string name="content_info">Informations sur le contenu</string>
     <string name="game_not_installed_title">Jeu non installé</string>
     <string name="game_not_installed_message">%s n\'est pas installé. Veuillez installer le jeu avant de le lancer.</string>
+    <string name="intent_launch_failed">Impossible de lancer le jeu : raccourci de lancement invalide</string>
+    <string name="intent_launch_steam_login_required">Connexion Steam requise pour lancer ce jeu</string>
     <string name="game_executable_not_found_title">Impossible de lancer</string>
     <string name="game_executable_not_found">L\'exécutable n\'a pas pu être sélectionné automatiquement. Veuillez définir le chemin de l\'exécutable dans les paramètres du conteneur.</string>
     <string name="save_container_settings_title">Enregistrer la configuration du conteneur ?</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -169,6 +169,8 @@
     <string name="content_info">Info Contenuto</string>
     <string name="game_not_installed_title">Gioco Non Installato</string>
     <string name="game_not_installed_message">%s non è installato. Installa prima il gioco per avviarlo.</string>
+    <string name="intent_launch_failed">Impossibile avviare il gioco: collegamento di avvio non valido</string>
+    <string name="intent_launch_steam_login_required">Accesso a Steam necessario per avviare questo gioco</string>
     <string name="game_executable_not_found_title">Impossibile avviare</string>
     <string name="game_executable_not_found">L\'eseguibile non è stato selezionato automaticamente. Imposta il percorso dell\'eseguibile nelle impostazioni del Container.</string>
     <string name="save_container_settings_title">Salvare Configurazione Container?</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -178,6 +178,8 @@
     <string name="content_info">콘텐츠 정보</string>
     <string name="game_not_installed_title">게임이 설치되지 않음</string>
     <string name="game_not_installed_message">%s이(가) 설치되지 않았습니다. 실행하기 전에 먼저 게임을 설치하세요.</string>
+    <string name="intent_launch_failed">게임을 실행할 수 없습니다: 잘못된 실행 바로가기</string>
+    <string name="intent_launch_steam_login_required">이 게임을 실행하려면 Steam 로그인이 필요합니다</string>
     <string name="game_executable_not_found_title">실행할 수 없음</string>
     <string name="game_executable_not_found">실행 파일을 자동으로 선택할 수 없습니다. 컨테이너 설정에서 실행 파일 경로를 지정하세요.</string>
     <string name="save_container_settings_title">컨테이너 구성을 저장하시겠습니까?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -177,6 +177,8 @@
     <string name="content_info">Info o zawartości</string>
     <string name="game_not_installed_title">Gra nie zainstalowana</string>
     <string name="game_not_installed_message">%s nie jest zainstalowana. Proszę zainstalować grę przed uruchomieniem.</string>
+    <string name="intent_launch_failed">Nie udało się uruchomić gry: nieprawidłowy skrót uruchamiania</string>
+    <string name="intent_launch_steam_login_required">Wymagane logowanie do Steam, aby uruchomić tę grę</string>
     <string name="game_executable_not_found_title">Nie można uruchomić</string>
     <string name="game_executable_not_found">Nie udało się automatycznie wybrać pliku wykonywalnego. Ustaw ścieżkę do pliku wykonywalnego w ustawieniach kontenera.</string>
     <string name="save_container_settings_title">Zapisać konfigurację kontenera?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -93,6 +93,8 @@
     <string name="content_info">Info de Conteúdo</string>
     <string name="game_not_installed_title">Jogo Não instalado</string>
     <string name="game_not_installed_message">%s não está instalado. Por favor instale o jogo primeiro antes de iniciar.</string>
+    <string name="intent_launch_failed">Não foi possível iniciar o jogo: atalho de inicialização inválido</string>
+    <string name="intent_launch_steam_login_required">Login no Steam necessário para iniciar este jogo</string>
     <string name="game_executable_not_found_title">Não é possível iniciar</string>
     <string name="game_executable_not_found">O executável não pôde ser selecionado automaticamente. Defina o caminho do executável nas configurações do contêiner.</string>
     <string name="save_container_settings_title">Salvar configuração do contêiner?</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -167,6 +167,8 @@
     <string name="content_info">Informații conținut</string>
     <string name="game_not_installed_title">Joc neinstalat</string>
     <string name="game_not_installed_message">%s nu este instalat. Instalează jocul înainte de a-l porni.</string>
+    <string name="intent_launch_failed">Nu s-a putut lansa jocul: comandă rapidă de lansare invalidă</string>
+    <string name="intent_launch_steam_login_required">Autentificare Steam necesară pentru a lansa acest joc</string>
     <string name="game_executable_not_found_title">Nu se poate porni</string>
     <string name="game_executable_not_found">Executabilul nu a putut fi selectat automat. Setează calea executabilului în setările containerului.</string>
     <string name="save_container_settings_title">Salvezi configurația containerului?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -429,6 +429,8 @@
     <string name="game_feedback_issues_question">Выберите проблемы, которые вы встретили:</string>
     <string name="game_information">Информация об игре</string>
     <string name="game_not_installed_message">%s не установлена. Пожалуйста, установите игру перед запуском.</string>
+    <string name="intent_launch_failed">Не удалось запустить игру: недействительный ярлык запуска</string>
+    <string name="intent_launch_steam_login_required">Для запуска этой игры требуется вход в Steam</string>
     <string name="game_not_installed_title">Игра не установлена</string>
     <string name="game_options_cloud_saves">Облачные сохранения</string>
     <string name="game_options_container">Контейнер</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -161,6 +161,8 @@
     <string name="content_info">Інформація про вміст</string>
     <string name="game_not_installed_title">Гра не інстальована</string>
     <string name="game_not_installed_message">Гра %s не інстальована. Будь ласка, інсталюйте гру перед запуском.</string>
+    <string name="intent_launch_failed">Не вдалося запустити гру: недійсний ярлик запуску</string>
+    <string name="intent_launch_steam_login_required">Для запуску цієї гри потрібен вхід у Steam</string>
     <string name="game_executable_not_found_title">Неможливо запустити</string>
     <string name="game_executable_not_found">Виконуваний файл не вдалося вибрати автоматично. Вкажіть шлях до виконуваного файлу в налаштуваннях контейнера.</string>
     <string name="save_container_settings_title">Зберегти налаштування контейнера?</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -164,6 +164,8 @@
     <string name="content_info">内容信息</string>
     <string name="game_not_installed_title">游戏未安装</string>
     <string name="game_not_installed_message">%s 未安装，请在启动前先安装游戏</string>
+    <string name="intent_launch_failed">无法启动游戏：启动快捷方式无效</string>
+    <string name="intent_launch_steam_login_required">启动此游戏需要登录 Steam</string>
     <string name="game_executable_not_found_title">无法启动</string>
     <string name="game_executable_not_found">无法自动选择可执行文件。请在容器设置中指定可执行文件路径。</string>
     <string name="save_container_settings_title">保存容器配置？</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -164,6 +164,8 @@
     <string name="content_info">內容信息</string>
     <string name="game_not_installed_title">遊戲未安裝</string>
     <string name="game_not_installed_message">%s 未安裝, 請在啟動前先安裝遊戲</string>
+    <string name="intent_launch_failed">無法啟動遊戲：啟動捷徑無效</string>
+    <string name="intent_launch_steam_login_required">啟動此遊戲需要登入 Steam</string>
     <string name="game_executable_not_found_title">無法啟動</string>
     <string name="game_executable_not_found">無法自動選擇可執行檔。請在容器配置中指定可執行檔路徑。</string>
     <string name="save_container_settings_title">保存容器配置?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,8 @@
     <string name="content_info">Content Info</string>
     <string name="game_not_installed_title">Game Not Installed</string>
     <string name="game_not_installed_message">%s is not installed. Please install the game first before launching.</string>
+    <string name="intent_launch_failed">Could not launch game: invalid launch shortcut</string>
+    <string name="intent_launch_steam_login_required">Steam login required to launch this game</string>
     <string name="game_executable_not_found_title">Cannot Launch</string>
     <string name="game_executable_not_found">The executable could not be auto-selected. Please set the executable path in container settings.</string>
     <string name="save_container_settings_title">Save Container Configuration?</string>


### PR DESCRIPTION
Closes #883

## Summary
- Fix cold-start intent: split into warm (`onNewIntent` → emit event) vs cold (store pending, PluviaMain consumes when UI ready)
- Snackbar on unparseable LAUNCH_GAME intent
- Dialog when intent targets uninstalled game
- Snackbar when Steam login required for cold-start intent
- Remove trivial `resolveNotInstalledGameName` wrapper

## Test plan
- [ ] Cold launch via `adb shell am start -a app.gamenative.LAUNCH_GAME --es app_id <id>` — game launches after login
- [ ] Warm launch via same intent while app open — launches immediately
- [ ] Intent with invalid app_id → snackbar error
- [ ] Intent for uninstalled game → "not installed" dialog
- [ ] Steam game cold launch while logged out → snackbar, launches after login

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped LAUNCH_GAME intents on cold start by queuing them until the UI is ready; warm launches still fire immediately. Adds clear, localized feedback when an intent is invalid, the game isn’t installed, or Steam login is required.

- **Bug Fixes**
  - Split intent handling: warm launches emit on `onNewIntent`; all cold launches are stored and consumed by `PluviaMain` when the UI is ready.
  - Prevented cold-start launches (including non‑Steam) from failing silently due to a non-replaying event bus.
  - Ignored intents re-delivered from Recents to avoid duplicate launches.

- **New Features**
  - Snackbar when a LAUNCH_GAME intent has invalid extras.
  - Dialog when the target game is not installed (shows the game name).
  - Snackbar when Steam login is required; the intent is queued and retried after login.

<sup>Written for commit 3e44cf893698a6e6d292ef264ca2b475d5a4cac0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved external game-launch handling with pending-request support at startup.
  * Detects Steam login requirements and defers launches until login when needed.
  * Shows user-facing notifications for invalid or failed launch shortcuts.

* **Localization**
  * Added translations for launch-failure and Steam-login-required messages across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->