### PR TITLE
Check that the keycode is within the valid keycode range

### DIFF
--- a/app/src/main/java/com/winlator/xserver/Keyboard.java
+++ b/app/src/main/java/com/winlator/xserver/Keyboard.java
@@ -107,6 +107,11 @@ public class Keyboard {
         int action = event.getAction();
         if (action == KeyEvent.ACTION_DOWN || action == KeyEvent.ACTION_UP) {
             int keyCode = event.getKeyCode();
+
+            // Check that the keycode is within the valid keycode range
+            // in case the device sends a custom keycode outside the range
+            if (keyCode >= keycodeMap.length) return false;
+
             XKeycode xKeycode = keycodeMap[keyCode];
             if (xKeycode == null) return false;
 


### PR DESCRIPTION
This fixes a crash when the device sends a custom keycode outside the valid keycode range. For example, the Zenfone 9's Smart Key swipe sends keycode 917.

Fixes https://discord.com/channels/1378308569287622737/1482426222297219102

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate incoming keycodes before indexing into the map to prevent crashes when devices send custom codes outside the valid range. Out-of-range keys are ignored to avoid ArrayIndexOutOfBounds (e.g., Zenfone 9 Smart Key swipe with keycode 917).

<sup>Written for commit e4bf45efe2185c5ea99b41c3b759f135b88f7cd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling to properly manage unsupported key codes, enhancing stability and preventing unexpected behavior during keyboard operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->