### PR TITLE
Fixed a bug with steam 2017 vc redists

### DIFF
--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/VcRedistStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/VcRedistStep.kt
@@ -20,7 +20,7 @@ private val vcRedistMap: Map<String, String> = mapOf(
     "A:\\_CommonRedist\\vcredist\\2015\\vc_redist.x86.exe" to "/install /passive /norestart",
     "A:\\_CommonRedist\\vcredist\\2015\\vc_redist.x64.exe" to "/install /passive /norestart",
     "A:\\_CommonRedist\\vcredist\\2017\\vc_redist.x86.exe" to "/install /passive /norestart",
-    "A:\\_CommonRedist\\vcredist\\2017\\vc_redist_x64\\vc_redist.x64.exe" to "/install /passive /norestart",
+    "A:\\_CommonRedist\\vcredist\\2017\\vc_redist.x64.exe" to "/install /passive /norestart",
     "A:\\_CommonRedist\\vcredist\\2019\\vc_redist.x86.exe" to "/install /passive /norestart",
     "A:\\_CommonRedist\\vcredist\\2019\\vc_redist.x64.exe" to "/install /passive /norestart",
     "A:\\redist\\vcredist_x86.exe" to "",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the Steam 2017 VC++ x64 redistributable path in `VcRedistStep` so the installer is found and runs during preinstall. Updated the mapping from "A:\_CommonRedist\vcredist\2017\vc_redist_x64\vc_redist.x64.exe" to "A:\_CommonRedist\vcredist\2017\vc_redist.x64.exe".

<sup>Written for commit 7e58766008fd6c3e54e29f90d92cbff107c3822e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected the installation path for the 2017 Visual C++ Redistributable (x64) component to ensure proper file resolution during the pre-installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->