### PR TITLE
feat: Imagefs symlink setup

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1559,14 +1559,14 @@ fun preLaunchApp(
         // Migrate legacy on-disk imagefs layout (e.g. legacy Proton → shared paths) before manifest
         // installs or launch deps — resolveMissingManifestInstallRequests can install Proton too.
         val legacyImageFsRoot = File(context.filesDir, "imagefs")
-        val migrationOk = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(
+        val symlinksOk = ImageFsInstaller.ensureImageFsSymlinks(
             context,
             legacyImageFsRoot,
-            container.wineVersion,
+            container,
         )
-        if (!migrationOk) {
+        if (!symlinksOk) {
             Timber.tag("preLaunchApp").e(
-                "Legacy ImageFS migration failed: ${legacyImageFsRoot.absolutePath}",
+                "ImageFS symlinks failed: ${legacyImageFsRoot.absolutePath}",
             )
             setLoadingDialogVisible(false)
             setMessageDialogState(

--- a/app/src/main/java/com/winlator/xenvironment/ImageFSLegacyMigrator.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFSLegacyMigrator.java
@@ -20,6 +20,10 @@ public final class ImageFSLegacyMigrator {
         if (!migrateLegacyProtonToShared(context, legacyImageFsRoot)) {
             return false;
         }
+        if (!removeLegacyImageFsRootIfNeeded(legacyImageFsRoot)) {
+            return false;
+        }
+
         return true;
     }
 
@@ -105,5 +109,31 @@ public final class ImageFSLegacyMigrator {
         }
 
         return true;
+    }
+
+    /**
+     * After migration, remove legacy imagefs root directory when it is a real directory.
+     */
+    private static boolean removeLegacyImageFsRootIfNeeded(File legacyImageFsRoot) {
+        if (!legacyImageFsRoot.exists()) {
+            return true;
+        }
+        if (!legacyImageFsRoot.isDirectory() || FileUtils.isSymlink(legacyImageFsRoot)) {
+            return true;
+        }
+        File[] optEntries = new File(legacyImageFsRoot, "opt").listFiles();
+        if (optEntries != null) {
+            for (File entry : optEntries) {
+                if (entry.isDirectory() && !FileUtils.isSymlink(entry) && entry.getName().startsWith("proton-")) {
+                    Log.w("ImageFSLegacyMigrator", "Keeping legacy imagefs root because unmigrated Proton dir remains: " + entry.getName());
+                    return false;
+                }
+            }
+        }
+        if (FileUtils.delete(legacyImageFsRoot)) {
+            return true;
+        }
+        Log.w("ImageFSLegacyMigrator", "Failed to delete legacy imagefs root: " + legacyImageFsRoot.getAbsolutePath());
+        return false;
     }
 }

--- a/app/src/main/java/com/winlator/xenvironment/ImageFSLegacyMigrator.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFSLegacyMigrator.java
@@ -11,17 +11,15 @@ public final class ImageFSLegacyMigrator {
     private ImageFSLegacyMigrator() {}
 
     /**
-     * Migrate legacy directories if needed. After that, ensure the shared home and proton are symlinked.
+     * Migrate legacy directories if needed.
      */
-    public static boolean migrateLegacyDirsIfNeeded(Context context, File legacyImageFsRoot, String wineVersion) {
+    public static boolean migrateLegacyDirsIfNeeded(Context context, File legacyImageFsRoot) {
         if (!migrateLegacyHomeToShared(context, legacyImageFsRoot)) {
             return false;
         }
         if (!migrateLegacyProtonToShared(context, legacyImageFsRoot)) {
             return false;
         }
-        ImageFsInstaller.ensureSharedHomeRoot(context, legacyImageFsRoot);
-        ImageFsInstaller.ensureProtonVersionSymlink(context, legacyImageFsRoot, wineVersion);
         return true;
     }
 

--- a/app/src/main/java/com/winlator/xenvironment/ImageFs.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFs.java
@@ -43,6 +43,18 @@ public class ImageFs {
         return sharedProtonDir;
     }
 
+    /**
+     * Root directory for a given variant's imagefs. Both variants can be installed in parallel:
+     * files/glibc/imagefs and files/bionic/imagefs.
+     */
+    public static File getVariantRootDir(Context context, String variant) {
+        File variantRootDir = new File(context.getFilesDir(), variant + "/imagefs");
+        if (!variantRootDir.exists()) {
+            variantRootDir.mkdirs();
+        }
+        return variantRootDir;
+    }
+
     public static ImageFs find(Context context) {
         ImageFs local = INSTANCE;
         if (local != null) return local;

--- a/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
@@ -64,21 +64,27 @@ public abstract class ImageFsInstaller {
 
     public static void installWineFromAssets(final Context context, AssetManager assetManager) {
         String[] versions = context.getResources().getStringArray(R.array.bionic_wine_entries);
-        File rootDir = ImageFs.find(context).getRootDir();
+        File protonDir = ImageFs.getSharedProtonDir(context);
         for (String version : versions) {
-            File outFile = new File(rootDir, "/opt/" + version);
+            File outFile = new File(protonDir, version);
             outFile.mkdirs();
             TarCompressorUtils.extract(TarCompressorUtils.Type.XZ, assetManager, version + ".txz", outFile);
         }
     }
 
-    public static void installWineFromDownloads(final Context context) {
+    public static void installWineFromDownloads(final Context context, File rootDir) {
         String[] versions = context.getResources().getStringArray(R.array.bionic_wine_entries);
-        File rootDir = ImageFs.find(context).getRootDir();
-        ImageFs imageFs = ImageFs.find(context);
+        File downloadsDir = context.getFilesDir();
+        File protonDir = ImageFs.getSharedProtonDir(context);
         for (String version : versions) {
-            File downloaded = new File(imageFs.getFilesDir(), version + ".txz");
-            File outFile = new File(rootDir, "/opt/" + version);
+            File downloaded = new File(downloadsDir, version + ".txz");
+            if (!downloaded.exists()) continue;
+            File outFile = new File(protonDir, version);
+            File binDir = new File(outFile, "bin");
+            if (binDir.exists() && binDir.isDirectory()) continue;
+            if (outFile.exists()) {
+                FileUtils.delete(outFile);
+            }
             outFile.mkdirs();
             TarCompressorUtils.extract(
                 TarCompressorUtils.Type.XZ,
@@ -96,8 +102,8 @@ public abstract class ImageFsInstaller {
             Callback<Integer> onProgress
     ) {
         // AppUtils.keepScreenOn(context);
-        ImageFs imageFs = ImageFs.find(context);
-        final File rootDir = imageFs.getRootDir();
+        final File rootDir = ImageFs.getVariantRootDir(context, containerVariant);
+        ImageFs imageFs = ImageFs.find(rootDir);
 
         PrefManager.init(context);
         PrefManager.putString("current_box64_version", "");
@@ -105,20 +111,16 @@ public abstract class ImageFsInstaller {
         // final DownloadProgressDialog dialog = new DownloadProgressDialog(context);
         // dialog.show(R.string.installing_system_files);
         return Executors.newSingleThreadExecutor().submit(() -> {
-            clearRootDir(context, rootDir);
-            ensureSharedHomeRoot(context, rootDir);
-            ensureProtonVersionSymlink(context, rootDir, wineVersion);
-
             final byte compressionRatio = 22;
             String imagefsFile = containerVariant.equals(Container.GLIBC) ? "imagefs_gamenative.txz" : "imagefs_bionic.txz";
-            File downloaded = new File(imageFs.getFilesDir(), imagefsFile);
+            File downloaded = new File(context.getFilesDir(), imagefsFile);
 
             boolean success = false;
 
             if (Arrays.asList(context.getAssets().list("")).contains(imagefsFile) == true){
                 final long contentLength = (long) (FileUtils.getSize(assetManager, imagefsFile) * (100.0f / compressionRatio));
                 AtomicLong totalSizeRef = new AtomicLong();
-                Log.d("Extraction", "extracting " + imagefsFile);
+                Log.d("Extraction", "extracting " + imagefsFile + " to " + rootDir.getPath());
 
                 success = TarCompressorUtils.extract(TarCompressorUtils.Type.XZ, assetManager, imagefsFile, rootDir, (file, size) -> {
                     if (size > 0) {
@@ -135,7 +137,7 @@ public abstract class ImageFsInstaller {
             else if (downloaded.exists()){
                 final long contentLength = (long) (FileUtils.getSize(downloaded) * (100.0f / compressionRatio));
                 AtomicLong totalSizeRef = new AtomicLong();
-                Log.d("Extraction", "extracting " + imagefsFile);
+                Log.d("Extraction", "extracting " + imagefsFile + " to " + rootDir.getPath());
                 success = TarCompressorUtils.extract(TarCompressorUtils.Type.XZ, downloaded, rootDir, (file, size) -> {
                     if (size > 0) {
                         long totalSize = totalSizeRef.addAndGet(size);
@@ -149,12 +151,20 @@ public abstract class ImageFsInstaller {
             }
 
             if (success) {
-                Log.d("ImageFsInstaller", "Successfully installed system files");
+                Log.d("ImageFsInstaller", "Successfully installed system files for " + containerVariant);
                 ContainerManager containerManager = new ContainerManager(context);
 
-                installWineFromDownloads(context);
-                installGuestLibs(context);
+                installGuestLibs(context, rootDir);
                 imageFs.createImgVersionFile(LATEST_VERSION);
+                imageFs.createVariantFile(containerVariant);
+
+        
+                if (containerVariant.equals(Container.BIONIC)) {
+                    installWineFromDownloads(context, rootDir);
+                    //re-ensure proton symlinks after wine install
+                    ensureProtonVersionSymlink(context, rootDir, wineVersion);
+                }
+
                 resetContainerImgVersions(context);
 
                 // Clear Steam DLL markers for all games
@@ -172,9 +182,8 @@ public abstract class ImageFsInstaller {
         });
     }
 
-    private static void installGuestLibs(Context ctx) {
+    private static void installGuestLibs(Context ctx, File imagefs) {
         final String ASSET_TAR = "redirect.tzst";          // ➊  add this to assets/
-        File imagefs = new File(ctx.getFilesDir(), "imagefs");
         // ➋  Unpack straight into imagefs, preserving relative paths.
         try (InputStream in  = ctx.getAssets().open(ASSET_TAR)) {
             TarCompressorUtils.extract(
@@ -209,18 +218,15 @@ public abstract class ImageFsInstaller {
     private static void chmod(File f) { if (f.exists()) FileUtils.chmod(f, 0755);}
 
     public static Future<Boolean> installIfNeededFuture(final Context context, AssetManager assetManager, Container container, Callback<Integer> onProgress) {
-        ImageFs imageFs = ImageFs.find(context);
+        String variant = container.getContainerVariant();
         String wineVersion = container.getWineVersion();
-        if (!ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, imageFs.getRootDir())) {
-            Log.w("ImageFsInstaller", "Failed to migrate legacy directories before installation.");
-            return Executors.newSingleThreadExecutor().submit(() -> false);
-        }
-        if (!imageFs.isValid() || imageFs.getVersion() < LATEST_VERSION || !imageFs.getVariant().equals(container.getContainerVariant())) {
+        Log.d("ImageFsInstaller", "Variant: " + variant);
+        if (!isVariantImageFsValid(context, variant)) {
             Log.d("ImageFsInstaller", "Installing image from assets");
             return installFromAssetsFuture(
                     context,
                     assetManager,
-                    container.getContainerVariant(),
+                    variant,
                     wineVersion,
                     onProgress
             );
@@ -230,74 +236,6 @@ public abstract class ImageFsInstaller {
                 return true;
             });
         }
-    }
-
-    private static boolean isImportedWineProton(Context context, String fileName) {
-        String lowerName = fileName.toLowerCase();
-
-        // Not a Wine/Proton directory
-        if (!lowerName.startsWith("wine-") && !lowerName.startsWith("proton-")) {
-            return false;
-        }
-
-        // Get bundled versions from resource arrays
-        String[] bionicWineEntries = context.getResources().getStringArray(R.array.bionic_wine_entries);
-        String[] glibcWineEntries = context.getResources().getStringArray(R.array.glibc_wine_entries);
-
-        // Check if it's a bundled version
-        for (String version : bionicWineEntries) {
-            if (lowerName.equals(version.toLowerCase())) return false;
-        }
-        for (String version : glibcWineEntries) {
-            if (lowerName.equals(version.toLowerCase())) return false;
-        }
-
-        // It's Wine/Proton but not bundled, so it's imported
-        return true;
-    }
-
-    private static void clearOptDir(Context context, File optDir) {
-        File[] files = optDir.listFiles();
-        if (files == null) return;
-
-        for (File file : files) {
-            String fileName = file.getName();
-
-            if (fileName.equals("installed-wine")) continue;
-
-            // Keep imported Wine/Proton installations
-            if (isImportedWineProton(context, fileName)) {
-                Log.d("ImageFsInstaller", "Preserving imported installation: " + fileName);
-                continue;
-            }
-
-            // Delete everything else
-            FileUtils.delete(file);
-        }
-    }
-
-    private static void clearRootDir(Context context, File rootDir) {
-        if (rootDir.isDirectory()) {
-            File[] files = rootDir.listFiles();
-            if (files != null) {
-                for (File file : files) {
-                    if (file.isDirectory()) {
-                        String name = file.getName();
-                        if (name.equals("home")) {
-                            continue;
-                        }
-                        // Preserve imported Wine/Proton installations in opt/
-                        if (name.equals("opt")) {
-                            Log.d("ImageFsInstaller", "Clearing opt directory while preserving imported Wine/Proton installations");
-                            clearOptDir(context, file);
-                            continue;
-                        }
-                    }
-                    FileUtils.delete(file);
-                }
-            }
-        }
-        else rootDir.mkdirs();
     }
 
     public static void generateCompactContainerPattern(final Context context, AssetManager assetManager) {
@@ -423,6 +361,46 @@ public abstract class ImageFsInstaller {
     }
 
     /**
+     * Makes files/imagefs a symlink to files/{variant}/imagefs so ImageFs.find(context)
+     * resolves to the selected variant.
+     */
+    private static void ensureImageFsSymlink(Context context, String variant) {
+        File link = new File(context.getFilesDir(), "imagefs");
+        File target = ImageFs.getVariantRootDir(context, variant);
+        if (!target.isDirectory()) {
+            return;
+        }
+        try {
+            File desiredTarget = target.getCanonicalFile();
+            if (Files.isSymbolicLink(link.toPath())) {
+                File currentTarget = link.getCanonicalFile();
+                if (currentTarget.equals(desiredTarget)) {
+                    return;
+                }
+                if (!FileUtils.delete(link)) {
+                    Log.e("ImageFsInstaller", "Failed to delete old imagefs symlink: " + link.getAbsolutePath());
+                    return;
+                }
+            } else if (link.exists()) {
+                Log.w("ImageFsInstaller", "imagefs path exists and is not a symlink: " + link.getAbsolutePath());
+                return;
+            }
+
+            FileUtils.symlink(target.getAbsolutePath(), link.getAbsolutePath());
+            if (!Files.isSymbolicLink(link.toPath())) {
+                Log.e("ImageFsInstaller", "Failed to create imagefs symlink: " + link.getAbsolutePath());
+                return;
+            }
+            File linkedTarget = link.getCanonicalFile();
+            if (!linkedTarget.equals(desiredTarget)) {
+                Log.e("ImageFsInstaller", "imagefs symlink points to unexpected target: " + linkedTarget);
+            }
+        } catch (IOException e) {
+            Log.e("ImageFsInstaller", "Failed to ensure imagefs symlink", e);
+        }
+    }
+
+    /**
      * For Bionic: ensures rootDir/opt/<protonVersion> points to imagefs_shared/proton/<protonVersion>.
      * This keeps only the active Proton version linked in opt, matching pre-branch layout.
      */
@@ -459,6 +437,22 @@ public abstract class ImageFsInstaller {
             Log.d("ImageFsInstaller", "Created opt/" + protonVersion + " -> " + targetVersionDir.getAbsolutePath());
         } catch (Exception e) {
             Log.e("ImageFsInstaller", "ensureProtonVersionSymlink failed for " + protonVersion, e);
+        }
+    }
+
+    /** True if the given variant's imagefs is installed and at latest version. */
+    public static boolean isVariantImageFsValid(Context context, String variant) {
+        File root = ImageFs.getVariantRootDir(context, variant);
+        if (!root.isDirectory()) return false;
+        File versionFile = new File(root, ".winlator/.img_version");
+        if (!versionFile.exists()) return false;
+        try {
+            List<String> lines = FileUtils.readLines(versionFile);
+            if (lines == null || lines.isEmpty()) return false;
+            int version = Integer.parseInt(lines.get(0).trim());
+            return version >= LATEST_VERSION;
+        } catch (Exception e) {
+            return false;
         }
     }
 
@@ -523,6 +517,7 @@ public abstract class ImageFsInstaller {
 
         String wineVersion = container.getWineVersion();
         String variant = container.getContainerVariant();
+        ensureImageFsSymlink(context, variant);
         ensureSharedHomeRoot(context, legacyImageFsRoot);
         if (Container.BIONIC.equals(variant)) {
             ensureProtonVersionSymlink(context, legacyImageFsRoot, wineVersion);

--- a/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
@@ -211,7 +211,7 @@ public abstract class ImageFsInstaller {
     public static Future<Boolean> installIfNeededFuture(final Context context, AssetManager assetManager, Container container, Callback<Integer> onProgress) {
         ImageFs imageFs = ImageFs.find(context);
         String wineVersion = container.getWineVersion();
-        if (!ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, imageFs.getRootDir(), wineVersion)) {
+        if (!ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, imageFs.getRootDir())) {
             Log.w("ImageFsInstaller", "Failed to migrate legacy directories before installation.");
             return Executors.newSingleThreadExecutor().submit(() -> false);
         }
@@ -488,7 +488,7 @@ public abstract class ImageFsInstaller {
             return ContentsManager.getInstallDir(context, profile);
         }
         return new File(ImageFs.getSharedProtonDir(context), protonVersion);
-    }
+        }
 
     /**
      * Removes the current Proton symlink(s) from opt/ so it can be replaced with the current proton
@@ -511,5 +511,23 @@ public abstract class ImageFsInstaller {
                 FileUtils.delete(entry);
             }
         }
+    }
+
+    /**
+     * Migrate legacy directories if needed. After that, ensure the shared home and proton are symlinked.
+     */
+    public static boolean ensureImageFsSymlinks(Context context, File legacyImageFsRoot, Container container) {
+        if (!ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)) {
+            return false;
+        }
+
+        String wineVersion = container.getWineVersion();
+        String variant = container.getContainerVariant();
+        ensureSharedHomeRoot(context, legacyImageFsRoot);
+        if (Container.BIONIC.equals(variant)) {
+            ensureProtonVersionSymlink(context, legacyImageFsRoot, wineVersion);
+        }
+
+        return true;
     }
 }

--- a/app/src/test/java/com/winlator/xenvironment/ImageFSLegacyMigratorTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFSLegacyMigratorTest.kt
@@ -2,12 +2,7 @@ package com.winlator.xenvironment
 
 import androidx.test.core.app.ApplicationProvider
 import java.io.File
-import io.mockk.every
-import io.mockk.just
-import io.mockk.mockkStatic
-import io.mockk.runs
-import io.mockk.unmockkStatic
-import io.mockk.verify
+import java.nio.file.Files
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -29,34 +24,22 @@ class ImageFSLegacyMigratorTest {
         filesDir = context.filesDir
         legacyImageFsRoot = File(filesDir, "legacy-imagefs-test-${System.nanoTime()}").apply { mkdirs() }
         sharedDir = File(filesDir, "imagefs_shared").apply { deleteRecursively() }
-        mockkStatic(ImageFsInstaller::class)
-        every { ImageFsInstaller.ensureSharedHomeRoot(any(), any()) } just runs
-        every { ImageFsInstaller.ensureProtonVersionSymlink(any(), any(), any()) } just runs
     }
 
     @After
     fun tearDown() {
-        unmockkStatic(ImageFsInstaller::class)
         legacyImageFsRoot.deleteRecursively()
         sharedDir.deleteRecursively()
-    }
-
-    private fun assertEnsureCalls(wineVersion: String) {
-        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
-        verify(exactly = 1) { ImageFsInstaller.ensureSharedHomeRoot(context, legacyImageFsRoot) }
-        verify(exactly = 1) {
-            ImageFsInstaller.ensureProtonVersionSymlink(context, legacyImageFsRoot, wineVersion)
-        }
     }
 
     @Test
     fun migrateLegacyDirsIfNeeded_returnsTrueWhenLegacyHomeMissing() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
 
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "")
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
 
         assertTrue(migrated)
-        assertEnsureCalls("")
+        assertFalse(File(legacyImageFsRoot, "home").exists())
     }
 
     @Test
@@ -65,10 +48,10 @@ class ImageFSLegacyMigratorTest {
         val legacyHome = File(legacyImageFsRoot, "home").apply { mkdirs() }
         val legacyFile = File(legacyHome, "marker.txt").apply { writeText("legacy-content") }
 
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "")
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
 
         assertTrue(migrated)
-        assertEnsureCalls("")
+        assertFalse("Legacy home should have been moved away", legacyHome.exists())
         val sharedHome = File(sharedDir, "home")
         assertTrue(sharedHome.exists())
         assertEquals("legacy-content", File(sharedHome, legacyFile.name).readText())
@@ -83,21 +66,24 @@ class ImageFSLegacyMigratorTest {
         val legacyHome = File(legacyImageFsRoot, "home").apply { mkdirs() }
         File(legacyHome, "new.txt").writeText("new-legacy")
 
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "")
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
 
         assertTrue(migrated)
-        assertEnsureCalls("")
         assertFalse(File(sharedHome, "old.txt").exists())
         assertEquals("new-legacy", File(sharedHome, "new.txt").readText())
     }
 
     @Test
-    fun migrateLegacyDirsIfNeeded_callsEnsureMethodsWhenNoLegacyHomeExists() {
+    fun migrateLegacyDirsIfNeeded_succeedsWhenLegacyHomeIsSymlinkAndKeepsLegacyRoot() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "")
+        val realHome = File(legacyImageFsRoot, "real-home").apply { mkdirs() }
+        val symlinkPath = File(legacyImageFsRoot, "home").toPath()
+        Files.createSymbolicLink(symlinkPath, realHome.toPath())
+
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
 
         assertTrue(migrated)
-        assertEnsureCalls("")
+        assertTrue("Migrator only moves legacy directories and does not delete root", legacyImageFsRoot.exists())
     }
 
     @Test
@@ -106,11 +92,10 @@ class ImageFSLegacyMigratorTest {
         val protonDir = File(legacyImageFsRoot, "opt/proton-ge-9-2").apply { mkdirs() }
         val protonFile = File(protonDir, "version.txt").apply { writeText("ge-9-2") }
 
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "proton-ge-9-2")
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
 
         val sharedProtonDir = File(sharedDir, "proton/proton-ge-9-2")
         assertTrue(migrated)
-        assertEnsureCalls("proton-ge-9-2")
         assertFalse("Legacy proton dir should be moved away", protonDir.exists())
         assertTrue("Shared proton dir should exist", sharedProtonDir.exists())
         assertEquals("ge-9-2", File(sharedProtonDir, protonFile.name).readText())
@@ -122,11 +107,18 @@ class ImageFSLegacyMigratorTest {
         val optDir = File(legacyImageFsRoot, "opt").apply { mkdirs() }
         File(optDir, "wine-ge-custom").apply { mkdirs() }
 
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "")
+        val protonReal = File(legacyImageFsRoot, "proton-real").apply { mkdirs() }
+        val protonSymlinkPath = File(optDir, "proton-symlink").toPath()
+        Files.createSymbolicLink(protonSymlinkPath, protonReal.toPath())
+
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
 
         assertTrue(migrated)
-        assertEnsureCalls("")
+        assertTrue("Skipped opt entries remain under legacy root until installer cleanup", legacyImageFsRoot.exists())
         assertTrue(File(optDir, "wine-ge-custom").exists())
+        assertTrue(Files.isSymbolicLink(protonSymlinkPath))
+        assertFalse(File(sharedDir, "proton/wine-ge-custom").exists())
+        assertFalse(File(sharedDir, "proton/proton-symlink").exists())
     }
 
     @Test
@@ -138,10 +130,9 @@ class ImageFSLegacyMigratorTest {
         val existingShared = File(sharedDir, "proton/proton-ge-9-5").apply { mkdirs() }
         File(existingShared, "existing.txt").writeText("shared")
 
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "")
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
 
         assertTrue(migrated)
-        assertEnsureCalls("")
         assertFalse("Legacy proton should be removed when shared exists", legacyProton.exists())
         assertEquals("shared", File(existingShared, "existing.txt").readText())
     }

--- a/app/src/test/java/com/winlator/xenvironment/ImageFSLegacyMigratorTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFSLegacyMigratorTest.kt
@@ -74,7 +74,7 @@ class ImageFSLegacyMigratorTest {
     }
 
     @Test
-    fun migrateLegacyDirsIfNeeded_succeedsWhenLegacyHomeIsSymlinkAndKeepsLegacyRoot() {
+    fun migrateLegacyDirsIfNeeded_succeedsWhenLegacyHomeIsSymlinkAndRemovesLegacyRoot() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
         val realHome = File(legacyImageFsRoot, "real-home").apply { mkdirs() }
         val symlinkPath = File(legacyImageFsRoot, "home").toPath()
@@ -83,7 +83,10 @@ class ImageFSLegacyMigratorTest {
         val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
 
         assertTrue(migrated)
-        assertTrue("Migrator only moves legacy directories and does not delete root", legacyImageFsRoot.exists())
+        assertFalse(
+            "Home symlink case skips home migration but legacy root is still removed afterward",
+            legacyImageFsRoot.exists(),
+        )
     }
 
     @Test
@@ -114,9 +117,10 @@ class ImageFSLegacyMigratorTest {
         val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
 
         assertTrue(migrated)
-        assertTrue("Skipped opt entries remain under legacy root until installer cleanup", legacyImageFsRoot.exists())
-        assertTrue(File(optDir, "wine-ge-custom").exists())
-        assertTrue(Files.isSymbolicLink(protonSymlinkPath))
+        assertFalse(
+            "Those opt entries are not migrated to shared but go away with the legacy root",
+            legacyImageFsRoot.exists(),
+        )
         assertFalse(File(sharedDir, "proton/wine-ge-custom").exists())
         assertFalse(File(sharedDir, "proton/proton-symlink").exists())
     }
@@ -135,5 +139,23 @@ class ImageFSLegacyMigratorTest {
         assertTrue(migrated)
         assertFalse("Legacy proton should be removed when shared exists", legacyProton.exists())
         assertEquals("shared", File(existingShared, "existing.txt").readText())
+    }
+
+    @Test
+    fun migrateLegacyDirsIfNeeded_deletesLegacyRootAfterSuccessfulMigration() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        File(legacyImageFsRoot, "home").apply {
+            mkdirs()
+            File(this, "marker.txt").writeText("home")
+        }
+        File(legacyImageFsRoot, "opt/proton-ge-9-2").apply {
+            mkdirs()
+            File(this, "version.txt").writeText("ge-9-2")
+        }
+
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+
+        assertTrue(migrated)
+        assertFalse("Legacy root should be removed after migration", legacyImageFsRoot.exists())
     }
 }

--- a/app/src/test/java/com/winlator/xenvironment/ImageFsInstallerTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFsInstallerTest.kt
@@ -187,6 +187,102 @@ class ImageFsInstallerTest {
     }
 
     @Test
+    fun ensureImageFsSymlink_createsSymlinkToVariantRoot() {
+        val glibcRoot = ImageFs.getVariantRootDir(context, "glibc")
+        if (Files.exists(imageFsLink.toPath()) || Files.isSymbolicLink(imageFsLink.toPath())) {
+            imageFsLink.deleteRecursively()
+        }
+
+        mockkStatic(FileUtils::class)
+        try {
+            every { FileUtils.symlink(any<String>(), any<String>()) } answers {
+                val linkTarget = firstArg<String>()
+                val linkPath = secondArg<String>()
+                val linkFile = File(linkPath)
+                if (Files.exists(linkFile.toPath()) || Files.isSymbolicLink(linkFile.toPath())) {
+                    Files.deleteIfExists(linkFile.toPath())
+                }
+                Files.createSymbolicLink(linkFile.toPath(), File(linkTarget).toPath())
+            }
+
+            invokeEnsureImageFsSymlink(context, "glibc")
+        } finally {
+            unmockkStatic(FileUtils::class)
+        }
+
+        assertTrue("imagefs should be a symlink", Files.isSymbolicLink(imageFsLink.toPath()))
+        assertEquals(glibcRoot.canonicalPath, imageFsLink.canonicalPath)
+    }
+
+    @Test
+    fun ensureImageFsSymlink_retargetsExistingSymlink() {
+        val glibcRoot = ImageFs.getVariantRootDir(context, "glibc")
+        val bionicRoot = ImageFs.getVariantRootDir(context, "bionic")
+        if (Files.exists(imageFsLink.toPath()) || Files.isSymbolicLink(imageFsLink.toPath())) {
+            imageFsLink.deleteRecursively()
+        }
+        Files.createSymbolicLink(imageFsLink.toPath(), glibcRoot.toPath())
+
+        mockkStatic(FileUtils::class)
+        try {
+            every { FileUtils.delete(any<File>()) } answers { firstArg<File>().delete() }
+            every { FileUtils.symlink(any<String>(), any<String>()) } answers {
+                val linkTarget = firstArg<String>()
+                val linkPath = secondArg<String>()
+                val linkFile = File(linkPath)
+                if (Files.exists(linkFile.toPath()) || Files.isSymbolicLink(linkFile.toPath())) {
+                    Files.deleteIfExists(linkFile.toPath())
+                }
+                Files.createSymbolicLink(linkFile.toPath(), File(linkTarget).toPath())
+            }
+
+            invokeEnsureImageFsSymlink(context, "bionic")
+        } finally {
+            unmockkStatic(FileUtils::class)
+        }
+
+        assertTrue("imagefs should remain a symlink", Files.isSymbolicLink(imageFsLink.toPath()))
+        assertEquals(bionicRoot.canonicalPath, imageFsLink.canonicalPath)
+    }
+
+    @Test
+    fun isVariantImageFsValid_returnsFalseWhenVersionFileMissing() {
+        ImageFs.getVariantRootDir(context, "glibc")
+
+        val valid = ImageFsInstaller.isVariantImageFsValid(context, "glibc")
+
+        assertFalse(valid)
+    }
+
+    @Test
+    fun isVariantImageFsValid_returnsFalseWhenVersionIsOutdated() {
+        val rootDir = ImageFs.getVariantRootDir(context, "glibc")
+        val versionFile = File(rootDir, ".winlator/.img_version").apply {
+            parentFile?.mkdirs()
+            writeText((ImageFsInstaller.LATEST_VERSION - 1).toString())
+        }
+
+        val valid = ImageFsInstaller.isVariantImageFsValid(context, "glibc")
+
+        assertTrue(versionFile.exists())
+        assertFalse(valid)
+    }
+
+    @Test
+    fun isVariantImageFsValid_returnsTrueWhenVersionIsLatest() {
+        val rootDir = ImageFs.getVariantRootDir(context, "bionic")
+        val versionFile = File(rootDir, ".winlator/.img_version").apply {
+            parentFile?.mkdirs()
+            writeText(ImageFsInstaller.LATEST_VERSION.toString())
+        }
+
+        val valid = ImageFsInstaller.isVariantImageFsValid(context, "bionic")
+
+        assertTrue(versionFile.exists())
+        assertTrue(valid)
+    }
+
+    @Test
     fun removeCurrentProtonSymlink_removesOnlyNonActiveProtonSymlinks() {
         val optDir = File(filesDir, "imagefs-opt-remove-proton-${System.nanoTime()}").apply { mkdirs() }
         val active = File(optDir, "proton-ge-9-2").apply { mkdirs() }
@@ -228,6 +324,106 @@ class ImageFsInstallerTest {
         }
     }
 
+    @Test
+    fun ensureImageFsSymlinks_withGlibcContainer_setsImageFsSymlinkAndEnsuresSharedHome() {
+        val legacyRoot = File(filesDir, "legacy-glibc-${System.nanoTime()}").apply { mkdirs() }
+        val glibcRoot = ImageFs.getVariantRootDir(context, "glibc").apply { mkdirs() }
+        if (Files.exists(imageFsLink.toPath()) || Files.isSymbolicLink(imageFsLink.toPath())) {
+            imageFsLink.deleteRecursively()
+        }
+
+        val container = mockk<Container>()
+        every { container.getWineVersion() } returns "wine-9.0"
+        every { container.getContainerVariant() } returns Container.GLIBC
+
+        mockkStatic(ImageFSLegacyMigrator::class)
+        mockkStatic(FileUtils::class)
+        try {
+            every { ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(any(), any()) } returns true
+            every { FileUtils.isSymlink(any()) } returns false
+            every { FileUtils.symlink(any<String>(), any<String>()) } answers {
+                val linkTarget = firstArg<String>()
+                val linkPath = secondArg<String>()
+                val linkFile = File(linkPath)
+                linkFile.parentFile?.mkdirs()
+                if (Files.exists(linkFile.toPath()) || Files.isSymbolicLink(linkFile.toPath())) {
+                    Files.deleteIfExists(linkFile.toPath())
+                }
+                Files.createSymbolicLink(linkFile.toPath(), File(linkTarget).toPath())
+            }
+
+            assertTrue(ImageFsInstaller.ensureImageFsSymlinks(context, legacyRoot, container))
+
+            assertTrue("imagefs should be a symlink", Files.isSymbolicLink(imageFsLink.toPath()))
+            assertEquals(glibcRoot.canonicalPath, imageFsLink.canonicalPath)
+            val sharedHome = File(sharedDir, "home")
+            assertTrue("Shared home backing dir should exist", sharedHome.exists())
+            verify(atLeast = 1) { FileUtils.symlink(sharedHome.path, File(legacyRoot, "home").path) }
+            verify(atLeast = 1) { FileUtils.symlink(glibcRoot.absolutePath, imageFsLink.absolutePath) }
+        } finally {
+            unmockkStatic(FileUtils::class)
+            unmockkStatic(ImageFSLegacyMigrator::class)
+            legacyRoot.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun ensureImageFsSymlinks_withBionicContainer_alsoCreatesProtonSymlink() {
+        val legacyRoot = File(filesDir, "legacy-bionic-${System.nanoTime()}").apply { mkdirs() }
+        ImageFs.getVariantRootDir(context, "bionic").apply { mkdirs() }
+        val activeProtonVersion = "proton-ge-9-2"
+        val sharedProtonTarget = File(sharedDir, "proton/$activeProtonVersion").apply { mkdirs() }
+        val expectedLink = File(legacyRoot, "opt/$activeProtonVersion")
+
+        if (Files.exists(imageFsLink.toPath()) || Files.isSymbolicLink(imageFsLink.toPath())) {
+            imageFsLink.deleteRecursively()
+        }
+
+        val container = mockk<Container>()
+        every { container.getWineVersion() } returns activeProtonVersion
+        every { container.getContainerVariant() } returns Container.BIONIC
+
+        mockkStatic(ImageFSLegacyMigrator::class)
+        mockkStatic(FileUtils::class)
+        try {
+            every { ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(any(), any()) } returns true
+            every { FileUtils.isSymlink(any()) } returns false
+            every { FileUtils.delete(any<File>()) } returns true
+            every { FileUtils.symlink(any<String>(), any<String>()) } answers {
+                val linkTarget = firstArg<String>()
+                val linkPath = secondArg<String>()
+                val linkFile = File(linkPath)
+                linkFile.parentFile?.mkdirs()
+                if (Files.exists(linkFile.toPath()) || Files.isSymbolicLink(linkFile.toPath())) {
+                    Files.deleteIfExists(linkFile.toPath())
+                }
+                Files.createSymbolicLink(linkFile.toPath(), File(linkTarget).toPath())
+            }
+
+            assertTrue(ImageFsInstaller.ensureImageFsSymlinks(context, legacyRoot, container))
+
+            assertEquals(
+                ImageFs.getVariantRootDir(context, "bionic").canonicalPath,
+                imageFsLink.canonicalPath,
+            )
+            assertTrue(
+                "Proton opt symlink is under the legacy imagefs root passed to ensureImageFsSymlinks",
+                Files.isSymbolicLink(expectedLink.toPath()),
+            )
+            assertEquals(
+                sharedProtonTarget.canonicalPath,
+                expectedLink.canonicalFile.absolutePath,
+            )
+            verify(atLeast = 1) {
+                FileUtils.symlink(sharedProtonTarget.absolutePath, expectedLink.absolutePath)
+            }
+        } finally {
+            unmockkStatic(FileUtils::class)
+            unmockkStatic(ImageFSLegacyMigrator::class)
+            legacyRoot.deleteRecursively()
+        }
+    }
+
     private fun invokeEnsureSharedHomeRoot(context: android.content.Context, rootDir: File) {
         val method: Method = ImageFsInstaller::class.java.getDeclaredMethod(
             "ensureSharedHomeRoot",
@@ -246,6 +442,16 @@ class ImageFsInstallerTest {
         )
         method.isAccessible = true
         method.invoke(null, optDir, activeProtonVersion)
+    }
+
+    private fun invokeEnsureImageFsSymlink(context: android.content.Context, variant: String) {
+        val method: Method = ImageFsInstaller::class.java.getDeclaredMethod(
+            "ensureImageFsSymlink",
+            android.content.Context::class.java,
+            String::class.java,
+        )
+        method.isAccessible = true
+        method.invoke(null, context, variant)
     }
 
 }

--- a/app/src/test/java/com/winlator/xenvironment/ImageFsInstallerTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFsInstallerTest.kt
@@ -1,11 +1,13 @@
 package com.winlator.xenvironment
 
 import androidx.test.core.app.ApplicationProvider
+import com.winlator.container.Container
 import com.winlator.core.FileUtils
 import java.io.File
 import java.lang.reflect.Method
 import java.nio.file.Files
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
@@ -22,10 +24,18 @@ class ImageFsInstallerTest {
     private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
     private val filesDir = context.filesDir
     private val sharedDir = File(filesDir, "imagefs_shared")
+    private val imageFsLink = File(filesDir, "imagefs")
+    private val glibcDir = File(filesDir, "glibc")
+    private val bionicDir = File(filesDir, "bionic")
 
     @After
     fun tearDown() {
         sharedDir.deleteRecursively()
+        if (Files.isSymbolicLink(imageFsLink.toPath()) || imageFsLink.exists()) {
+            imageFsLink.delete()
+        }
+        glibcDir.deleteRecursively()
+        bionicDir.deleteRecursively()
     }
 
     @Test
@@ -200,6 +210,22 @@ class ImageFsInstallerTest {
         }
 
         optDir.deleteRecursively()
+    }
+
+    @Test
+    fun ensureImageFsSymlinks_returnsFalseWhenLegacyMigrationFails() {
+        val legacyRoot = File(filesDir, "legacy-migration-fail-${System.nanoTime()}").apply { mkdirs() }
+        val container = mockk<Container>(relaxed = true)
+
+        mockkStatic(ImageFSLegacyMigrator::class)
+        try {
+            every { ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(any(), any()) } returns false
+
+            assertFalse(ImageFsInstaller.ensureImageFsSymlinks(context, legacyRoot, container))
+        } finally {
+            unmockkStatic(ImageFSLegacyMigrator::class)
+            legacyRoot.deleteRecursively()
+        }
     }
 
     private fun invokeEnsureSharedHomeRoot(context: android.content.Context, rootDir: File) {

--- a/app/src/test/java/com/winlator/xenvironment/ImageFsTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFsTest.kt
@@ -13,10 +13,14 @@ import org.robolectric.RobolectricTestRunner
 class ImageFsTest {
     private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
     private val sharedDir = File(context.filesDir, "imagefs_shared")
+    private val glibcDir = File(context.filesDir, "glibc")
+    private val bionicDir = File(context.filesDir, "bionic")
 
     @After
     fun tearDown() {
         sharedDir.deleteRecursively()
+        glibcDir.deleteRecursively()
+        bionicDir.deleteRecursively()
     }
 
     @Test
@@ -46,5 +50,24 @@ class ImageFsTest {
         val expected = File(sharedRoot, "proton")
 
         assertEquals(expected.absolutePath, sharedProton.absolutePath)
+    }
+
+    @Test
+    fun getVariantRootDir_createsAndReturnsVariantDirectory() {
+        val actual = ImageFs.getVariantRootDir(context, "glibc")
+        val expected = File(context.filesDir, "glibc/imagefs")
+
+        assertTrue("Variant root dir should exist after call", actual.exists())
+        assertTrue("Variant root dir should be a directory", actual.isDirectory)
+        assertEquals(expected.absolutePath, actual.absolutePath)
+    }
+
+    @Test
+    fun getVariantRootDir_returnsDistinctPathsPerVariant() {
+        val glibcRoot = ImageFs.getVariantRootDir(context, "glibc")
+        val bionicRoot = ImageFs.getVariantRootDir(context, "bionic")
+
+        assertEquals(File(context.filesDir, "glibc/imagefs").absolutePath, glibcRoot.absolutePath)
+        assertEquals(File(context.filesDir, "bionic/imagefs").absolutePath, bionicRoot.absolutePath)
     }
 }


### PR DESCRIPTION
INFO: previously had this open in another PR https://github.com/utkarshdalal/GameNative/pull/860 but accidentally closed that. sorry...

Makes it possible to swap between glibc and bionic without reinstall.

Just a small video of why we want this:

Before (master branch. As you can see it even requires an additional game restart before it works) 
https://discord.com/channels/1378308569287622737/1485208315389673555/1486727750965268531

After (imagefs branch):
https://discord.com/channels/1378308569287622737/1485208315389673555/1486722723047538751

# Advantages:

- Speed. Install for glibc and bionic is both only once when used for the first time. Afterwards all switching is super fast.
- Proton builds are in a shared dir now and symlinked into the bionic variant. Download builds once, never look back. No more endless extracting.
- container variant scope: glibc and bionic is no longer in the same dir. So they don't overlap anymore.
- Code path clearity. Code is easier to read.

# Disadvantages:

- None aside from testing.

# To test
- Make sure you have gamenative installed and you have a game already running before the update.
- Update to this version, then run a game again. This way the "migration" path is run. (imagefs just get's deleted and auto-installs the glibc again. But still, good to test).
- Test a game(or container) in glibc.
- Test a game(or container) in bionic.
- Test different proton version.

# Migration path:

This has been tested and is automatic. If imagefs folder (so no symlink) is detected, it will delete it and simply auto-install the currently selected imagefs variant and symlink so that we are certain the new structure is used.

# New structure:

imagefs/
- symlinked by glibc or bionic.

glibc/imagefs/
- home → symlink → imagefs_shared/home
- opt/ → real dir. extracted from the tar.
- opt/wine -> real dir. extracted from the tar.

bionic/imagefs/
- home → imagefs_shared/home
- opt/ → real dir. extracted from the tar.
- opt/<current_inuse_proton> → symlinked to imagefs_shared/proton/<current_inuse_proton>

imagefs_shared/
- home/ — xuser → xuser-GOG_1136126792, plus xuser-GOG_1136126792 dir
- proton/ — proton-9.0-arm64ec, proton-9.0-x86_64, proton-10.0-arm64ec


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-variant imagefs for glibc and bionic with a stable `files/imagefs` symlink to the selected variant. Proton is shared across variants; pre-launch now runs migration and symlink setup so switching is instant.

- **New Features**
  - Variant roots at `files/glibc/imagefs` and `files/bionic/imagefs`; `files/imagefs` is retargeted at pre-launch via `ensureImageFsSymlinks`.
  - Per-variant install and validation (`isVariantImageFsValid`); writes `.winlator/.img_version` and the variant marker; installs guest libs into the variant root.
  - Proton archives from assets/downloads extract into `files/imagefs_shared/proton`; Bionic ensures `opt/<protonVersion>` points to the shared build.

- **Migration**
  - Legacy `files/imagefs` is migrated: `/home` → `imagefs_shared/home`, Proton → `imagefs_shared/proton`; the old root is removed unless real, unmigrated `opt/proton-*` dirs remain.
  - Pre-launch calls `ensureImageFsSymlinks` to run migration and set up symlinks; failures block launch with a clear error.

<sup>Written for commit fd640e045b4a23ac80bd9fa8cbe523ecaaf3aeed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bionic containers now get automatic, on-demand Proton provisioning at launch.

* **Refactor**
  * Consolidated Proton runtimes into a shared directory to reduce duplication.
  * Variant-aware image roots and symlink handling improve multi-variant installs and upgrades.
  * Guest Z: drive mapping updated to point to the resolved shared image root.

* **Bug Fixes / Reliability**
  * Improved install/extraction flow and per-variant validation for more robust upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->