### PR TITLE
Fix SD card game detection after crash

### DIFF
--- a/app/src/main/java/app/gamenative/db/dao/DownloadingAppInfoDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/DownloadingAppInfoDao.kt
@@ -17,6 +17,9 @@ interface DownloadingAppInfoDao {
     @Query("DELETE from downloading_app_info WHERE appId = :appId")
     suspend fun deleteApp(appId: Int)
 
+    @Query("SELECT * FROM downloading_app_info")
+    suspend fun getAll(): List<DownloadingAppInfo>
+
     @Query("DELETE from downloading_app_info")
     suspend fun deleteAll()
 }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -666,8 +666,10 @@ class SteamService : Service(), IChallengeUrlChanged {
         fun filterForDownloadableDepots(depot: DepotInfo, has64Bit: Boolean, preferredLanguage: String, ownedDlc: Map<Int, DepotInfo>?): Boolean {
             if (depot.manifests.isEmpty() && depot.encryptedManifests.isNotEmpty())
                 return false
-            // 1. Has something to download
+            // 1. Has something to download (0-byte manifests = stale PICS data from interrupted fetch)
             if (depot.manifests.isEmpty() && !depot.sharedInstall)
+                return false
+            if (depot.manifests.isNotEmpty() && depot.manifests.values.all { it.size == 0L || it.download == 0L })
                 return false
             // 2. Supported OS
             if (!(depot.osList.contains(OS.windows) ||
@@ -772,20 +774,36 @@ class SteamService : Service(), IChallengeUrlChanged {
             return appName
         }
 
+        /**
+         * Resolve best matching directory: completed install > partial > null.
+         * Extracted for testability — called by [getAppDirPath].
+         */
+        fun resolveExistingAppDir(installPaths: List<String>, names: List<String>): String? {
+            var firstExisting: String? = null
+            for (basePath in installPaths) {
+                for (name in names) {
+                    if (name.isEmpty()) continue
+                    val path = Paths.get(basePath, name)
+                    if (Files.isDirectory(path)) {
+                        if (MarkerUtils.hasMarker(path.pathString, Marker.DOWNLOAD_COMPLETE_MARKER)) {
+                            return path.pathString
+                        }
+                        if (firstExisting == null) firstExisting = path.pathString
+                    }
+                }
+            }
+            return firstExisting
+        }
+
         fun getAppDirPath(gameId: Int): String {
             val info = getAppInfoOf(gameId)
             val appName = getAppDirName(info)
             val oldName = info?.name.orEmpty()
+            val names = if (oldName.isNotEmpty() && oldName != appName) listOf(appName, oldName) else listOf(appName)
 
-            // search internal, configured external, and all mounted volumes
-            for (basePath in allInstallPaths) {
-                val path = Paths.get(basePath, appName)
-                if (Files.exists(path)) return path.pathString
-                if (oldName.isNotEmpty()) {
-                    val oldPath = Paths.get(basePath, oldName)
-                    if (Files.exists(oldPath)) return oldPath.pathString
-                }
-            }
+            // prefer completed installs over partial/stale directories
+            val resolved = resolveExistingAppDir(allInstallPaths, names)
+            if (resolved != null) return resolved
 
             // nothing on disk yet — default to preferred install location
             if (PrefManager.useExternalStorage) {
@@ -1010,8 +1028,9 @@ class SteamService : Service(), IChallengeUrlChanged {
         }
 
         fun deleteApp(appId: Int): Boolean {
-            // Remove any download-complete marker
-            MarkerUtils.removeMarker(getAppDirPath(appId), Marker.DOWNLOAD_COMPLETE_MARKER)
+            // snapshot path before marker removal (removing the marker changes resolution)
+            val appDirPath = getAppDirPath(appId)
+            MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
             // Remove from DB
             with(instance!!) {
                 scope.launch {
@@ -1030,8 +1049,6 @@ class SteamService : Service(), IChallengeUrlChanged {
                     }
                 }
             }
-
-            val appDirPath = getAppDirPath(appId)
 
             return File(appDirPath).deleteRecursively()
         }
@@ -2889,6 +2906,15 @@ class SteamService : Service(), IChallengeUrlChanged {
         }
 
         PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
+
+        // clear stale download records (completed games) but keep interrupted ones (preserves DLC selection)
+        scope.launch {
+            for (record in downloadingAppInfoDao.getAll()) {
+                if (isAppInstalled(record.appId)) {
+                    downloadingAppInfoDao.deleteApp(record.appId)
+                }
+            }
+        }
 
         notificationHelper = NotificationHelper(applicationContext)
         // pause downloads when WiFi/Ethernet is lost

--- a/app/src/test/java/app/gamenative/service/SdCardDetectionTest.kt
+++ b/app/src/test/java/app/gamenative/service/SdCardDetectionTest.kt
@@ -1,0 +1,162 @@
+package app.gamenative.service
+
+import app.gamenative.data.DepotInfo
+import app.gamenative.data.ManifestInfo
+import app.gamenative.enums.Marker
+import app.gamenative.enums.OS
+import app.gamenative.enums.OSArch
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.EnumSet
+
+class SdCardDetectionTest {
+
+    @get:Rule
+    val tmpDir = TemporaryFolder()
+
+    // -- filterForDownloadableDepots: 0-byte manifest filtering --
+
+    private fun depot(
+        manifests: Map<String, ManifestInfo> = emptyMap(),
+        encryptedManifests: Map<String, ManifestInfo> = emptyMap(),
+        sharedInstall: Boolean = false,
+        osList: EnumSet<OS> = EnumSet.of(OS.windows),
+        osArch: OSArch = OSArch.Arch64,
+        dlcAppId: Int = SteamService.INVALID_APP_ID,
+        language: String = "",
+    ) = DepotInfo(
+        depotId = 1,
+        dlcAppId = dlcAppId,
+        depotFromApp = 0,
+        sharedInstall = sharedInstall,
+        osList = osList,
+        osArch = osArch,
+        manifests = manifests,
+        encryptedManifests = encryptedManifests,
+        language = language,
+    )
+
+    private fun manifest(size: Long = 1000L, download: Long = 800L) = ManifestInfo(
+        name = "public",
+        gid = 123L,
+        size = size,
+        download = download,
+    )
+
+    @Test
+    fun `valid depot with normal manifest passes filter`() {
+        val d = depot(manifests = mapOf("public" to manifest()))
+        assertTrue(SteamService.filterForDownloadableDepots(d, true, "english", null))
+    }
+
+    @Test
+    fun `depot with 0-byte manifest is rejected`() {
+        val d = depot(manifests = mapOf("public" to manifest(size = 0L, download = 0L)))
+        assertFalse(SteamService.filterForDownloadableDepots(d, true, "english", null))
+    }
+
+    @Test
+    fun `depot with nonzero size but 0-byte download is rejected`() {
+        val d = depot(manifests = mapOf("public" to manifest(size = 1000L, download = 0L)))
+        assertFalse(SteamService.filterForDownloadableDepots(d, true, "english", null))
+    }
+
+    @Test
+    fun `depot with mix of 0 and nonzero manifests passes`() {
+        val d = depot(manifests = mapOf(
+            "public" to manifest(size = 1000L, download = 800L),
+            "beta" to manifest(size = 0L, download = 0L),
+        ))
+        assertTrue(SteamService.filterForDownloadableDepots(d, true, "english", null))
+    }
+
+    @Test
+    fun `encrypted-only depot is rejected`() {
+        val d = depot(
+            manifests = emptyMap(),
+            encryptedManifests = mapOf("public" to manifest()),
+        )
+        assertFalse(SteamService.filterForDownloadableDepots(d, true, "english", null))
+    }
+
+    @Test
+    fun `depot with both regular and encrypted manifests passes`() {
+        val d = depot(
+            manifests = mapOf("public" to manifest()),
+            encryptedManifests = mapOf("beta" to manifest()),
+        )
+        assertTrue(SteamService.filterForDownloadableDepots(d, true, "english", null))
+    }
+
+    @Test
+    fun `depot with empty manifests and no shared install is rejected`() {
+        val d = depot(manifests = emptyMap(), sharedInstall = false)
+        assertFalse(SteamService.filterForDownloadableDepots(d, true, "english", null))
+    }
+
+    @Test
+    fun `depot with empty manifests but shared install passes`() {
+        val d = depot(manifests = emptyMap(), sharedInstall = true)
+        assertTrue(SteamService.filterForDownloadableDepots(d, true, "english", null))
+    }
+
+    // -- getAppDirPath: prefer completed installs over partial --
+
+    private fun createGameDir(base: File, gameName: String, complete: Boolean): File {
+        val dir = File(base, gameName)
+        dir.mkdirs()
+        if (complete) {
+            File(dir, Marker.DOWNLOAD_COMPLETE_MARKER.fileName).createNewFile()
+        }
+        return dir
+    }
+
+    @Test
+    fun `completed install on second volume preferred over partial on first`() {
+        val internal = tmpDir.newFolder("internal", "Steam", "steamapps", "common")
+        val sdcard = tmpDir.newFolder("sdcard", "Steam", "steamapps", "common")
+
+        createGameDir(internal, "MyGame", complete = false)
+        createGameDir(sdcard, "MyGame", complete = true)
+
+        val paths = listOf(internal.absolutePath, sdcard.absolutePath)
+        val result = SteamService.resolveExistingAppDir(paths, listOf("MyGame"))
+
+        assertEquals(File(sdcard, "MyGame").absolutePath, result)
+    }
+
+    @Test
+    fun `falls back to first existing when none are complete`() {
+        val internal = tmpDir.newFolder("internal", "Steam", "steamapps", "common")
+        val sdcard = tmpDir.newFolder("sdcard", "Steam", "steamapps", "common")
+
+        createGameDir(internal, "MyGame", complete = false)
+        createGameDir(sdcard, "MyGame", complete = false)
+
+        val paths = listOf(internal.absolutePath, sdcard.absolutePath)
+        val result = SteamService.resolveExistingAppDir(paths, listOf("MyGame"))
+
+        assertEquals(File(internal, "MyGame").absolutePath, result)
+    }
+
+    @Test
+    fun `returns null when no directory exists`() {
+        val internal = tmpDir.newFolder("internal", "Steam", "steamapps", "common")
+        val paths = listOf(internal.absolutePath)
+        val result = SteamService.resolveExistingAppDir(paths, listOf("MyGame"))
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `empty name is skipped — never returns install root`() {
+        val internal = tmpDir.newFolder("internal", "Steam", "steamapps", "common")
+        val paths = listOf(internal.absolutePath)
+        val result = SteamService.resolveExistingAppDir(paths, listOf(""))
+
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
Closes #888

## Summary
- `getAppDirPath`: prefer directories with `.download_complete` marker over partial/stale dirs across volumes
- `filterForDownloadableDepots`: reject depots where all manifests have 0-byte size or download (stale PICS data)
- Clear stale `DownloadingAppInfo` DB records on startup (only for already-installed games — preserves DLC selection for interrupted downloads)
- Extracted `resolveExistingAppDir` for testability, added unit tests

## Test plan
- [ ] Download game to SD card, verify it shows as installed
- [ ] Create partial download dir on internal for same game — verify SD card install still detected
- [ ] Force-kill app during PICS fetch, restart — verify no 0-byte install dialogs
- [ ] Interrupt a download with DLC selected, restart — verify DLC selection preserved on resume
- [ ] Unit tests pass: `SdCardDetectionTest` (9 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SD card game detection after crashes by preferring completed installs and cleaning stale records. Prevents 0‑byte/0‑download install prompts and preserves DLC selections on resume. Closes #888.

- **Bug Fixes**
  - `getAppDirPath`/`resolveExistingAppDir`: prefer `.download_complete` installs across volumes; SD card installs are detected even if a partial internal dir exists.
  - `filterForDownloadableDepots`: skip depots where all manifests have size or download of 0 (stale PICS), preventing 0‑byte prompts.
  - On startup, remove stale `DownloadingAppInfo` for already‑installed games; keep interrupted downloads.

<sup>Written for commit 97f0da3bd435cdb1a877d44ab6fe1514b7401bc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a way to list all in-progress download records.

* **Bug Fixes**
  * Improved app installation directory detection; avoids choosing stale or incomplete directories.
  * Depots with empty or zero-sized manifests (or zero download entries) are now rejected.
  * Safer marker removal to prevent directory-resolution races.
  * Automatic cleanup of stale download records on service startup.

* **Tests**
  * Added comprehensive tests for depot filtering and app directory resolution.

* **Documentation**
  * Expanded inline docs to aid resolver clarity and testability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->