### PR TITLE
fix: case-insensitive .exe filter in getWindowsLaunchInfos

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1958,7 +1958,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             return getAppInfoOf(appId)?.let { appInfo ->
                 appInfo.config.launch.filter { launchInfo ->
                     // since configOS was unreliable and configArch was even more unreliable
-                    launchInfo.executable.endsWith(".exe")
+                    launchInfo.executable.endsWith(".exe", ignoreCase = true)
                 }
             }.orEmpty()
         }


### PR DESCRIPTION
## Root cause

`getWindowsLaunchInfos` filtered launch entries using a case-sensitive `.endsWith(".exe")` check. Games like DEVIL BLADE REBOOT have `executable: DEVIL_BLADE.EXE` (uppercase) in their Steam appinfo, so the filter returned empty and `appLaunchInfo` became null — causing the launch to fall back to `wfm.exe` (the desktop).

## Fix

Use `endsWith(".exe", ignoreCase = true)`.

This also fixes the same issue in `getInstalledExe`'s fallback paths and in `MainViewModel`'s process tracking, which all go through `getWindowsLaunchInfos`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows game executable detection to recognize launch files regardless of extension casing (e.g., .exe, .EXE), enhancing compatibility with games using non-standard naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->