### PR TITLE
Added ubisoft connect configure toggle

### DIFF
--- a/app/src/main/java/app/gamenative/enums/Marker.kt
+++ b/app/src/main/java/app/gamenative/enums/Marker.kt
@@ -11,4 +11,5 @@ enum class Marker(val fileName: String ) {
     PHYSX_INSTALLED(".physx_installed"),
     OPENAL_INSTALLED(".openal_installed"),
     XNA_INSTALLED(".xna_installed"),
+    UBISOFT_CONNECT_INSTALLED(".ubisoft_connect_installed"),
 }

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
@@ -349,6 +349,12 @@ fun GeneralTabContent(
             state = config.launchRealSteam,
             onCheckedChange = { state.config.value = config.copy(launchRealSteam = it) },
         )
+        SettingsSwitch(
+            colors = settingsTileColorsAlt(),
+            title = { Text(text = stringResource(R.string.container_config_install_ubisoft_connect)) },
+            state = config.installUbisoftConnect,
+            onCheckedChange = { enabled -> state.config.value = config.copy(installUbisoftConnect = enabled) },
+        )
         val steamTypeItems = listOf("Normal", "Light", "Ultra Light")
         val currentSteamTypeIndex = when (config.steamType.lowercase()) {
             Container.STEAM_TYPE_LIGHT -> 1

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -243,6 +243,7 @@ object ContainerUtils {
         val enableD = apiOrdinal == PreferredInputApi.DINPUT.ordinal || apiOrdinal == PreferredInputApi.BOTH.ordinal
         val mapperType = container.getDinputMapperType()
         val useSteamInput = container.getExtra("useSteamInput", "false").toBoolean()
+        val installUbisoftConnect = container.getExtra("installUbisoftConnect", "false").toBoolean()
         // Read disable-mouse flag from container
         val disableMouse = container.isDisableMouseInput()
         // Read touchscreen-mode flag from container
@@ -314,6 +315,7 @@ object ContainerUtils {
             sharpnessEffect = container.getExtra("sharpnessEffect", "None"),
             sharpnessLevel = container.getExtra("sharpnessLevel", "100").toIntOrNull() ?: 100,
             sharpnessDenoise = container.getExtra("sharpnessDenoise", "100").toIntOrNull() ?: 100,
+            installUbisoftConnect = installUbisoftConnect,
         )
     }
 
@@ -479,6 +481,7 @@ object ContainerUtils {
         container.putExtra("sharpnessEffect", containerData.sharpnessEffect)
         container.putExtra("sharpnessLevel", containerData.sharpnessLevel.toString())
         container.putExtra("sharpnessDenoise", containerData.sharpnessDenoise.toString())
+        container.putExtra("installUbisoftConnect", containerData.installUbisoftConnect.toString())
         try {
             container.language = containerData.language
         } catch (e: Exception) {

--- a/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
+++ b/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
@@ -4,8 +4,9 @@ import android.content.Context
 import app.gamenative.R
 import app.gamenative.data.GameSource
 import app.gamenative.utils.launchdependencies.GogScriptInterpreterDependency
-import app.gamenative.utils.launchdependencies.LaunchDependencyCallbacks
 import app.gamenative.utils.launchdependencies.LaunchDependency
+import app.gamenative.utils.launchdependencies.LaunchDependencyCallbacks
+import app.gamenative.utils.launchdependencies.UbisoftConnectDependency
 import com.winlator.container.Container
 
 const val LOADING_PROGRESS_UNKNOWN: Float = -1f
@@ -19,6 +20,7 @@ class LaunchDependencies {
     companion object {
         private val launchDependencies: List<LaunchDependency> = listOf(
             GogScriptInterpreterDependency,
+            UbisoftConnectDependency,
         )
     }
 

--- a/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
@@ -30,6 +30,7 @@ object PreInstallSteps {
         OpenALStep,
         XnaFrameworkStep,
         GogScriptInterpreterStep,
+        UbisoftConnectStep,
     )
 
     private val allMarkers = steps.map { it.marker }.distinct()

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/UbisoftConnectDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/UbisoftConnectDependency.kt
@@ -1,0 +1,135 @@
+package app.gamenative.utils.launchdependencies
+
+import android.content.Context
+import app.gamenative.data.GameSource
+import app.gamenative.enums.Marker
+import app.gamenative.utils.MarkerUtils
+import app.gamenative.utils.Net
+import com.winlator.container.Container
+import java.io.File
+import java.io.FileOutputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Request
+import timber.log.Timber
+
+/**
+ * Downloads the Ubisoft Connect installer into the game's _CommonRedist folder so that
+ * the corresponding pre-install step can run it inside Wine.
+ */
+object UbisoftConnectDependency : LaunchDependency {
+
+    private const val TAG = "UbisoftConnectDependency"
+    private const val INSTALLER_URL =
+        "https://ubistatic3-a.akamaihd.net/orbit/launcher_installer/UbisoftConnectInstaller.exe"
+
+    override fun appliesTo(container: Container, gameSource: GameSource, gameId: Int): Boolean {
+        if (!container.getExtra("installUbisoftConnect", "false").toBoolean()) return false
+
+        val gameDir = getGameDir(container) ?: return false
+        val gameDirPath = gameDir.absolutePath
+
+        if (MarkerUtils.hasMarker(gameDirPath, Marker.UBISOFT_CONNECT_INSTALLED)) return false
+
+        return true
+    }
+
+    override fun isSatisfied(
+        context: Context,
+        container: Container,
+        gameSource: GameSource,
+        gameId: Int,
+    ): Boolean {
+        val gameDir = getGameDir(container) ?: return true
+        return getInstallerFile(gameDir).isFile
+    }
+
+    override fun getLoadingMessage(
+        context: Context,
+        container: Container,
+        gameSource: GameSource,
+        gameId: Int,
+    ): String = "Downloading Ubisoft Connect installer"
+
+    override suspend fun install(
+        context: Context,
+        container: Container,
+        callbacks: LaunchDependencyCallbacks,
+        gameSource: GameSource,
+        gameId: Int,
+    ) {
+        val gameDir = getGameDir(container)
+        if (gameDir == null) {
+            Timber.tag(TAG).w("No A: drive found for container, cannot download Ubisoft Connect installer")
+            return
+        }
+
+        val installerFile = getInstallerFile(gameDir)
+        if (installerFile.isFile) {
+            Timber.tag(TAG).d("Ubisoft Connect installer already present at %s", installerFile.absolutePath)
+            return
+        }
+
+        installerFile.parentFile?.mkdirs()
+
+        Timber.tag(TAG).i("Downloading Ubisoft Connect installer to %s", installerFile.absolutePath)
+
+        withContext(Dispatchers.IO) {
+            val request = Request.Builder()
+                .url(INSTALLER_URL)
+                .build()
+
+            try {
+                Net.http.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        Timber.tag(TAG).w(
+                            "Failed to download Ubisoft Connect installer, HTTP %d",
+                            response.code,
+                        )
+                        return@withContext
+                    }
+
+                    val body = response.body
+
+                    val contentLength = body.contentLength()
+                    var downloaded = 0L
+
+                    body.byteStream().use { input ->
+                        FileOutputStream(installerFile).use { output ->
+                            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                            while (true) {
+                                val read = input.read(buffer)
+                                if (read <= 0) break
+                                output.write(buffer, 0, read)
+                                downloaded += read
+
+                                if (contentLength > 0L) {
+                                    val progress = downloaded.toFloat() / contentLength.toFloat()
+                                    callbacks.setLoadingProgress(progress.coerceIn(0f, 1f))
+                                }
+                            }
+                        }
+                    }
+
+                    Timber.tag(TAG).i(
+                        "Finished downloading Ubisoft Connect installer (%d bytes)",
+                        downloaded,
+                    )
+                }
+            } catch (t: Throwable) {
+                Timber.tag(TAG).w(t, "Error while downloading Ubisoft Connect installer")
+            }
+        }
+    }
+
+    private fun getGameDir(container: Container): File? {
+        for (drive in Container.drivesIterator(container.drives)) {
+            if (drive[0].equals("A", ignoreCase = true)) return File(drive[1])
+        }
+        return null
+    }
+
+    private fun getInstallerFile(gameDir: File): File =
+        File(gameDir, "_CommonRedist/UbisoftConnect/UbisoftConnectInstaller.exe")
+}
+

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/UbisoftConnectStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/UbisoftConnectStep.kt
@@ -1,0 +1,48 @@
+package app.gamenative.utils
+
+import app.gamenative.data.GameSource
+import app.gamenative.enums.Marker
+import com.winlator.container.Container
+import java.io.File
+import timber.log.Timber
+
+object UbisoftConnectStep : PreInstallStep {
+    override val marker: Marker = Marker.UBISOFT_CONNECT_INSTALLED
+
+    override fun appliesTo(
+        container: Container,
+        gameSource: GameSource,
+        gameDirPath: String,
+    ): Boolean {
+        if (MarkerUtils.hasMarker(gameDirPath, Marker.UBISOFT_CONNECT_INSTALLED)) return false
+        if (!container.getExtra("installUbisoftConnect", "false").toBoolean()) return false
+
+        return true
+    }
+
+    override fun buildCommand(
+        container: Container,
+        appId: String,
+        gameSource: GameSource,
+        gameDir: File,
+        gameDirPath: String,
+    ): String? {
+        // The Ubisoft Connect installer is downloaded ahead of time by a LaunchDependency
+        // into _CommonRedist/UbisoftConnect under the game directory. We just invoke it.
+        val installerHostPath = File(gameDir, "_CommonRedist/UbisoftConnect/UbisoftConnectInstaller.exe")
+        if (!installerHostPath.isFile) {
+            Timber.tag("UbisoftConnectStep").i(
+                "Ubisoft Connect installer not present at expected path for game at %s",
+                gameDirPath,
+            )
+            return null
+        }
+
+        val winePath = "A:\\_CommonRedist\\UbisoftConnect\\UbisoftConnectInstaller.exe"
+        val command = "$winePath /S"
+        Timber.tag("UbisoftConnectStep").i("Using Ubisoft Connect installer (silent): %s", command)
+
+        return command
+    }
+}
+

--- a/app/src/main/java/com/winlator/container/ContainerData.kt
+++ b/app/src/main/java/com/winlator/container/ContainerData.kt
@@ -93,6 +93,7 @@ data class ContainerData(
     val sharpnessEffect: String = "None",
     val sharpnessLevel: Int = 100,
     val sharpnessDenoise: Int = 100,
+    val installUbisoftConnect: Boolean = false,
 ) {
     companion object {
         val Saver = mapSaver(
@@ -155,6 +156,7 @@ data class ContainerData(
                     "sharpnessEffect" to state.sharpnessEffect,
                     "sharpnessLevel" to state.sharpnessLevel,
                     "sharpnessDenoise" to state.sharpnessDenoise,
+                    "installUbisoftConnect" to state.installUbisoftConnect,
                 )
             },
             restore = { savedMap ->
@@ -216,6 +218,7 @@ data class ContainerData(
                     sharpnessEffect = (savedMap["sharpnessEffect"] as? String) ?: "None",
                     sharpnessLevel = (savedMap["sharpnessLevel"] as? Int) ?: 100,
                     sharpnessDenoise = (savedMap["sharpnessDenoise"] as? Int) ?: 100,
+                    installUbisoftConnect = (savedMap["installUbisoftConnect"] as? Boolean) ?: false,
                 )
             },
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -790,6 +790,9 @@
     <string name="settings_emulation_wine_proton_manager_title">Wine/Proton Manager</string>
     <string name="settings_emulation_wine_proton_manager_subtitle">Import custom Wine/Proton versions (Bionic only)</string>
 
+    <!-- Container Config: General -->
+    <string name="container_config_install_ubisoft_connect">Install Ubisoft Connect</string>
+
     <!-- Settings: Debug Group -->
     <string name="settings_debug_title">Debug</string>
     <string name="settings_debug_wine_channels_title">Select Wine Debug Channels</string>


### PR DESCRIPTION
Adds a toggle to the container settings which can download and install Ubisoft Connect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a toggle to install Ubisoft Connect on first launch. When enabled, the app downloads the installer and runs a silent Wine install once, tracked by a marker.

- **New Features**
  - Added settings switch “Install Ubisoft Connect” in the General tab; persists in `ContainerData` and saves as `installUbisoftConnect` in container extras.
  - New launch dependency `UbisoftConnectDependency` that downloads `UbisoftConnectInstaller.exe` to `_CommonRedist/UbisoftConnect` with progress when enabled and not already installed.
  - New pre-install step `UbisoftConnectStep` that runs the installer silently (`/S`) and writes the `.ubisoft_connect_installed` marker.

<sup>Written for commit 898db44aa19546309dcabe707a3da143755b38a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle in General settings to enable automatic Ubisoft Connect installation.
  * When enabled, the app will download the Ubisoft Connect installer, run a pre-install step (silent) before game launch, and display progress/loading messages.
  * Installation is skipped if already present; the setting is persisted with container configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->