### PR TITLE
Bugfix: Launch deps should be run in offline mode

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1510,32 +1510,28 @@ fun preLaunchApp(
             return@launch
         }
 
-        if (!isOffline) {
-            try {
-                LaunchDependencies().ensureLaunchDependencies(
-                    context = context,
-                    container = container,
-                    gameSource = gameSource,
-                    gameId = gameId,
-                    setLoadingMessage = setLoadingMessage,
-                    setLoadingProgress = setLoadingProgress,
-                )
-            } catch (e: Exception) {
-                Timber.tag("preLaunchApp").e(e, "ensureLaunchDependencies failed")
-                setLoadingDialogVisible(false)
-                setMessageDialogState(
-                    MessageDialogState(
-                        visible = true,
-                        type = DialogType.SYNC_FAIL,
-                        title = context.getString(R.string.launch_dependency_failed_title),
-                        message = e.message ?: context.getString(R.string.launch_dependency_failed_message),
-                        dismissBtnText = context.getString(R.string.ok),
-                    ),
-                )
-                return@launch
-            }
-        } else {
-            Timber.tag("preLaunchApp").e("Offline mode, skipping launch dependencies")
+        try {
+            LaunchDependencies().ensureLaunchDependencies(
+                context = context,
+                container = container,
+                gameSource = gameSource,
+                gameId = gameId,
+                setLoadingMessage = setLoadingMessage,
+                setLoadingProgress = setLoadingProgress,
+            )
+        } catch (e: Exception) {
+            Timber.tag("preLaunchApp").e(e, "ensureLaunchDependencies failed")
+            setLoadingDialogVisible(false)
+            setMessageDialogState(
+                MessageDialogState(
+                    visible = true,
+                    type = DialogType.SYNC_FAIL,
+                    title = context.getString(R.string.launch_dependency_failed_title),
+                    message = e.message ?: context.getString(R.string.launch_dependency_failed_message),
+                    dismissBtnText = context.getString(R.string.ok),
+                ),
+            )
+            return@launch
         }
 
         val loadingMessage = if (container.containerVariant.equals(Container.GLIBC)) {


### PR DESCRIPTION
Launch deps should not depend on `isOfflineMode`. Previous "launch deps" in pluvia don't do that either and it stops scriptinterpreter from running while logged out of steam.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dependency installation process to consistently attempt installation with improved error handling. Users now receive failure notifications and detailed logging when installation encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->