### PR TITLE
Skip symlinks in exe search

### DIFF
--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -1159,12 +1159,14 @@ object ContainerUtils {
 
             Timber.d("Scanning for executables in A: drive: $aDrivePath")
 
-            // Recursively scan for .exe files using listFiles with depth limit
+            // Recursively scan for .exe files using listFiles with depth limit.
+            // Symlinked directories are skipped to avoid cycles (e.g. GOG ISI rootdir -> game root).
             fun scanRecursive(dir: File, baseDir: File, depth: Int = 0, maxDepth: Int = 10) {
                 if (depth > maxDepth) return
 
                 dir.listFiles()?.forEach { file ->
                     if (file.isDirectory) {
+                        if (FileUtils.isSymlink(file)) return@forEach
                         scanRecursive(file, baseDir, depth + 1, maxDepth)
                     } else if (file.isFile && file.name.lowercase().endsWith(".exe")) {
                         // Convert to relative Windows path format


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip symlinked directories during recursive .exe search to avoid cycles and speed up scans. Prevents infinite recursion and unnecessary deep traversal while keeping the depth limit.

<sup>Written for commit 3e055aced0c6b9b94a448c30e9ebe8956b86ce19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when scanning storage devices by skipping symlinked directories during directory enumeration. This prevents recursive cycles that could cause hangs or excessive resource use, making device scanning more reliable and responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->