### PR TITLE
fix: preserve settings on Steam logout

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -82,6 +82,30 @@ object PrefManager {
         }
     }
 
+    /**
+     * Clears only Steam account/session state while preserving app-wide settings.
+     *
+     * This is used during Steam logout so user-configured defaults (container
+     * settings, download preferences, tips, theme, etc.) are not wiped.
+     */
+    fun clearSteamSessionPreferences() {
+        scope.launch {
+            dataStore.edit { pref ->
+                pref.remove(USER_NAME)
+                pref.remove(ACCESS_TOKEN_ENC)
+                pref.remove(REFRESH_TOKEN_ENC)
+                pref.remove(CLIENT_ID)
+                pref.remove(PERSONA_STATE)
+                pref.remove(STEAM_USER_ACCOUNT_ID)
+                pref.remove(STEAM_USER_STEAM_ID_64)
+                pref.remove(STEAM_USER_AVATAR_HASH)
+                pref.remove(STEAM_USER_NAME)
+                pref.remove(LAST_PICS_CHANGE_NUMBER)
+                pref.remove(STEAM_GAMES_COUNT)
+            }
+        }
+    }
+
     fun getBoolean(key: String, defaultValue: Boolean): Boolean =
         getPref(booleanPreferencesKey(key), defaultValue)
 

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2519,7 +2519,7 @@ class SteamService : Service(), IChallengeUrlChanged {
         }
 
         private fun clearUserData(clearCloudSyncState: Boolean = false) {
-            PrefManager.clearPreferences()
+            PrefManager.clearSteamSessionPreferences()
 
             clearDatabase(clearCloudSyncState = clearCloudSyncState)
         }


### PR DESCRIPTION

https://discord.com/channels/1378308569287622737/1482337518472134846


0.8.1 pre release 

After signing out of steam any changes made to the default config are reset

Other setting like download speed or stopping to show the tip message are also reset

Looks like all settings are erased



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents app settings from being wiped on Steam logout by clearing only Steam session and account data.

Adds `PrefManager.clearSteamSessionPreferences()` and updates `SteamService.clearUserData` to use it, removing tokens and Steam user fields while keeping theme, download prefs, tips, and container settings intact.

<sup>Written for commit 71d8c7ade10834d9d8c09d1daaa854786e800fe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Steam session data cleanup to reliably remove authentication credentials, tokens, and session information while preserving other app preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->