### PR TITLE
Fix connection banner visibility and slow disconnect detection

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -304,6 +304,9 @@ fun PluviaMain(
     // Track if connection banner was dismissed by user
     var connectionBannerDismissed by rememberSaveable { mutableStateOf(false) }
 
+    // suppress CONNECTING banner during first attempt; DISCONNECTED always shows
+    var initialConnectDone by rememberSaveable { mutableStateOf(SteamService.isConnected) }
+
     // Track previous connection state to detect actual changes (not just recomposition)
     val previousConnectionState = remember { mutableStateOf(state.connectionState) }
 
@@ -312,6 +315,10 @@ fun PluviaMain(
         if (previousConnectionState.value != state.connectionState) {
             connectionBannerDismissed = false
             previousConnectionState.value = state.connectionState
+        }
+        // first attempt resolved (connected or failed)
+        if (state.connectionState != ConnectionState.CONNECTING) {
+            initialConnectDone = true
         }
     }
 
@@ -1227,7 +1234,7 @@ fun PluviaMain(
             }
 
             // Connection status banner (overlay) - dismissible so users can access navigation
-            if (state.currentScreen != PluviaScreen.LoginUser && !connectionBannerDismissed && !SteamService.isConnected &&
+            if (state.currentScreen != PluviaScreen.LoginUser && !connectionBannerDismissed && initialConnectDone && !state.isSteamConnected &&
                 PrefManager.refreshToken.isNotEmpty() && PrefManager.username.isNotEmpty()) {
                 Box(modifier = Modifier.zIndex(5f)) {
                     ConnectionStatusBanner(


### PR DESCRIPTION
Closes #917

## Summary
- Use `state.isSteamConnected` (Compose-observable StateFlow) instead of `SteamService.isConnected` (static boolean invisible to recomposition) for banner visibility
- Suppress banner during initial connection attempt; only show after first failure (`DISCONNECTED`) or after a successful connection drops
- Run `steamClient.connect()` as cancellable child coroutine concurrent with 5s timeout (was sequential — blocked 30s+ on TCP timeout through dead VPN)
- Observe `NetworkMonitor.hasInternet` in SteamService to proactively disconnect when internet drops (faster than 60s OkHttp readTimeout)

## Test plan
- [ ] Cold start with internet → banner never appears
- [ ] Cold start without internet → banner appears after ~5s with retry button
- [ ] Connected, then disable WiFi → banner appears within seconds (not 60s)
- [ ] Connected, disconnect, reconnect → banner hides when Steam reconnects
- [ ] Banner dismiss button works, banner reappears on next state change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stuck or missing connection banner and speeds up disconnect detection by driving the UI from Compose state, suppressing the first CONNECTING banner, and force‑disconnecting on internet loss. Fixes #917.

- **Bug Fixes**
  - Drive banner visibility from `state.isSteamConnected` (`StateFlow`) and gate with `initialConnectDone`; show on `DISCONNECTED` or after a dropped connection.
  - Run `steamClient.connect()` in a cancellable child coroutine using `runInterruptible`, and cancel after 5s if no progress to avoid 30s+ hangs.
  - Observe `NetworkMonitor.hasInternet` with a 2s debounce to force fast disconnect on internet loss; cancel the observer during service teardown.

<sup>Written for commit 18580ca15e36766462d1772cd4f62bfc99295d77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Service now auto-disconnects when internet is lost, after a short verification delay.
  * Connection attempts are cancellable and time out to avoid indefinite hangs.
  * Connection-status banner is suppressed during the initial connection attempt and shown thereafter.
  * Background internet observer is stopped during service shutdown to avoid lingering activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->