### PR TITLE
Added Ubisoft Connect preinstall step

### DIFF
--- a/app/src/main/java/app/gamenative/enums/Marker.kt
+++ b/app/src/main/java/app/gamenative/enums/Marker.kt
@@ -11,4 +11,5 @@ enum class Marker(val fileName: String ) {
     PHYSX_INSTALLED(".physx_installed"),
     OPENAL_INSTALLED(".openal_installed"),
     XNA_INSTALLED(".xna_installed"),
+    UBISOFT_CONNECT_INSTALLED(".ubisoft_connect_installed"),
 }

--- a/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
@@ -30,6 +30,7 @@ object PreInstallSteps {
         OpenALStep,
         XnaFrameworkStep,
         GogScriptInterpreterStep,
+        UbisoftConnectStep,
     )
 
     private val allMarkers = steps.map { it.marker }.distinct()

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/UbisoftConnectStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/UbisoftConnectStep.kt
@@ -1,0 +1,75 @@
+package app.gamenative.utils
+
+import app.gamenative.data.GameSource
+import app.gamenative.enums.Marker
+import com.winlator.container.Container
+import java.io.File
+import java.nio.file.Files
+import timber.log.Timber
+
+object UbisoftConnectStep : PreInstallStep {
+    private const val TAG = "UbisoftConnectStep"
+    private const val INSTALLER_NAME = "UbisoftConnectInstaller.exe"
+    private const val COMMON_REDIST_SUBDIR = "_CommonRedist/UbisoftConnect"
+    private const val WINE_INSTALLER_PATH = "A:\\_CommonRedist\\UbisoftConnect\\UbisoftConnectInstaller.exe"
+
+    override val marker: Marker = Marker.UBISOFT_CONNECT_INSTALLED
+
+    override fun appliesTo(
+        container: Container,
+        gameSource: GameSource,
+        gameDirPath: String,
+    ): Boolean {
+         if (MarkerUtils.hasMarker(gameDirPath, Marker.UBISOFT_CONNECT_INSTALLED)) return false
+
+        return true
+    }
+
+    override fun buildCommand(
+        container: Container,
+        appId: String,
+        gameSource: GameSource,
+        gameDir: File,
+        gameDirPath: String,
+    ): String? {
+        val rootInstaller = File(gameDir, INSTALLER_NAME)
+        val commonRedistDir = File(gameDir, COMMON_REDIST_SUBDIR)
+        val commonRedistInstaller = File(commonRedistDir, INSTALLER_NAME)
+
+        if (!ensureInstallerAtCommonRedist(rootInstaller, commonRedistDir, commonRedistInstaller)) {
+            Timber.tag(TAG).i(
+                "Ubisoft Connect installer not present at expected _CommonRedist path for game at %s",
+                gameDirPath,
+            )
+            return null
+        }
+
+        val command = "$WINE_INSTALLER_PATH /S"
+        Timber.tag(TAG).i("Using Ubisoft Connect installer (silent): %s", command)
+
+        return command
+    }
+
+    /**
+     * IMPORTANT: Ubisoft Connect installer cannot be run from the game root directory.
+     * Ensures the Ubisoft Connect installer is present at the expected _CommonRedist path.
+     * If it's only present in the game root, creates a symlink there first.
+     */
+    private fun ensureInstallerAtCommonRedist(
+        rootInstaller: File,
+        commonRedistDir: File,
+        commonRedistInstaller: File,
+    ): Boolean {
+        if (commonRedistInstaller.isFile) return true
+        if (!rootInstaller.isFile) return false
+
+        try {
+            commonRedistDir.mkdirs()
+            Files.createSymbolicLink(commonRedistInstaller.toPath(), rootInstaller.toPath())
+            return commonRedistInstaller.exists()
+        } catch (t: Throwable) {
+            Timber.tag(TAG).w(t, "Failed creating Ubisoft Connect symlink")
+            return false
+        }
+    }
+}


### PR DESCRIPTION
Ubisoft games come with UbisoftConnectInstaller.exe. Run it if found so the game will not miss ubisoft connect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Ubisoft Connect preinstall step that silently runs the bundled installer so Ubisoft games don’t fail due to a missing client.

- **New Features**
  - Adds `UbisoftConnectStep` to `PreInstallSteps`; runs `A:\_CommonRedist\UbisoftConnect\UbisoftConnectInstaller.exe /S`.
  - If the installer is only in the game root, creates a symlink under `_CommonRedist/UbisoftConnect` (installer cannot run from root); skips if not found.
  - Tracks `UBISOFT_CONNECT_INSTALLED` marker to avoid re-running.

<sup>Written for commit a642a2f06faad040ae876caa5672829024e5213e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic Ubisoft Connect installation added to the pre-install workflow.
  * Installer is launched silently when applicable to avoid user prompts.
  * A persistent marker prevents the step from rerunning for games where it already completed.
  * If a suitable installer isn't found or an issue occurs, the step is skipped and a diagnostic entry is logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->