### PR TITLE
Fix "Resume" button staying after completed download/update

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1854,6 +1854,10 @@ class SteamService : Service(), IChallengeUrlChanged {
                     MarkerUtils.removeMarker(appDirPath, Marker.STEAM_DLL_REPLACED)
                     MarkerUtils.removeMarker(appDirPath, Marker.STEAM_COLDCLIENT_USED)
                 }
+
+                // clean up DB record BEFORE notifying UI to avoid stale "Resume" button
+                instance?.downloadingAppInfoDao?.deleteApp(downloadInfo.gameId)
+
                 PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(downloadInfo.gameId))
 
                 // Clear persisted bytes file on successful completion


### PR DESCRIPTION
Closes #922

## Summary
- Move `DownloadingAppInfo` DB record deletion into `completeAppDownload`, before
  emitting `LibraryInstallStatusChanged`, so the single UI refresh sees clean state
- Caller's existing delete at line 1783 becomes a harmless no-op (Room delete is idempotent)

## Test plan
- [ ] Download a new game → button shows "Play" immediately after completion (not "Resume")
- [ ] Update an installed game → button shows "Play" after update completes
- [ ] Pause a download mid-progress → button shows "Resume"
- [ ] Pause an update mid-progress → button shows "Resume"
- [ ] Cancel a download → button shows "Install"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stale "Resume" button after completed downloads/updates by deleting the `DownloadingAppInfo` record before notifying the UI, so the button switches to "Play" immediately.

- **Bug Fixes**
  - Move DB delete into `completeAppDownload` before emitting `LibraryInstallStatusChanged`; the former delete path is a no-op (Room delete is idempotent).

<sup>Written for commit 52d073d90888c2621e2dc368b95ade7ee0ef952d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a timing issue in the app download completion process that could result in a stale "Resume" option appearing in the app library, improving the accuracy of download status representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->