### PR TITLE
Support old manifest download size format (Assassin's Creed 1 fix)

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -669,7 +669,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             // 1. Has something to download (0-byte manifests = stale PICS data from interrupted fetch)
             if (depot.manifests.isEmpty() && !depot.sharedInstall)
                 return false
-            if (depot.manifests.isNotEmpty() && depot.manifests.values.all { it.size == 0L || it.download == 0L })
+            if (depot.manifests.isNotEmpty() && depot.manifests.values.all { it.size == 0L && it.download == 0L })
                 return false
             // 2. Supported OS
             if (!(depot.osList.contains(OS.windows) ||

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GameManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GameManagerDialog.kt
@@ -55,6 +55,7 @@ import app.gamenative.ui.component.topbar.BackButton
 import app.gamenative.ui.data.GameDisplayInfo
 import app.gamenative.ui.internal.fakeAppInfo
 import app.gamenative.ui.theme.PluviaTheme
+import app.gamenative.utils.SteamUtils
 import app.gamenative.utils.StorageUtils
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.coil.CoilImage
@@ -171,7 +172,7 @@ fun GameManagerDialog(
                 it.manifests["public"]?.size ?: 0
             }
             val downloadBytes = depotsForBaseGame.values.sumOf {
-                it.manifests["public"]?.download ?: 0
+                SteamUtils.getDownloadBytes(it.manifests["public"])
             }
 
             return Pair(
@@ -189,7 +190,7 @@ fun GameManagerDialog(
             it.manifests["public"]?.size ?: 0
         }
         val downloadBytes = depotsForDlc.values.sumOf {
-            it.manifests["public"]?.download ?: 0
+            SteamUtils.getDownloadBytes(it.manifests["public"])
         }
 
         return Pair(
@@ -215,7 +216,9 @@ fun GameManagerDialog(
             downloadableDepots
                 .filter { (_, depot) ->
                     depot.dlcAppId == INVALID_APP_ID
-                }.values.sumOf { it.manifests["public"]?.download ?: 0 }
+                }.values.sumOf {
+                    SteamUtils.getDownloadBytes(it.manifests["public"])
+                }
         } else {
             0L
         }
@@ -231,7 +234,9 @@ fun GameManagerDialog(
             .filter { (_, depot) ->
                 selectedAppIds[depot.dlcAppId] == true && enabledAppIds[depot.dlcAppId] == true
             }
-            .values.sumOf { it.manifests["public"]?.download ?: 0 }
+            .values.sumOf {
+                SteamUtils.getDownloadBytes(it.manifests["public"])
+            }
 
         return InstallSizeInfo(
             downloadSize = StorageUtils.formatBinarySize(baseGameDownloadBytes + selectedDownloadBytes),

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -1054,7 +1054,7 @@ class SteamAppScreen : BaseAppScreen() {
                     Timber.i("There are ${depots.size} depots belonging to ${libraryItem.appId}")
                     val availableBytes = StorageUtils.getAvailableSpace(SteamService.defaultStoragePath)
                     val downloadBytes = depots.values.sumOf {
-                        it.manifests["public"]?.download ?: 0
+                        SteamUtils.getDownloadBytes(it.manifests["public"])
                     }
                     val installBytes = depots.values.sumOf { it.manifests["public"]?.size ?: 0 }
                     InstallSizeInfo(

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.provider.Settings
 import app.gamenative.PrefManager
 import app.gamenative.data.DepotInfo
+import app.gamenative.data.ManifestInfo
 import app.gamenative.data.SteamApp
 import app.gamenative.enums.Marker
 import app.gamenative.enums.SpecialGameSaveMapping
@@ -38,6 +39,11 @@ import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 
 object SteamUtils {
+
+    fun getDownloadBytes(manifest: ManifestInfo?): Long {
+        if (manifest == null) return 0L
+        return if (manifest.download > 0L) manifest.download else manifest.size
+    }
 
     internal val http = Net.http.newBuilder()
         .readTimeout(5, TimeUnit.MINUTES)

--- a/app/src/test/java/app/gamenative/service/SdCardDetectionTest.kt
+++ b/app/src/test/java/app/gamenative/service/SdCardDetectionTest.kt
@@ -59,9 +59,9 @@ class SdCardDetectionTest {
     }
 
     @Test
-    fun `depot with nonzero size but 0-byte download is rejected`() {
+    fun `depot with nonzero size but 0-byte download is accepted`() {
         val d = depot(manifests = mapOf("public" to manifest(size = 1000L, download = 0L)))
-        assertFalse(SteamService.filterForDownloadableDepots(d, true, "english", null))
+        assertTrue(SteamService.filterForDownloadableDepots(d, true, "english", null))
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds compatibility for old Steam manifest format where download bytes are stored in size when download=0. Fixes 0B download estimates and prevents skipped installs for affected games (e.g., Assassin’s Creed 1).

- Bug Fixes
  - Added `SteamUtils.getDownloadBytes()`: use `manifest.download` if > 0, else fall back to `manifest.size`.
  - Replaced direct download reads in dialogs and the app screen with the helper for correct size calculations.
  - Updated depot filter to skip only when both `size` and `download` are 0; adjusted tests to accept nonzero `size` with 0 `download`.

<sup>Written for commit 66b8e6ffb660f46bc060830b590bb17aa121e71d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted eligibility rules so depots with non-empty manifests and nonzero sizes are correctly considered downloadable.

* **Refactor**
  * Consolidated download-size computation across the UI and service logic for consistent results.

* **Tests**
  * Updated test expectations to reflect the corrected depot-filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->