### PR TITLE
fix(): silent hill 4 reg fixes

### DIFF
--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1141086411.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1141086411.kt
@@ -1,0 +1,16 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+
+val GOG_Fix_1141086411: KeyedGameFix = KeyedRegistryKeyFix(
+    gameSource = GameSource.GOG,
+    gameId = "1141086411",
+    registryKey = "Software\\Wow6432Node\\KONAMI\\SILENT HILL 4\\1.00.000",
+    defaultValues = mapOf(
+        "Install Language" to "English",
+        "Install Path" to INSTALL_PATH_PLACEHOLDER,
+        "Movie Install" to INSTALL_PATH_PLACEHOLDER,
+        "Uninstall Path" to INSTALL_PATH_PLACEHOLDER,
+    ),
+)

--- a/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
@@ -16,6 +16,7 @@ object GameFixesRegistry {
     private const val GAME_DRIVE_LETTER = "A"
 
     private val fixes: Map<Pair<GameSource, String>, GameFix> = listOf(
+        GOG_Fix_1141086411,
         GOG_Fix_1454315831,
         GOG_Fix_1454587428,
         GOG_Fix_1458058109,


### PR DESCRIPTION
This PR adds the Registry fixes required to run Silent Hill 4: The Room.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GOG registry fix for Silent Hill 4: The Room to set required install keys so the game launches correctly. Registers `GOG_Fix_1141086411` in `GameFixesRegistry` with default language and install paths under `Software\\Wow6432Node\\KONAMI\\SILENT HILL 4\\1.00.000`.

<sup>Written for commit c18cfd6c17fd8015ad08a5345d3a7cb25d982dda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added game fix support for Silent Hill 4 on GOG with default configuration for installation language and system paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->