### PR TITLE
Added launch argument gamefixes

### DIFF
--- a/app/src/main/java/app/gamenative/gamefixes/EPIC_59a0c86d02da42e8ba6444cb171e61bf.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/EPIC_59a0c86d02da42e8ba6444cb171e61bf.kt
@@ -2,6 +2,9 @@ package app.gamenative.gamefixes
 
 import app.gamenative.data.GameSource
 
+/**
+ * The Elder Scrolls IV: Oblivion (Epic)
+ */
 val EPIC_Fix_59a0c86d02da42e8ba6444cb171e61bf: KeyedGameFix = KeyedRegistryKeyFix(
     gameSource = GameSource.EPIC,
     gameId = "59a0c86d02da42e8ba6444cb171e61bf",

--- a/app/src/main/java/app/gamenative/gamefixes/EPIC_b1b4e0b67a044575820cb5e63028dcae.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/EPIC_b1b4e0b67a044575820cb5e63028dcae.kt
@@ -2,6 +2,9 @@ package app.gamenative.gamefixes
 
 import app.gamenative.data.GameSource
 
+/**
+ * Fallout 3 (Epic)
+ */
 val EPIC_Fix_b1b4e0b67a044575820cb5e63028dcae: KeyedGameFix = KeyedRegistryKeyFix(
     gameSource = GameSource.EPIC,
     gameId = "b1b4e0b67a044575820cb5e63028dcae",

--- a/app/src/main/java/app/gamenative/gamefixes/EPIC_dabb52e328834da7bbe99691e374cb84.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/EPIC_dabb52e328834da7bbe99691e374cb84.kt
@@ -2,6 +2,9 @@ package app.gamenative.gamefixes
 
 import app.gamenative.data.GameSource
 
+/**
+ * Fallout: New Vegas (Epic)
+ */
 val EPIC_Fix_dabb52e328834da7bbe99691e374cb84: KeyedGameFix = KeyedRegistryKeyFix(
     gameSource = GameSource.EPIC,
     gameId = "dabb52e328834da7bbe99691e374cb84",

--- a/app/src/main/java/app/gamenative/gamefixes/GOGDependencyFix.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOGDependencyFix.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import app.gamenative.data.GameSource
 import app.gamenative.service.gog.GOGConstants
 import app.gamenative.service.gog.GOGService
+import com.winlator.container.Container
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -25,6 +26,7 @@ class GOGDependencyFix(
         gameId: String,
         installPath: String,
         installPathWindows: String,
+        container: Container,
     ): Boolean {
         if (isSatisfied(installPath)) return true
         val downloadManager = GOGService.getInstance()?.gogDownloadManager ?: return false

--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1129934535.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1129934535.kt
@@ -1,0 +1,12 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Mars: War Logs (GOG)
+ */
+val GOG_Fix_1129934535: KeyedGameFix = KeyedLaunchArgFix(
+    gameSource = GameSource.GOG,
+    gameId = "1129934535",
+    launchArgs = "-lang=eng",
+)

--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1141086411.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1141086411.kt
@@ -2,7 +2,9 @@ package app.gamenative.gamefixes
 
 import app.gamenative.data.GameSource
 
-
+/**
+ * Silent Hill 4 (GOG)
+ */
 val GOG_Fix_1141086411: KeyedGameFix = KeyedRegistryKeyFix(
     gameSource = GameSource.GOG,
     gameId = "1141086411",

--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1177610018.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1177610018.kt
@@ -1,0 +1,13 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Of Orcs and Men (GOG)
+ */
+val GOG_Fix_1177610018: KeyedGameFix = KeyedLaunchArgFix(
+    gameSource = GameSource.GOG,
+    gameId = "1177610018",
+    launchArgs = "-lang=eng",
+)
+

--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1454315831.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1454315831.kt
@@ -2,6 +2,9 @@ package app.gamenative.gamefixes
 
 import app.gamenative.data.GameSource
 
+/**
+ * Fallout 3 (GOG)
+ */
 val GOG_Fix_1454315831: KeyedGameFix = KeyedRegistryKeyFix(
     gameSource = GameSource.GOG,
     gameId = "1454315831",

--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1454587428.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1454587428.kt
@@ -2,6 +2,9 @@ package app.gamenative.gamefixes
 
 import app.gamenative.data.GameSource
 
+/**
+ * Fallout: New Vegas (GOG)
+ */
 val GOG_Fix_1454587428: KeyedGameFix = KeyedRegistryKeyFix(
     gameSource = GameSource.GOG,
     gameId = "1454587428",

--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1458058109.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1458058109.kt
@@ -2,6 +2,9 @@ package app.gamenative.gamefixes
 
 import app.gamenative.data.GameSource
 
+/**
+ * The Elder Scrolls IV: Oblivion (GOG)
+ */
 val GOG_Fix_1458058109: KeyedGameFix = KeyedRegistryKeyFix(
     gameSource = GameSource.GOG,
     gameId = "1458058109",

--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1589319779.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1589319779.kt
@@ -3,8 +3,7 @@ package app.gamenative.gamefixes
 import app.gamenative.data.GameSource
 
 /**
- * Moonlighter (GOG): manifest does not list MSVC2017_x64; ensure it is downloaded and available
- * in _CommonRedist so the fix can run VC_redist.x64.exe.
+ * Moonlighter (GOG)
  */
 val GOG_Fix_1589319779: KeyedGameFix = GOGDependencyFix(
     gameSource = GameSource.GOG,

--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1635627436.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1635627436.kt
@@ -1,0 +1,13 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Dome Keeper (GOG)
+ */
+val GOG_Fix_1635627436: KeyedGameFix = KeyedLaunchArgFix(
+    gameSource = GameSource.GOG,
+    gameId = "1635627436",
+    launchArgs = "--rendering-driver vulkan",
+)
+

--- a/app/src/main/java/app/gamenative/gamefixes/GOG_1787707874.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_1787707874.kt
@@ -1,0 +1,13 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Bound by Flame (GOG)
+ */
+val GOG_Fix_1787707874: KeyedGameFix = KeyedLaunchArgFix(
+    gameSource = GameSource.GOG,
+    gameId = "1787707874",
+    launchArgs = "-lang=eng",
+)
+

--- a/app/src/main/java/app/gamenative/gamefixes/GOG_2147483047.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GOG_2147483047.kt
@@ -3,8 +3,7 @@ package app.gamenative.gamefixes
 import app.gamenative.data.GameSource
 
 /**
- * Moonlighter (GOG): manifest does not list MSVC2017_x64; ensure it is downloaded and available
- * in _CommonRedist so the fix can run VC_redist.x64.exe.
+ * Moonlighter (GOG)
  */
 val GOG_Fix_2147483047: KeyedGameFix = GOGDependencyFix(
     gameSource = GameSource.GOG,

--- a/app/src/main/java/app/gamenative/gamefixes/GameFix.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFix.kt
@@ -2,6 +2,7 @@ package app.gamenative.gamefixes
 
 import android.content.Context
 import app.gamenative.data.GameSource
+import com.winlator.container.Container
 
 interface GameFix {
     fun apply(
@@ -9,6 +10,7 @@ interface GameFix {
         gameId: String,
         installPath: String,
         installPathWindows: String,
+        container: Container,
     ): Boolean
 }
 

--- a/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
@@ -7,6 +7,7 @@ import app.gamenative.service.gog.GOGConstants
 import app.gamenative.service.gog.GOGService
 import app.gamenative.service.SteamService
 import app.gamenative.service.epic.EpicService
+import com.winlator.container.Container
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -16,21 +17,28 @@ object GameFixesRegistry {
     private const val GAME_DRIVE_LETTER = "A"
 
     private val fixes: Map<Pair<GameSource, String>, GameFix> = listOf(
+        GOG_Fix_1129934535,
         GOG_Fix_1141086411,
+        GOG_Fix_1177610018,
         GOG_Fix_1454315831,
         GOG_Fix_1454587428,
         GOG_Fix_1458058109,
         GOG_Fix_1589319779,
         GOG_Fix_2147483047,
+        GOG_Fix_1787707874,
+        GOG_Fix_1635627436,
         STEAM_Fix_22300,
         STEAM_Fix_22380,
         STEAM_Fix_22330,
+        STEAM_Fix_400,
+        STEAM_Fix_3373660,
+        STEAM_Fix_1637320,
         EPIC_Fix_b1b4e0b67a044575820cb5e63028dcae,
         EPIC_Fix_dabb52e328834da7bbe99691e374cb84,
         EPIC_Fix_59a0c86d02da42e8ba6444cb171e61bf,
     ).associateBy { it.gameSource to it.gameId }
 
-    fun applyFor(context: Context, appId: String) {
+    fun applyFor(context: Context, appId: String, container: Container) {
         val source = ContainerUtils.extractGameSourceFromContainerId(appId)
         val gameId = ContainerUtils.extractGameIdFromContainerId(appId)?.toString() ?: return
         val catalogId = when (source) {
@@ -44,7 +52,7 @@ object GameFixesRegistry {
         Timber.i("GameFixesRegistry: Applying fixes for game: $source $catalogId if available")
         val fix = fixes[source to catalogId] ?: return
         val (installPath, installPathWindows) = resolvePaths(context, source, gameId) ?: return
-        fix.apply(context, gameId, installPath, installPathWindows)
+        fix.apply(context, catalogId, installPath, installPathWindows, container)
     }
 
     private fun resolvePaths(context: Context, source: GameSource, gameId: String): Pair<String, String>? {

--- a/app/src/main/java/app/gamenative/gamefixes/LaunchArgFix.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/LaunchArgFix.kt
@@ -1,0 +1,40 @@
+package app.gamenative.gamefixes
+
+import android.content.Context
+import app.gamenative.data.GameSource
+import timber.log.Timber
+import com.winlator.container.Container
+
+class LaunchArgFix(
+    private val launchArgs: String,
+) : GameFix {
+    override fun apply(
+        context: Context,
+        gameId: String,
+        installPath: String,
+        installPathWindows: String,
+        container: Container,
+    ): Boolean {
+        return try {
+            val currentArgs = container.execArgs.trim()
+            if (currentArgs.isNotEmpty()) {
+                // Do not override / append when the user already configured custom launch args.
+                return true
+            }
+
+            container.execArgs = launchArgs
+            container.saveData()
+            Timber.tag("GameFixes").i("Added launch args '$launchArgs' for game $gameId")
+            true
+        } catch (e: Exception) {
+            Timber.tag("GameFixes").e(e, "Failed to add launch args '$launchArgs' for game $gameId")
+            false
+        }
+    }
+}
+
+class KeyedLaunchArgFix(
+    override val gameSource: GameSource,
+    override val gameId: String,
+    launchArgs: String,
+) : KeyedGameFix, GameFix by LaunchArgFix(launchArgs)

--- a/app/src/main/java/app/gamenative/gamefixes/RegistryKeyFix.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/RegistryKeyFix.kt
@@ -2,6 +2,7 @@ package app.gamenative.gamefixes
 
 import android.content.Context
 import app.gamenative.data.GameSource
+import com.winlator.container.Container
 import com.winlator.core.WineRegistryEditor
 import com.winlator.xenvironment.ImageFs
 import timber.log.Timber
@@ -18,6 +19,7 @@ class RegistryKeyFix(
         gameId: String,
         installPath: String,
         installPathWindows: String,
+        container: Container,
     ): Boolean {
         val imageFs = ImageFs.find(context)
         val systemRegFile = File(imageFs.wineprefix, "system.reg")

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_1637320.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_1637320.kt
@@ -1,0 +1,13 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Dome Keeper (Steam)
+ */
+val STEAM_Fix_1637320: KeyedGameFix = KeyedLaunchArgFix(
+    gameSource = GameSource.STEAM,
+    gameId = "1637320",
+    launchArgs = "--rendering-driver vulkan",
+)
+

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_22300.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_22300.kt
@@ -2,6 +2,9 @@ package app.gamenative.gamefixes
 
 import app.gamenative.data.GameSource
 
+/**
+ * Fallout 3 (Steam)
+ */
 val STEAM_Fix_22300: KeyedGameFix = KeyedRegistryKeyFix(
     gameSource = GameSource.STEAM,
     gameId = "22300",

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_22330.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_22330.kt
@@ -2,6 +2,9 @@ package app.gamenative.gamefixes
 
 import app.gamenative.data.GameSource
 
+/**
+ * The Elder Scrolls IV: Oblivion (Steam)
+ */
 val STEAM_Fix_22330: KeyedGameFix = KeyedRegistryKeyFix(
     gameSource = GameSource.STEAM,
     gameId = "22330",

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_22380.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_22380.kt
@@ -2,6 +2,9 @@ package app.gamenative.gamefixes
 
 import app.gamenative.data.GameSource
 
+/**
+ * Fallout: New Vegas (Steam)
+ */
 val STEAM_Fix_22380: KeyedGameFix = KeyedRegistryKeyFix(
     gameSource = GameSource.STEAM,
     gameId = "22380",

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_3373660.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_3373660.kt
@@ -1,0 +1,13 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Look Outside (Steam)
+ */
+val STEAM_Fix_3373660: KeyedGameFix = KeyedLaunchArgFix(
+    gameSource = GameSource.STEAM,
+    gameId = "3373660",
+    launchArgs = "--no-sandbox",
+)
+

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_400.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_400.kt
@@ -1,0 +1,13 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Portal (Steam)
+ */
+val STEAM_Fix_400: KeyedGameFix = KeyedLaunchArgFix(
+    gameSource = GameSource.STEAM,
+    gameId = "400",
+    launchArgs = "-game portal",
+)
+

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2548,7 +2548,7 @@ private fun setupXEnvironment(
 
     if (container != null) {
         try {
-            GameFixesRegistry.applyFor(context, appId)
+            GameFixesRegistry.applyFor(context, appId, container)
         } catch (e: Exception) {
             Timber.tag("GameFixes").w(e, "Game fixes failed before launch")
         }


### PR DESCRIPTION
Fixes a couple of games

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a generic launch-argument fix that sets default `execArgs` when user args are empty to improve first-run compatibility on Steam and GOG. Game fixes now receive the active container so we can set `execArgs` safely before launch.

- **New Features**
  - Added `LaunchArgFix` and `KeyedLaunchArgFix` to set default launch args without overriding user settings.
  - New fixes:
    - Dome Keeper (Steam/GOG): `--rendering-driver vulkan`
    - Portal (Steam): `-game portal`; Look Outside (Steam): `--no-sandbox`
    - Mars: War Logs / Of Orcs and Men / Bound by Flame (GOG): `-lang=eng`

- **Refactors**
  - `GameFix.apply` now takes `container`; updated `GOGDependencyFix`, `RegistryKeyFix`, and call sites (`GameFixesRegistry.applyFor`, `XServerScreen`).
  - Added concise game-name comments across fixes; simplified Moonlighter comments.

<sup>Written for commit ceb53491cb0a0388fede59c55bcef8af06c5c5d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiple targeted launch-argument fixes for Epic, GOG, and Steam titles (language flags, Vulkan rendering driver, --no-sandbox, -game portal).

* **Bug Fixes**
  * Pre-launch fix application now runs with container context so launch configurations are applied reliably before starting games.

* **Documentation**
  * Added and refined in-code documentation for numerous game fixes to clarify game mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->