### PR TITLE
Fix old games with 0-byte download metadata filtered out as stale

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -669,7 +669,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             // 1. Has something to download (0-byte manifests = stale PICS data from interrupted fetch)
             if (depot.manifests.isEmpty() && !depot.sharedInstall)
                 return false
-            if (depot.manifests.isNotEmpty() && depot.manifests.values.all { it.size == 0L || it.download == 0L })
+            if (depot.manifests.isNotEmpty() && depot.manifests.values.all { it.size == 0L && it.download == 0L })
                 return false
             // 2. Supported OS
             if (!(depot.osList.contains(OS.windows) ||

--- a/app/src/test/java/app/gamenative/service/SdCardDetectionTest.kt
+++ b/app/src/test/java/app/gamenative/service/SdCardDetectionTest.kt
@@ -59,9 +59,9 @@ class SdCardDetectionTest {
     }
 
     @Test
-    fun `depot with nonzero size but 0-byte download is rejected`() {
+    fun `depot with nonzero size but 0-byte download passes (old game without download metadata)`() {
         val d = depot(manifests = mapOf("public" to manifest(size = 1000L, download = 0L)))
-        assertFalse(SteamService.filterForDownloadableDepots(d, true, "english", null))
+        assertTrue(SteamService.filterForDownloadableDepots(d, true, "english", null))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Change stale-PICS manifest check from `||` to `&&` — only reject depots where **both** size and download are zero
- Old games (e.g. FEAR 2, app 16450) have `size > 0` but `download == 0` because download metadata wasn't tracked when those depots were created
- Regression from #889 (commit 2010357f4)

## Test plan
- [ ] FEAR 2 (16450) shows correct download size instead of 0 bytes
- [ ] Games with truly stale PICS data (both size and download == 0) are still filtered out

Fixes #936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where some Steam depots with partial manifest data were incorrectly excluded from downloads; depots are now correctly identified as downloadable only when truly empty.
* **Tests**
  * Updated test expectations to reflect the corrected depot-filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->