### PR TITLE
fix: exclude expired licenses from owned app query

### DIFF
--- a/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
@@ -22,12 +22,20 @@ interface SteamAppDao {
     suspend fun update(app: SteamApp)
 
     @Query(
-        "SELECT * FROM steam_app " +
-            "WHERE id != 480 " + // Actively filter out Spacewar
+        "SELECT * FROM steam_app AS app " +
+            "WHERE app.id != 480 " + // Actively filter out Spacewar
             // "AND (owner_account_id IN (:ownerIds) OR license_flags & :borrowedCode = :borrowedCode) " +
-            "AND package_id != :invalidPkgId " +
-            "AND type != 0 " +
-            "ORDER BY LOWER(name)",
+            "AND app.package_id != :invalidPkgId " +
+            "AND app.type != 0 " +
+            "AND EXISTS (" +
+            "  SELECT 1 FROM steam_license AS license " +
+            "  WHERE (license.license_flags & 8 = 0) " + // exclude Expired licenses (e.g. free weekends)
+            "  AND (" +
+            "    (license.packageId = app.package_id AND license.app_ids = '[]') " + // this app's package PICS not yet fetched — allow provisionally
+            "    OR REPLACE(REPLACE(license.app_ids, '[', ','), ']', ',') LIKE ('%,' || app.id || ',%')" + // any non-expired license lists this appId
+            "  )" +
+            ") " +
+            "ORDER BY LOWER(app.name)",
     )
     fun getAllOwnedApps(
         // ownerIds: List<Int>,

--- a/app/src/test/java/app/gamenative/db/dao/SteamAppDaoTest.kt
+++ b/app/src/test/java/app/gamenative/db/dao/SteamAppDaoTest.kt
@@ -1,0 +1,156 @@
+package app.gamenative.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import app.gamenative.data.SteamApp
+import app.gamenative.data.SteamLicense
+import app.gamenative.db.PluviaDatabase
+import app.gamenative.enums.AppType
+import app.gamenative.service.SteamService.Companion.INVALID_PKG_ID
+import `in`.dragonbra.javasteam.enums.ELicenseFlags
+import `in`.dragonbra.javasteam.enums.ELicenseType
+import `in`.dragonbra.javasteam.enums.EPaymentMethod
+import java.util.Date
+import java.util.EnumSet
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SteamAppDaoTest {
+
+    private lateinit var db: PluviaDatabase
+    private lateinit var appDao: SteamAppDao
+    private lateinit var licenseDao: SteamLicenseDao
+
+    @Before
+    fun setup() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            PluviaDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        appDao = db.steamAppDao()
+        licenseDao = db.steamLicenseDao()
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+
+    // --- helpers ---
+
+    private fun license(packageId: Int, appIds: List<Int> = emptyList(), expired: Boolean = false) = SteamLicense(
+        packageId = packageId,
+        lastChangeNumber = 0,
+        timeCreated = Date(0),
+        timeNextProcess = Date(0),
+        minuteLimit = 0,
+        minutesUsed = 0,
+        paymentMethod = EPaymentMethod.None,
+        licenseFlags = if (expired) ELicenseFlags.from(8) else EnumSet.noneOf(ELicenseFlags::class.java),
+        purchaseCode = "",
+        licenseType = ELicenseType.SinglePurchase,
+        territoryCode = 0,
+        accessToken = 0L,
+        ownerAccountId = emptyList(),
+        masterPackageID = 0,
+        appIds = appIds,
+    )
+
+    private fun app(id: Int, packageId: Int, type: AppType = AppType.game) = SteamApp(
+        id = id,
+        packageId = packageId,
+        type = type,
+        name = "App $id",
+        receivedPICS = type != AppType.invalid,
+    )
+
+    private fun ids(apps: List<SteamApp>) = apps.map { it.id }.toSet()
+
+    // --- tests ---
+
+    @Test
+    fun `app with valid license listing its appId appears`() = runBlocking {
+        licenseDao.insertAll(listOf(license(packageId = 100, appIds = listOf(1000))))
+        appDao.insert(app(id = 1000, packageId = 100))
+
+        val result = appDao.getAllOwnedApps().first()
+        assertTrue(ids(result).contains(1000))
+    }
+
+    @Test
+    fun `app whose license was deleted does not appear`() = runBlocking {
+        // Insert license, then delete it (simulates expired free weekend)
+        licenseDao.insertAll(listOf(license(packageId = 100, appIds = listOf(1000))))
+        appDao.insert(app(id = 1000, packageId = 100))
+        licenseDao.deleteStaleLicenses(listOf(100))
+
+        val result = appDao.getAllOwnedApps().first()
+        assertFalse(ids(result).contains(1000))
+    }
+
+    @Test
+    fun `app with INVALID_PKG_ID does not appear`() = runBlocking {
+        appDao.insert(app(id = 1000, packageId = INVALID_PKG_ID))
+
+        val result = appDao.getAllOwnedApps().first()
+        assertFalse(ids(result).contains(1000))
+    }
+
+    @Test
+    fun `app with valid license but empty app_ids appears provisionally`() = runBlocking {
+        // Package PICS not yet fetched — app_ids is still []
+        licenseDao.insertAll(listOf(license(packageId = 100, appIds = emptyList())))
+        appDao.insert(app(id = 1000, packageId = 100))
+
+        val result = appDao.getAllOwnedApps().first()
+        assertTrue(ids(result).contains(1000))
+    }
+
+    @Test
+    fun `app with license listing only other appIds does not appear`() = runBlocking {
+        licenseDao.insertAll(listOf(license(packageId = 100, appIds = listOf(9999))))
+        appDao.insert(app(id = 1000, packageId = 100))
+
+        val result = appDao.getAllOwnedApps().first()
+        assertFalse(ids(result).contains(1000))
+    }
+
+    @Test
+    fun `app with expired free weekend license does not appear`() = runBlocking {
+        licenseDao.insertAll(listOf(license(packageId = 100, appIds = listOf(1000), expired = true)))
+        appDao.insert(app(id = 1000, packageId = 100))
+
+        val result = appDao.getAllOwnedApps().first()
+        assertFalse(ids(result).contains(1000))
+    }
+
+    @Test
+    fun `app appears when purchased after an expired free weekend`() = runBlocking {
+        // package_id points to expired free weekend, but a separate purchase license also lists the app
+        licenseDao.insertAll(listOf(
+            license(packageId = 100, appIds = listOf(1000), expired = true),
+            license(packageId = 200, appIds = listOf(1000)),
+        ))
+        appDao.insert(app(id = 1000, packageId = 100))
+
+        val result = appDao.getAllOwnedApps().first()
+        assertTrue(ids(result).contains(1000))
+    }
+
+    @Test
+    fun `stub app with type invalid does not appear even with valid license`() = runBlocking {
+        licenseDao.insertAll(listOf(license(packageId = 100, appIds = listOf(1000))))
+        appDao.insert(app(id = 1000, packageId = 100, type = AppType.invalid))
+
+        val result = appDao.getAllOwnedApps().first()
+        assertFalse(ids(result).contains(1000))
+    }
+}


### PR DESCRIPTION
Games from expired free weekends were appearing in the library because getAllOwnedApps only checked that a steam_app row had a non-invalid package_id. The matching steam_license row was never consulted, so expired free weekend packages (which Steam retains as $0 licenses with the Expired flag set) still passed the filter.

The query now requires a matching steam_license row where:
- the Expired flag (bit 8) is not set
- the license's app_ids lists this app's id, or is empty (PICS not yet fetched)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the owned apps query to exclude expired Steam licenses, so games from past free weekends no longer appear in the library.

- **Bug Fixes**
  - Require an existing `steam_license` for each app where the Expired flag (bit 8) is not set.
  - Treat an app as owned only if the license’s `app_ids` includes the app id, or `app_ids` is empty (PICS not yet fetched).
  - Added DAO tests for valid vs expired licenses, missing licenses, invalid app type, and `INVALID_PKG_ID`.

<sup>Written for commit f2e046f56cdaace40ae44f30c149461392a46cd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the logic for retrieving owned games to ensure accurate license validation and filtering.

* **Tests**
  * Added comprehensive test coverage for game library database operations, including license validation, expiration handling, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->