### PR TITLE
feat: add new keyboard QuickMenu navigation keys

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -19,6 +19,7 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.hardware.input.InputManager
 import android.view.InputDevice
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -1048,8 +1049,9 @@ fun XServerScreen(
                     !keepPausedForEditor
             // logD("onKeyEvent(${it.event.device.sources})\n\tisGamepad: $isGamepad\n\tisKeyboard: $isKeyboard\n\t${it.event}")
 
-            if (waitingForManualResume && isGamepad) {
+            if (waitingForManualResume) {
                 when (it.event.keyCode) {
+                    KeyEvent.KEYCODE_ENTER,
                     KeyEvent.KEYCODE_BUTTON_A,
                     KeyEvent.KEYCODE_BUTTON_START -> {
                         if (it.event.action == KeyEvent.ACTION_DOWN && it.event.repeatCount == 0) {
@@ -1060,8 +1062,16 @@ fun XServerScreen(
                     else -> false
                 }
             } else if ((showElementEditor || keepPausedForEditor || showQuickMenu || isEditMode) && (isGamepad || isKeyboard)) {
-                // Let Compose focus system handle keyboard and gamepad navigation/selection while menu is visible.
-                false
+                val escPressed = isKeyboard && !keepPausedForEditor && it.event.keyCode == KeyEvent.KEYCODE_ESCAPE &&
+                        it.event.action == KeyEvent.ACTION_DOWN &&
+                        it.event.repeatCount == 0
+                if (escPressed) {
+                    (context as? ComponentActivity)?.onBackPressedDispatcher?.onBackPressed()
+                    true
+                } else {
+                    // Let Compose focus system handle keyboard and gamepad navigation/selection while menu is visible.
+                    false
+                }
             } else {
                 var handled = false
                 if (isGamepad) {
@@ -1071,7 +1081,17 @@ fun XServerScreen(
                     if (!handled) handled = xServerView!!.getxServer().winHandler.onKeyEvent(it.event)
                 }
                 if (!handled && isKeyboard) {
-                    handled = keyboard?.onKeyEvent(it.event) == true
+                    val isShiftEscPressed = it.event.keyCode == KeyEvent.KEYCODE_ESCAPE &&
+                            it.event.isShiftPressed &&
+                            it.event.action == KeyEvent.ACTION_DOWN &&
+                            it.event.repeatCount == 0
+                    if (isShiftEscPressed &&
+                        !showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode) {
+                        gameBack()
+                        handled = true
+                    } else {
+                        handled = keyboard?.onKeyEvent(it.event) == true
+                    }
                 }
                 handled
             }


### PR DESCRIPTION
- add Shift + Esc combination to bring up QuickMenu
- with menus open, pressing Esc triggers Android back button action, except in the on-screen controller editor overlay
- pressing Enter unpauses the game/container

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keyboard shortcuts to control QuickMenu and resume from pause. Shift+Esc opens QuickMenu, Esc backs out of open menus, and Enter resumes when paused.

- **New Features**
  - Shift+Esc opens QuickMenu when no editor or overlay is active.
  - Esc sends Android back while menus are open; ignored in the on‑screen controller editor.
  - Enter resumes from manual pause (in addition to A/Start).

<sup>Written for commit 20b9410d2ca00f578f47af934ae254609f371ee7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ESC now closes overlays and menus to improve keyboard/back navigation.
  * ENTER added as an alternative to gamepad A/Start for resuming from manual pause.
  * Shift+ESC provides a quick back/navigation action when no editor or menus are active.
  * Keypress handling updated for more immediate and consistent keyboard behavior across input modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->