### PR TITLE
Fix library view not updating after game uninstall

### DIFF
--- a/app/src/main/java/app/gamenative/service/DownloadService.kt
+++ b/app/src/main/java/app/gamenative/service/DownloadService.kt
@@ -9,8 +9,8 @@ import timber.log.Timber
 import java.io.File
 
 object DownloadService {
-    private var lastUpdateTime: Long = 0
-    private var downloadDirectoryApps: MutableList<String>? = null
+    @Volatile private var lastUpdateTime: Long = 0
+    @Volatile private var downloadDirectoryApps: MutableList<String>? = null
     var baseDataDirPath: String = ""
         private set(value) {
             field = value
@@ -44,6 +44,12 @@ object DownloadService {
             .map { it.absolutePath }
     }
 
+    @Synchronized
+    fun invalidateCache() {
+        lastUpdateTime = 0
+    }
+
+    @Synchronized
     fun getDownloadDirectoryApps (): MutableList<String> {
         // What apps have folders in the download area?
         // Isn't checking for "complete" marker - incomplete is accepted

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/AmazonAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/AmazonAppScreen.kt
@@ -22,6 +22,7 @@ import app.gamenative.R
 import app.gamenative.data.AmazonGame
 import app.gamenative.data.LibraryItem
 import app.gamenative.events.AndroidEvent
+import app.gamenative.service.DownloadService
 import app.gamenative.service.amazon.AmazonConstants
 import app.gamenative.service.amazon.AmazonService
 import app.gamenative.ui.component.dialog.AmazonInstallDialog
@@ -345,6 +346,7 @@ override fun isInstalled(context: Context, libraryItem: LibraryItem): Boolean =
         Timber.tag(TAG).i("performUninstall: deleting game $productId")
         CoroutineScope(Dispatchers.IO).launch {
             val result = AmazonService.deleteGame(context, productId)
+            DownloadService.invalidateCache()
             if (result.isSuccess) {
                 Timber.tag(TAG).i("Uninstall succeeded for $productId")
             } else {
@@ -633,6 +635,7 @@ override fun isInstalled(context: Context, libraryItem: LibraryItem): Boolean =
                         scope.launch {
                             downloadInfo?.awaitCompletion()
                             AmazonService.deleteGame(context, productId)
+                            DownloadService.invalidateCache()
                             withContext(Dispatchers.Main) {
                                 BaseAppScreen.hideInstallDialog(appId)
                                 val gameId = libraryItem.gameId

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.stringResource
 import app.gamenative.R
 import app.gamenative.data.EpicGame
 import app.gamenative.data.LibraryItem
+import app.gamenative.service.DownloadService
 import app.gamenative.service.epic.EpicCloudSavesManager
 import app.gamenative.service.epic.EpicConstants
 import app.gamenative.service.epic.EpicService
@@ -465,6 +466,7 @@ class EpicAppScreen : BaseAppScreen() {
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 val result = EpicService.deleteGame(context, libraryItem.gameId)
+                DownloadService.invalidateCache()
 
                 if (result.isSuccess) {
                     Timber.tag(TAG).i("Epic game uninstalled successfully: ${libraryItem.appId}")
@@ -760,6 +762,7 @@ class EpicAppScreen : BaseAppScreen() {
                             downloadInfo?.awaitCompletion()
                             EpicService.cleanupDownload(context, gameId)
                             EpicService.deleteGame(context, gameId)
+                            DownloadService.invalidateCache()
                             withContext(Dispatchers.Main) {
                                 BaseAppScreen.hideInstallDialog(appId)
                                 app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.DownloadStatusChanged(gameId, false))

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.res.stringResource
 import app.gamenative.R
 import app.gamenative.data.GOGGame
 import app.gamenative.data.LibraryItem
+import app.gamenative.enums.Marker
+import app.gamenative.service.DownloadService
 import app.gamenative.service.gog.GOGConstants
 import app.gamenative.service.gog.GOGService
 import app.gamenative.utils.MarkerUtils
@@ -353,6 +355,7 @@ class GOGAppScreen : BaseAppScreen() {
             try {
                 // Delegate to GOGService which calls GOGManager.deleteGame
                 val result = GOGService.deleteGame(context, libraryItem)
+                DownloadService.invalidateCache()
 
                 if (result.isSuccess) {
                     Timber.i("Successfully uninstalled GOG game: ${libraryItem.appId}")
@@ -626,6 +629,7 @@ class GOGAppScreen : BaseAppScreen() {
                             }
 
                             val result = GOGService.deleteGame(context, libraryItem)
+                            DownloadService.invalidateCache()
                             if (wasDownloading && !isInstalledAfterCancel) {
                                 SnackbarManager.show("Download cancelled")
                             }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -1034,6 +1034,7 @@ class SteamAppScreen : BaseAppScreen() {
                         SteamService.workshopPausedApps.remove(gameId)
                         CoroutineScope(Dispatchers.IO).launch {
                             SteamService.deleteApp(gameId)
+                            DownloadService.invalidateCache()
                             PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(gameId))
                             withContext(Dispatchers.Main) {
                                 hideInstallDialog(gameId)
@@ -1157,6 +1158,7 @@ class SteamAppScreen : BaseAppScreen() {
 
                             CoroutineScope(Dispatchers.IO).launch {
                                 val success = SteamService.deleteApp(gameId)
+                                DownloadService.invalidateCache()
                                 withContext(Dispatchers.Main) {
                                     ContainerUtils.deleteContainer(context, libraryItem.appId)
                                 }


### PR DESCRIPTION
## Description
add `DownloadService.invalidateCache()` to reset the directory listing TTL. call it after uninstall/cancel-download in Steam, Epic, GOG, and Amazon app screens before emitting `LibraryInstallStatusChanged`, so the refresh gets fresh data.

fixes #955.

## Recording
n/a — fixes stale state, no visible UI change beyond correct refresh

## Test plan
- [ ] Install a Steam game
- [ ] Uninstall it from the library
- [ ] Verify library view immediately reflects the uninstall (no stale "installed" state)
- [ ] Same for Epic/GOG/Amazon
- [ ] Cancel a download, verify library updates

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved app and download status information reliability across Steam, Epic, GOG, and Amazon platforms when uninstalling apps or canceling downloads to ensure accurate, up-to-date data display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->