### PR TITLE
fix: use full 64-bit Steam ID when fetching owned games for playtime

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -409,7 +409,7 @@ class SteamAppScreen : BaseAppScreen() {
         // Get playtime text
         var playtimeText by remember { mutableStateOf("0 hrs") }
         LaunchedEffect(gameId) {
-            val steamID = SteamService.userSteamId?.accountID?.toLong()
+            val steamID = SteamService.userSteamId?.convertToUInt64()
             if (steamID != null) {
                 val games = SteamService.getOwnedGames(steamID)
                 val game = games.firstOrNull { it.appId == gameId }


### PR DESCRIPTION
accountID is the 32-bit portion; the Steam API requires the full 64-bit steamid, causing getOwnedGames to return no matches and playtime to always display 0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes playtime always showing 0 by using the full 64‑bit Steam ID to fetch owned games. Replaces the 32‑bit `accountID` with `convertToUInt64()` so `getOwnedGames` returns matches and playtime renders correctly.

<sup>Written for commit f27f0c6004fe53d7d16466831075b73e144c504e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Steam user identifier conversion when retrieving owned games in the library screen, ensuring the correct format is used for game data lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->