### PR TITLE
feat: add Xbox controller style toggle to swap A↔B and X↔Y button icons

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -926,6 +926,14 @@ object PrefManager {
             setPref(HIDE_STATUS_BAR_WHEN_NOT_IN_GAME, value)
         }
 
+    // Whether to swap A↔B and X↔Y button icons to match Xbox controller layout.
+    private val SWAP_FACE_BUTTONS = booleanPreferencesKey("swap_face_buttons")
+    var swapFaceButtons: Boolean
+        get() = getPref(SWAP_FACE_BUTTONS, false)
+        set(value) {
+            setPref(SWAP_FACE_BUTTONS, value)
+        }
+
     private val ITEMS_PER_PAGE = intPreferencesKey("items_per_page")
     var itemsPerPage: Int
         get() = getPref(ITEMS_PER_PAGE, 50)

--- a/app/src/main/java/app/gamenative/ui/component/GamepadActionBar.kt
+++ b/app/src/main/java/app/gamenative/ui/component/GamepadActionBar.kt
@@ -70,6 +70,7 @@ data class GamepadAction(
 @Composable
 private fun GamepadButtonHint(
     action: GamepadAction,
+    swapFaceButtons: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val clickableModifier = if (action.onClick != null) {
@@ -79,6 +80,17 @@ private fun GamepadButtonHint(
     }
 
     val label = stringResource(action.labelResId)
+    val iconRes = if (swapFaceButtons) {
+        when (action.button) {
+            GamepadButton.A -> GamepadButton.B.iconRes
+            GamepadButton.B -> GamepadButton.A.iconRes
+            GamepadButton.X -> GamepadButton.Y.iconRes
+            GamepadButton.Y -> GamepadButton.X.iconRes
+            else -> action.button.iconRes
+        }
+    } else {
+        action.button.iconRes
+    }
 
     Row(
         modifier = clickableModifier.padding(horizontal = 8.dp, vertical = 4.dp),
@@ -86,7 +98,7 @@ private fun GamepadButtonHint(
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         Image(
-            painter = painterResource(action.button.iconRes),
+            painter = painterResource(iconRes),
             contentDescription = label,
             modifier = Modifier.size(28.dp),
         )
@@ -107,6 +119,7 @@ fun GamepadActionBar(
     visible: Boolean = true,
 ) {
     val showGamepadUI = shouldShowGamepadUI()
+    val swapFaceButtons = PrefManager.swapFaceButtons
 
     AnimatedVisibility(
         visible = visible && actions.isNotEmpty() && showGamepadUI,
@@ -155,7 +168,7 @@ fun GamepadActionBar(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     actions.forEach { action ->
-                        GamepadButtonHint(action = action)
+                        GamepadButtonHint(action = action, swapFaceButtons = swapFaceButtons)
                     }
                 }
             }

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
@@ -110,6 +110,7 @@ fun SettingsGroupInterface(
     var pendingStatusBarValue by rememberSaveable { mutableStateOf<Boolean?>(null) }
     var showStatusBarLoadingDialog by rememberSaveable { mutableStateOf(false) }
     var hideStatusBar by rememberSaveable { mutableStateOf(PrefManager.hideStatusBarWhenNotInGame) }
+    var swapFaceButtons by rememberSaveable { mutableStateOf(PrefManager.swapFaceButtons) }
 
     // Language selection dialog
     var openLanguageDialog by rememberSaveable { mutableStateOf(false) }
@@ -226,6 +227,17 @@ fun SettingsGroupInterface(
                 // Store the pending value and show confirmation dialog
                 pendingStatusBarValue = newValue
                 showStatusBarRestartDialog = true
+            },
+        )
+
+        SettingsSwitch(
+            colors = settingsTileColorsAlt(),
+            title = { Text(text = stringResource(R.string.settings_interface_swap_face_buttons_title)) },
+            subtitle = { Text(text = stringResource(R.string.settings_interface_swap_face_buttons_subtitle)) },
+            state = swapFaceButtons,
+            onCheckedChange = {
+                swapFaceButtons = it
+                PrefManager.swapFaceButtons = it
             },
         )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -833,6 +833,8 @@
     <string name="settings_interface_external_links_subtitle">Links open with your main web browser</string>
     <string name="settings_interface_hide_statusbar_title">Hide status bar when not in game</string>
     <string name="settings_interface_hide_statusbar_subtitle">Hide Android status bar in game list, settings, etc. App will restart when changed.</string>
+    <string name="settings_interface_swap_face_buttons_title">Swap face buttons</string>
+    <string name="settings_interface_swap_face_buttons_subtitle">Swap A↔B and X↔Y button icons</string>
     <string name="settings_interface_icon_style">Icon style</string>
     <string name="settings_interface_wifi_only_title">Download only over Wi-Fi/LAN</string>
     <string name="settings_interface_wifi_only_subtitle">Prevent downloads on cellular data</string>


### PR DESCRIPTION
On my Odin 2 I use the XBox controller style, thus the icons are swapped. This gives me the option to show them correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Swap face buttons” toggle that swaps A↔B and X↔Y icons to match Xbox-labeled controllers. The gamepad action bar now shows the correct icons when enabled.

- New Features
  - Added Interface settings switch; persists as `swapFaceButtons` (default off).
  - Gamepad action bar remaps A/B and X/Y icons when the toggle is on.
  - Added title and subtitle strings for the new setting.

<sup>Written for commit 18d2770178133d50d0bdfe356311a2dea6929d1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings → Interface toggle to switch to Xbox-style face-button layout.
  * When enabled, A↔B and X↔Y face-button icons are swapped across the app.
  * Button icons update immediately when the setting is changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->