### PR TITLE
Fix CursorWindow crash on large Steam libraries

### DIFF
--- a/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
@@ -4,10 +4,27 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 import app.gamenative.data.SteamApp
 import app.gamenative.service.SteamService.Companion.INVALID_PKG_ID
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+
+private const val OWNED_APPS_WHERE =
+    "WHERE app.id != 480 " + // Actively filter out Spacewar
+    "AND app.package_id != :invalidPkgId " +
+    "AND app.type != 0 " +
+    "AND EXISTS (" +
+    "  SELECT 1 FROM steam_license AS license " +
+    "  WHERE license.packageId = app.package_id " +
+    "  AND (license.license_flags & 8 = 0) " + // exclude expired licenses (e.g. free weekends)
+    ") "
+
+private const val PAGE_SIZE = 50
 
 @Dao
 interface SteamAppDao {
@@ -21,21 +38,58 @@ interface SteamAppDao {
     @Update
     suspend fun update(app: SteamApp)
 
+    // observe change count — triggers re-load without pulling all blobs into one CursorWindow
     @Query(
-        "SELECT * FROM steam_app AS app " +
-            "WHERE app.id != 480 " + // Actively filter out Spacewar
-            "AND app.package_id != :invalidPkgId " +
-            "AND app.type != 0 " +
-            "AND EXISTS (" +
-            "  SELECT 1 FROM steam_license AS license " +
-            "  WHERE license.packageId = app.package_id " +
-            "  AND (license.license_flags & 8 = 0) " + // exclude expired licenses (e.g. free weekends)
-            ") " +
-            "ORDER BY LOWER(app.name)",
+        "SELECT COUNT(*) FROM steam_app AS app " + OWNED_APPS_WHERE,
     )
+    fun _observeOwnedAppCount(
+        invalidPkgId: Int = INVALID_PKG_ID,
+    ): Flow<Int>
+
+    // paged data load — each page fits comfortably in a CursorWindow
+    @Query(
+        "SELECT * FROM steam_app AS app " + OWNED_APPS_WHERE +
+            "ORDER BY LOWER(app.name), app.id LIMIT :limit OFFSET :offset",
+    )
+    suspend fun _getOwnedAppsPage(
+        limit: Int,
+        offset: Int,
+        invalidPkgId: Int = INVALID_PKG_ID,
+    ): List<SteamApp>
+
+    @Transaction
+    suspend fun _getAllOwnedAppsPaged(invalidPkgId: Int = INVALID_PKG_ID): List<SteamApp> {
+        val result = mutableListOf<SteamApp>()
+        var offset = 0
+        while (true) {
+            // reset per-offset: try full fetch on first page, PAGE_SIZE thereafter
+            var pageSize = if (offset == 0) Int.MAX_VALUE else PAGE_SIZE
+            while (true) {
+                try {
+                    val page = _getOwnedAppsPage(pageSize, offset, invalidPkgId)
+                    if (page.isEmpty()) return result
+                    result += page
+                    if (pageSize == Int.MAX_VALUE) return result // got everything in one shot
+                    offset += page.size
+                    break
+                } catch (e: android.database.sqlite.SQLiteBlobTooBigException) {
+                    if (pageSize <= 1) throw e // single row exceeds window, can't recover
+                    pageSize = if (pageSize == Int.MAX_VALUE) PAGE_SIZE else (pageSize / 2).coerceAtLeast(1)
+                }
+            }
+        }
+    }
+
+    // emits full list on count changes, loaded in pages to avoid CursorWindow overflow.
+    // property-only updates (name, icon) won't re-emit until the next count change.
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun getAllOwnedApps(
         invalidPkgId: Int = INVALID_PKG_ID,
-    ): Flow<List<SteamApp>>
+    ): Flow<List<SteamApp>> = _observeOwnedAppCount(invalidPkgId)
+        .distinctUntilChanged() // skip reload when count unchanged
+        .flatMapLatest { // cancel stale reloads during rapid PICS inserts
+            flow { emit(_getAllOwnedAppsPaged(invalidPkgId)) }
+        }
 
     @Query("SELECT * FROM steam_app WHERE received_pics = 0 AND package_id != :invalidPkgId AND owner_account_id = :ownerId")
     fun getAllOwnedAppsWithoutPICS(


### PR DESCRIPTION
## Summary
- Try loading all owned apps in one shot (zero overhead for normal libraries)
- On `SQLiteBlobTooBigException`, retry with progressively smaller pages (50 → 25 → ... → 1)
- Rethrows if a single row exceeds the window (nothing we can do at the DB layer)
- Flow reactivity preserved via `COUNT(*)` observer with `distinctUntilChanged` + `flatMapLatest`
- Property-only updates (name, icon) won't re-emit until the next count change

## Test plan
- [ ] Normal library (<100 games) loads without regression
- [ ] Large library (450+ games with big depot blobs) no longer crashes
- [ ] Library updates correctly when PICS data arrives (Flow still reactive)

Fixes #960

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes on large Steam libraries by paging the owned-apps query and handling `SQLiteBlobTooBigException`. Small libraries still load in one shot; the app list reloads only when the owned-app count changes. Fixes #960.

- **Bug Fixes**
  - Try full load; on overflow, fall back to smaller pages (50 → 25 → ... → 1).
  - Rethrow if a single row still exceeds the `CursorWindow`.
  - Reload only on `COUNT(*)` changes with `distinctUntilChanged` + `flatMapLatest` to cancel stale reloads.
  - Load pages in a Room `@Transaction` and sort by `LOWER(name), id` with `LIMIT/OFFSET` for stable, consistent results.

<sup>Written for commit af8849be1a63bb62a1d30538a2a06c2aec770e07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * App list now reloads based on owned-app count to avoid unnecessary refreshes and cancels in-flight reloads during rapid changes.
  * Pagination added for loading large libraries to reduce memory and CPU usage.
  * App list ordering refined to be more deterministic for consistent browsing.

* **Stability**
  * Adaptive page sizing handles oversized datasets to prevent load failures.
  * Full-list loads run transactionally to avoid partial or inconsistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->