### PR TITLE
Fix library scroll position + decouple offline state from nav routes

### DIFF
--- a/app/src/main/java/app/gamenative/events/AndroidEvent.kt
+++ b/app/src/main/java/app/gamenative/events/AndroidEvent.kt
@@ -27,5 +27,8 @@ interface AndroidEvent<T> : Event<T> {
     data class GOGAuthCodeReceived(val authCode: String) : AndroidEvent<Unit>
     data class EpicAuthCodeReceived(val authCode: String) : AndroidEvent<Unit>
     data object ServiceReady : AndroidEvent<Unit>
+    // used by components without ViewModel access (ProfileDialog, SystemMenu)
+    // to toggle offline state; PluviaMain listens and forwards to MainViewModel
+    data class SetOffline(val offline: Boolean) : AndroidEvent<Unit>
     // data class SetAppBarVisibility(val visible: Boolean) : AndroidEvent<Unit>
 }

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -418,9 +418,9 @@ fun PluviaMain(
                             context, launchRequest.appId, launchRequest.containerConfig,
                         )
                     }
-                    val homeRoute = PluviaScreen.Home.route + "?offline={offline}"
-                    if (navController.currentDestination?.route != homeRoute) {
-                        navController.navigate(PluviaScreen.Home.route + "?offline=false") {
+                    viewModel.setOffline(false)
+                    if (navController.currentDestination?.route != PluviaScreen.Home.route) {
+                        navController.navigate(PluviaScreen.Home.route) {
                             popUpTo(navController.graph.startDestinationId) { saveState = false }
                         }
                     }
@@ -527,6 +527,8 @@ fun PluviaMain(
                 is MainViewModel.MainUiEvent.OnLogonEnded -> {
                     when (event.result) {
                         LoginResult.Success -> {
+                            // login succeeded — we're online regardless of current screen
+                            viewModel.setOffline(false)
                             val pending = MainActivity.peekPendingLaunchRequest()
                             if (pending != null && !needsDeferLaunch(context, pending.appId)) {
                                 processPendingLaunch("user is now logged in")
@@ -535,16 +537,6 @@ fun PluviaMain(
                                 val targetRoute = viewModel.getPersistedRoute() ?: PluviaScreen.Home.route
                                 if (currentRoute == PluviaScreen.LoginUser.route) {
                                     navController.navigateFromLoginIfNeeded(targetRoute, "LogonEnded")
-                                } else if (currentRoute == PluviaScreen.Home.route + "?offline={offline}") {
-                                    val isCurrentlyOffline = navController.currentBackStackEntry
-                                        ?.arguments?.getBoolean("offline") ?: false
-                                    if (isCurrentlyOffline) {
-                                        navController.navigate(PluviaScreen.Home.route + "?offline=false") {
-                                            popUpTo(PluviaScreen.Home.route + "?offline={offline}") {
-                                                inclusive = true
-                                            }
-                                        }
-                                    }
                                 }
                             }
                         }
@@ -693,14 +685,14 @@ fun PluviaMain(
             if (PlatformAuthUtils.isSignedInToAnyPlatform(context) && !SteamService.keepAlive) {
                 val baseRoute = viewModel.getPersistedRoute() ?: PluviaScreen.Home.route
                 val targetRoute = if (SteamService.isLoggedIn) {
+                    // don't clear offline here — user may have explicitly chosen
+                    // "Go Offline" via system menu/profile dialog
                     baseRoute
                 } else {
-                    // Non-Steam platforms: ensure offline param for Home
                     if (baseRoute.startsWith(PluviaScreen.Home.route)) {
-                        PluviaScreen.Home.route + "?offline=true"
-                    } else {
-                        baseRoute
+                        viewModel.setOffline(true)
                     }
+                    baseRoute
                 }
                 navController.navigateFromLoginIfNeeded(targetRoute, "ResumeSession")
             }
@@ -736,15 +728,23 @@ fun PluviaMain(
         )
     }
 
+    // event bus bridge: lets components without ViewModel access (ProfileDialog,
+    // SystemMenu) set offline state without threading callbacks through every layer
+    val onSetOffline: (AndroidEvent.SetOffline) -> Unit = { event ->
+        viewModel.setOffline(event.offline)
+    }
+
     LaunchedEffect(Unit) {
         PluviaApp.events.on<AndroidEvent.PromptSaveContainerConfig, Unit>(onPromptSaveConfig)
         PluviaApp.events.on<AndroidEvent.ShowGameFeedback, Unit>(onShowGameFeedback)
+        PluviaApp.events.on<AndroidEvent.SetOffline, Unit>(onSetOffline)
     }
 
     DisposableEffect(Unit) {
         onDispose {
             PluviaApp.events.off<AndroidEvent.PromptSaveContainerConfig, Unit>(onPromptSaveConfig)
             PluviaApp.events.off<AndroidEvent.ShowGameFeedback, Unit>(onShowGameFeedback)
+            PluviaApp.events.off<AndroidEvent.SetOffline, Unit>(onSetOffline)
         }
     }
 
@@ -1250,14 +1250,18 @@ fun PluviaMain(
 
             val startDestination = rememberSaveable {
                 when {
-                    SteamService.isLoggedIn -> PluviaScreen.Home.route + "?offline=false"
-                    // skip login screen if any service has stored credentials
+                    SteamService.isLoggedIn -> PluviaScreen.Home.route
                     (PrefManager.username.isNotEmpty() && PrefManager.refreshToken.isNotEmpty()) ||
                         GOGService.hasStoredCredentials(context) ||
                         EpicService.hasStoredCredentials(context) ||
-                        AmazonService.hasStoredCredentials(context) ->
-                        PluviaScreen.Home.route + "?offline=true"
+                        AmazonService.hasStoredCredentials(context) -> PluviaScreen.Home.route
                     else -> PluviaScreen.LoginUser.route
+                }
+            }
+            // set initial offline state outside rememberSaveable to avoid re-execution on recomposition
+            LaunchedEffect(startDestination) {
+                if (startDestination == PluviaScreen.Home.route) {
+                    viewModel.setOffline(!SteamService.isLoggedIn)
                 }
             }
 
@@ -1271,10 +1275,12 @@ fun PluviaMain(
                         connectionState = state.connectionState,
                         onRetryConnection = viewModel::retryConnection,
                         onContinueOffline = {
-                            navController.navigate(PluviaScreen.Home.route + "?offline=true")
+                            viewModel.setOffline(true)
+                            navController.navigate(PluviaScreen.Home.route)
                         },
                         onPlatformSignedIn = {
-                            navController.navigate(PluviaScreen.Home.route + "?offline=true") {
+                            viewModel.setOffline(true)
+                            navController.navigate(PluviaScreen.Home.route) {
                                 popUpTo(PluviaScreen.LoginUser.route) { inclusive = true }
                             }
                         },
@@ -1282,16 +1288,10 @@ fun PluviaMain(
                 }
                 /** Library, Downloads **/
                 composable(
-                    route = PluviaScreen.Home.route + "?offline={offline}",
+                    route = PluviaScreen.Home.route,
                     deepLinks = listOf(navDeepLink { uriPattern = "pluvia://home" }),
-                    arguments = listOf(
-                        navArgument("offline") {
-                            type = NavType.BoolType
-                            defaultValue = false // default when the query param isn’t present
-                        },
-                    ),
-                ) { backStackEntry ->
-                    val isOffline = backStackEntry.arguments?.getBoolean("offline") ?: false
+                ) {
+                    val isOffline by viewModel.isOffline.collectAsStateWithLifecycle()
 
                     // Show update/crash/support dialogs when Home is first displayed
                     // Skip when offline with Steam credentials (avoid flash when Steam reconnects)
@@ -1345,7 +1345,7 @@ fun PluviaMain(
                             viewModel.setLaunchedAppId(appId)
                             viewModel.setBootToContainer(asContainer)
                             viewModel.setTestGraphics(false)
-                            viewModel.setOffline(isOffline)
+
                             preLaunchApp(
                                 context = context,
                                 appId = appId,
@@ -1362,7 +1362,7 @@ fun PluviaMain(
                             viewModel.setLaunchedAppId(appId)
                             viewModel.setBootToContainer(true)
                             viewModel.setTestGraphics(true)
-                            viewModel.setOffline(isOffline)
+
                             preLaunchApp(
                                 context = context,
                                 appId = appId,
@@ -1394,11 +1394,13 @@ fun PluviaMain(
                         onLogout = {
                             SteamService.logOut()
                         },
+                        // callback instead of event bus because going online may
+                        // need navController to redirect to login
                         onGoOnline = {
-                            navController.navigate(
-                                if (!SteamService.isLoggedIn) PluviaScreen.LoginUser.route
-                                else PluviaScreen.Home.route
-                            )
+                            viewModel.setOffline(false)
+                            if (!SteamService.isLoggedIn) {
+                                navController.navigate(PluviaScreen.LoginUser.route)
+                            }
                         },
                         isOffline = isOffline,
                     )

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ProfileDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ProfileDialog.kt
@@ -1,6 +1,8 @@
 package app.gamenative.ui.component.dialog
 
 import android.content.res.Configuration
+import app.gamenative.PluviaApp
+import app.gamenative.events.AndroidEvent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -176,7 +178,8 @@ fun ProfileDialog(
                                     }
                                 } else {
                                     FilledTonalButton(modifier = Modifier.fillMaxWidth(), onClick = {
-                                        onNavigateRoute(PluviaScreen.Home.route + "?offline=true")
+                                        PluviaApp.events.emit(AndroidEvent.SetOffline(true))
+                                        onDismiss()
                                     }) {
                                         Icon(imageVector = Icons.AutoMirrored.Filled.AirplaneTicket, contentDescription = null)
                                         Spacer(modifier = Modifier.size(ButtonDefaults.IconSize))

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -44,6 +44,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import java.util.EnumSet
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import kotlin.math.max
 import kotlin.math.min
@@ -102,6 +103,14 @@ class LibraryViewModel @Inject constructor(
     // Cached recommendation (fetched once at startup)
     @Volatile private var cachedRecommendation: RecommendedGame? = null
 
+    // don't emit data until all sources have fired once — prevents keyed grid
+    // from jumping as later sources reorder the combined list.
+    // safe to gate on all 4: Room flows emit current DB state immediately on
+    // collection (even empty list), so all sources fire within the first frame.
+    private enum class SourceKind { STEAM, GOG, EPIC, AMAZON }
+    private val sourcesReady = ConcurrentHashMap.newKeySet<SourceKind>()
+    private fun allSourcesReady() = sourcesReady.size >= SourceKind.entries.size
+
     // Track debounce job for search
     private var searchDebounceJob: Job? = null
     private val SEARCH_DEBOUNCE_MS = 500L // 500ms debounce
@@ -123,51 +132,56 @@ class LibraryViewModel @Inject constructor(
         }
     }
 
+    private fun collectSource(block: suspend () -> Unit) {
+        viewModelScope.launch(Dispatchers.IO) { block() }
+    }
+
     init {
-        viewModelScope.launch(Dispatchers.IO) {
+        collectSource {
             steamAppDao.getAllOwnedApps(
                 // ownerIds = SteamService.familyMembers.ifEmpty { listOf(SteamService.userSteamId!!.accountID.toInt()) },
             ).collect { apps ->
                 Timber.tag("LibraryViewModel").d("Collecting ${apps.size} apps")
-                // Check if the list has actually changed before triggering a re-filter
-                if (appList.size != apps.size) {
-                    appList = apps
+                val hasChanges = appList.size != apps.size
+                appList = apps
+                val justBecameReady = sourcesReady.add(SourceKind.STEAM) && allSourcesReady()
+                if (hasChanges || justBecameReady) {
                     onFilterApps(paginationCurrentPage)
                 }
             }
         }
 
-        // Collect GOG games
-        viewModelScope.launch(Dispatchers.IO) {
+        collectSource {
             gogGameDao.getAll().collect { games ->
                 Timber.tag("LibraryViewModel").d("Collecting ${games.size} GOG games")
-                // Check if the list has actually changed before triggering a re-filter
-                if (gogGameList != games) {
-                    gogGameList = games
+                val hasChanges = gogGameList != games
+                gogGameList = games
+                val justBecameReady = sourcesReady.add(SourceKind.GOG) && allSourcesReady()
+                if (hasChanges || justBecameReady) {
                     onFilterApps(paginationCurrentPage)
                 }
             }
         }
 
-        viewModelScope.launch(Dispatchers.IO) {
+        collectSource {
             epicGameDao.getAll().collect { games ->
                 Timber.tag("LibraryViewModel").d("Collecting ${games.size} Epic games")
-
                 val hasChanges = epicGameList.size != games.size || epicGameList != games
                 epicGameList = games
-
-                if (hasChanges) {
+                val justBecameReady = sourcesReady.add(SourceKind.EPIC) && allSourcesReady()
+                if (hasChanges || justBecameReady) {
                     onFilterApps(paginationCurrentPage)
                 }
             }
         }
 
-        viewModelScope.launch(Dispatchers.IO) {
+        collectSource {
             amazonGameDao.getAll().collect { games ->
                 Timber.tag("LibraryViewModel").d("Collecting ${games.size} Amazon games")
                 val hasChanges = amazonGameList.size != games.size || amazonGameList != games
                 amazonGameList = games
-                if (hasChanges) {
+                val justBecameReady = sourcesReady.add(SourceKind.AMAZON) && allSourcesReady()
+                if (hasChanges || justBecameReady) {
                     onFilterApps(paginationCurrentPage)
                 }
             }
@@ -249,25 +263,22 @@ class LibraryViewModel @Inject constructor(
 
     fun onTabChanged(tab: LibraryTab) {
         _state.update { it.copy(currentTab = tab) }
-        onFilterApps(0) // Reset to first page and refresh
+        onFilterApps(0)
+        viewModelScope.launch { listState.scrollToItem(0) }
     }
 
     fun onNextTab() {
-        _state.update { currentState ->
-            val nextTab = currentState.currentTab.next()
-            Timber.tag("LibraryViewModel").d("Tab next via bumper: ${currentState.currentTab} -> $nextTab")
-            currentState.copy(currentTab = nextTab)
-        }
-        onFilterApps(0)
+        val current = _state.value.currentTab
+        val next = current.next()
+        Timber.tag("LibraryViewModel").d("Tab next via bumper: $current -> $next")
+        onTabChanged(next)
     }
 
     fun onPreviousTab() {
-        _state.update { currentState ->
-            val previousTab = currentState.currentTab.previous()
-            Timber.tag("LibraryViewModel").d("Tab previous via bumper: ${currentState.currentTab} -> $previousTab")
-            currentState.copy(currentTab = previousTab)
-        }
-        onFilterApps(0)
+        val current = _state.value.currentTab
+        val previous = current.previous()
+        Timber.tag("LibraryViewModel").d("Tab previous via bumper: $current -> $previous")
+        onTabChanged(previous)
     }
 
     fun onSearchQuery(value: String) {
@@ -368,8 +379,12 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun onFilterApps(paginationPage: Int = 0): Job {
-        Timber.tag("LibraryViewModel").d("onFilterApps - appList.size: ${appList.size}, isFirstLoad: $isFirstLoad")
+        Timber.tag("LibraryViewModel").d("onFilterApps - appList.size: ${appList.size}, isFirstLoad: $isFirstLoad, allSourcesReady: ${allSourcesReady()}")
         return viewModelScope.launch(Dispatchers.IO) {
+            // don't touch state until every source has emitted at least once —
+            // partial updates cause empty→populated list transitions that reset
+            // scroll position and can pop navigation
+            if (!allSourcesReady()) return@launch
             _state.update { it.copy(isLoading = true) }
 
             val currentState = _state.value
@@ -741,7 +756,7 @@ class LibraryViewModel @Inject constructor(
                     currentPaginationPage = paginationPage + 1, // visual display is not 0 indexed
                     lastPaginationPage = lastPageInCurrentFilter + 1,
                     totalAppsInFilter = totalFound,
-                    isLoading = false, // Loading complete
+                    isLoading = false,
                     // Per-source counts for tab badges
                     // Use user prefs + auth state only (not current tab) so badges stay stable across tab switches
                     allCount = (if (currentState.showSteamInLibrary) steamEntries.size else 0) +

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -372,8 +372,8 @@ class MainViewModel @Inject constructor(
     }
 
     fun setCurrentScreen(currentScreen: String?) {
-        // Route matching accounts for query params and path params in templates
-        // e.g., "home?offline={offline}" should match Home, "chat/{id}" should match Chat
+        // route matching accounts for path params in templates
+        // e.g., "chat/{id}" should match Chat
         val screen = when {
             currentScreen == null -> PluviaScreen.LoginUser
             currentScreen == PluviaScreen.LoginUser.route -> PluviaScreen.LoginUser

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/SystemMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/SystemMenu.kt
@@ -77,6 +77,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.gamenative.PluviaApp
+import app.gamenative.events.AndroidEvent
 import app.gamenative.PrefManager
 import app.gamenative.R
 import app.gamenative.data.SteamFriend
@@ -623,7 +624,7 @@ fun SystemMenu(
                                 text = stringResource(R.string.steam_go_offline),
                                 icon = Icons.AutoMirrored.Filled.AirplaneTicket,
                                 onClick = {
-                                    onNavigateRoute(PluviaScreen.Home.route + "?offline=true") // TODO: test this
+                                    PluviaApp.events.emit(AndroidEvent.SetOffline(true))
                                     onDismiss()
                                 },
                             )


### PR DESCRIPTION
## Description

Two fixes:

### 1. Event bus for offline state
Offline mode was encoded as a nav route query param (`?offline=true/false`). Toggling offline required navigating to a new route, which tore down and rebuilt the entire Home composable — destroying all local state including scroll position, selection, and ViewModel-scoped data. Any `navigate()` call that omitted the param also silently reset offline state. Hoisting the source of truth to `MainViewModel.isOffline` (StateFlow) means toggling offline is just a state change, no recomposition of the nav destination. `AndroidEvent.SetOffline` bridges components without ViewModel access (ProfileDialog, SystemMenu).

### 2. Library scroll position retention
The library grid collects from 4 Room DAOs (Steam, GOG, Epic, Amazon) in parallel. Each emission triggered `onFilterApps`, which updated the list — causing empty→populated transitions that reset LazyGrid scroll position. Now gates `onFilterApps` until all sources have emitted at least once. Safe because Room flows emit current DB state immediately on collection.

closes #964.

## Recording
Before:
https://github.com/user-attachments/assets/e74c55c3-d2d4-498b-b7f6-1646fda9035a

After:
https://github.com/user-attachments/assets/aed7f0ca-f833-49eb-b4fe-6b99a913ecc9

## Test plan
- [ ] Scroll down in library, wait for offline→online transition — scroll position retained
- [ ] Switch tabs — grid resets to top, no bleed from previous tab
- [ ] Open system menu → "Go Offline" — library switches to offline state (installed games only)
- [ ] While offline, system menu → "Go Online" / "Sign In" — reconnects without resetting scroll
- [ ] Kill app, disable wifi, relaunch — lands on Home in offline mode
- [ ] Kill app, enable wifi, relaunch — lands on Home in online mode

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized offline state handling and simplified startup/navigation flows.
  * Coordinated data loading so UI waits until all sources are ready before updating lists.

* **New Features**
  * Added a global offline toggle event so dialogs and menus can switch offline/online state without route parameters.

* **Bug Fixes**
  * Fixed tab/filter navigation to reliably reset and scroll lists on tab changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->