### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
   "items": {
     "driver": [
       {
-        "id": "Turnip-Gen8-V23",
-        "name": "Turnip-Gen8-V23",
+        "id": "Turnip_Gen8_V23",
+        "name": "Turnip_Gen8_V23",
         "url": "https://downloads.gamenative.app/drivers/Turnip_Gen8_V23.zip",
         "variant": "bionic"
       },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized the driver entry for Turnip Gen8 V23 by switching `id` and `name` to underscore format to match the download URL. This keeps the manifest consistent and avoids lookup mismatches in clients.

<sup>Written for commit d1d7dd05826626836a3411444c8601cd30d803a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Turnip Gen8 V23 driver identifier naming convention to use underscores instead of hyphens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->