### PR TITLE
fix: stabilize carousel cpu perf on idle

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
@@ -87,6 +87,16 @@ private const val CAROUSEL_CARD_VERTICAL_OVERFLOW = 32f
 private const val CAROUSEL_BADGE_RESERVED_HEIGHT = 0f
 private const val CAROUSEL_MOUSE_WHEEL_SCROLL_MULTIPLIER = 72f
 
+private data class CarouselLayoutSnapshot(
+    val viewportCenter: Float = 0f,
+    val viewportSpan: Float = 1f,
+    val visibleItemCenters: Map<Int, Float> = emptyMap(),
+    val visibleCount: Int = 0,
+    val lastVisibleIndex: Int? = null,
+    val firstVisibleItemIndex: Int = 0,
+    val firstVisibleItemScrollOffset: Int = 0,
+)
+
 private fun Modifier.carouselMouseInput(listState: LazyListState): Modifier =
     pointerInput(listState) {
         coroutineScope {
@@ -219,26 +229,40 @@ internal fun LibraryCarouselPane(
     val firstTileOffsetPx = cardWidthPx * 0.08f
     val cameraDistancePx = with(density) { CAROUSEL_CAMERA_DISTANCE_DP.dp.toPx() }
 
-    val centeredIndex by remember(state.appInfoList, listState.layoutInfo) {
+    val layoutSnapshot by produceState(initialValue = CarouselLayoutSnapshot(), listState) {
+        snapshotFlow {
+            val layoutInfo = listState.layoutInfo
+            val viewportCenter = (layoutInfo.viewportStartOffset + layoutInfo.viewportEndOffset) / 2f
+            CarouselLayoutSnapshot(
+                viewportCenter = viewportCenter,
+                viewportSpan = (layoutInfo.viewportEndOffset - layoutInfo.viewportStartOffset)
+                    .toFloat()
+                    .coerceAtLeast(1f),
+                visibleItemCenters = layoutInfo.visibleItemsInfo.associate { itemInfo ->
+                    itemInfo.index to (itemInfo.offset + itemInfo.size / 2f)
+                },
+                visibleCount = layoutInfo.visibleItemsInfo.size,
+                lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index,
+                firstVisibleItemIndex = listState.firstVisibleItemIndex,
+                firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset,
+            )
+        }
+            .distinctUntilChanged()
+            .collect { value = it }
+    }
+
+    val centeredIndex by remember(layoutSnapshot) {
         derivedStateOf {
-            val visibleItems = listState.layoutInfo.visibleItemsInfo
-            if (visibleItems.isEmpty()) return@derivedStateOf -1
-
-            val viewportCenter =
-                (listState.layoutInfo.viewportStartOffset + listState.layoutInfo.viewportEndOffset) / 2f
-
-            visibleItems
-                .minByOrNull { itemInfo ->
-                    abs((itemInfo.offset + itemInfo.size / 2f) - viewportCenter)
-                }
-                ?.index ?: -1
+            layoutSnapshot.visibleItemCenters.minByOrNull { (_, itemCenter) ->
+                abs(itemCenter - layoutSnapshot.viewportCenter)
+            }?.key ?: -1
         }
     }
 
     fun currentTargetIndex(): Int {
         val lastIndex = state.appInfoList.lastIndex
         if (lastIndex < 0) return 0
-        val preferredIndex = focusTargetListIndex ?: centeredIndex.takeIf { it >= 0 } ?: listState.firstVisibleItemIndex
+        val preferredIndex = focusTargetListIndex ?: centeredIndex.takeIf { it >= 0 } ?: layoutSnapshot.firstVisibleItemIndex
         return preferredIndex.coerceIn(0, lastIndex)
     }
 
@@ -261,7 +285,7 @@ internal fun LibraryCarouselPane(
     }
 
     LaunchedEffect(listState, state.appInfoList.size, state.totalAppsInFilter) {
-        snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
+        snapshotFlow { layoutSnapshot.lastVisibleIndex }
             .filterNotNull()
             .distinctUntilChanged()
             .collect { lastVisibleIndex ->
@@ -307,7 +331,7 @@ internal fun LibraryCarouselPane(
             val selectedBackdropItem = if (state.appInfoList.isEmpty()) {
                 null
             } else {
-                val fallbackIndex = listState.firstVisibleItemIndex.coerceIn(0, state.appInfoList.lastIndex)
+                val fallbackIndex = layoutSnapshot.firstVisibleItemIndex.coerceIn(0, state.appInfoList.lastIndex)
                 val backdropIndex = centeredIndex.takeIf { it in state.appInfoList.indices } ?: fallbackIndex
                 state.appInfoList.getOrNull(backdropIndex)
             }
@@ -350,17 +374,12 @@ internal fun LibraryCarouselPane(
                             key = { listIndex -> state.appInfoList[listIndex].appId },
                         ) { listIndex ->
                             val item = state.appInfoList[listIndex]
-                            val itemLayoutInfo = listState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == listIndex }
-                            val viewportCenter =
-                                (listState.layoutInfo.viewportStartOffset + listState.layoutInfo.viewportEndOffset) / 2f
-
-                            val itemCenter = itemLayoutInfo?.let { info ->
-                                info.offset + info.size / 2f
-                            } ?: viewportCenter
+                            val viewportCenter = layoutSnapshot.viewportCenter
+                            val itemCenter = layoutSnapshot.visibleItemCenters[listIndex] ?: viewportCenter
 
                             val distanceFromCenter = itemCenter - viewportCenter
                             val normalizedDistance =
-                                (distanceFromCenter / (listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset).toFloat())
+                                (distanceFromCenter / layoutSnapshot.viewportSpan)
                                     .coerceIn(-1f, 1f)
                             val absDistance = abs(normalizedDistance)
                             val itemStepDistancePx = (carouselItemSlotWidthPx + carouselItemSpacingPx).coerceAtLeast(1f)
@@ -401,7 +420,7 @@ internal fun LibraryCarouselPane(
                                 val tiltInfluence = if (CAROUSEL_TILT_ANGLE > 0.1f) tiltAngle / CAROUSEL_TILT_ANGLE else 1f
                                 val baseOffsetRatio = CAROUSEL_SIDE_OFFSET_RATIO + (distanceInSteps * CAROUSEL_STEP_OFFSET_RATIO)
                                 val baseShift = direction * cardWidthPx * baseOffsetRatio * tiltInfluence
-                                val edgeOffset = if (listIndex == 0 && listState.firstVisibleItemIndex == 0) {
+                                val edgeOffset = if (listIndex == 0 && layoutSnapshot.firstVisibleItemIndex == 0) {
                                     firstTileOffsetPx
                                 } else {
                                     0f


### PR DESCRIPTION
snapshot layout on idle to prevent redraws at hz rate which causes high cpu usage on render thread and lock up after extended idle on center focused item.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilized the library carousel by snapshotting layout metrics and computing the centered item from a consistent source. This removes flicker and incorrect centering during initial load and scrolling.

- **Bug Fixes**
  - Added `CarouselLayoutSnapshot` and a `produceState` + `snapshotFlow(...).distinctUntilChanged()` to capture viewport center/span, visible item centers, and first/last visible indexes.
  - Replaced direct `listState.layoutInfo` reads with the snapshot to avoid transient values causing jitter.
  - Normalized calculations using the snapshot’s viewport span and indices, fixing fallback selection and first-card edge offset.

<sup>Written for commit 222f2989ca8ca7f0754ff089a4c08c4b36139a81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved carousel performance by refactoring internal layout calculations to reduce redundant computations and minimize unnecessary state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->