### PR TITLE
feat: Add option to disable audio processing

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -4373,10 +4373,10 @@ private fun changeWineAudioDriver(audioDriver: String, container: Container, ima
         val rootDir = imageFs.rootDir
         val userRegFile = File(rootDir, ImageFs.WINEPREFIX + "/user.reg")
         WineRegistryEditor(userRegFile).use { registryEditor ->
-            if (audioDriver == "alsa") {
-                registryEditor.setStringValue("Software\\Wine\\Drivers", "Audio", "alsa")
-            } else if (audioDriver == "pulseaudio") {
-                registryEditor.setStringValue("Software\\Wine\\Drivers", "Audio", "pulse")
+            when (audioDriver) {
+                "alsa" -> registryEditor.setStringValue("Software\\Wine\\Drivers", "Audio", "alsa")
+                "pulseaudio" -> registryEditor.setStringValue("Software\\Wine\\Drivers", "Audio", "pulse")
+                "none" -> registryEditor.setStringValue("Software\\Wine\\Drivers", "Audio", "")
             }
         }
         container.putExtra("audioDriver", audioDriver)

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -69,6 +69,7 @@
     <string-array name="audio_driver_entries">
         <item>ALSA</item>
         <item>PulseAudio</item>
+        <item>None</item>
     </string-array>
     <string-array name="binding_type_entries">
         <item>Keyboard</item>


### PR DESCRIPTION
https://discord.com/channels/1378308569287622737/1458099885197758525

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a “None” option to disable Wine audio processing from the audio driver settings. This helps when running without audio or troubleshooting audio-related issues.

- **New Features**
  - Added “None” to the audio driver list in the settings UI.
  - Selecting “None” writes an empty value to Wine’s `Software\Wine\Drivers` `Audio` key, disabling the audio backend.

<sup>Written for commit d295126b423a91049dc93ecc86957afcd0494c7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added "None" as a new audio driver option alongside ALSA and PulseAudio

<!-- end of auto-generated comment: release notes by coderabbit.ai -->