### PR TITLE
fix: verify controller characteristics as detection

### DIFF
--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -7,6 +7,7 @@ import android.hardware.input.InputManager;
 import android.preference.PreferenceManager;
 import android.util.SparseArray;
 import android.view.InputDevice;
+import android.view.KeyEvent;
 
 import app.gamenative.PrefManager;
 
@@ -132,16 +133,30 @@ public class ControllerManager {
     public static boolean isGameController(InputDevice device) {
         if (device == null) return false;
 
-        int sources = device.getSources();
+        boolean isGamepad = device.supportsSource(InputDevice.SOURCE_GAMEPAD);
+        boolean isJoystick = device.supportsSource(InputDevice.SOURCE_JOYSTICK);
 
-        boolean isGamepad = (sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD;
-        boolean isJoystick = (sources & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK;
+        boolean hasAxes =
+                device.getMotionRange(android.view.MotionEvent.AXIS_X) != null ||
+                        device.getMotionRange(android.view.MotionEvent.AXIS_Y) != null;
 
-        if (device.getKeyboardType() == InputDevice.KEYBOARD_TYPE_ALPHABETIC) {
-            return false;
+        boolean[] hasGamepadKeysArray = device.hasKeys(
+                KeyEvent.KEYCODE_BUTTON_A,
+                KeyEvent.KEYCODE_BUTTON_B,
+                KeyEvent.KEYCODE_BUTTON_X,
+                KeyEvent.KEYCODE_BUTTON_Y
+        );
+
+        boolean hasGamepadKeys = false;
+        for (boolean hasKey : hasGamepadKeysArray) {
+            if (hasKey) {
+                hasGamepadKeys = true;
+                break;
+            }
         }
 
-        return isGamepad || isJoystick;
+        return (isGamepad && hasGamepadKeys) ||
+                (isJoystick && hasAxes);
     }
 
     /**

--- a/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
@@ -364,16 +364,30 @@ public class ExternalController {
         if (device == null) return false;
         if (device.isVirtual()) return false;
 
-        int sources = device.getSources();
+        boolean isGamepad = device.supportsSource(InputDevice.SOURCE_GAMEPAD);
+        boolean isJoystick = device.supportsSource(InputDevice.SOURCE_JOYSTICK);
 
-        boolean isGamepad = (sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD;
-        boolean isJoystick = (sources & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK;
+        boolean hasAxes =
+                device.getMotionRange(android.view.MotionEvent.AXIS_X) != null ||
+                        device.getMotionRange(android.view.MotionEvent.AXIS_Y) != null;
 
-        if (device.getKeyboardType() == InputDevice.KEYBOARD_TYPE_ALPHABETIC) {
-            return false;
+        boolean[] hasGamepadKeysArray = device.hasKeys(
+                KeyEvent.KEYCODE_BUTTON_A,
+                KeyEvent.KEYCODE_BUTTON_B,
+                KeyEvent.KEYCODE_BUTTON_X,
+                KeyEvent.KEYCODE_BUTTON_Y
+        );
+
+        boolean hasGamepadKeys = false;
+        for (boolean hasKey : hasGamepadKeysArray) {
+            if (hasKey) {
+                hasGamepadKeys = true;
+                break;
+            }
         }
 
-        return isGamepad || isJoystick;
+        return (isGamepad && hasGamepadKeys) ||
+                (isJoystick && hasAxes);
     }
 
     public static float getCenteredAxis(MotionEvent event, int axis, int historyPos) {


### PR DESCRIPTION
I got a user report that their controller stopped being detected as gamepad due to
`if (device.getKeyboardType() == InputDevice.KEYBOARD_TYPE_ALPHABETIC)`

let's try checking for controller characteristics instead

these extra checks are required because for some reason some keyboards report having SOURCE_GAMEPAD or SOURCE_JOYSTICK capabilities and we need to prevent them from being detected as gamepads as it can confuse games and cause input bugs when trying to play from a keyboard

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes gamepad detection by verifying controller characteristics (buttons/axes) instead of relying on keyboard type. Restores detection for real controllers and prevents keyboards from being misidentified as gamepads.

- **Bug Fixes**
  - Detect controllers if they support GAMEPAD with A/B/X/Y keys or JOYSTICK with X/Y axes.
  - Replace `getSources()` bitmask with `supportsSource(...)`. Remove the `KEYBOARD_TYPE_ALPHABETIC` check to avoid rejecting valid controllers. Ignore virtual devices.

<sup>Written for commit cfbaa80fdc17ce38d867b917e2bcaa77514c7be7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced game controller detection for external controllers to more reliably identify proper gaming devices and reduce false positives with keyboard peripherals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->