### PR TITLE
fix: preserve Steam session state on unexpected auth loss

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2555,6 +2555,13 @@ class SteamService : Service(), IChallengeUrlChanged {
             }
         }
 
+        private fun cancelLongLivedSteamJobs() {
+            // Cancel previous continuous jobs or else they will continue to run even after logout
+            instance?.picsGetProductInfoJob?.cancel()
+            instance?.picsChangesCheckerJob?.cancel()
+            instance?.friendCheckerJob?.cancel()
+        }
+
         private fun performLogOffDuties(clearCloudSyncState: Boolean = false) {
             val username = PrefManager.username
 
@@ -2563,10 +2570,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             val event = SteamEvent.LoggedOut(username)
             PluviaApp.events.emit(event)
 
-            // Cancel previous continuous jobs or else they will continue to run even after logout
-            instance?.picsGetProductInfoJob?.cancel()
-            instance?.picsChangesCheckerJob?.cancel()
-            instance?.friendCheckerJob?.cancel()
+            cancelLongLivedSteamJobs()
         }
 
         suspend fun getOwnedGames(friendID: Long): List<OwnedGames> = withContext(Dispatchers.IO) {
@@ -3320,6 +3324,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             scope.launch { stop() }
         } else if (callback.result == EResult.LogonSessionReplaced) {
             // Unexpected session replacement should not wipe persisted Steam state.
+            cancelLongLivedSteamJobs()
             scope.launch { stop() }
         } else if (callback.result == EResult.LoggedInElsewhere) {
             // received when a client runs an app and wants to forcibly close another


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Steam session state on unexpected auth loss and cancels long‑lived background jobs on session replacement.

- **Bug Fixes**
  - Only clear user data for specific `EResult` cases (e.g., invalid password, 2FA/auth code errors, parental controls, cached credential invalid).
  - On `LogonSessionReplaced`, cancel long‑lived Steam jobs and stop the service without running logout duties to keep local state intact.

<sup>Written for commit 63252dfe41aca702ed36b460ec8457e91544ed07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clear saved Steam user data only for specific authentication failures (invalid/expired credentials, 2FA/account lockouts), preserving data for other error cases.
  * Avoid wiping persisted Steam state when a session is replaced.

* **Refactor**
  * Centralized cancellation of long-lived Steam tasks to reduce duplicated logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->