### PR TITLE
fix: prevent quick menu controller tab focus bounce

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -517,6 +517,11 @@ fun QuickMenu(
     LaunchedEffect(isVisible) {
         if (isVisible) {
             selectedTab = QuickMenuTab.HUD
+        }
+    }
+
+    LaunchedEffect(isVisible, selectedTab) {
+        if (isVisible && selectedTab == QuickMenuTab.HUD) {
             repeat(3) {
                 try {
                     hudTabFocusRequester.requestFocus()


### PR DESCRIPTION
https://discord.com/channels/1378308569287622737/1482942532995256503

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Quick Menu controller tab from bouncing focus when the menu opens. HUD focus is now requested only after the menu is visible and the HUD tab is selected, avoiding repeated focus shifts.

<sup>Written for commit 5aa1b345fed00455bf487d93e988227d927673f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quick menu focus behavior to more accurately respond when navigating to the HUD tab, enhancing overall menu responsiveness and navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->