### PR TITLE
Fix ControlsProfile binding deserialization

### DIFF
--- a/app/src/main/java/com/winlator/inputcontrols/ControlsProfile.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControlsProfile.java
@@ -281,9 +281,10 @@ public class ControlsProfile implements Comparable<ControlsProfile> {
 
                 boolean hasGamepadBinding = true;
                 JSONArray bindingsJSONArray = elementJSONObject.getJSONArray("bindings");
+                element.setBindingCount(Math.max(bindingsJSONArray.length(), 4));
                 for (int j = 0; j < bindingsJSONArray.length(); j++) {
                     Binding binding = Binding.fromString(bindingsJSONArray.getString(j));
-                    element.setBindingAt(j, Binding.fromString(bindingsJSONArray.getString(j)));
+                    element.setBindingAt(j, binding);
                     if (!binding.isGamepad()) hasGamepadBinding = false;
                 }
 


### PR DESCRIPTION
Call setBindingCount before the binding loop so the element allocates the correct number of binding slots. Also reuse the already-parsed binding variable instead of parsing it a second time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ControlsProfile binding deserialization by allocating at least 4 binding slots before iterating and reusing the parsed binding object. Prevents index errors for directional elements and avoids redundant parsing.

- **Bug Fixes**
  - Call setBindingCount(Math.max(bindingsJSONArray.length(), 4)) before the loop to ensure the 4-slot minimum for D_PAD, STICK, and TRACKPAD.
  - Parse each binding once and pass it to setBindingAt.

<sup>Written for commit 1f80c78869f9ccf581b7f312ef0aeb0659260600. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved control profile loading for faster startup and more reliable recognition of gamepad and other input bindings when profiles are imported or refreshed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->