### PR TITLE
Add relative mouse movement toggle for containers

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/ControllerTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ControllerTab.kt
@@ -98,6 +98,13 @@ fun ControllerTabContent(state: ContainerConfigState, default: Boolean) {
             state = config.shooterMode,
             onCheckedChange = { state.config.value = config.copy(shooterMode = it) },
         )
+        SettingsSwitch(
+            colors = settingsTileColorsAlt(),
+            title = { Text(text = stringResource(R.string.relative_mouse_movement)) },
+            subtitle = { Text(text = stringResource(R.string.relative_mouse_movement_description)) },
+            state = config.relativeMouseMovement,
+            onCheckedChange = { state.config.value = config.copy(relativeMouseMovement = it) },
+        )
         SettingsListDropdown(
             colors = settingsTileColors(),
             title = { Text(text = stringResource(R.string.external_display_input)) },

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1657,6 +1657,14 @@ fun XServerScreen(
 
                 // Set container-level shooter mode
                 setContainerShooterMode(container.isShooterMode)
+
+                // Enable relative mouse movement for FPS-style games.
+                // Uses suppressCursorWarp flag which:
+                // 1) Disables CursorLocker (no edge-damping)
+                // 2) Skips WarpPointer (game's SetCursorPos is a no-op)
+                // 3) Routes touchpad deltas via WinHandler UDP as true
+                //    relative mouse_event calls to Wine
+                xServerView.getxServer().setSuppressCursorWarp(container.isRelativeMouseMovement)
             }
             PluviaApp.inputControlsView = icView
 

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -249,6 +249,8 @@ object ContainerUtils {
         val touchscreenMode = container.isTouchscreenMode()
         // Read shooter-mode flag from container
         val shooterMode = container.isShooterMode()
+        // Read relative mouse movement flag from container
+        val relativeMouseMovement = container.isRelativeMouseMovement()
         // Read gesture configuration JSON
         val gestureConfig = container.getGestureConfig()
         val externalDisplayMode = container.getExternalDisplayMode()
@@ -301,6 +303,7 @@ object ContainerUtils {
             disableMouseInput = disableMouse,
             touchscreenMode = touchscreenMode,
             shooterMode = shooterMode,
+            relativeMouseMovement = relativeMouseMovement,
             gestureConfig = gestureConfig,
             externalDisplayMode = externalDisplayMode,
             externalDisplaySwap = externalDisplaySwap,
@@ -464,6 +467,7 @@ object ContainerUtils {
         container.setDisableMouseInput(containerData.disableMouseInput)
         container.setTouchscreenMode(containerData.touchscreenMode)
         container.setShooterMode(containerData.shooterMode)
+        container.setRelativeMouseMovement(containerData.relativeMouseMovement)
         container.setGestureConfig(containerData.gestureConfig)
         container.setExternalDisplayMode(containerData.externalDisplayMode)
         container.setExternalDisplaySwap(containerData.externalDisplaySwap)

--- a/app/src/main/java/com/winlator/container/Container.java
+++ b/app/src/main/java/com/winlator/container/Container.java
@@ -128,6 +128,8 @@ public class Container {
     private boolean touchscreenMode = false;
     // Shooter mode
     private boolean shooterMode = true;
+    // Relative mouse movement (bypasses X11 pointer, sends deltas via WinHandler)
+    private boolean relativeMouseMovement = false;
     // Serialised JSON gesture configuration (used when touchscreenMode is true)
     private String gestureConfig = "";
     // External display input handling
@@ -678,6 +680,7 @@ public class Container {
             data.put("touchscreenMode", touchscreenMode);
             // Shooter mode flag
             data.put("shooterMode", shooterMode);
+            data.put("relativeMouseMovement", relativeMouseMovement);
             // Gesture configuration JSON
             if (gestureConfig != null && !gestureConfig.isEmpty()) {
                 data.put("gestureConfig", gestureConfig);
@@ -866,6 +869,9 @@ public class Container {
                     break;
                 case "shooterMode" :
                     setShooterMode(data.getBoolean(key));
+                    break;
+                case "relativeMouseMovement" :
+                    setRelativeMouseMovement(data.getBoolean(key));
                     break;
                 case "gestureConfig" :
                     setGestureConfig(data.optString(key, ""));
@@ -1067,6 +1073,15 @@ public class Container {
 
     public void setShooterMode(boolean shooterMode) {
         this.shooterMode = shooterMode;
+    }
+
+    // Relative mouse movement
+    public boolean isRelativeMouseMovement() {
+        return relativeMouseMovement;
+    }
+
+    public void setRelativeMouseMovement(boolean relativeMouseMovement) {
+        this.relativeMouseMovement = relativeMouseMovement;
     }
 
     // Gesture configuration JSON

--- a/app/src/main/java/com/winlator/container/ContainerData.kt
+++ b/app/src/main/java/com/winlator/container/ContainerData.kt
@@ -76,6 +76,8 @@ data class ContainerData(
     val touchscreenMode: Boolean = false,
     /** Shooter mode (auto-replace sticks with dynamic joysticks) **/
     val shooterMode: Boolean = true,
+    /** Relative mouse movement (bypasses X11 pointer, sends deltas via WinHandler) **/
+    val relativeMouseMovement: Boolean = false,
     /** Serialised JSON gesture configuration (used when touchscreenMode is true) **/
     val gestureConfig: String = "",
     /** External display input handling: off|touchpad|keyboard|hybrid **/
@@ -141,6 +143,7 @@ data class ContainerData(
                     "disableMouseInput" to state.disableMouseInput,
                     "touchscreenMode" to state.touchscreenMode,
                     "shooterMode" to state.shooterMode,
+                    "relativeMouseMovement" to state.relativeMouseMovement,
                     "gestureConfig" to state.gestureConfig,
                     "externalDisplayMode" to state.externalDisplayMode,
                     "externalDisplaySwap" to state.externalDisplaySwap,
@@ -202,6 +205,7 @@ data class ContainerData(
                     disableMouseInput = savedMap["disableMouseInput"] as Boolean,
                     touchscreenMode = savedMap["touchscreenMode"] as Boolean,
                     shooterMode = (savedMap["shooterMode"] as? Boolean) ?: true,
+                    relativeMouseMovement = (savedMap["relativeMouseMovement"] as? Boolean) ?: false,
                     gestureConfig = (savedMap["gestureConfig"] as? String) ?: "",
                     externalDisplayMode = (savedMap["externalDisplayMode"] as? String) ?: Container.DEFAULT_EXTERNAL_DISPLAY_MODE,
                     externalDisplaySwap = (savedMap["externalDisplaySwap"] as? Boolean) ?: false,

--- a/app/src/main/java/com/winlator/xserver/XServer.java
+++ b/app/src/main/java/com/winlator/xserver/XServer.java
@@ -5,6 +5,7 @@ import android.util.SparseArray;
 
 import com.winlator.core.CursorLocker;
 import com.winlator.renderer.GLRenderer;
+import com.winlator.winhandler.MouseEventFlags;
 import com.winlator.winhandler.WinHandler;
 import com.winlator.xserver.extensions.BigReqExtension;
 import com.winlator.xserver.extensions.DRI3Extension;
@@ -42,7 +43,8 @@ public class XServer {
     private GLRenderer renderer;
     private WinHandler winHandler;
     private final EnumMap<Lockable, ReentrantLock> locks = new EnumMap<>(Lockable.class);
-    private boolean relativeMouseMovement = false;
+    private volatile boolean relativeMouseMovement = false;
+    private volatile boolean suppressCursorWarp = false;
     private boolean simulateTouchScreen = false;
 
     public XServer(ScreenInfo screenInfo) {
@@ -68,8 +70,17 @@ public class XServer {
     }
 
     public void setRelativeMouseMovement(boolean relativeMouseMovement) {
-        cursorLocker.setEnabled(!relativeMouseMovement);
         this.relativeMouseMovement = relativeMouseMovement;
+        cursorLocker.setEnabled(!(relativeMouseMovement || suppressCursorWarp));
+    }
+
+    public boolean isSuppressCursorWarp() {
+        return suppressCursorWarp;
+    }
+
+    public void setSuppressCursorWarp(boolean suppressCursorWarp) {
+        this.suppressCursorWarp = suppressCursorWarp;
+        cursorLocker.setEnabled(!(relativeMouseMovement || suppressCursorWarp));
     }
 
     public boolean isSimulateTouchScreen() { return simulateTouchScreen; }
@@ -159,8 +170,12 @@ public class XServer {
     }
 
     public void injectPointerMoveDelta(int dx, int dy) {
-        try (XLock lock = lock(Lockable.WINDOW_MANAGER, Lockable.INPUT_DEVICE)) {
-            pointer.setPosition(pointer.getX() + dx, pointer.getY() + dy);
+        if (suppressCursorWarp && winHandler != null) {
+            winHandler.mouseEvent(MouseEventFlags.MOVE, dx, dy, 0);
+        } else {
+            try (XLock lock = lock(Lockable.WINDOW_MANAGER, Lockable.INPUT_DEVICE)) {
+                pointer.setPosition(pointer.getX() + dx, pointer.getY() + dy);
+            }
         }
     }
 

--- a/app/src/main/java/com/winlator/xserver/requests/WindowRequests.java
+++ b/app/src/main/java/com/winlator/xserver/requests/WindowRequests.java
@@ -317,7 +317,7 @@ public abstract class WindowRequests {
     }
 
     public static void warpPointer(XClient client, XInputStream inputStream, XOutputStream outputStream) throws IOException, XRequestError {
-        if (client.xServer.isRelativeMouseMovement()) {
+        if (client.xServer.isRelativeMouseMovement() || client.xServer.isSuppressCursorWarp()) {
             client.skipRequest();
             return;
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -673,6 +673,8 @@
     <string name="touchscreen_mode_description">For visual novels and RTS games</string>
     <string name="shooter_mode_toggle">Shooter Mode</string>
     <string name="shooter_mode_toggle_description">Auto-replace stick elements with dynamic joysticks</string>
+    <string name="relative_mouse_movement">Relative Mouse Movement</string>
+    <string name="relative_mouse_movement_description">Bypass X11 pointer tracking and send raw deltas to the game</string>
     <string name="shooter_mode_on">Enable Mouse</string>
     <string name="shooter_mode_off">Enable Sticks</string>
 


### PR DESCRIPTION
Add a per-container setting to enable relative mouse movement, which bypasses X11 pointer tracking and sends raw deltas to the game via WinHandler. This is useful for FPS-style games that need mouse capture.

Changes:
- Container.java: field, getter/setter, JSON serialization
- ContainerData.kt: property, toMap/fromMap
- ContainerUtils.kt: toContainerData/applyToContainer mapping
- ControllerTab.kt: SettingsSwitch UI toggle
- XServerScreen.kt: apply setting at launch
- strings.xml: label and description strings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-container toggle for relative mouse movement that bypasses X11 pointer warp and routes raw deltas through `WinHandler` for smoother FPS-style capture.

- **New Features**
  - Settings switch in controller tab with new strings.
  - Persisted in `Container`/`ContainerData` and mapped via `ContainerUtils`.
  - Applied on launch in `XServerScreen`; `XServer` sets `suppressCursorWarp` to disable `CursorLocker`, no-op `WarpPointer` (also in `WindowRequests`), and send relative moves via `MouseEventFlags.MOVE`.

<sup>Written for commit 325314c9a6908875ce3316239a5b5a7cd2c73bb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Relative Mouse Movement" toggle in controller settings with title and description; the setting is persisted per container.
* **Behavior / Bug Fixes**
  * Changing the toggle takes effect immediately in active sessions: the app now sends raw mouse deltas and can suppress cursor-warping to reduce pointer jumps and improve responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->