### PR TITLE
fix: defer intent launches until GOG/Epic/Amazon service is ready

### DIFF
--- a/app/src/main/java/app/gamenative/events/AndroidEvent.kt
+++ b/app/src/main/java/app/gamenative/events/AndroidEvent.kt
@@ -25,5 +25,6 @@ interface AndroidEvent<T> : Event<T> {
     data class CustomGameImagesFetched(val appId: String) : AndroidEvent<Unit>
     data class GOGAuthCodeReceived(val authCode: String) : AndroidEvent<Unit>
     data class EpicAuthCodeReceived(val authCode: String) : AndroidEvent<Unit>
+    data object ServiceReady : AndroidEvent<Unit>
     // data class SetAppBarVisibility(val visible: Boolean) : AndroidEvent<Unit>
 }

--- a/app/src/main/java/app/gamenative/service/amazon/AmazonService.kt
+++ b/app/src/main/java/app/gamenative/service/amazon/AmazonService.kt
@@ -746,6 +746,7 @@ class AmazonService : Service() {
         super.onCreate()
         instance = this
         PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
+        PluviaApp.events.emit(AndroidEvent.ServiceReady)
         Timber.i("[Amazon] Service created")
     }
 

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -503,6 +503,7 @@ class EpicService : Service() {
         // Initialize notification helper for foreground service
         notificationHelper = NotificationHelper(applicationContext)
         PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
+        PluviaApp.events.emit(AndroidEvent.ServiceReady)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -553,6 +553,7 @@ class GOGService : Service() {
         // Initialize notification helper for foreground service
         notificationHelper = NotificationHelper(applicationContext)
         PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
+        PluviaApp.events.emit(AndroidEvent.ServiceReady)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -118,6 +119,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
+private const val PENDING_LAUNCH_TIMEOUT_MS = 10_000L
+
 private fun NavHostController.navigateFromLoginIfNeeded(
     targetRoute: String,
     logTag: String = "PluviaMain",
@@ -198,22 +201,46 @@ private fun resolveGameAppId(context: Context, appId: String): GameResolutionRes
 }
 
 
-/** Steam game that needs login before launch (excludes offline-mode games) */
-private fun needsSteamLogin(context: Context, appId: String): Boolean {
+/** Check if launch should be deferred — Steam needs login, GOG/Epic/Amazon need service startup */
+private fun needsDeferLaunch(context: Context, appId: String): Boolean {
     val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
-    if (gameSource != GameSource.STEAM || SteamService.isLoggedIn) return false
-    // offline-mode games can launch without Steam
-    return try {
-        !ContainerUtils.getContainer(context, appId).isSteamOfflineMode()
-    } catch (_: Exception) {
-        true // no container → needs login
+    return when (gameSource) {
+        GameSource.STEAM -> {
+            if (SteamService.isLoggedIn) return false
+            try {
+                !ContainerUtils.getContainer(context, appId).isSteamOfflineMode()
+            } catch (_: Exception) {
+                true // no container → needs login
+            }
+        }
+        GameSource.GOG -> !GOGService.isRunning
+        GameSource.EPIC -> !EpicService.isRunning
+        GameSource.AMAZON -> !AmazonService.isRunning
+        else -> false
     }
 }
 
-/** Consume pending launch request only if it's a Steam game needing login, and show failure snackbar. */
-private fun consumePendingLaunchWithError(context: Context) {
+/** Show snackbar for a deferred launch based on the game's source. Returns true if shown. */
+private fun showDeferredLaunchSnackbar(context: Context, appId: String): Boolean {
+    val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
+    return when {
+        gameSource == GameSource.STEAM && SteamService.isConnected -> {
+            SnackbarManager.show(context.getString(R.string.intent_launch_steam_pending))
+            true
+        }
+        gameSource != GameSource.STEAM -> {
+            SnackbarManager.show(context.getString(R.string.intent_launch_service_pending))
+            true
+        }
+        else -> false
+    }
+}
+
+/** Consume pending launch request only if it's a Steam login failure, and show failure snackbar. */
+private fun consumePendingSteamLoginError(context: Context) {
     val request = MainActivity.peekPendingLaunchRequest() ?: return
-    if (!needsSteamLogin(context, request.appId)) return
+    val gameSource = ContainerUtils.extractGameSourceFromContainerId(request.appId)
+    if (gameSource != GameSource.STEAM || SteamService.isLoggedIn) return
     MainActivity.consumePendingLaunchRequest()
     SnackbarManager.show(context.getString(R.string.intent_launch_steam_login_failed))
 }
@@ -258,6 +285,8 @@ fun PluviaMain(
 
     var isConnecting by rememberSaveable { mutableStateOf(false) }
     var shownPendingLaunchSnackbar by rememberSaveable { mutableStateOf(false) }
+    // incremented each time a launch is deferred, so the timeout restarts per request
+    var pendingLaunchGeneration by rememberSaveable { mutableIntStateOf(0) }
 
     var gameBackAction by remember { mutableStateOf<() -> Unit?>({}) }
 
@@ -297,17 +326,13 @@ fun PluviaMain(
     LaunchedEffect(Unit) {
         MainActivity.consumePendingLaunchRequest()?.let { launchRequest ->
             Timber.i("[PluviaMain]: Processing pending launch request for app ${launchRequest.appId}")
-            // Steam games needing login will be handled by OnLogonEnded/SteamDisconnected.
+            // defer if service isn't ready yet — will be processed on ServiceReady/OnLogonEnded
             // consume+requeue is safe: both calls are non-suspending, so no other coroutine
             // can interleave between them on the main dispatcher (cooperative scheduling).
-            if (needsSteamLogin(context, launchRequest.appId)) {
+            if (needsDeferLaunch(context, launchRequest.appId)) {
                 MainActivity.setPendingLaunchRequest(launchRequest)
-                shownPendingLaunchSnackbar = false
-                // stay quiet on first pass; snackbar shows after a failure
-                if (SteamService.isConnected) {
-                    shownPendingLaunchSnackbar = true
-                    SnackbarManager.show(context.getString(R.string.intent_launch_steam_pending))
-                }
+                pendingLaunchGeneration++
+                shownPendingLaunchSnackbar = showDeferredLaunchSnackbar(context, launchRequest.appId)
                 return@let
             }
             when (val resolution = resolveGameAppId(context, launchRequest.appId)) {
@@ -348,6 +373,70 @@ fun PluviaMain(
         }
     }
 
+    // timeout stale pending requests — if service never starts, don't hang indefinitely
+    // keyed on generation so timeout restarts each time a new request is deferred
+    LaunchedEffect(pendingLaunchGeneration) {
+        if (pendingLaunchGeneration == 0) return@LaunchedEffect
+        delay(PENDING_LAUNCH_TIMEOUT_MS)
+        MainActivity.peekPendingLaunchRequest()?.let { request ->
+            if (needsDeferLaunch(context, request.appId)) {
+                Timber.tag("IntentLaunch").w("Pending launch timed out for ${request.appId}")
+                MainActivity.consumePendingLaunchRequest()
+                SnackbarManager.show(context.getString(R.string.intent_launch_service_timeout))
+            }
+        }
+    }
+
+    // shared handler for deferred intent launches (Steam login, GOG/Epic/Amazon service startup)
+    val processPendingLaunch: (String) -> Unit = { reason ->
+        MainActivity.consumePendingLaunchRequest()?.let { launchRequest ->
+            Timber.tag("IntentLaunch")
+                .i("Processing pending launch for ${launchRequest.appId} ($reason)")
+            when (val resolution = resolveGameAppId(context, launchRequest.appId)) {
+                is GameResolutionResult.NotFound -> {
+                    val appName = ContainerUtils.resolveGameName(resolution.originalAppId)
+                    Timber.tag("IntentLaunch").w("Game not installed: $appName (${launchRequest.appId})")
+                    msgDialogState = MessageDialogState(
+                        visible = true,
+                        type = DialogType.SYNC_FAIL,
+                        title = context.getString(R.string.game_not_installed_title),
+                        message = context.getString(R.string.game_not_installed_message, appName),
+                        dismissBtnText = context.getString(R.string.ok),
+                    )
+                }
+
+                is GameResolutionResult.Success -> {
+                    if (launchRequest.containerConfig != null) {
+                        IntentLaunchManager.applyTemporaryConfigOverride(
+                            context, launchRequest.appId, launchRequest.containerConfig,
+                        )
+                    }
+                    val homeRoute = PluviaScreen.Home.route + "?offline={offline}"
+                    if (navController.currentDestination?.route != homeRoute) {
+                        navController.navigate(PluviaScreen.Home.route + "?offline=false") {
+                            popUpTo(navController.graph.startDestinationId) { saveState = false }
+                        }
+                    }
+                    MainActivity.wasLaunchedViaExternalIntent = true
+                    // finalAppId — track what actually launched (may differ from launchRequest.appId after resolution)
+                    trackGameLaunched(resolution.finalAppId)
+                    viewModel.setLaunchedAppId(resolution.finalAppId)
+                    viewModel.setBootToContainer(false)
+                    preLaunchApp(
+                        context = context,
+                        appId = resolution.finalAppId,
+                        useTemporaryOverride = launchRequest.containerConfig != null,
+                        setLoadingDialogVisible = viewModel::setLoadingDialogVisible,
+                        setLoadingProgress = viewModel::setLoadingDialogProgress,
+                        setLoadingMessage = viewModel::setLoadingDialogMessage,
+                        setMessageDialogState = setMessageDialogState,
+                        onSuccess = viewModel::launchApp,
+                    )
+                }
+            }
+        }
+    }
+
     LaunchedEffect(Unit) {
         viewModel.uiEvent.collect { event ->
             when (event) {
@@ -358,8 +447,8 @@ fun PluviaMain(
                 is MainViewModel.MainUiEvent.ExternalGameLaunch -> {
                     Timber.i("[PluviaMain]: Received ExternalGameLaunch UI event for app ${event.appId}")
 
-                    // Steam games need login before launch (cloud sync uses userSteamId)
-                    if (needsSteamLogin(context, event.appId)) {
+                    // defer if service isn't ready yet
+                    if (needsDeferLaunch(context, event.appId)) {
                         // preserve any container config override already applied by handleLaunchIntent
                         MainActivity.setPendingLaunchRequest(
                             IntentLaunchManager.LaunchRequest(
@@ -367,11 +456,8 @@ fun PluviaMain(
                                 containerConfig = IntentLaunchManager.getTemporaryOverride(event.appId),
                             )
                         )
-                        shownPendingLaunchSnackbar = false
-                        if (SteamService.isConnected) {
-                            shownPendingLaunchSnackbar = true
-                            SnackbarManager.show(context.getString(R.string.intent_launch_steam_pending))
-                        }
+                        pendingLaunchGeneration++
+                        shownPendingLaunchSnackbar = showDeferredLaunchSnackbar(context, event.appId)
                         return@collect
                     }
 
@@ -434,62 +520,10 @@ fun PluviaMain(
                 is MainViewModel.MainUiEvent.OnLogonEnded -> {
                     when (event.result) {
                         LoginResult.Success -> {
-                            if (MainActivity.hasPendingLaunchRequest()) {
-                                MainActivity.consumePendingLaunchRequest()?.let { launchRequest ->
-                                    Timber.tag("IntentLaunch")
-                                        .i("Processing pending launch request for app ${launchRequest.appId} (user is now logged in)")
-                                    when (val resolution = resolveGameAppId(context, launchRequest.appId)) {
-                                        is GameResolutionResult.NotFound -> {
-                                            val appName = ContainerUtils.resolveGameName(resolution.originalAppId)
-                                            Timber.tag("IntentLaunch").w("Game not installed: $appName (${launchRequest.appId})")
-                                            msgDialogState = MessageDialogState(
-                                                visible = true,
-                                                type = DialogType.SYNC_FAIL,
-                                                title = context.getString(R.string.game_not_installed_title),
-                                                message = context.getString(R.string.game_not_installed_message, appName),
-                                                dismissBtnText = context.getString(R.string.ok),
-                                            )
-                                            return@let
-                                        }
-
-                                        is GameResolutionResult.Success -> {
-                                            if (launchRequest.containerConfig != null) {
-                                                IntentLaunchManager.applyTemporaryConfigOverride(
-                                                    context,
-                                                    launchRequest.appId,
-                                                    launchRequest.containerConfig,
-                                                )
-                                                Timber.tag("IntentLaunch")
-                                                    .i("Applied container config override for app ${launchRequest.appId}")
-                                            }
-
-                                            // Navigate to Home if not already there (for pending launch requests)
-                                            if (navController.currentDestination?.route != PluviaScreen.Home.route) {
-                                                navController.navigate(PluviaScreen.Home.route) {
-                                                    popUpTo(navController.graph.startDestinationId) {
-                                                        saveState = false
-                                                    }
-                                                }
-                                            }
-
-                                            MainActivity.wasLaunchedViaExternalIntent = true
-                                            trackGameLaunched(launchRequest.appId)
-                                            viewModel.setLaunchedAppId(launchRequest.appId)
-                                            viewModel.setBootToContainer(false)
-                                            preLaunchApp(
-                                                context = context,
-                                                appId = launchRequest.appId,
-                                                useTemporaryOverride = launchRequest.containerConfig != null,
-                                                setLoadingDialogVisible = viewModel::setLoadingDialogVisible,
-                                                setLoadingProgress = viewModel::setLoadingDialogProgress,
-                                                setLoadingMessage = viewModel::setLoadingDialogMessage,
-                                                setMessageDialogState = setMessageDialogState,
-                                                onSuccess = viewModel::launchApp,
-                                            )
-                                        }
-                                    }
-                                }
-                            } else if (PluviaApp.xEnvironment == null) {
+                            val pending = MainActivity.peekPendingLaunchRequest()
+                            if (pending != null && !needsDeferLaunch(context, pending.appId)) {
+                                processPendingLaunch("user is now logged in")
+                            } else if (pending == null && PluviaApp.xEnvironment == null) {
                                 val currentRoute = navController.currentDestination?.route
                                 val targetRoute = viewModel.getPersistedRoute() ?: PluviaScreen.Home.route
                                 if (currentRoute == PluviaScreen.LoginUser.route) {
@@ -510,7 +544,7 @@ fun PluviaMain(
 
                         LoginResult.Failed -> {
                             Timber.i("Login failed: ${event.result}")
-                            consumePendingLaunchWithError(context)
+                            consumePendingSteamLoginError(context)
                         }
 
                         else -> {
@@ -522,13 +556,20 @@ fun PluviaMain(
                 is MainViewModel.MainUiEvent.SteamDisconnected -> {
                     if (event.isTerminal) {
                         shownPendingLaunchSnackbar = false
-                        consumePendingLaunchWithError(context)
+                        consumePendingSteamLoginError(context)
                     } else if (!shownPendingLaunchSnackbar) {
                         val appId = MainActivity.peekPendingLaunchRequest()?.appId
-                        if (appId != null && needsSteamLogin(context, appId)) {
+                        if (appId != null && needsDeferLaunch(context, appId)) {
                             shownPendingLaunchSnackbar = true
                             SnackbarManager.show(context.getString(R.string.intent_launch_steam_pending))
                         }
+                    }
+                }
+
+                MainViewModel.MainUiEvent.ServiceReady -> {
+                    val pending = MainActivity.peekPendingLaunchRequest()
+                    if (pending != null && !needsDeferLaunch(context, pending.appId)) {
+                        processPendingLaunch("service now ready")
                     }
                 }
 

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -65,6 +65,7 @@ class MainViewModel @Inject constructor(
         data class SteamDisconnected(val isTerminal: Boolean) : MainUiEvent()
         data object ShowDiscordSupportDialog : MainUiEvent()
         data class ShowGameFeedbackDialog(val appId: String) : MainUiEvent()
+        data object ServiceReady : MainUiEvent()
     }
 
     private val _state = MutableStateFlow(MainState())
@@ -198,6 +199,12 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    private val onServiceReady: (AndroidEvent.ServiceReady) -> Unit = {
+        viewModelScope.launch {
+            _uiEvent.send(MainUiEvent.ServiceReady)
+        }
+    }
+
     private val onSetBootingSplashText: (AndroidEvent.SetBootingSplashText) -> Unit = {
         setBootingSplashText(it.text)
         setShowBootingSplash(true)
@@ -243,6 +250,7 @@ class MainViewModel @Inject constructor(
         PluviaApp.events.on<SteamEvent.LogonStarted, Unit>(onLoggingIn)
         PluviaApp.events.on<SteamEvent.LogonEnded, Unit>(onLogonEnded)
         PluviaApp.events.on<SteamEvent.LoggedOut, Unit>(onLoggedOut)
+        PluviaApp.events.on<AndroidEvent.ServiceReady, Unit>(onServiceReady)
 
         // Collect theme preferences
         viewModelScope.launch {
@@ -268,6 +276,7 @@ class MainViewModel @Inject constructor(
         PluviaApp.events.off<SteamEvent.LogonStarted, Unit>(onLoggingIn)
         PluviaApp.events.off<SteamEvent.LogonEnded, Unit>(onLogonEnded)
         PluviaApp.events.off<SteamEvent.LoggedOut, Unit>(onLoggedOut)
+        PluviaApp.events.off<AndroidEvent.ServiceReady, Unit>(onServiceReady)
         connectionTimeoutJob?.cancel()
     }
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -95,7 +95,9 @@
     <string name="game_not_installed_message">%s er ikke installeret. Installér spillet før du starter det.</string>
     <string name="intent_launch_failed">Kunne ikke starte spillet: ugyldig startgenvej</string>
     <string name="intent_launch_steam_pending">Spillet starter, når Steam opretter forbindelse</string>
+    <string name="intent_launch_service_pending">Spillet starter, når tjenesten er klar</string>
     <string name="intent_launch_steam_login_failed">Steam-login mislykkedes — spilstart annulleret</string>
+    <string name="intent_launch_service_timeout">Spiltjenesten kunne ikke starte — spilstart annulleret</string>
     <string name="game_executable_not_found_title">Kan ikke starte</string>
     <string name="game_executable_not_found">Den eksekverbare fil kunne ikke vælges automatisk. Angiv stien til den eksekverbare fil i containerindstillinger.</string>
     <string name="save_container_settings_title">Gem containerkonfiguration?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -160,7 +160,9 @@
     <string name="game_not_installed_message">%s ist nicht installiert. Bitte installiere das Spiel, bevor du es startest.</string>
     <string name="intent_launch_failed">Spiel konnte nicht gestartet werden: ungültige Startverknüpfung</string>
     <string name="intent_launch_steam_pending">Spiel wird gestartet, sobald Steam verbunden ist</string>
+    <string name="intent_launch_service_pending">Spiel wird gestartet, sobald der Dienst bereit ist</string>
     <string name="intent_launch_steam_login_failed">Steam-Anmeldung fehlgeschlagen — Spielstart abgebrochen</string>
+    <string name="intent_launch_service_timeout">Spieldienst konnte nicht gestartet werden — Spielstart abgebrochen</string>
     <string name="game_executable_not_found_title">Start nicht möglich</string>
     <string name="game_executable_not_found">Die ausführbare Datei konnte nicht automatisch ausgewählt werden. Bitte lege den Pfad in den Containereinstellungen fest.</string>
     <string name="save_container_settings_title">Container-Konfiguration speichern?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -182,7 +182,9 @@
     <string name="game_not_installed_message">%s no está instalado. Instala el juego antes de iniciarlo.</string>
     <string name="intent_launch_failed">No se pudo iniciar el juego: acceso directo de inicio no válido</string>
     <string name="intent_launch_steam_pending">El juego se iniciará cuando Steam se conecte</string>
+    <string name="intent_launch_service_pending">El juego se iniciará cuando el servicio esté listo</string>
     <string name="intent_launch_steam_login_failed">Error de inicio de sesión en Steam — lanzamiento del juego cancelado</string>
+    <string name="intent_launch_service_timeout">El servicio del juego no pudo iniciarse — lanzamiento del juego cancelado</string>
     <string name="game_executable_not_found_title">No se puede iniciar</string>
     <string name="game_executable_not_found">No se pudo seleccionar automáticamente el ejecutable. Establece la ruta en los ajustes del contenedor.</string>
     <string name="save_container_settings_title">Guardar configuración del contenedor</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -167,7 +167,9 @@
     <string name="game_not_installed_message">%s n\'est pas installé. Veuillez installer le jeu avant de le lancer.</string>
     <string name="intent_launch_failed">Impossible de lancer le jeu : raccourci de lancement invalide</string>
     <string name="intent_launch_steam_pending">Le jeu se lancera une fois Steam connecté</string>
+    <string name="intent_launch_service_pending">Le jeu se lancera une fois le service prêt</string>
     <string name="intent_launch_steam_login_failed">Échec de la connexion Steam — lancement du jeu annulé</string>
+    <string name="intent_launch_service_timeout">Échec du démarrage du service de jeu — lancement du jeu annulé</string>
     <string name="game_executable_not_found_title">Impossible de lancer</string>
     <string name="game_executable_not_found">L\'exécutable n\'a pas pu être sélectionné automatiquement. Veuillez définir le chemin de l\'exécutable dans les paramètres du conteneur.</string>
     <string name="save_container_settings_title">Enregistrer la configuration du conteneur ?</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -171,7 +171,9 @@
     <string name="game_not_installed_message">%s non è installato. Installa prima il gioco per avviarlo.</string>
     <string name="intent_launch_failed">Impossibile avviare il gioco: collegamento di avvio non valido</string>
     <string name="intent_launch_steam_pending">Il gioco verrà avviato quando Steam si connette</string>
+    <string name="intent_launch_service_pending">Il gioco verrà avviato quando il servizio è pronto</string>
     <string name="intent_launch_steam_login_failed">Accesso a Steam non riuscito — avvio del gioco annullato</string>
+    <string name="intent_launch_service_timeout">Avvio del servizio di gioco non riuscito — avvio del gioco annullato</string>
     <string name="game_executable_not_found_title">Impossibile avviare</string>
     <string name="game_executable_not_found">L\'eseguibile non è stato selezionato automaticamente. Imposta il percorso dell\'eseguibile nelle impostazioni del Container.</string>
     <string name="save_container_settings_title">Salvare Configurazione Container?</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -180,7 +180,9 @@
     <string name="game_not_installed_message">%s이(가) 설치되지 않았습니다. 실행하기 전에 먼저 게임을 설치하세요.</string>
     <string name="intent_launch_failed">게임을 실행할 수 없습니다: 잘못된 실행 바로가기</string>
     <string name="intent_launch_steam_pending">Steam 연결 시 게임이 실행됩니다</string>
+    <string name="intent_launch_service_pending">서비스 준비 시 게임이 실행됩니다</string>
     <string name="intent_launch_steam_login_failed">Steam 로그인 실패 — 게임 실행이 취소되었습니다</string>
+    <string name="intent_launch_service_timeout">게임 서비스 시작 실패 — 게임 실행이 취소되었습니다</string>
     <string name="game_executable_not_found_title">실행할 수 없음</string>
     <string name="game_executable_not_found">실행 파일을 자동으로 선택할 수 없습니다. 컨테이너 설정에서 실행 파일 경로를 지정하세요.</string>
     <string name="save_container_settings_title">컨테이너 구성을 저장하시겠습니까?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -179,7 +179,9 @@
     <string name="game_not_installed_message">%s nie jest zainstalowana. Proszę zainstalować grę przed uruchomieniem.</string>
     <string name="intent_launch_failed">Nie udało się uruchomić gry: nieprawidłowy skrót uruchamiania</string>
     <string name="intent_launch_steam_pending">Gra zostanie uruchomiona po połączeniu ze Steam</string>
+    <string name="intent_launch_service_pending">Gra zostanie uruchomiona po uruchomieniu usługi</string>
     <string name="intent_launch_steam_login_failed">Logowanie do Steam nie powiodło się — uruchomienie gry anulowane</string>
+    <string name="intent_launch_service_timeout">Nie udało się uruchomić usługi gry — uruchomienie gry anulowane</string>
     <string name="game_executable_not_found_title">Nie można uruchomić</string>
     <string name="game_executable_not_found">Nie udało się automatycznie wybrać pliku wykonywalnego. Ustaw ścieżkę do pliku wykonywalnego w ustawieniach kontenera.</string>
     <string name="save_container_settings_title">Zapisać konfigurację kontenera?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -95,7 +95,9 @@
     <string name="game_not_installed_message">%s não está instalado. Por favor instale o jogo primeiro antes de iniciar.</string>
     <string name="intent_launch_failed">Não foi possível iniciar o jogo: atalho de inicialização inválido</string>
     <string name="intent_launch_steam_pending">O jogo será iniciado quando o Steam se conectar</string>
+    <string name="intent_launch_service_pending">O jogo será iniciado quando o serviço estiver pronto</string>
     <string name="intent_launch_steam_login_failed">Falha no login do Steam — inicialização do jogo cancelada</string>
+    <string name="intent_launch_service_timeout">Falha ao iniciar o serviço do jogo — inicialização do jogo cancelada</string>
     <string name="game_executable_not_found_title">Não é possível iniciar</string>
     <string name="game_executable_not_found">O executável não pôde ser selecionado automaticamente. Defina o caminho do executável nas configurações do contêiner.</string>
     <string name="save_container_settings_title">Salvar configuração do contêiner?</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -169,7 +169,9 @@
     <string name="game_not_installed_message">%s nu este instalat. Instalează jocul înainte de a-l porni.</string>
     <string name="intent_launch_failed">Nu s-a putut lansa jocul: comandă rapidă de lansare invalidă</string>
     <string name="intent_launch_steam_pending">Jocul va fi lansat când Steam se conectează</string>
+    <string name="intent_launch_service_pending">Jocul va fi lansat când serviciul este pregătit</string>
     <string name="intent_launch_steam_login_failed">Autentificarea Steam a eșuat — lansarea jocului a fost anulată</string>
+    <string name="intent_launch_service_timeout">Serviciul de joc nu a pornit — lansarea jocului a fost anulată</string>
     <string name="game_executable_not_found_title">Nu se poate porni</string>
     <string name="game_executable_not_found">Executabilul nu a putut fi selectat automat. Setează calea executabilului în setările containerului.</string>
     <string name="save_container_settings_title">Salvezi configurația containerului?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -431,7 +431,9 @@
     <string name="game_not_installed_message">%s не установлена. Пожалуйста, установите игру перед запуском.</string>
     <string name="intent_launch_failed">Не удалось запустить игру: недействительный ярлык запуска</string>
     <string name="intent_launch_steam_pending">Игра запустится после подключения к Steam</string>
+    <string name="intent_launch_service_pending">Игра запустится после запуска сервиса</string>
     <string name="intent_launch_steam_login_failed">Ошибка входа в Steam — запуск игры отменён</string>
+    <string name="intent_launch_service_timeout">Не удалось запустить игровой сервис — запуск игры отменён</string>
     <string name="game_not_installed_title">Игра не установлена</string>
     <string name="game_options_cloud_saves">Облачные сохранения</string>
     <string name="game_options_container">Контейнер</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -163,7 +163,9 @@
     <string name="game_not_installed_message">Гра %s не інстальована. Будь ласка, інсталюйте гру перед запуском.</string>
     <string name="intent_launch_failed">Не вдалося запустити гру: недійсний ярлик запуску</string>
     <string name="intent_launch_steam_pending">Гра запуститься після підключення до Steam</string>
+    <string name="intent_launch_service_pending">Гра запуститься після запуску сервісу</string>
     <string name="intent_launch_steam_login_failed">Помилка входу в Steam — запуск гри скасовано</string>
+    <string name="intent_launch_service_timeout">Не вдалося запустити ігровий сервіс — запуск гри скасовано</string>
     <string name="game_executable_not_found_title">Неможливо запустити</string>
     <string name="game_executable_not_found">Виконуваний файл не вдалося вибрати автоматично. Вкажіть шлях до виконуваного файлу в налаштуваннях контейнера.</string>
     <string name="save_container_settings_title">Зберегти налаштування контейнера?</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -166,7 +166,9 @@
     <string name="game_not_installed_message">%s 未安装，请在启动前先安装游戏</string>
     <string name="intent_launch_failed">无法启动游戏：启动快捷方式无效</string>
     <string name="intent_launch_steam_pending">Steam 连接后将启动游戏</string>
+    <string name="intent_launch_service_pending">服务就绪后将启动游戏</string>
     <string name="intent_launch_steam_login_failed">Steam 登录失败 — 游戏启动已取消</string>
+    <string name="intent_launch_service_timeout">游戏服务启动失败 — 游戏启动已取消</string>
     <string name="game_executable_not_found_title">无法启动</string>
     <string name="game_executable_not_found">无法自动选择可执行文件。请在容器设置中指定可执行文件路径。</string>
     <string name="save_container_settings_title">保存容器配置？</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -166,7 +166,9 @@
     <string name="game_not_installed_message">%s 未安裝, 請在啟動前先安裝遊戲</string>
     <string name="intent_launch_failed">無法啟動遊戲：啟動捷徑無效</string>
     <string name="intent_launch_steam_pending">Steam 連線後將啟動遊戲</string>
+    <string name="intent_launch_service_pending">服務就緒後將啟動遊戲</string>
     <string name="intent_launch_steam_login_failed">Steam 登入失敗 — 遊戲啟動已取消</string>
+    <string name="intent_launch_service_timeout">遊戲服務啟動失敗 — 遊戲啟動已取消</string>
     <string name="game_executable_not_found_title">無法啟動</string>
     <string name="game_executable_not_found">無法自動選擇可執行檔。請在容器配置中指定可執行檔路徑。</string>
     <string name="save_container_settings_title">保存容器配置?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,7 +182,9 @@
     <string name="game_not_installed_message">%s is not installed. Please install the game first before launching.</string>
     <string name="intent_launch_failed">Could not launch game: invalid launch shortcut</string>
     <string name="intent_launch_steam_pending">Game will launch when Steam connects</string>
+    <string name="intent_launch_service_pending">Game will launch when service is ready</string>
     <string name="intent_launch_steam_login_failed">Steam login failed — game launch cancelled</string>
+    <string name="intent_launch_service_timeout">Game service failed to start — game launch cancelled</string>
     <string name="game_executable_not_found_title">Cannot Launch</string>
     <string name="game_executable_not_found">The executable could not be auto-selected. Please set the executable path in container settings.</string>
     <string name="save_container_settings_title">Save Container Configuration?</string>


### PR DESCRIPTION
Closes #986

## Summary
- Generalize `needsSteamLogin` → `needsDeferLaunch` to cover all game sources: Steam (login), GOG/Epic/Amazon (service startup)
- Add `AndroidEvent.ServiceReady` emitted from each non-Steam service's `onCreate`, routed through `MainViewModel` → `PluviaMain`
- Extract duplicated launch logic into shared `processPendingLaunch` handler (was inlined in `OnLogonEnded`)
- Add 10s timeout for stale pending requests so the app doesn't hang if a service never starts
- i18n: new `intent_launch_service_timeout` string across all 15 locales

## Background
We've been iterating on the intent launch deferral system — it originally only handled Steam games needing login before launch. This left a gap: GOG, Epic, and Amazon games hit the same race condition (intent arrives before the foreground service is running) but had no deferral mechanism, causing silent launch failures.

## Test plan
- [ ] Launch GOG game via home screen shortcut with app cold-started — should defer and launch after service ready
- [ ] Same for Epic and Amazon games
- [ ] Steam intent launch still works (login deferral unchanged)
- [ ] Kill service before timeout elapses — verify timeout snackbar appears after 10s
- [ ] Normal in-app launch unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cold-start failures for external game intents by waiting for Steam login or GOG/Epic/Amazon services before launching. Adds a per-request 10s timeout and clearer snackbar messages.

- **Bug Fixes**
  - Defer intent launches until preconditions are met; emit ServiceReady from each service and process pending launches in `MainViewModel` → `PluviaMain`.
  - Show store-appropriate pending snackbar (Steam vs generic service) and a timeout snackbar if a service never starts.
  - Fix Home navigation route when resuming a pending launch to include the `offline` parameter.

- **Refactors**
  - Extract shared pending-launch handler and rename needsSteamLogin → needsDeferLaunch.
  - i18n: add `intent_launch_service_pending` and `intent_launch_service_timeout` across all locales.

<sup>Written for commit c794dd2a718ccb3e3dd2a737eec692dfe842344f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Services now emit a readiness signal; pending game launches defer until required services are ready and resume automatically.
  * Deferred launches include a shared resolution path and a 10s generation-scoped timeout to avoid indefinite waits; timeout shows a cancel message.

* **Localization**
  * Added pending/timeout launch messages for the service-ready flow across multiple languages (16 locales).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->