### PR TITLE
fix: correct FEX_SMC_CHECKS env var to FEX_SMCCHECKS

### DIFF
--- a/app/src/main/assets/fexcore_env_vars.json
+++ b/app/src/main/assets/fexcore_env_vars.json
@@ -8,7 +8,7 @@
   {"name" : "FEX_MAXINST", "values" : ["5000"], "editText" : true, "defaultValue" : "5000"},
   {"name" : "FEX_HOSTFEATURES", "values" : ["enablesve", "disablesve", "enableavx", "disableavx", "off"], "defaultValue" : "off"},
   {"name" : "FEX_SMALLTSCSCALE", "values" : ["0", "1"], "toggleswitch" : true, "defaultValue" : "1"},
-  {"name" : "FEX_SMC_CHECKS", "values" : ["none", "mtrack", "full"], "defaultValue" : "mtrack"},
+  {"name" : "FEX_SMCCHECKS", "values" : ["none", "mtrack", "full"], "defaultValue" : "mtrack"},
   {"name" : "FEX_VOLATILEMETADATA", "values" : ["0", "1"], "toggleswitch" : true, "defaultValue" : "1"},
   {"name" : "FEX_MONOHACKS", "values" : ["0", "1"], "toggleswitch" : true, "defaultValue" : "1"},
   {"name" : "FEX_HIDEHYPERVISORBIT", "values" : ["0", "1"], "toggleswitch" : true, "defaultValue" : "0"},

--- a/app/src/main/java/com/winlator/core/envvars/EnvVarInfo.kt
+++ b/app/src/main/java/com/winlator/core/envvars/EnvVarInfo.kt
@@ -137,8 +137,8 @@ data class EnvVarInfo(
                 selectionType = EnvVarSelectionType.TOGGLE,
                 possibleValues = listOf("0", "1"),
             ),
-            "FEX_SMC_CHECKS" to EnvVarInfo(
-                identifier = "FEX_SMC_CHECKS",
+            "FEX_SMCCHECKS" to EnvVarInfo(
+                identifier = "FEX_SMCCHECKS",
                 possibleValues = listOf("none", "mtrack", "full"),
             ),
             "FEX_VOLATILEMETADATA" to EnvVarInfo(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -444,7 +444,7 @@
     <string name="fexcore_env_var_help__multiblock">Aktiviert Multiblock-Codekompilierung. Kann längere Kompilierzeiten und Ruckler verursachen.</string>
     <string name="fexcore_env_var_help__hostfeatures">Steuert CPU-Feature-Emulation/Erzwingung.</string>
     <string name="fexcore_env_var_help__smalltscscale">TSC auf langsamen Systemen skalieren.</string>
-    <string name="fexcore_env_var_help__smc_checks">Checks für sich selbst modifizierenden Code (SMC).</string>
+    <string name="fexcore_env_var_help__smcchecks">Checks für sich selbst modifizierenden Code (SMC).</string>
     <string name="fexcore_env_var_help__volatilemetadata">Verwendet volatile Metadaten aus PE-Dateien für TSO, falls verfügbar.</string>
     <string name="fexcore_env_var_help__monohacks">Spezielle SMC+JIT-Block-Hacks für Mono-Erkennung.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Hypervisor-Bit in CPUID verstecken (bei Crashs von Apps mit Hypervisor).</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -505,7 +505,7 @@
     <string name="fexcore_env_var_help__multiblock">Habilita la compilación de código multibloque. Puede causar una compilación JIT más larga y tirones.</string>
     <string name="fexcore_env_var_help__hostfeatures">Controla el forzado de características de la CPU.</string>
     <string name="fexcore_env_var_help__smalltscscale">Escala el TSC en sistemas de baja frecuencia.</string>
-    <string name="fexcore_env_var_help__smc_checks">Comprobaciones de código automodificable (SMC).</string>
+    <string name="fexcore_env_var_help__smcchecks">Comprobaciones de código automodificable (SMC).</string>
     <string name="fexcore_env_var_help__volatilemetadata">Usa metadatos volátiles de archivos PE para TSO cuando estén disponibles.</string>
     <string name="fexcore_env_var_help__monohacks">Hacks especiales de bloques SMC + JIT para la detección de Mono.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Oculta el bit de hipervisor de CPUID (útil para aplicaciones que fallan con él).</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -457,7 +457,7 @@
     <string name="fexcore_env_var_help__multiblock">Active la compilation de code multibloc. Peut causer une compilation JIT plus longue et des saccades.</string>
     <string name="fexcore_env_var_help__hostfeatures">Contrôle le forçage des fonctionnalités CPU.</string>
     <string name="fexcore_env_var_help__smalltscscale">Met à l\'échelle TSC sur les systèmes à basse fréquence.</string>
-    <string name="fexcore_env_var_help__smc_checks">Vérifications de code auto-modifiable.</string>
+    <string name="fexcore_env_var_help__smcchecks">Vérifications de code auto-modifiable.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Utilise les métadonnées volatiles des fichiers PE pour TSO lorsqu\'elles sont disponibles.</string>
     <string name="fexcore_env_var_help__monohacks">Hacks spéciaux SMC + bloc JIT pour la détection Mono.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Masque le bit hyperviseur CPUID (utile pour les applications qui plantent avec).</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -461,7 +461,7 @@
     <string name="fexcore_env_var_help__multiblock">Abilita compilazione codice multiblocco. Può causare compilazione JIT più lunga e stuttering.</string>
     <string name="fexcore_env_var_help__hostfeatures">Controlla forzatura funzionalità CPU.</string>
     <string name="fexcore_env_var_help__smalltscscale">Scala TSC su sistemi a bassa frequenza.</string>
-    <string name="fexcore_env_var_help__smc_checks">Controlli Codice Auto-Modificante (SMC).</string>
+    <string name="fexcore_env_var_help__smcchecks">Controlli Codice Auto-Modificante (SMC).</string>
     <string name="fexcore_env_var_help__volatilemetadata">Usa metadati volatili dai file PE per TSO quando disponibili.</string>
     <string name="fexcore_env_var_help__monohacks">Hack speciali blocco SMC + JIT per rilevamento Mono.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Nasconde bit hypervisor CPUID (utile per app che crashano con esso).</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -470,7 +470,7 @@
     <string name="fexcore_env_var_help__multiblock">멀티블록 코드 컴파일을 활성화합니다. JIT 컴파일 시간이 길어지고 끊김이 발생할 수 있습니다.</string>
     <string name="fexcore_env_var_help__hostfeatures">CPU 기능 강제를 제어합니다.</string>
     <string name="fexcore_env_var_help__smalltscscale">저주파수 시스템에서 TSC를 스케일링합니다.</string>
-    <string name="fexcore_env_var_help__smc_checks">자체 수정 코드 검사.</string>
+    <string name="fexcore_env_var_help__smcchecks">자체 수정 코드 검사.</string>
     <string name="fexcore_env_var_help__volatilemetadata">가능한 경우 TSO에 대한 PE 파일의 휘발성 메타데이터를 사용합니다.</string>
     <string name="fexcore_env_var_help__monohacks">Mono 감지를 위한 특수 SMC + JIT 블록 해킹.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">CPUID 하이퍼바이저 비트를 숨깁니다(이것으로 충돌하는 앱에 유용).</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -469,7 +469,7 @@
     <string name="fexcore_env_var_help__multiblock">Włącza kompilację kodu wieloblokowego. Może powodować dłuższą kompilację JIT i przycięcia.</string>
     <string name="fexcore_env_var_help__hostfeatures">Kontroluje wymuszanie funkcji CPU.</string>
     <string name="fexcore_env_var_help__smalltscscale">Skaluje TSC na systemach o niskiej częstotliwości.</string>
-    <string name="fexcore_env_var_help__smc_checks">Sprawdzanie kodu samomodyfikującego się (SMC).</string>
+    <string name="fexcore_env_var_help__smcchecks">Sprawdzanie kodu samomodyfikującego się (SMC).</string>
     <string name="fexcore_env_var_help__volatilemetadata">Używa ulotnych metadanych z plików PE dla TSO, gdy są dostępne.</string>
     <string name="fexcore_env_var_help__monohacks">Specjalne hacki SMC + bloki JIT dla wykrywania Mono.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Ukrywa bit hiperwizora CPUID (przydatne dla aplikacji, które przez to awariują).</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -463,7 +463,7 @@
     <string name="fexcore_env_var_help__multiblock">Activează compilarea multiblock (poate cauza stutter)</string>
     <string name="fexcore_env_var_help__hostfeatures">Controlează forțarea capabilităților CPU</string>
     <string name="fexcore_env_var_help__smalltscscale">Scalează TSC pe sisteme cu frecvență redusă</string>
-    <string name="fexcore_env_var_help__smc_checks">Verificări pentru Self‑Modifying Code</string>
+    <string name="fexcore_env_var_help__smcchecks">Verificări pentru Self‑Modifying Code</string>
     <string name="fexcore_env_var_help__volatilemetadata">Folosește metadata volatilă din fișiere PE pentru TSO</string>
     <string name="fexcore_env_var_help__monohacks">Hack‑uri speciale SMC + JIT pentru detectarea Mono</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Ascunde bitul CPUID hypervisor (util pentru aplicații care crash‑uiesc cu el)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -411,7 +411,7 @@
     <string name="fexcore_env_var_help__monohacks">Специальные хаки SMC + JIT блока для определения Mono.</string>
     <string name="fexcore_env_var_help__multiblock">Включает многоблочную компиляцию кода. Может вызвать более длительную компиляцию JIT и заикание.</string>
     <string name="fexcore_env_var_help__smalltscscale">Масштабирует TSC на низкочастотных системах.</string>
-    <string name="fexcore_env_var_help__smc_checks">Проверки самомодифицирующегося кода.</string>
+    <string name="fexcore_env_var_help__smcchecks">Проверки самомодифицирующегося кода.</string>
     <string name="fexcore_env_var_help__tsoenabled">Включает операции TSO IR (требуется для многопоточных приложений).</string>
     <string name="fexcore_env_var_help__vectortsoenabled">Делает загрузки/сохранения векторов атомарными при включённом TSO.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Использует летучие метаданные из PE файлов для TSO, когда они доступны.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -453,7 +453,7 @@
     <string name="fexcore_env_var_help__multiblock">Вмикає компіляцію мультиблоків (multiblock). Може збільшити час JIT-компіляції та спричинити ривки.</string>
     <string name="fexcore_env_var_help__hostfeatures">Керує примусовим увімкненням функцій CPU.</string>
     <string name="fexcore_env_var_help__smalltscscale">Масштабує TSC на системах з низькою частотою.</string>
-    <string name="fexcore_env_var_help__smc_checks">Перевірки коду, що модифікує сам себе (SMC).</string>
+    <string name="fexcore_env_var_help__smcchecks">Перевірки коду, що модифікує сам себе (SMC).</string>
     <string name="fexcore_env_var_help__volatilemetadata">Використовує volatile метадані з PE-файлів для TSO, коли це можливо.</string>
     <string name="fexcore_env_var_help__monohacks">Спеціальні хаки SMC + JIT блоків для виявлення Mono.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Приховує біт гіпервізора в CPUID (корисно для програм, що вилітають через нього).</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -456,7 +456,7 @@
     <string name="fexcore_env_var_help__multiblock">启用多区块代码编译，可能导致JIT编译时间延长及画面卡顿</string>
     <string name="fexcore_env_var_help__hostfeatures">控制 CPU 功能强制执行</string>
     <string name="fexcore_env_var_help__smalltscscale">调整低频系统中TSC的系数</string>
-    <string name="fexcore_env_var_help__smc_checks">自我修改代码检查</string>
+    <string name="fexcore_env_var_help__smcchecks">自我修改代码检查</string>
     <string name="fexcore_env_var_help__volatilemetadata">在可用的情况下，使用PE文件中的易失性元数据进行TSO作业</string>
     <string name="fexcore_env_var_help__monohacks">针对 Mono 应用程序检测的特殊处理（SMC + JIT block hacks）</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">隐藏 CPUID 虚拟机管理器位（适用于因该位导致崩溃的应用程序）</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -456,7 +456,7 @@
     <string name="fexcore_env_var_help__multiblock">啟用多區塊程式碼編譯, 可能導致JIT編譯時間延長及畫面卡頓</string>
     <string name="fexcore_env_var_help__hostfeatures">控制 CPU 功能強制執行</string>
     <string name="fexcore_env_var_help__smalltscscale">調整低頻系統中TSC的係數</string>
-    <string name="fexcore_env_var_help__smc_checks">自我修改程式碼檢查</string>
+    <string name="fexcore_env_var_help__smcchecks">自我修改程式碼檢查</string>
     <string name="fexcore_env_var_help__volatilemetadata">在可用的情況下, 使用PE檔案中的揮發性元資料進行TSO作業</string>
     <string name="fexcore_env_var_help__monohacks">針對 Mono 應用程式偵測的特殊處理 (SMC + JIT block hacks)</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">隱藏 CPUID 虛擬化管理程式位元 (適用於因該位元導致崩潰的應用程式)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -505,7 +505,7 @@
     <string name="fexcore_env_var_help__multiblock">Enables multiblock code compilation. Can cause longer JIT compilation and stutter.</string>
     <string name="fexcore_env_var_help__hostfeatures">Controls CPU feature forcing.</string>
     <string name="fexcore_env_var_help__smalltscscale">Scales TSC on low-frequency systems.</string>
-    <string name="fexcore_env_var_help__smc_checks">Self-Modifying Code checks.</string>
+    <string name="fexcore_env_var_help__smcchecks">Self-Modifying Code checks.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Uses volatile metadata from PE files for TSO when available.</string>
     <string name="fexcore_env_var_help__monohacks">Special SMC + JIT block hacks for Mono detection.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Hides CPUID hypervisor bit (useful for apps that crash with it).</string>


### PR DESCRIPTION
Closes #989

## Summary
- FEX presets editor was setting `FEX_SMC_CHECKS` which FEX silently ignored
- Correct env var is `FEX_SMCCHECKS` (FEX_ + config key, no extra underscores)
- Verified against FEX source: `SMCCHECKS` in 9 files, `SMC_CHECKS` in zero
- Denuvo preset already used the correct name

## Test plan
- Set SMC checks to `none` via presets editor, confirm container behavior changes (V8 JIT breaks without SMC tracking)
- Set to `full`, confirm increased overhead vs `mtrack`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the SMC checks env var in the FEX presets editor by renaming FEX_SMC_CHECKS to FEX_SMCCHECKS so FEX applies the setting. Updated the editor mapping and help string keys across all locales to match the correct name (closes #989).

<sup>Written for commit 42e151f8cf5ed55f281f69d1096abb44d33ab880. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated environment variable identifier and localization key references for self-modifying code checks configuration across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->