### PR TITLE
fix: prevent quick menu tab debounce when controller active

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -269,6 +269,7 @@ fun QuickMenu(
     }
 
     val hudScrollState = rememberScrollState()
+    val effectsScrollState = rememberScrollState()
     val effectsTabFocusRequester = remember { FocusRequester() }
     val controllerScrollState = rememberScrollState()
     val hudTabFocusRequester = remember { FocusRequester() }
@@ -467,6 +468,7 @@ fun QuickMenu(
                                                 renderer = renderer,
                                                 modifier = Modifier.fillMaxSize(),
                                                 firstItemFocusRequester = effectsItemFocusRequester,
+                                                scrollState = effectsScrollState,
                                             )
                                         } else {
                                             Box(

--- a/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -83,6 +84,7 @@ fun ScreenEffectsTabContent(
     renderer: GLRenderer,
     modifier: Modifier = Modifier,
     firstItemFocusRequester: FocusRequester? = null,
+    scrollState: ScrollState = rememberScrollState(),
 ) {
     val composer = renderer.effectComposer
     val initialColorEffect = composer.getEffect(ColorEffect::class.java)
@@ -148,7 +150,7 @@ fun ScreenEffectsTabContent(
 
     Column(
         modifier = modifier
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(scrollState)
             .focusGroup()
             .padding(vertical = 12.dp),
     ) {


### PR DESCRIPTION
follow up from https://github.com/utkarshdalal/GameNative/pull/976 

handles focus debounce in case where invoked with controller but tab touched on touch screen, rather than back with touch swipe then tab change on touch without controller active to render border focusable.

also restores selected tab and scroll position so you are not bumped to top of menu every invoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quick menu now preserves the previously selected tab when reopened and improves focus behavior so HUD content consistently receives focus.
* **New Features**
  * Screen Effects tab now retains and accepts an external scroll state so its scroll position is preserved across view changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->