### PR TITLE
Make images fill their container for library layout: hero

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryGridCard.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryGridCard.kt
@@ -188,6 +188,7 @@ internal fun GridViewCard(
                     imageModifier = Modifier
                         .fillMaxSize()
                         .alpha(imageAlpha),
+                    contentScale = getGridContentScale(paneType),
                     image = { currentImageUrl },
                     onFailure = {
                         if (imageUrls.fallback.isNotEmpty() && currentImageUrl == imageUrls.primary) {
@@ -372,6 +373,14 @@ private fun GridStatusIcons(appInfo: LibraryItem) {
  * Primary and optional fallback image URL for grid view (e.g. Steam header -> hero).
  */
 internal data class GridImageUrls(val primary: String, val fallback: String = "")
+
+private fun getGridContentScale(paneType: PaneType): ContentScale {
+    return if (paneType == PaneType.GRID_HERO) {
+        ContentScale.Crop
+    } else {
+        ContentScale.Fit
+    }
+}
 
 /**
  * Gets the appropriate image URL(s) for a game in grid view.

--- a/app/src/main/java/app/gamenative/ui/util/Images.kt
+++ b/app/src/main/java/app/gamenative/ui/util/Images.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -30,6 +31,7 @@ internal fun ListItemImage(
     imageModifier: Modifier = Modifier.clip(CircleShape),
     contentDescription: String? = null,
     size: Dp = 40.dp,
+    contentScale: ContentScale = ContentScale.Fit,
     image: () -> Any?,
     onFailure: () -> Unit = {},
 ) {
@@ -39,7 +41,7 @@ internal fun ListItemImage(
             .then(imageModifier),
         imageModel = image,
         imageOptions = ImageOptions(
-            contentScale = ContentScale.Fit,
+            contentScale = contentScale,
             contentDescription = contentDescription,
         ),
         loading = {


### PR DESCRIPTION
Slight quality loss for GOG, since those images are already small. But that's a problem with GOG images. For Epic and Amazon it's not noticeable. For all platforms it looks so much more polished IMO. 

Before:
<img width="1339" height="753" alt="image" src="https://github.com/user-attachments/assets/7223d1e7-1b64-4f73-a66a-06b60995388d" />

After:
<img width="1339" height="753" alt="image" src="https://github.com/user-attachments/assets/63c7d54c-1119-4295-9f59-7c2754679c96" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Crop hero images in the grid layout so artwork fills the card and avoids letterboxing. Adds a configurable `contentScale` to `ListItemImage` and applies `ContentScale.Crop` for `GRID_HERO`, defaulting to `ContentScale.Fit` for other panes.

<sup>Written for commit 5d61cb22a484cee7917c0b4d1d342535b21e413e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Style**
  * Updated image scaling behavior in grid views. Images in hero grid displays now use crop scaling for optimal visual presentation, while other grid view types maintain proportional fit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->