### PR TITLE
Revert "fix: set ExeRunDir to game root in ColdClientLoader.ini"

### DIFF
--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -339,7 +339,6 @@ object SteamUtils {
         val gameName = getAppDirName(getAppInfoOf(steamAppId))
         val executablePath = container.executablePath.replace("/", "\\")
         val exePath = "steamapps\\common\\$gameName\\$executablePath"
-        val exeRunDir = "steamapps\\common\\$gameName"
         val exeCommandLine = container.execArgs
         val iniFile = File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/ColdClientLoader.ini")
         iniFile.parentFile?.mkdirs()
@@ -363,7 +362,7 @@ object SteamUtils {
                 [SteamClient]
 
                 Exe=$exePath
-                ExeRunDir=$exeRunDir
+                ExeRunDir=
                 ExeCommandLine=$exeCommandLine
                 AppId=$steamAppId
 


### PR DESCRIPTION
Reverts utkarshdalal/GameNative#775

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that set `ExeRunDir` to the game root in `ColdClientLoader.ini`. `ExeRunDir` is now left empty to restore default behavior and prevent launch issues with some games.

<sup>Written for commit bb6de141e3629bff021090915ae05ad1eeadcf99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted how the game execution directory is initialized, now using system defaults instead of custom path configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->