### PR TITLE
fix: set ColdClientLoader.ini ExeRunDir to exe directory when no workingDir in appinfo

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2891,7 +2891,7 @@ private fun getWineStartCommand(
         }
         if (!container.isUseLegacyDRM){
             // Create ColdClientLoader.ini file
-            SteamUtils.writeColdClientIni(gameId, container)
+            SteamUtils.writeColdClientIni(gameId, container, appLaunchInfo)
         }
         val controllerVdfText = SteamService.resolveSteamControllerVdfText(gameId)
         if (controllerVdfText.isNullOrEmpty()) {

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.provider.Settings
 import app.gamenative.PrefManager
 import app.gamenative.data.DepotInfo
+import app.gamenative.data.LaunchInfo
 import app.gamenative.data.ManifestInfo
 import app.gamenative.data.SteamApp
 import app.gamenative.enums.Marker
@@ -335,16 +336,19 @@ object SteamUtils {
         Timber.i("Finished restoreSteamclientFiles for appId: $steamAppId. Restored $restoredCount file(s)")
     }
 
-    internal fun writeColdClientIni(steamAppId: Int, container: Container) {
-        val gameName = getAppDirName(getAppInfoOf(steamAppId))
-        val executablePath = container.executablePath.replace("/", "\\")
-        val exePath = "steamapps\\common\\$gameName\\$executablePath"
-        val exeCommandLine = container.execArgs
-        val iniFile = File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/ColdClientLoader.ini")
-        iniFile.parentFile?.mkdirs()
+    internal fun generateColdClientIni(
+        gameName: String,
+        executablePath: String,
+        exeCommandLine: String,
+        steamAppId: Int,
+        workingDir: String?,
+        isUnpackFiles: Boolean,
+    ): String {
+        val exePath = "steamapps\\common\\$gameName\\${executablePath.replace("/", "\\")}"
+        val exeRunDir = if (workingDir.isNullOrEmpty()) exePath.substringBeforeLast("\\") else ""
 
         // Only include DllsToInjectFolder if unpackFiles is enabled
-        val injectionSection = if (container.isUnpackFiles) {
+        val injectionSection = if (isUnpackFiles) {
             """
                 [Injection]
                 IgnoreLoaderArchDifference=1
@@ -357,12 +361,11 @@ object SteamUtils {
             """
         }
 
-        iniFile.writeText(
-            """
+        return """
                 [SteamClient]
 
                 Exe=$exePath
-                ExeRunDir=
+                ExeRunDir=$exeRunDir
                 ExeCommandLine=$exeCommandLine
                 AppId=$steamAppId
 
@@ -371,7 +374,23 @@ object SteamUtils {
                 SteamClient64Dll=steamclient64.dll
 
                 $injectionSection
-            """.trimIndent(),
+            """.trimIndent()
+    }
+
+    internal fun writeColdClientIni(steamAppId: Int, container: Container, launchInfo: LaunchInfo? = null) {
+        val gameName = getAppDirName(getAppInfoOf(steamAppId))
+        val workingDir = launchInfo?.workingDir
+        val iniFile = File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/ColdClientLoader.ini")
+        iniFile.parentFile?.mkdirs()
+        iniFile.writeText(
+            generateColdClientIni(
+                gameName = gameName,
+                executablePath = container.executablePath,
+                exeCommandLine = container.execArgs,
+                steamAppId = steamAppId,
+                workingDir = workingDir,
+                isUnpackFiles = container.isUnpackFiles,
+            )
         )
     }
 

--- a/app/src/test/java/app/gamenative/utils/SteamUtilsColdClientIniTest.kt
+++ b/app/src/test/java/app/gamenative/utils/SteamUtilsColdClientIniTest.kt
@@ -1,0 +1,46 @@
+package app.gamenative.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SteamUtilsColdClientIniTest {
+
+    private fun generate(
+        gameName: String = "Batman Arkham Asylum GOTY",
+        executablePath: String = "Binaries\\BmLauncher.exe",
+        exeCommandLine: String = "",
+        steamAppId: Int = 35140,
+        workingDir: String? = null,
+        isUnpackFiles: Boolean = false,
+    ) = SteamUtils.generateColdClientIni(
+        gameName = gameName,
+        executablePath = executablePath,
+        exeCommandLine = exeCommandLine,
+        steamAppId = steamAppId,
+        workingDir = workingDir,
+        isUnpackFiles = isUnpackFiles,
+    )
+
+    private fun String.iniValue(key: String): String =
+        lines().first { it.startsWith("$key=") }.removePrefix("$key=")
+
+    @Test
+    fun `ExeRunDir is exe directory when no workingDir`() {
+        val ini = generate(gameName = "New Star GP", executablePath = "release/NSGP.exe", workingDir = null)
+        assertEquals("steamapps\\common\\New Star GP\\release", ini.iniValue("ExeRunDir"))
+    }
+
+    @Test
+    fun `ExeRunDir is blank when workingDir is set`() {
+        // workingDir set: leave blank (legacy behaviour, same as master)
+        val ini = generate(workingDir = "Binaries")
+        assertEquals("", ini.iniValue("ExeRunDir"))
+    }
+
+    @Test
+    fun `ExeRunDir is exe directory when workingDir is empty string`() {
+        val ini = generate(gameName = "New Star GP", executablePath = "release/NSGP.exe", workingDir = "")
+        assertEquals("steamapps\\common\\New Star GP\\release", ini.iniValue("ExeRunDir"))
+    }
+
+}


### PR DESCRIPTION
PR #775 introduced ExeRunDir to fix save loading in New Star GP, whose exe lives in a subdirectory (`release/NSGP.exe`) and opens saves via a relative path from the game install root. Without ExeRunDir set correctly, ColdClientLoader defaults the working directory to the exe's parent, so the save file was never found.

However, hardcoding ExeRunDir to the game root broke games like Batman: Arkham Asylum GOTY (PR #950), which declares `workingdir: Binaries` in its appinfo. For these games the correct CWD is the subdirectory, not the root — and the previous empty ExeRunDir happened to work because ColdClientLoader defaulted to the exe's parent.

This fix derives ExeRunDir from the exe path when `workingDir` is absent in appinfo, so New Star GP gets `release/` as its CWD. When `workingDir` is present, ExeRunDir is left blank to preserve legacy behaviour (ColdClientLoader uses the loader's own CWD).

The INI content is extracted into `generateColdClientIni()` for testability, with unit tests covering the New Star GP case and the workingDir-set case.

Fixes: https://github.com/utkarshdalal/GameNative/pull/775
Fixes: https://github.com/utkarshdalal/GameNative/pull/950

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launcher now forwards extra launch context for non-legacy DRM containers to improve Steam start behavior.
  * INI/config generation now respects explicit working directories, derives executable run directories when absent, and conditionally includes DLL-injection settings.

* **Tests**
  * Added tests validating INI output for working-dir variants, run-directory derivation, AppID output, and conditional DLL injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->