### PR TITLE
feat: disable IME extract UI and centralize singleLine keyboard behavior

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/NoExtractOutlinedTextField.kt
+++ b/app/src/main/java/app/gamenative/ui/component/NoExtractOutlinedTextField.kt
@@ -1,0 +1,103 @@
+package app.gamenative.ui.component
+
+import android.view.inputmethod.EditorInfo
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.InterceptPlatformTextInput
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.PlatformTextInputMethodRequest
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.VisualTransformation
+
+/**
+ * OutlinedTextField wrapper that sets IME_FLAG_NO_EXTRACT_UI on the EditorInfo.
+ * Works around a GBoard bug where the composition overlay renders stale text
+ * on mid-text deletion in Compose TextFields.
+ */
+@OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+@Composable
+fun NoExtractOutlinedTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = LocalTextStyle.current,
+    label: @Composable (() -> Unit)? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    prefix: @Composable (() -> Unit)? = null,
+    suffix: @Composable (() -> Unit)? = null,
+    supportingText: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions? = null,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    shape: Shape = OutlinedTextFieldDefaults.shape,
+    colors: TextFieldColors = OutlinedTextFieldDefaults.colors(),
+) {
+    val focusManager = LocalFocusManager.current
+
+    val resolvedOptions = if (keyboardOptions.imeAction == ImeAction.Default && singleLine) {
+        keyboardOptions.copy(imeAction = ImeAction.Done)
+    } else {
+        keyboardOptions
+    }
+
+    val resolvedActions = keyboardActions
+        ?: if (singleLine) KeyboardActions(onDone = { focusManager.clearFocus() })
+        else KeyboardActions.Default
+
+    InterceptPlatformTextInput(
+        interceptor = { request, nextHandler ->
+            val modifiedRequest = PlatformTextInputMethodRequest { outAttributes ->
+                request.createInputConnection(outAttributes).also {
+                    outAttributes.imeOptions = outAttributes.imeOptions or
+                        EditorInfo.IME_FLAG_NO_EXTRACT_UI
+                }
+            }
+            nextHandler.startInputMethod(modifiedRequest)
+        },
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = modifier,
+            enabled = enabled,
+            readOnly = readOnly,
+            textStyle = textStyle,
+            label = label,
+            placeholder = placeholder,
+            leadingIcon = leadingIcon,
+            trailingIcon = trailingIcon,
+            prefix = prefix,
+            suffix = suffix,
+            supportingText = supportingText,
+            isError = isError,
+            visualTransformation = visualTransformation,
+            keyboardOptions = resolvedOptions,
+            keyboardActions = resolvedActions,
+            singleLine = singleLine,
+            maxLines = maxLines,
+            minLines = minLines,
+            interactionSource = interactionSource,
+            shape = shape,
+            colors = colors,
+        )
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/component/dialog/Box64PresetsDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/Box64PresetsDialog.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -39,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import app.gamenative.R
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import app.gamenative.ui.component.settings.SettingsEnvVars
 import app.gamenative.ui.theme.settingsTileColors
 import com.winlator.box86_64.Box86_64Preset
@@ -98,7 +98,7 @@ fun Box64PresetsDialog(
                             .fillMaxSize()
                             .padding(paddingValues),
                     ) {
-                        OutlinedTextField(
+                        NoExtractOutlinedTextField(
                             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
                             value = presetName,
                             enabled = isCustom(),
@@ -107,6 +107,7 @@ fun Box64PresetsDialog(
                                 Box86_64PresetManager.editPreset(prefix, context, presetId, presetName, EnvVars(envVars))
                             },
                             label = { Text(stringResource(R.string.preset_name)) },
+                            singleLine = true,
                             trailingIcon = {
                                 IconButton(
                                     colors = IconButtonDefaults.iconButtonColors()

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -40,7 +40,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.OutlinedTextField
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.CircularProgressIndicator
@@ -1226,7 +1226,7 @@ internal fun ExecutablePathDropdown(
         onExpandedChange = { expanded = it },
         modifier = modifier
     ) {
-        OutlinedTextField(
+        NoExtractOutlinedTextField(
             value = value,
             onValueChange = onValueChange,
             readOnly = true,

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ControllerBindingDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ControllerBindingDialog.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import com.winlator.inputcontrols.Binding
 
 /**
@@ -195,7 +196,7 @@ fun ControllerBindingDialog(
                             }
                         } else {
                             // Expanded search field
-                            OutlinedTextField(
+                            NoExtractOutlinedTextField(
                                 value = searchQuery,
                                 onValueChange = {
                                     searchQuery = it
@@ -232,7 +233,7 @@ fun ControllerBindingDialog(
                                     .fillMaxWidth()
                                     .height(44.dp), // Even more compact when expanded
                                 singleLine = true,
-                                textStyle = MaterialTheme.typography.bodySmall
+                                textStyle = MaterialTheme.typography.bodySmall,
                             )
                         }
 

--- a/app/src/main/java/app/gamenative/ui/component/dialog/DrivesTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/DrivesTab.kt
@@ -13,7 +13,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.DropdownMenu
@@ -110,7 +110,7 @@ fun DrivesTabContent(state: ContainerConfigState) {
             title = { Text(text = stringResource(R.string.add_drive)) },
             text = {
                 Column {
-                    OutlinedTextField(
+                    NoExtractOutlinedTextField(
                         value = state.selectedDriveLetter.value,
                         onValueChange = {},
                         readOnly = true,

--- a/app/src/main/java/app/gamenative/ui/component/dialog/EnvironmentTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/EnvironmentTab.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -25,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import app.gamenative.R
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import app.gamenative.ui.component.settings.SettingsCenteredLabel
 import app.gamenative.ui.component.settings.SettingsEnvVars
 import app.gamenative.ui.component.settings.SettingsMultiListDropdown
@@ -93,10 +93,11 @@ fun EnvironmentTabContent(state: ContainerConfigState) {
                 var knownVarsMenuOpen by rememberSaveable { mutableStateOf(false) }
                 Column {
                     Row {
-                        OutlinedTextField(
+                        NoExtractOutlinedTextField(
                             value = envVarName,
                             onValueChange = { envVarName = it },
                             label = { Text(text = stringResource(R.string.name)) },
+                            singleLine = true,
                             trailingIcon = {
                                 IconButton(
                                     onClick = { knownVarsMenuOpen = true },
@@ -157,10 +158,11 @@ fun EnvironmentTabContent(state: ContainerConfigState) {
                     } else {
                         var suggestionsExpanded by remember { mutableStateOf(false) }
                         val hasSuggestions = selectedEnvVarInfo?.selectionType == EnvVarSelectionType.SUGGESTIONS
-                        OutlinedTextField(
+                        NoExtractOutlinedTextField(
                             value = envVarValue,
                             onValueChange = { envVarValue = it },
                             label = { Text(text = stringResource(R.string.value)) },
+                            singleLine = true,
                             trailingIcon = if (hasSuggestions) {
                                 {
                                     IconButton(onClick = { suggestionsExpanded = true }) {

--- a/app/src/main/java/app/gamenative/ui/component/dialog/FEXCorePresetsDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/FEXCorePresetsDialog.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -41,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import app.gamenative.R
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import app.gamenative.ui.component.settings.SettingsEnvVars
 import app.gamenative.ui.theme.settingsTileColors
 import com.winlator.core.StringUtils
@@ -112,7 +112,7 @@ fun FEXCorePresetsDialog(
                         .fillMaxSize()
                         .padding(paddingValues),
                 ) {
-                    OutlinedTextField(
+                    NoExtractOutlinedTextField(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp),
@@ -123,6 +123,7 @@ fun FEXCorePresetsDialog(
                             FEXCorePresetManager.editPreset(context, presetId, presetName, EnvVars(envVars))
                         },
                         label = { Text(stringResource(R.string.preset_name)) },
+                        singleLine = true,
                         trailingIcon = {
                             IconButton(
                                 colors = IconButtonDefaults.iconButtonColors()

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GameFeedbackDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GameFeedbackDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import app.gamenative.R
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import app.gamenative.ui.component.dialog.state.GameFeedbackDialogState
 import timber.log.Timber
 
@@ -120,7 +121,7 @@ fun GameFeedbackDialog(
                     }
 
                     // Feedback text box
-                    OutlinedTextField(
+                    NoExtractOutlinedTextField(
                         value = state.feedbackText,
                         onValueChange = { onStateChange(state.copy(feedbackText = it)) },
                         label = { Text(stringResource(R.string.describe_what_happened)) },
@@ -128,7 +129,7 @@ fun GameFeedbackDialog(
                             .fillMaxWidth()
                             .heightIn(min = 100.dp)
                             .padding(bottom = 16.dp),
-                        maxLines = 5
+                        maxLines = 5,
                     )
 
                     // Discord support link

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
@@ -6,12 +6,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -19,12 +20,16 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.gamenative.R
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import app.gamenative.ui.component.settings.SettingsListDropdown
 import com.alorma.compose.settings.ui.SettingsSwitch
 import app.gamenative.ui.theme.settingsTileColors
@@ -64,14 +69,17 @@ fun GeneralTabContent(
             onDismissRequest = { state.showCustomResolutionDialog.value = false },
             title = { Text(text = stringResource(R.string.container_config_custom_resolution_title)) },
             text = {
+                val heightFocusRequester = remember { FocusRequester() }
                 Column {
                     Row {
-                        OutlinedTextField(
+                        NoExtractOutlinedTextField(
                             modifier = Modifier.width(128.dp),
                             value = state.customScreenWidth.value,
                             onValueChange = { state.customScreenWidth.value = it },
-                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Next),
+                            keyboardActions = KeyboardActions(onNext = { heightFocusRequester.requestFocus() }),
                             label = { Text(text = stringResource(R.string.width)) },
+                            singleLine = true,
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
@@ -80,12 +88,13 @@ fun GeneralTabContent(
                             style = TextStyle(fontSize = 16.sp),
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        OutlinedTextField(
-                            modifier = Modifier.width(128.dp),
+                        NoExtractOutlinedTextField(
+                            modifier = Modifier.width(128.dp).focusRequester(heightFocusRequester),
                             value = state.customScreenHeight.value,
                             onValueChange = { state.customScreenHeight.value = it },
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                             label = { Text(text = stringResource(R.string.height)) },
+                            singleLine = true,
                         )
                     }
                     if (state.customResolutionValidationError.value != null) {
@@ -253,12 +262,13 @@ fun GeneralTabContent(
             onValueChange = { state.config.value = config.copy(executablePath = it) },
             containerData = config,
         )
-        OutlinedTextField(
+        NoExtractOutlinedTextField(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
             value = config.execArgs,
             onValueChange = { state.config.value = config.copy(execArgs = it) },
             label = { Text(text = stringResource(R.string.exec_arguments)) },
             placeholder = { Text(text = stringResource(R.string.exec_arguments_example)) },
+            singleLine = true,
         )
         val displayNameForLanguage: (String) -> String = { code ->
             when (code) {

--- a/app/src/main/java/app/gamenative/ui/component/dialog/TouchGestureSettingsDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/TouchGestureSettingsDialog.kt
@@ -3,6 +3,7 @@ package app.gamenative.ui.component.dialog
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -231,7 +232,7 @@ private fun DelayTextField(
 ) {
     var text by remember(value) { mutableStateOf(value.toString()) }
 
-    OutlinedTextField(
+    NoExtractOutlinedTextField(
         value = text,
         onValueChange = { newText ->
             // Allow only digits

--- a/app/src/main/java/app/gamenative/ui/component/dialog/WorkshopManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/WorkshopManagerDialog.kt
@@ -27,7 +27,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -222,7 +222,7 @@ fun WorkshopManagerDialog(
 
                 // Search bar
                 if (!isLoading && !fetchFailed && workshopItems.isNotEmpty()) {
-                    OutlinedTextField(
+                    NoExtractOutlinedTextField(
                         value = searchQuery,
                         onValueChange = { searchQuery = it },
                         modifier = Modifier

--- a/app/src/main/java/app/gamenative/ui/component/settings/SettingsTextField.kt
+++ b/app/src/main/java/app/gamenative/ui/component/settings/SettingsTextField.kt
@@ -3,7 +3,6 @@ package app.gamenative.ui.component.settings
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ListItemDefaults
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -11,6 +10,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import com.alorma.compose.settings.ui.SettingsMenuLink
 import com.alorma.compose.settings.ui.base.internal.LocalSettingsGroupEnabled
 import com.alorma.compose.settings.ui.base.internal.SettingsTileColors
@@ -39,13 +39,14 @@ fun SettingsTextField(
         subtitle = subtitle,
         action = {
             Row {
-                OutlinedTextField(
+                NoExtractOutlinedTextField(
                     modifier = Modifier
                         .focusRequester(focusRequester)
                         .width(76.dp),
                     enabled = enabled,
                     value = value,
                     onValueChange = onValueChange,
+                    singleLine = true,
                 )
                 action?.invoke()
             }

--- a/app/src/main/java/app/gamenative/ui/component/settings/SettingsTextFieldWithSuggestions.kt
+++ b/app/src/main/java/app/gamenative/ui/component/settings/SettingsTextFieldWithSuggestions.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItemDefaults
-import androidx.compose.material3.OutlinedTextField
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -60,7 +60,7 @@ fun SettingsTextFieldWithSuggestions(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                OutlinedTextField(
+                NoExtractOutlinedTextField(
                     modifier = Modifier
                         .focusRequester(focusRequester)
                         .weight(1f),

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
-import androidx.compose.material3.OutlinedTextField
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
@@ -1390,7 +1390,7 @@ private fun SteamChangeBranchDialog(
                     expanded = branchExpanded,
                     onExpandedChange = { branchExpanded = it },
                 ) {
-                    OutlinedTextField(
+                    NoExtractOutlinedTextField(
                         value = selectedBranch,
                         onValueChange = {},
                         readOnly = true,
@@ -1418,7 +1418,7 @@ private fun SteamChangeBranchDialog(
 
                 Spacer(modifier = Modifier.height(16.dp))
 
-                OutlinedTextField(
+                NoExtractOutlinedTextField(
                     value = privateBranchPassword,
                     onValueChange = {
                         privateBranchPassword = it

--- a/app/src/main/java/app/gamenative/ui/screen/login/TwoFactorAuthScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/login/TwoFactorAuthScreen.kt
@@ -16,8 +16,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -114,7 +114,7 @@ private fun TwoFactorTextField(
             modifier = Modifier.padding(bottom = 8.dp)
         )
 
-        OutlinedTextField(
+        NoExtractOutlinedTextField(
             modifier = Modifier
                 .fillMaxWidth()
                 .focusRequester(focusRequester)
@@ -137,7 +137,6 @@ private fun TwoFactorTextField(
             },
             keyboardOptions = KeyboardOptions(
                 keyboardType = KeyboardType.Text,
-                imeAction = ImeAction.Done,
             ),
             shape = RoundedCornerShape(8.dp),
             colors = OutlinedTextFieldDefaults.colors(

--- a/app/src/main/java/app/gamenative/ui/screen/login/UserLoginScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/login/UserLoginScreen.kt
@@ -50,8 +50,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -690,7 +690,7 @@ private fun CredentialsForm(
                 }
                 Spacer(modifier = Modifier.height(8.dp))
             }
-            OutlinedTextField(
+            NoExtractOutlinedTextField(
                 value = username,
                 onValueChange = onUsername,
                 singleLine = true,
@@ -728,7 +728,7 @@ private fun CredentialsForm(
             )
         }
 
-        OutlinedTextField(
+        NoExtractOutlinedTextField(
             value = password,
             onValueChange = onPassword,
             singleLine = true,

--- a/app/src/main/java/app/gamenative/ui/screen/settings/ContentsManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/ContentsManagerDialog.kt
@@ -21,7 +21,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -247,7 +247,7 @@ fun ContentsManagerDialog(open: Boolean, onDismiss: () -> Unit) {
                     onExpandedChange = { typeExpanded = !typeExpanded },
                     modifier = Modifier.fillMaxWidth().padding(top = 8.dp)
                 ) {
-                    OutlinedTextField(
+                    NoExtractOutlinedTextField(
                         value = currentType.toString(),
                         onValueChange = {},
                         readOnly = true,
@@ -392,7 +392,7 @@ fun ContentsManagerDialog(open: Boolean, onDismiss: () -> Unit) {
 private fun InfoRow(label: String, value: String) {
     Column(modifier = Modifier.padding(bottom = 4.dp)) {
         Text(text = label, style = MaterialTheme.typography.labelMedium)
-        OutlinedTextField(value = value, onValueChange = {}, readOnly = true, modifier = Modifier.fillMaxWidth())
+        NoExtractOutlinedTextField(value = value, onValueChange = {}, readOnly = true, modifier = Modifier.fillMaxWidth())
     }
 }
 

--- a/app/src/main/java/app/gamenative/ui/screen/settings/DriverManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/DriverManagerDialog.kt
@@ -25,7 +25,7 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Button
-import androidx.compose.material3.OutlinedTextField
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.MaterialTheme
@@ -310,7 +310,7 @@ fun DriverManagerDialog(open: Boolean, onDismiss: () -> Unit) {
                         onExpandedChange = { isExpanded = !isExpanded },
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        OutlinedTextField(
+                        NoExtractOutlinedTextField(
                             value = selectedDriverKey,
                             onValueChange = {},
                             readOnly = true,

--- a/app/src/main/java/app/gamenative/ui/screen/settings/WineProtonManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/WineProtonManagerDialog.kt
@@ -31,7 +31,7 @@ import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
+import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -642,7 +642,7 @@ fun WineProtonManagerDialog(open: Boolean, onDismiss: () -> Unit) {
                         onExpandedChange = { isExpanded = !isExpanded },
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        OutlinedTextField(
+                        NoExtractOutlinedTextField(
                             value = selectedWineKey,
                             onValueChange = {},
                             readOnly = true,
@@ -967,7 +967,7 @@ fun WineProtonManagerDialog(open: Boolean, onDismiss: () -> Unit) {
 private fun InfoRow(label: String, value: String) {
     Column(modifier = Modifier.padding(bottom = 8.dp)) {
         Text(text = label, style = MaterialTheme.typography.labelMedium)
-        OutlinedTextField(
+        NoExtractOutlinedTextField(
             value = value,
             onValueChange = {},
             readOnly = true,


### PR DESCRIPTION
## Description
adds `NoExtractOutlinedTextField` wrapper that sets `IME_FLAG_NO_EXTRACT_UI`, opting out of the IME's fullscreen extract editing mode. centralizes `ImeAction.Done` + `clearFocus()` for `singleLine` fields, removing per-callsite boilerplate. migrates all `OutlinedTextField` usages across the app (11 files).

closes #1013.

## Recording
before:
https://github.com/user-attachments/assets/c195692d-3120-44bb-8221-a6fc94844d3e

after:
https://github.com/user-attachments/assets/b96dcd62-6adc-4b44-a26c-66b3969b2695

## Test plan
- [ ] Open any container config dialog, type in a text field, delete mid-word — no extract UI overlay
- [ ] Single-line fields show "Done" IME action and dismiss keyboard on tap
- [ ] Multi-line field (game feedback) still works normally without Done action

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text inputs now prevent full-screen IME/keyboard extraction on devices, keeping surrounding UI visible during typing.

* **Refactor**
  * Replaced standard outlined text fields across dialogs, forms, and settings (presets, env vars, login, feedback, managers) with the improved input component while preserving existing behaviors and layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->