### PR TITLE
fix: skip cloud sync and loading message for games without cloud saves

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2049,6 +2049,11 @@ class SteamService : Service(), IChallengeUrlChanged {
                         PrefManager.clientId?.let { clientId ->
                             instance?.let { steamInstance ->
                                 getAppInfoOf(appId)?.let { appInfo ->
+                                    if (appInfo.ufs.quota == 0) {
+                                        Timber.i("Skipping cloud sync for appId=$appId: no UFS quota")
+                                        syncResult = PostSyncInfo(SyncResult.UpToDate)
+                                        return@async syncResult
+                                    }
                                     steamInstance._steamCloud?.let { steamCloud ->
                                         val postSyncInfo = SteamAutoCloud.syncUserFiles(
                                             appInfo = appInfo,
@@ -2137,6 +2142,11 @@ class SteamService : Service(), IChallengeUrlChanged {
                         PrefManager.clientId?.let { clientId ->
                             instance?.let { steamInstance ->
                                 getAppInfoOf(appId)?.let { appInfo ->
+                                    if (appInfo.ufs.quota == 0) {
+                                        Timber.i("Skipping cloud sync for appId=$appId: no UFS quota")
+                                        syncResult = PostSyncInfo(SyncResult.UpToDate)
+                                        return@async syncResult
+                                    }
                                     steamInstance._steamCloud?.let { steamCloud ->
                                         val postSyncInfo = SteamAutoCloud.syncUserFiles(
                                             appInfo = appInfo,
@@ -2198,6 +2208,10 @@ class SteamService : Service(), IChallengeUrlChanged {
                             PrefManager.clientId?.let { clientId ->
                                 instance?.let { steamInstance ->
                                     getAppInfoOf(appId)?.let { appInfo ->
+                                        if (appInfo.ufs.quota == 0) {
+                                            Timber.i("Skipping cloud sync for appId=$appId: no UFS quota")
+                                            return@async
+                                        }
                                         steamInstance._steamCloud?.let { steamCloud ->
                                             val postSyncInfo = SteamAutoCloud.syncUserFiles(
                                                 appInfo = appInfo,

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1808,9 +1808,8 @@ fun preLaunchApp(
         val prefixToPath: (String) -> String = { prefix ->
             PathType.from(prefix).toAbsPath(context, gameId, SteamService.userSteamId!!.accountID)
         }
-        val hasSavePatterns = SteamService.getAppInfoOf(gameId)
-            ?.ufs?.saveFilePatterns?.isNotEmpty() == true
-        if (hasSavePatterns) {
+        val hasCloudSaves = (SteamService.getAppInfoOf(gameId)?.ufs?.quota ?: 0) > 0
+        if (hasCloudSaves) {
             setLoadingMessage("Syncing cloud saves")
         }
         setLoadingProgress(-1f)

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1808,7 +1808,11 @@ fun preLaunchApp(
         val prefixToPath: (String) -> String = { prefix ->
             PathType.from(prefix).toAbsPath(context, gameId, SteamService.userSteamId!!.accountID)
         }
-        setLoadingMessage("Syncing cloud saves")
+        val hasSavePatterns = SteamService.getAppInfoOf(gameId)
+            ?.ufs?.saveFilePatterns?.isNotEmpty() == true
+        if (hasSavePatterns) {
+            setLoadingMessage("Syncing cloud saves")
+        }
         setLoadingProgress(-1f)
         val postSyncInfo = SteamService.beginLaunchApp(
             appId = gameId,


### PR DESCRIPTION
## Summary

- Steam games without cloud save support were briefly showing a "Syncing cloud saves" loading message during launch, and the sync code was running unnecessarily for them
- Fixed by gating on `ufs.quota > 0`: the loading message is only shown and cloud sync only runs for games that actually have cloud save support

## Test plan

- [x] Launch a Steam game **with** cloud saves (`ufs.quota > 0`) — should show "Syncing cloud saves" and sync normally
- [x] Launch a Steam game **without** cloud saves (`ufs.quota == 0`) — should not show the cloud saves message and should skip sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Loading UI message "Syncing cloud saves" now appears only when cloud saves exist, avoiding confusing notifications during launch.
  * Cloud sync is skipped when no cloud storage quota is available, preventing unnecessary sync attempts and improving launch responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->