### PR TITLE
removed blurred background on non carousel views - too visually jarring

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -182,16 +181,6 @@ internal fun LibraryListPane(
     }
 
     var targetOfScroll by remember { mutableIntStateOf(-1) }
-    val backdropItem by remember(state.appInfoList, listState.firstVisibleItemIndex, targetOfScroll, currentLayout) {
-        derivedStateOf {
-            if (currentLayout == PaneType.LIST || state.appInfoList.isEmpty()) {
-                null
-            } else {
-                val preferredIndex = if (targetOfScroll >= 0) targetOfScroll else listState.firstVisibleItemIndex
-                state.appInfoList.getOrNull(preferredIndex.coerceIn(0, state.appInfoList.lastIndex))
-            }
-        }
-    }
     LaunchedEffect(targetOfScroll) {
         if (targetOfScroll != -1) {
             listState.animateScrollToItem(targetOfScroll, -100)
@@ -207,13 +196,6 @@ internal fun LibraryListPane(
                 .fillMaxSize()
                 .padding(paddingValues),
         ) {
-            if (currentLayout != PaneType.LIST) {
-                LibraryDynamicBackdrop(
-                    appInfo = backdropItem,
-                    imageRefreshCounter = state.imageRefreshCounter,
-                    modifier = Modifier.fillMaxSize(),
-                )
-            }
             var shouldShowSkeletonOverlay by remember { mutableStateOf(true) }
 
             val skeletonAlpha by animateFloatAsState(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the blurred background from non‑carousel library views to reduce visual distraction and improve readability. Carousel view remains unchanged; removed backdrop computation and LibraryDynamicBackdrop usage in LibraryListPane.

<sup>Written for commit b50e1b47e54905406f380ef2765ffd6567e41c50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed dynamic backdrop from library view in non-list layouts, streamlining the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->