### PR TITLE
fix: download steam_controller_config.vdf after depot download completes

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1617,6 +1617,20 @@ class SteamService : Service(), IChallengeUrlChanged {
                             depotDownloader.add(dlcAppItem)
                         }
 
+                        // Signal that no more items will be added
+                        depotDownloader.finishAdding()
+
+                        // Start Download
+                        depotDownloader.startDownloading()
+
+                        Timber.i("Downloading game to " + defaultAppInstallPath)
+
+                        // Wait for completion
+                        depotDownloader.getCompletion().await()
+
+                        // Close the downloader
+                        depotDownloader.close()
+
                         val appConfig = getAppInfoOf(appId)?.config
                         if (appConfig?.steamControllerTemplateIndex == 1) {
                             val controllerConfig = appConfig.steamControllerConfigDetails
@@ -1748,20 +1762,6 @@ class SteamService : Service(), IChallengeUrlChanged {
                                 }
                             }
                         }
-
-                        // Signal that no more items will be added
-                        depotDownloader.finishAdding()
-
-                        // Start Download
-                        depotDownloader.startDownloading()
-
-                        Timber.i("Downloading game to " + defaultAppInstallPath)
-
-                        // Wait for completion
-                        depotDownloader.getCompletion().await()
-
-                        // Close the downloader
-                        depotDownloader.close()
 
                         // Complete app download
                         if (mainAppDepots.isNotEmpty()) {


### PR DESCRIPTION
## Summary

Without this fix, the `steam_controller_config.vdf` download silently fails because the game directory doesn't exist yet when it's attempted — it's only created by `DepotDownloader` during depot extraction.

This moves the VDF download to after `DepotDownloader` completes, so the directory is guaranteed to exist.

Fixes Spin Rhythm XD without a workaround as discussed in discord: https://discord.com/channels/1378308569287622737/1485775586977779742

## Test plan

- [x] Install a game that has `steamControllerTemplateIndex == 1` and verify `steam_controller_config.vdf` is present in the game directory after install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the sequence of download operations during app installation to improve process flow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->