### PR TITLE
fix: correct Steam download size reporting

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -696,18 +696,48 @@ class SteamService : Service(), IChallengeUrlChanged {
             return true
         }
 
+        private fun getAuthorizedDepotIds(appIds: Set<Int>): Set<Int> {
+            if (appIds.isEmpty()) return emptySet()
+
+            return runBlocking {
+                instance?.licenseDao?.getAllLicenses().orEmpty()
+            }.asSequence()
+                .filter { license ->
+                    license.depotIds.isNotEmpty() && license.appIds.any { it in appIds }
+                }
+                .flatMap { it.depotIds.asSequence() }
+                .toSet()
+        }
+
+        private fun filterAuthorizedDepots(
+            depots: Map<Int, DepotInfo>,
+            authorizedDepotIds: Set<Int>,
+        ): Map<Int, DepotInfo> {
+            if (depots.isEmpty() || authorizedDepotIds.isEmpty()) return depots
+            return depots.filterKeys { it in authorizedDepotIds }.ifEmpty { depots }
+        }
+
         fun getMainAppDepots(appId: Int, containerLanguage: String): Map<Int, DepotInfo> {
             val appInfo = getAppInfoOf(appId) ?: return emptyMap()
             val ownedDlc = runBlocking { getOwnedAppDlc(appId) }
+            val authorizedDepotIds = getAuthorizedDepotIds(
+                buildSet {
+                    add(appId)
+                    ownedDlc.values.mapTo(this) { it.dlcAppId }.remove(INVALID_APP_ID)
+                },
+            )
 
             // If the game ships any 64-bit depot, prefer those and ignore x86 ones
             val has64Bit = appInfo.depots.values.any { it.osArch == OSArch.Arch64 }
 
-            return appInfo.depots.asSequence()
-                .filter { (depotId, depot) ->
-                    return@filter filterForDownloadableDepots(depot, has64Bit, containerLanguage, ownedDlc)
-                }
-                .associate { it.toPair() }
+            return filterAuthorizedDepots(
+                appInfo.depots.asSequence()
+                    .filter { (_, depot) ->
+                        filterForDownloadableDepots(depot, has64Bit, containerLanguage, ownedDlc)
+                    }
+                    .associate { it.toPair() },
+                authorizedDepotIds,
+            )
         }
 
         /**
@@ -726,41 +756,52 @@ class SteamService : Service(), IChallengeUrlChanged {
         fun getDownloadableDepots(appId: Int, preferredLanguage: String): Map<Int, DepotInfo> {
             val appInfo = getAppInfoOf(appId) ?: return emptyMap()
             val ownedDlc = runBlocking { getOwnedAppDlc(appId) }
+            val indirectDlcApps = getDownloadableDlcAppsOf(appId).orEmpty()
+            val authorizedDepotIds = getAuthorizedDepotIds(
+                buildSet {
+                    add(appId)
+                    ownedDlc.values.mapTo(this) { it.dlcAppId }.remove(INVALID_APP_ID)
+                    indirectDlcApps.mapTo(this) { it.id }
+                },
+            )
 
             // If the game ships any 64-bit depot, prefer those and ignore x86 ones
             val has64Bit = appInfo.depots.values.any { it.osArch == OSArch.Arch64 }
 
-            val map = appInfo.depots
-                .asSequence()
-                .filter { (depotId, depot) ->
-                    return@filter filterForDownloadableDepots(depot, has64Bit, preferredLanguage, ownedDlc)
-                }
-                .associate { it.toPair() }
-                .toMutableMap()
-
-            val indirectDlcApps = getDownloadableDlcAppsOf(appId).orEmpty()
-            indirectDlcApps.forEach { dlcApp ->
-                dlcApp.depots
+            val map = filterAuthorizedDepots(
+                appInfo.depots
                     .asSequence()
-                    .filter { (depotId, depot) ->
-                        return@filter filterForDownloadableDepots(depot, has64Bit, preferredLanguage, null)
+                    .filter { (_, depot) ->
+                        filterForDownloadableDepots(depot, has64Bit, preferredLanguage, ownedDlc)
                     }
-                    .associate { it.toPair() }
-                    .forEach { (depotId, depot) ->
-                        // Add DLC Depots with custom object
-                        map[depotId] = DepotInfo(
-                            depotId = depot.depotId,
-                            dlcAppId = dlcApp.id, // Set to DLC App ID
-                            optionalDlcId = depot.optionalDlcId,
-                            depotFromApp = depot.depotFromApp,
-                            sharedInstall = depot.sharedInstall,
-                            osList = depot.osList,
-                            osArch = depot.osArch,
-                            language = depot.language,
-                            manifests = depot.manifests,
-                            encryptedManifests = depot.encryptedManifests,
-                        )
-                    }
+                    .associate { it.toPair() },
+                authorizedDepotIds,
+            ).toMutableMap()
+
+            indirectDlcApps.forEach { dlcApp ->
+                filterAuthorizedDepots(
+                    dlcApp.depots
+                        .asSequence()
+                        .filter { (_, depot) ->
+                            filterForDownloadableDepots(depot, has64Bit, preferredLanguage, null)
+                        }
+                        .associate { it.toPair() },
+                    authorizedDepotIds,
+                ).forEach { (depotId, depot) ->
+                    // Add DLC Depots with custom object
+                    map[depotId] = DepotInfo(
+                        depotId = depot.depotId,
+                        dlcAppId = dlcApp.id, // Set to DLC App ID
+                        optionalDlcId = depot.optionalDlcId,
+                        depotFromApp = depot.depotFromApp,
+                        sharedInstall = depot.sharedInstall,
+                        osList = depot.osList,
+                        osArch = depot.osArch,
+                        language = depot.language,
+                        manifests = depot.manifests,
+                        encryptedManifests = depot.encryptedManifests,
+                    )
+                }
             }
 
             return map

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -40,9 +40,22 @@ import java.util.concurrent.TimeUnit
 
 object SteamUtils {
 
+    private const val MAX_REASONABLE_DOWNLOAD_TO_INSTALL_RATIO = 2L
+
     fun getDownloadBytes(manifest: ManifestInfo?): Long {
         if (manifest == null) return 0L
-        return if (manifest.download > 0L) manifest.download else manifest.size
+
+        val download = manifest.download
+        val size = manifest.size
+
+        if (download <= 0L) return size
+        if (size <= 0L) return download
+
+        if (download > size && download / size >= MAX_REASONABLE_DOWNLOAD_TO_INSTALL_RATIO) {
+            return size
+        }
+
+        return download
     }
 
     internal val http = Net.http.newBuilder()


### PR DESCRIPTION
https://discord.com/channels/1378308569287622737/1390983459605971004/1390983459605971004
https://discord.com/channels/1378308569287622737/1486315594398699530/1486315594398699530


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated Steam download size for FINAL FANTASY XIII by using sane manifest values and counting only depots the user is licensed to download.

- Bug Fixes
  - Only include depots authorized by the user's licenses for the base app and DLC (including indirect DLC). Falls back to all depots if none are authorized.
  - Clamp unrealistic manifest download sizes (>=2x the install size) to the install size, with sensible fallbacks when either value is missing.

<sup>Written for commit 723f56bb46fdc6ba29fbd80ef1faebcc4f930da1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected depot filtering to respect user license entitlements when determining available downloadable content
  * Improved download size estimation accuracy by addressing inflated manifest values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->