### PR TITLE
Use canonical root for dosdevices (imagefs parent safeguard)

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3717,7 +3717,7 @@ private fun setupWineSystemFiles(
     }
 
     WineStartMenuCreator.create(context, container)
-    WineUtils.createDosdevicesSymlinks(container)
+    WineUtils.createDosdevicesSymlinks(context, container)
 
     val startupSelection = container.startupSelection.toString()
     if (startupSelection != container.getExtra("startupSelection")) {

--- a/app/src/main/java/com/winlator/core/WineUtils.java
+++ b/app/src/main/java/com/winlator/core/WineUtils.java
@@ -11,6 +11,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -20,13 +21,17 @@ import java.util.Locale;
 import timber.log.Timber;
 
 public abstract class WineUtils {
-    public static void createDosdevicesSymlinks(Container container) {
+    public static void createDosdevicesSymlinks(Context context, Container container) throws IOException {
         String dosdevicesPath = (new File(container.getRootDir(), ".wine/dosdevices")).getPath();
         File[] files = (new File(dosdevicesPath)).listFiles();
         if (files != null) for (File file : files) if (file.getName().matches("[a-z]:")) file.delete();
 
         FileUtils.symlink("../drive_c", dosdevicesPath+"/c:");
-        FileUtils.symlink(container.getRootDir().getPath() + "/../..", dosdevicesPath+"/z:");
+        // Z: must point at the resolved imagefs root so the guest sees only opt, home, usr, etc.,
+        // not the parent directory (files) which would expose imagefs_shared, etc.
+        File imagefsRoot = ImageFs.find(context).getRootDir();
+        String zTarget = imagefsRoot.getAbsoluteFile().getCanonicalPath();
+        FileUtils.symlink(zTarget, dosdevicesPath + "/z:");
 
 
         // Auto-fix containers missing D: and E: drives


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point the Wine Z: drive to the canonical imagefs root to prevent access to parent directories. This sandboxes the guest to the image filesystem.

- **Bug Fixes**
  - Resolve Z: using `ImageFs` and a canonical path instead of `"../.."`, preventing exposure of `imagefs_shared` and similar paths.
  - Update `XServerScreen.kt` to call `WineUtils.createDosdevicesSymlinks(context, container)`.

<sup>Written for commit 44f67c5bc727c1277a6cd5b1176c495ad07cd509. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Z: drive path resolution in Wine system configuration to ensure correct file system mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->