### PR TITLE
Refactored default Proton downloads to launch deps

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1592,45 +1592,6 @@ fun preLaunchApp(
                     this,
                     context = context,
                 ).await()
-            } else {
-                if (container.wineVersion.contains("proton-9.0-arm64ec") &&
-                    !SteamService.isFileInstallable(context, "proton-9.0-arm64ec.txz")
-                ) {
-                    setLoadingMessage("Downloading arm64ec Proton")
-                    SteamService.downloadFile(
-                        onDownloadProgress = { setLoadingProgress(it / 1.0f) },
-                        this,
-                        context = context,
-                        "proton-9.0-arm64ec.txz",
-                    ).await()
-                } else if (container.wineVersion.contains("proton-9.0-x86_64") &&
-                    !SteamService.isFileInstallable(context, "proton-9.0-x86_64.txz")
-                ) {
-                    setLoadingMessage("Downloading x86_64 Proton")
-                    SteamService.downloadFile(
-                        onDownloadProgress = { setLoadingProgress(it / 1.0f) },
-                        this,
-                        context = context,
-                        "proton-9.0-x86_64.txz",
-                    ).await()
-                }
-                if (container.wineVersion.contains("proton-9.0-x86_64") || container.wineVersion.contains("proton-9.0-arm64ec")) {
-                    val protonVersion = container.wineVersion
-                    val imageFs = ImageFs.find(context)
-                    val outFile = File(imageFs.rootDir, "/opt/$protonVersion")
-                    val binDir = File(outFile, "bin")
-                    if (!binDir.exists() || !binDir.isDirectory) {
-                        Timber.i("Extracting $protonVersion to /opt/")
-                        setLoadingMessage("Extracting $protonVersion")
-                        setLoadingProgress(-1f)
-                        val downloaded = File(imageFs.getFilesDir(), "$protonVersion.txz")
-                        TarCompressorUtils.extract(
-                            TarCompressorUtils.Type.XZ,
-                            downloaded,
-                            outFile,
-                        )
-                    }
-                }
             }
 
             if (!container.isUseLegacyDRM && !container.isLaunchRealSteam &&

--- a/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
+++ b/app/src/main/java/app/gamenative/utils/LaunchDependencies.kt
@@ -3,6 +3,7 @@ package app.gamenative.utils
 import android.content.Context
 import app.gamenative.R
 import app.gamenative.data.GameSource
+import app.gamenative.utils.launchdependencies.BionicDefaultProtonDependency
 import app.gamenative.utils.launchdependencies.GogScriptInterpreterDependency
 import app.gamenative.utils.launchdependencies.LaunchDependencyCallbacks
 import app.gamenative.utils.launchdependencies.LaunchDependency
@@ -18,6 +19,7 @@ const val LOADING_PROGRESS_UNKNOWN: Float = -1f
 class LaunchDependencies {
     companion object {
         private val launchDependencies: List<LaunchDependency> = listOf(
+            BionicDefaultProtonDependency,
             GogScriptInterpreterDependency,
         )
     }

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/BionicDefaultProtonDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/BionicDefaultProtonDependency.kt
@@ -1,0 +1,90 @@
+package app.gamenative.utils.launchdependencies
+
+import android.content.Context
+import app.gamenative.data.GameSource
+import app.gamenative.service.SteamService
+import app.gamenative.utils.LOADING_PROGRESS_UNKNOWN
+import com.winlator.container.Container
+import com.winlator.core.TarCompressorUtils
+import com.winlator.xenvironment.ImageFs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.File
+
+/**
+ * Ensures Proton (arm64ec or x86_64) is downloaded and extracted to imagefs_shared/proton for Bionic.
+ * Only runs when container variant is BIONIC and wine version is proton-9.0-arm64ec or proton-9.0-x86_64.
+ */
+object BionicDefaultProtonDependency : LaunchDependency {
+    override fun appliesTo(container: Container, gameSource: GameSource, gameId: Int): Boolean {
+        if (container.containerVariant != Container.BIONIC) return false
+        val v = container.wineVersion
+        return v.contains("proton-9.0-arm64ec") || v.contains("proton-9.0-x86_64")
+    }
+
+    override fun isSatisfied(context: Context, container: Container, gameSource: GameSource, gameId: Int): Boolean {
+        val protonVersion = container.wineVersion
+        val outFile = File(ImageFs.find(context).getRootDir(), "opt/$protonVersion")
+        val binDir = File(outFile, "bin")
+        return binDir.exists() && binDir.isDirectory
+    }
+
+    override fun getLoadingMessage(context: Context, container: Container, gameSource: GameSource, gameId: Int): String {
+        return when {
+            container.wineVersion.contains("proton-9.0-arm64ec") -> "Downloading arm64ec Proton"
+            container.wineVersion.contains("proton-9.0-x86_64") -> "Downloading x86_64 Proton"
+            else -> "Extracting Proton"
+        }
+    }
+
+    override suspend fun install(
+        context: Context,
+        container: Container,
+        callbacks: LaunchDependencyCallbacks,
+        gameSource: GameSource,
+        gameId: Int,
+    ) = coroutineScope {
+        val protonVersion = container.wineVersion
+        val imageFs = withContext(Dispatchers.IO) { ImageFs.find(context) }
+        val archiveName = when {
+            protonVersion.contains("proton-9.0-arm64ec") -> "proton-9.0-arm64ec.txz"
+            protonVersion.contains("proton-9.0-x86_64") -> "proton-9.0-x86_64.txz"
+            else -> return@coroutineScope
+        }
+
+        if (!withContext(Dispatchers.IO) { SteamService.isFileInstallable(context, archiveName) }) {
+            callbacks.setLoadingMessage("Downloading $protonVersion")
+            withContext(Dispatchers.IO) {
+                SteamService.downloadFile(
+                    onDownloadProgress = { callbacks.setLoadingProgress(it) },
+                    parentScope = this@coroutineScope,
+                    context = context,
+                    archiveName,
+                ).await()
+            }
+        }
+
+        val outFile = File(ImageFs.find(context).getRootDir(), "opt/$protonVersion")
+        val binDir = File(outFile, "bin")
+        val needsExtract = withContext(Dispatchers.IO) { !binDir.exists() || !binDir.isDirectory }
+        if (needsExtract) {
+            Timber.i("Extracting $protonVersion to ${outFile.absolutePath}")
+            callbacks.setLoadingMessage("Extracting $protonVersion")
+            callbacks.setLoadingProgress(LOADING_PROGRESS_UNKNOWN)
+            val downloaded = File(imageFs.getFilesDir(), archiveName)
+            withContext(Dispatchers.IO) {
+                val success = TarCompressorUtils.extract(
+                    TarCompressorUtils.Type.XZ,
+                    downloaded,
+                    outFile,
+                )
+                if (!success) {
+                    throw IllegalStateException("Failed to extract $protonVersion from ${downloaded.absolutePath}")
+                }
+                downloaded.delete()
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved default Proton 9.0 (arm64ec/x86_64) download and extraction into a launch dependency for Bionic containers. This simplifies pre-launch and standardizes behavior; GLIBC containers are unchanged.

- **Refactors**
  - Added `BionicDefaultProtonDependency` for `Container.BIONIC` when `wineVersion` is `proton-9.0-arm64ec` or `proton-9.0-x86_64`.
  - Registered in `LaunchDependencies` and removed inline handling from `PluviaMain`.
  - Checks install via `opt/<protonVersion>/bin`, downloads via `SteamService.downloadFile` with progress, extracts the `.txz` to `/opt/<protonVersion>`, then deletes the archive.

<sup>Written for commit c9f51eb1da8e4678580b1335db613095a6c126fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted launch dependency ordering so BIONIC Proton handling runs earlier; GLIBC pre-launch no longer performs Proton download/extract.

* **New Features**
  * BIONIC containers now detect and on-demand install Proton 9.0 (ARM64EC and x86_64) with progress/status updates, archive extraction, and cleanup; installation is skipped if already present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->