### PR TITLE
refactor: Symlink imagefs_shared proton in the variants + migrate old proton versions

### DIFF
--- a/app/src/main/java/app/gamenative/utils/launchdependencies/BionicDefaultProtonDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/BionicDefaultProtonDependency.kt
@@ -26,7 +26,7 @@ object BionicDefaultProtonDependency : LaunchDependency {
 
     override fun isSatisfied(context: Context, container: Container, gameSource: GameSource, gameId: Int): Boolean {
         val protonVersion = container.wineVersion
-        val outFile = File(ImageFs.find(context).getRootDir(), "opt/$protonVersion")
+        val outFile = File(ImageFs.getSharedProtonDir(context), protonVersion)
         val binDir = File(outFile, "bin")
         return binDir.exists() && binDir.isDirectory
     }
@@ -66,7 +66,7 @@ object BionicDefaultProtonDependency : LaunchDependency {
             }
         }
 
-        val outFile = File(ImageFs.find(context).getRootDir(), "opt/$protonVersion")
+        val outFile = File(ImageFs.getSharedProtonDir(context), protonVersion)
         val binDir = File(outFile, "bin")
         val needsExtract = withContext(Dispatchers.IO) { !binDir.exists() || !binDir.isDirectory }
         if (needsExtract) {

--- a/app/src/main/java/com/winlator/contents/ContentsManager.java
+++ b/app/src/main/java/com/winlator/contents/ContentsManager.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 
 import com.winlator.core.FileUtils;
 import com.winlator.core.TarCompressorUtils;
+import com.winlator.xenvironment.ImageFs;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -320,11 +321,10 @@ public class ContentsManager {
     }
 
     public static File getContentTypeDir(Context context, ContentProfile.ContentType type) {
-        // Wine/Proton must be installed inside imagefs/opt/ to run inside proot environment
-        // This is required for ARM64EC Wine to handle mmap(PROT_EXEC) calls properly
+        // Wine/Proton install to imagefs_shared/proton; symlinked into each variant's opt
         if (type == ContentProfile.ContentType.CONTENT_TYPE_WINE
                 || type == ContentProfile.ContentType.CONTENT_TYPE_PROTON) {
-            return new File(context.getFilesDir(), "imagefs/opt");
+            return ImageFs.getSharedProtonDir(context);
         }
         return new File(getContentDir(context), type.toString());
     }

--- a/app/src/main/java/com/winlator/xenvironment/ImageFSLegacyMigrator.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFSLegacyMigrator.java
@@ -14,6 +14,9 @@ public final class ImageFSLegacyMigrator {
         if (!migrateLegacyHomeToShared(context, legacyImageFsRoot)) {
             return false;
         }
+        if (!migrateLegacyProtonToShared(context, legacyImageFsRoot)) {
+            return false;
+        }
         return true;
     }
 
@@ -55,5 +58,45 @@ public final class ImageFSLegacyMigrator {
             Log.i("ImageFSLegacyMigrator", "Migrated legacy home via direct move to: " + sharedHomeRoot.getAbsolutePath());
             return true;
         }
+    }
+
+    /**
+     * Before deleting legacy opt/proton-<version> directories, preserve them by moving them into
+     * files/imagefs_shared/proton so they can be symlinked.
+     */
+    private static boolean migrateLegacyProtonToShared(Context context, File legacyImageFsRoot) {
+        File optDir = new File(legacyImageFsRoot, "opt");
+        File[] optEntries = optDir.listFiles();
+        if (optEntries == null) {
+            return true;
+        }
+
+        for (File entry : optEntries) {
+            if (!entry.isDirectory() || FileUtils.isSymlink(entry) || !entry.getName().startsWith("proton-")) {
+                continue;
+            }
+
+            File sharedProtonDir = new File(ImageFs.getSharedProtonDir(context), entry.getName());
+            if (sharedProtonDir.exists()) {
+                Log.w("ImageFSLegacyMigrator", "Shared Proton already exists; refusing to overwrite during migration: " + entry.getName());
+                continue;
+            }
+
+            if (!entry.renameTo(sharedProtonDir)) {
+                Log.w("ImageFSLegacyMigrator", "Direct move failed for Proton " + entry.getName() + "; falling back to copy+delete.");
+                boolean copied = FileUtils.copy(entry, sharedProtonDir);
+                if (copied) {
+                    FileUtils.delete(entry);
+                    Log.i("ImageFSLegacyMigrator", "Migrated Proton via copy+delete to: " + sharedProtonDir.getAbsolutePath());
+                    continue;
+                }
+                Log.w("ImageFSLegacyMigrator", "Failed to migrate Proton directory: " + entry.getAbsolutePath());
+                return false;
+            }
+
+            Log.i("ImageFSLegacyMigrator", "Migrated Proton via direct move to: " + sharedProtonDir.getAbsolutePath());
+        }
+
+        return true;
     }
 }

--- a/app/src/main/java/com/winlator/xenvironment/ImageFs.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFs.java
@@ -34,6 +34,15 @@ public class ImageFs {
         wineprefix = rootDir + WINEPREFIX;
     }
 
+    /** Shared Proton directory; opt/<version> in each variant symlinks here. */
+    public static File getSharedProtonDir(Context context) {
+        File sharedProtonDir = new File(context.getFilesDir(), "imagefs_shared/proton");
+        if (!sharedProtonDir.exists()) {
+            sharedProtonDir.mkdirs();
+        }
+        return sharedProtonDir;
+    }
+
     public static ImageFs find(Context context) {
         ImageFs local = INSTANCE;
         if (local != null) return local;

--- a/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
@@ -19,6 +19,7 @@ import com.winlator.PrefManager;
 import com.winlator.container.Container;
 import com.winlator.container.ContainerManager;
 // import com.winlator.core.DownloadProgressDialog;
+import com.winlator.contents.ContentProfile;
 import com.winlator.contents.ContentsManager;
 import com.winlator.core.Callback;
 import com.winlator.core.DefaultVersion;
@@ -86,7 +87,13 @@ public abstract class ImageFsInstaller {
         }
     }
 
-    private static Future<Boolean> installFromAssetsFuture(final Context context, AssetManager assetManager, String containerVariant, Callback<Integer> onProgress) {
+    private static Future<Boolean> installFromAssetsFuture(
+            final Context context,
+            AssetManager assetManager,
+            String containerVariant,
+            String wineVersion,
+            Callback<Integer> onProgress
+    ) {
         // AppUtils.keepScreenOn(context);
         ImageFs imageFs = ImageFs.find(context);
         final File rootDir = imageFs.getRootDir();
@@ -99,6 +106,7 @@ public abstract class ImageFsInstaller {
         return Executors.newSingleThreadExecutor().submit(() -> {
             clearRootDir(context, rootDir);
             ensureSharedHomeRoot(context, rootDir);
+            ensureProtonVersionSymlink(context, rootDir, wineVersion);
 
             final byte compressionRatio = 22;
             String imagefsFile = containerVariant.equals(Container.GLIBC) ? "imagefs_gamenative.txz" : "imagefs_bionic.txz";
@@ -204,17 +212,25 @@ public abstract class ImageFsInstaller {
     }
     public static Future<Boolean> installIfNeededFuture(final Context context, AssetManager assetManager, Container container, Callback<Integer> onProgress) {
         ImageFs imageFs = ImageFs.find(context);
+        String wineVersion = container.getWineVersion();
         if (!ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, imageFs.getRootDir())) {
             Log.w("ImageFsInstaller", "Failed to migrate legacy directories before installation.");
             return Executors.newSingleThreadExecutor().submit(() -> false);
         }
         if (!imageFs.isValid() || imageFs.getVersion() < LATEST_VERSION || !imageFs.getVariant().equals(container.getContainerVariant())) {
             Log.d("ImageFsInstaller", "Installing image from assets");
-            return installFromAssetsFuture(context, assetManager, container.getContainerVariant(), onProgress);
+            return installFromAssetsFuture(
+                    context,
+                    assetManager,
+                    container.getContainerVariant(),
+                    wineVersion,
+                    onProgress
+            );
         } else {
             Log.d("ImageFsInstaller", "Image FS already valid and at latest version");
             return Executors.newSingleThreadExecutor().submit(() -> {
                 ensureSharedHomeRoot(context, imageFs.getRootDir());
+                ensureProtonVersionSymlink(context, imageFs.getRootDir(), wineVersion);
                 return true;
             });
         }
@@ -408,5 +424,73 @@ public abstract class ImageFsInstaller {
         }
 
         FileUtils.symlink(sharedHomeRoot.getPath(), homePathInImageFs.getPath());
+    }
+
+    /**
+     * For Bionic: ensures rootDir/opt/<protonVersion> points to imagefs_shared/proton/<protonVersion>.
+     * This keeps only the active Proton version linked in opt, matching pre-branch layout.
+     */
+    public static void ensureProtonVersionSymlink(Context context, File rootDir, String protonVersion) {
+        if (protonVersion == null || protonVersion.isEmpty() || !protonVersion.startsWith("proton-")) return;
+        File optDir = new File(rootDir, "opt");
+        if (!optDir.exists()) {
+            optDir.mkdirs();
+        }
+        removeCurrentProtonSymlink(optDir, protonVersion);
+
+        File targetVersionDir = resolveInstalledProtonDir(context, protonVersion);
+        if (!targetVersionDir.isDirectory()) {
+            Log.w("ImageFsInstaller", "Skipping Proton symlink; shared dir missing for " + protonVersion);
+            return;
+        }
+        File optVersionLink = new File(optDir, protonVersion);
+        try {
+            if (optVersionLink.exists()) {
+                File currentTarget = optVersionLink.getCanonicalFile();
+                File desiredTarget = targetVersionDir.getCanonicalFile();
+                if (currentTarget.equals(desiredTarget)) {
+                    return;
+                }
+                FileUtils.delete(optVersionLink);
+            }
+            FileUtils.symlink(targetVersionDir.getAbsolutePath(), optVersionLink.getAbsolutePath());
+            Log.d("ImageFsInstaller", "Created opt/" + protonVersion + " -> " + targetVersionDir.getAbsolutePath());
+        } catch (Exception e) {
+            Log.e("ImageFsInstaller", "ensureProtonVersionSymlink failed for " + protonVersion, e);
+        }
+    }
+
+    private static File resolveInstalledProtonDir(Context context, String protonVersion) {
+        ContentsManager contentsManager = new ContentsManager(context);
+        contentsManager.syncContents();
+        ContentProfile profile = contentsManager.getProfileByEntryName(protonVersion);
+        if (profile != null && (profile.type == ContentProfile.ContentType.CONTENT_TYPE_WINE
+                || profile.type == ContentProfile.ContentType.CONTENT_TYPE_PROTON)) {
+            return ContentsManager.getInstallDir(context, profile);
+        }
+        return new File(ImageFs.getSharedProtonDir(context), protonVersion);
+    }
+
+    /**
+     * Removes the current Proton symlink(s) from opt/ so it can be replaced with the current proton
+     * version symlink.
+     */
+    private static void removeCurrentProtonSymlink(File optDir, String activeProtonVersion) {
+        File[] optEntries = optDir.listFiles();
+        if (optEntries == null) {
+            return;
+        }
+
+        for (File entry : optEntries) {
+            if (!entry.getName().startsWith("proton-")) {
+                continue;
+            }
+            if (entry.getName().equals(activeProtonVersion)) {
+                continue;
+            }
+            if (FileUtils.isSymlink(entry)) {
+                FileUtils.delete(entry);
+            }
+        }
     }
 }

--- a/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
@@ -35,6 +35,7 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -430,8 +431,9 @@ public abstract class ImageFsInstaller {
     public static void ensureProtonVersionSymlink(Context context, File rootDir, String protonVersion) {
         if (protonVersion == null || protonVersion.isEmpty() || !protonVersion.startsWith("proton-")) return;
         File optDir = new File(rootDir, "opt");
-        if (!optDir.exists()) {
-            optDir.mkdirs();
+        if (!optDir.exists() && !optDir.mkdirs()) {
+            Log.e("ImageFsInstaller", "Failed to create opt directory: " + optDir.getAbsolutePath());
+            return;
         }
         removeCurrentProtonSymlink(optDir, protonVersion);
 
@@ -442,19 +444,41 @@ public abstract class ImageFsInstaller {
         }
         File optVersionLink = new File(optDir, protonVersion);
         try {
-            if (optVersionLink.exists()) {
-                File currentTarget = optVersionLink.getCanonicalFile();
-                File desiredTarget = targetVersionDir.getCanonicalFile();
-                if (currentTarget.equals(desiredTarget)) {
-                    return;
-                }
-                FileUtils.delete(optVersionLink);
-            }
+            File desiredTarget = targetVersionDir.getCanonicalFile();
+            if (isLinkAlreadyCorrect(optVersionLink, desiredTarget)) return;
+            if (!deleteExistingPathIfPresent(optVersionLink)) return;
+
             FileUtils.symlink(targetVersionDir.getAbsolutePath(), optVersionLink.getAbsolutePath());
+            if (!Files.isSymbolicLink(optVersionLink.toPath())) {
+                Log.e("ImageFsInstaller", "Failed to create Proton symlink at: " + optVersionLink.getAbsolutePath());
+                return;
+            }
+            File linkedTarget = optVersionLink.getCanonicalFile();
+            if (!linkedTarget.equals(desiredTarget)) {
+                Log.e("ImageFsInstaller", "Proton symlink points to unexpected target: " + linkedTarget);
+                return;
+            }
             Log.d("ImageFsInstaller", "Created opt/" + protonVersion + " -> " + targetVersionDir.getAbsolutePath());
         } catch (Exception e) {
             Log.e("ImageFsInstaller", "ensureProtonVersionSymlink failed for " + protonVersion, e);
         }
+    }
+
+    private static boolean isLinkAlreadyCorrect(File optVersionLink, File desiredTarget) {
+        if (!Files.isSymbolicLink(optVersionLink.toPath())) return false;
+        try {
+            return optVersionLink.getCanonicalFile().equals(desiredTarget);
+        } catch (IOException ignored) {
+            // Dangling symlink (or inaccessible target): treat as incorrect and replace.
+            return false;
+        }
+    }
+
+    private static boolean deleteExistingPathIfPresent(File path) {
+        if (!Files.isSymbolicLink(path.toPath()) && !path.exists()) return true;
+        if (FileUtils.delete(path)) return true;
+        Log.e("ImageFsInstaller", "Failed to delete existing Proton path: " + path.getAbsolutePath());
+        return false;
     }
 
     private static File resolveInstalledProtonDir(Context context, String protonVersion) {

--- a/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
@@ -207,9 +207,6 @@ public abstract class ImageFsInstaller {
 
     private static void chmod(File f) { if (f.exists()) FileUtils.chmod(f, 0755);}
 
-    public static Future<Boolean> installIfNeededFuture(final Context context, AssetManager assetManager) {
-        return installIfNeededFuture(context, assetManager, null, null);
-    }
     public static Future<Boolean> installIfNeededFuture(final Context context, AssetManager assetManager, Container container, Callback<Integer> onProgress) {
         ImageFs imageFs = ImageFs.find(context);
         String wineVersion = container.getWineVersion();

--- a/app/src/test/java/app/gamenative/utils/launchdependencies/BionicDefaultProtonDependencyTest.kt
+++ b/app/src/test/java/app/gamenative/utils/launchdependencies/BionicDefaultProtonDependencyTest.kt
@@ -71,8 +71,7 @@ class BionicDefaultProtonDependencyTest {
     fun isSatisfied_returnsTrue_whenProtonBinDirectoryExists() {
         every { container.wineVersion } returns "proton-9.0-arm64ec"
 
-        val imageFsRoot = ImageFs.find(context).rootDir
-        val binDir = File(imageFsRoot, "opt/proton-9.0-arm64ec/bin")
+        val binDir = File(ImageFs.getSharedProtonDir(context), "proton-9.0-arm64ec/bin")
         binDir.mkdirs()
 
         val result = BionicDefaultProtonDependency.isSatisfied(context, container, GameSource.STEAM, 4)
@@ -125,8 +124,7 @@ class BionicDefaultProtonDependencyTest {
         every { container.wineVersion } returns "proton-9.0-arm64ec"
         mockkObject(SteamService.Companion)
 
-        val imageFsRoot = ImageFs.find(context).rootDir
-        val binDir = File(imageFsRoot, "opt/proton-9.0-arm64ec/bin")
+        val binDir = File(ImageFs.getSharedProtonDir(context), "proton-9.0-arm64ec/bin")
         binDir.mkdirs()
 
         every { SteamService.isFileInstallable(context, "proton-9.0-arm64ec.txz") } returns false

--- a/app/src/test/java/com/winlator/xenvironment/ImageFSLegacyMigratorTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFSLegacyMigratorTest.kt
@@ -85,4 +85,52 @@ class ImageFSLegacyMigratorTest {
         assertTrue(migrated)
         assertTrue("Symlink should remain untouched", Files.isSymbolicLink(symlinkPath))
     }
+
+    @Test
+    fun migrateLegacyDirsIfNeeded_movesLegacyProtonDirsToSharedProton() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val protonDir = File(legacyImageFsRoot, "opt/proton-ge-9-2").apply { mkdirs() }
+        val protonFile = File(protonDir, "version.txt").apply { writeText("ge-9-2") }
+
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+
+        val sharedProtonDir = File(sharedDir, "proton/proton-ge-9-2")
+        assertTrue(migrated)
+        assertFalse("Legacy proton dir should be moved away", protonDir.exists())
+        assertTrue("Shared proton dir should exist", sharedProtonDir.exists())
+        assertEquals("ge-9-2", File(sharedProtonDir, protonFile.name).readText())
+    }
+
+    @Test
+    fun migrateLegacyDirsIfNeeded_skipsNonProtonAndSymlinkEntriesInOpt() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val optDir = File(legacyImageFsRoot, "opt").apply { mkdirs() }
+        File(optDir, "wine-ge-custom").apply { mkdirs() }
+
+        val protonReal = File(legacyImageFsRoot, "proton-real").apply { mkdirs() }
+        val protonSymlinkPath = File(optDir, "proton-symlink").toPath()
+        Files.createSymbolicLink(protonSymlinkPath, protonReal.toPath())
+
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+
+        assertTrue(migrated)
+        assertTrue(File(optDir, "wine-ge-custom").exists())
+        assertTrue(Files.isSymbolicLink(protonSymlinkPath))
+    }
+
+    @Test
+    fun migrateLegacyDirsIfNeeded_doesNotOverwriteExistingSharedProtonDir() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val legacyProton = File(legacyImageFsRoot, "opt/proton-ge-9-5").apply { mkdirs() }
+        File(legacyProton, "from-legacy.txt").writeText("legacy")
+
+        val existingShared = File(sharedDir, "proton/proton-ge-9-5").apply { mkdirs() }
+        File(existingShared, "existing.txt").writeText("shared")
+
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+
+        assertTrue(migrated)
+        assertTrue("Legacy proton should remain when shared exists", legacyProton.exists())
+        assertEquals("shared", File(existingShared, "existing.txt").readText())
+    }
 }

--- a/app/src/test/java/com/winlator/xenvironment/ImageFsInstallerTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFsInstallerTest.kt
@@ -4,6 +4,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.winlator.core.FileUtils
 import java.io.File
 import java.lang.reflect.Method
+import java.nio.file.Files
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
@@ -129,6 +130,48 @@ class ImageFsInstallerTest {
         } finally {
             unmockkStatic(FileUtils::class)
         }
+
+        rootDir.deleteRecursively()
+    }
+
+    @Test
+    fun ensureProtonVersionSymlink_replacesDanglingSymlinkAtActivePath() {
+        val rootDir = File(filesDir, "imagefs-root-dangling-proton-${System.nanoTime()}").apply { mkdirs() }
+        val activeProtonVersion = "proton-ge-9-3"
+        val optDir = File(rootDir, "opt").apply { mkdirs() }
+        val optVersionLink = File(optDir, activeProtonVersion)
+        val missingTarget = File(rootDir, "missing-proton-target")
+        Files.createSymbolicLink(optVersionLink.toPath(), missingTarget.toPath())
+
+        val desiredTarget = File(sharedDir, "proton/$activeProtonVersion").apply { mkdirs() }
+
+        assertFalse("Dangling symlink should report exists=false", optVersionLink.exists())
+        assertTrue("Active path should still be a symlink", Files.isSymbolicLink(optVersionLink.toPath()))
+
+        mockkStatic(FileUtils::class)
+        try {
+            every { FileUtils.delete(optVersionLink) } answers { optVersionLink.delete() }
+            every { FileUtils.delete(any<File>()) } answers { firstArg<File>().delete() }
+            every { FileUtils.symlink(any<String>(), any<String>()) } answers {
+                val linkTarget = firstArg<String>()
+                val linkPath = secondArg<String>()
+                val linkFile = File(linkPath)
+                if (Files.exists(linkFile.toPath()) || Files.isSymbolicLink(linkFile.toPath())) {
+                    linkFile.delete()
+                }
+                Files.createSymbolicLink(linkFile.toPath(), File(linkTarget).toPath())
+            }
+
+            ImageFsInstaller.ensureProtonVersionSymlink(context, rootDir, activeProtonVersion)
+        } finally {
+            unmockkStatic(FileUtils::class)
+        }
+
+        assertTrue("Active path should remain a symlink", Files.isSymbolicLink(optVersionLink.toPath()))
+        assertEquals(
+            desiredTarget.canonicalPath,
+            optVersionLink.canonicalFile.absolutePath,
+        )
 
         rootDir.deleteRecursively()
     }

--- a/app/src/test/java/com/winlator/xenvironment/ImageFsInstallerTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFsInstallerTest.kt
@@ -10,6 +10,7 @@ import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -107,6 +108,57 @@ class ImageFsInstallerTest {
         rootDir.deleteRecursively()
     }
 
+    @Test
+    fun ensureProtonVersionSymlink_callsSymlinkForActiveProtonVersion() {
+        val rootDir = File(filesDir, "imagefs-root-proton-${System.nanoTime()}").apply { mkdirs() }
+        val activeProtonVersion = "proton-ge-9-2"
+        val sharedProtonTarget = File(sharedDir, "proton/$activeProtonVersion").apply { mkdirs() }
+        val expectedLink = File(rootDir, "opt/$activeProtonVersion")
+
+        mockkStatic(FileUtils::class)
+        try {
+            every { FileUtils.symlink(any<String>(), any<String>()) } returns Unit
+            every { FileUtils.delete(any<File>()) } returns true
+            every { FileUtils.isSymlink(any<File>()) } returns false
+
+            ImageFsInstaller.ensureProtonVersionSymlink(context, rootDir, activeProtonVersion)
+
+            verify(exactly = 1) {
+                FileUtils.symlink(sharedProtonTarget.absolutePath, expectedLink.absolutePath)
+            }
+        } finally {
+            unmockkStatic(FileUtils::class)
+        }
+
+        rootDir.deleteRecursively()
+    }
+
+    @Test
+    fun removeCurrentProtonSymlink_removesOnlyNonActiveProtonSymlinks() {
+        val optDir = File(filesDir, "imagefs-opt-remove-proton-${System.nanoTime()}").apply { mkdirs() }
+        val active = File(optDir, "proton-ge-9-2").apply { mkdirs() }
+        val stale = File(optDir, "proton-ge-8-1").apply { mkdirs() }
+        val nonProton = File(optDir, "wine-9.0").apply { mkdirs() }
+
+        mockkStatic(FileUtils::class)
+        try {
+            every { FileUtils.isSymlink(active) } returns false
+            every { FileUtils.isSymlink(stale) } returns true
+            every { FileUtils.isSymlink(nonProton) } returns false
+            every { FileUtils.delete(any<File>()) } returns true
+
+            invokeRemoveCurrentProtonSymlink(optDir, "proton-ge-9-2")
+
+            verify(exactly = 1) { FileUtils.delete(stale) }
+            verify(exactly = 0) { FileUtils.delete(active) }
+            verify(exactly = 0) { FileUtils.delete(nonProton) }
+        } finally {
+            unmockkStatic(FileUtils::class)
+        }
+
+        optDir.deleteRecursively()
+    }
+
     private fun invokeEnsureSharedHomeRoot(context: android.content.Context, rootDir: File) {
         val method: Method = ImageFsInstaller::class.java.getDeclaredMethod(
             "ensureSharedHomeRoot",
@@ -115,6 +167,16 @@ class ImageFsInstallerTest {
         )
         method.isAccessible = true
         method.invoke(null, context, rootDir)
+    }
+
+    private fun invokeRemoveCurrentProtonSymlink(optDir: File, activeProtonVersion: String) {
+        val method: Method = ImageFsInstaller::class.java.getDeclaredMethod(
+            "removeCurrentProtonSymlink",
+            File::class.java,
+            String::class.java,
+        )
+        method.isAccessible = true
+        method.invoke(null, optDir, activeProtonVersion)
     }
 
 }

--- a/app/src/test/java/com/winlator/xenvironment/ImageFsTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFsTest.kt
@@ -28,4 +28,23 @@ class ImageFsTest {
         assertTrue("Shared dir should be a directory", actual.isDirectory)
         assertEquals(expected.absolutePath, actual.absolutePath)
     }
+
+    @Test
+    fun getSharedProtonDir_createsAndReturnsSharedProtonDirectory() {
+        val actual = ImageFs.getSharedProtonDir(context)
+        val expected = File(context.filesDir, "imagefs_shared/proton")
+
+        assertTrue("Shared proton dir should exist after call", actual.exists())
+        assertTrue("Shared proton dir should be a directory", actual.isDirectory)
+        assertEquals(expected.absolutePath, actual.absolutePath)
+    }
+
+    @Test
+    fun getSharedProtonDir_isUnderSharedRoot() {
+        val sharedRoot = ImageFs.getImageFsSharedDir(context)
+        val sharedProton = ImageFs.getSharedProtonDir(context)
+        val expected = File(sharedRoot, "proton")
+
+        assertEquals(expected.absolutePath, sharedProton.absolutePath)
+    }
 }


### PR DESCRIPTION
This PR is build upon the canonical root and proton download refactor PRs. Merge those first so this PR shrinks in complexity.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes Proton under imagefs_shared/proton and symlinks the active version into each variant’s opt/<version>. Migrates legacy opt/proton-* and home dirs to the shared layout and now fixes or replaces dangling Proton symlinks.

- **New Features**
  - Shared Proton: `BionicDefaultProtonDependency` and `ContentsManager` use `ImageFs.getSharedProtonDir`; `ImageFsInstaller.ensureProtonVersionSymlink` links `opt/<version>` to shared, removes stale symlinks, replaces dangling/incorrect links, and runs on fresh and existing images; `ImageFSLegacyMigrator` moves real legacy `opt/proton-*` into shared (skips symlinks, no overwrite, copy+delete fallback).

- **Refactors**
  - Removed unused `installIfNeededFuture(context, assetManager)` overload.

<sup>Written for commit 1ad15d318838bfdec4a3ff9a37dc392eca2b4be1. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1034?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated Proton/Wine installs into a shared application directory (imagefs_shared/proton) instead of per-image storage
  * Automatic migration of legacy Proton directories into the shared location, preserving contents when possible
  * Symlink management to ensure each image's opt/<version> points to the active shared Proton version
  * Install/extraction flow updated to target the shared Proton location and avoid redundant extractions

* **Tests**
  * New and updated unit tests covering shared Proton directory creation, migration, and symlink handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->