### PR TITLE
fix: custom game exit quits app instead of returning to library

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
@@ -191,8 +191,8 @@ class CustomGameAppScreen : BaseAppScreen() {
         libraryItem: LibraryItem,
         onClickPlay: (Boolean) -> Unit
     ) {
-        // Launch the game; preLaunchApp will show EXECUTABLE_NOT_FOUND if no exe (getLaunchExecutable blank)
-        PluviaApp.events.emit(AndroidEvent.ExternalGameLaunch(libraryItem.appId))
+        // custom games don't need downloading — go straight to preLaunchApp
+        onClickPlay(false)
     }
 
     override fun onPauseResumeClick(context: Context, libraryItem: LibraryItem) {


### PR DESCRIPTION
## Summary
- `ExternalGameLaunch` handler set `wasLaunchedViaExternalIntent = true` unconditionally — in-app launches (e.g. from library) triggered `finish()` on game exit instead of navigating back
- Add `fromExternalIntent` param to `ExternalGameLaunch` event, thread it through `AndroidEvent` → `MainViewModel` → `PluviaMain` so the flag only applies to actual external intents

Fixes #1039

## Test plan
- Launch custom game from library → exit → should return to library
- Launch custom game via `adb` intent → exit → should close activity
- Launch Steam game from library → exit → should return to library

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an exit flow bug: custom games launched from the library now return to the library on exit, while games launched via an external intent still close the activity. Fixes #1039.

- **Bug Fixes**
  - Route in‑app custom game launches through onClickPlay(false) instead of ExternalGameLaunch.
  - Add fromExternalIntent to ExternalGameLaunch and set wasLaunchedViaExternalIntent from it.
  - Only emit ExternalGameLaunch with fromExternalIntent = true when launched via an external intent in MainActivity.

<sup>Written for commit dffdd8caeb8d55de3954209b6ab3db8cf6eb8e73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game launch behavior to immediately start playback for installed games, streamlining the experience by removing unnecessary intermediate event processing that could delay gameplay initiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->