### PR TITLE
fix: hard-stop active session when app is destroyed

### DIFF
--- a/app/src/main/java/app/gamenative/MainActivity.kt
+++ b/app/src/main/java/app/gamenative/MainActivity.kt
@@ -264,10 +264,62 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private fun shouldHardStopRunningSessionOnDestroy(): Boolean {
+        if (isChangingConfigurations) return false
+        return PluviaApp.xEnvironment != null || SteamService.keepAlive
+    }
+
+    private fun hardStopRunningSession(reason: String) {
+        Timber.w("Hard stopping running session: %s", reason)
+
+        runCatching {
+            PluviaApp.touchpadView?.releasePointerCapture()
+        }.onFailure {
+            Timber.w(it, "Failed to release pointer capture during hard stop")
+        }
+
+        runCatching {
+            PluviaApp.xServerView?.getxServer()?.winHandler?.stop()
+        }.onFailure {
+            Timber.w(it, "Failed to stop WinHandler during hard stop")
+        }
+
+        runCatching {
+            PluviaApp.xEnvironment?.stopEnvironmentComponents()
+        }.onFailure {
+            Timber.w(it, "Failed to stop environment components during hard stop")
+        }
+
+        runCatching {
+            PluviaApp.achievementWatcher?.stop()
+            PluviaApp.achievementWatcher = null
+            SteamService.clearCachedAchievements()
+        }.onFailure {
+            Timber.w(it, "Failed to clean up achievement state during hard stop")
+        }
+
+        SteamService.keepAlive = false
+        PluviaApp.clearActiveSuspendState()
+        PluviaApp.xEnvironment = null
+        PluviaApp.xServerView = null
+        PluviaApp.inputControlsView = null
+        PluviaApp.inputControlsManager = null
+        PluviaApp.touchpadView = null
+    }
+
     override fun onDestroy() {
+        val hardStoppedRunningSession = shouldHardStopRunningSessionOnDestroy()
+        if (hardStoppedRunningSession) {
+            hardStopRunningSession("MainActivity destroyed while a session is active")
+        }
+
         super.onDestroy()
 
-        PluviaApp.events.emit(AndroidEvent.ActivityDestroyed)
+        if (!hardStoppedRunningSession) {
+            PluviaApp.events.emit(AndroidEvent.ActivityDestroyed)
+        } else {
+            Timber.i("Skipped ActivityDestroyed event after hard-stopping active session")
+        }
 
         PluviaApp.events.off<AndroidEvent.SetSystemUIVisibility, Unit>(onSetSystemUi)
         PluviaApp.events.off<AndroidEvent.StartOrientator, Unit>(onStartOrientator)
@@ -275,11 +327,12 @@ class MainActivity : ComponentActivity() {
         PluviaApp.events.off<AndroidEvent.EndProcess, Unit>(onEndProcess)
 
         Timber.d(
-            "onDestroy - Index: %d, Connected: %b, Logged-In: %b, Changing-Config: %b",
+            "onDestroy - Index: %d, Connected: %b, Logged-In: %b, Changing-Config: %b, Hard-Stopped-Session: %b",
             index,
             SteamService.isConnected,
             SteamService.isLoggedIn,
             isChangingConfigurations,
+            hardStoppedRunningSession,
         )
 
         if (SteamService.isConnected && !SteamService.isLoggedIn && !isChangingConfigurations && !SteamService.keepAlive) {


### PR DESCRIPTION
https://discord.com/channels/1378308569287622737/1487200361713373216/1487200361713373216

Lots of cases on the discord where user launches a new game but it loads forever, because previous wine proc did not tear down. This seems to mostly happen when swiping app away out of task manager when game is running

This fixes that scenario via explicit teardown of env and xserver and other components on mainactivity kill via task manager swipe away

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hard-stops any active session when `MainActivity` is destroyed (e.g., app is swiped away), preventing zombie processes and stale `SteamService.keepAlive`. Skips hard stop during configuration changes.

- **Bug Fixes**
  - Added safe teardown that releases pointer capture, stops X server and environment, stops achievement watcher, clears cached achievements, resets `SteamService.keepAlive`, clears suspend state, and nulls static refs.
  - Emit `AndroidEvent.ActivityDestroyed` only when no hard stop occurs.
  - onDestroy log now includes a hard-stop flag.

<sup>Written for commit 7ad11b6005926ac3bac785feb95d7eaf10c52f13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced app lifecycle management to ensure proper session termination and resource cleanup when the application closes or during device configuration changes. The app now prevents orphaned resources and memory issues, providing better stability and improved overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->