### PR TITLE
feat: added multi-controller support

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
@@ -7,6 +7,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import com.winlator.inputcontrols.Binding
 import com.winlator.inputcontrols.ControlElement
+import com.winlator.inputcontrols.ControllerManager
 import com.winlator.inputcontrols.ControlsProfile
 import com.winlator.inputcontrols.ExternalController
 import com.winlator.inputcontrols.ExternalControllerBinding
@@ -86,7 +87,7 @@ class PhysicalControllerHandler(
                     val offset = if (event.action == KeyEvent.ACTION_DOWN &&
                         (controllerBinding.binding == Binding.GAMEPAD_BUTTON_L2 || controllerBinding.binding == Binding.GAMEPAD_BUTTON_R2)
                     ) 1f else 0f
-                    handleInputEvent(controllerBinding.binding, event.action == KeyEvent.ACTION_DOWN, offset)
+                    handleInputEvent(controllerBinding.binding, event.action == KeyEvent.ACTION_DOWN, offset, event.deviceId)
                     return true
                 }
             }
@@ -119,13 +120,16 @@ class PhysicalControllerHandler(
         if (profile != null) {
             val controller = profile?.getController(event.deviceId)
             if (controller != null && controller.updateStateFromMotionEvent(event)) {
+                val deviceId = event.deviceId
+
                 // Process trigger buttons (L2/R2)
                 var controllerBinding = controller.getControllerBinding(KeyEvent.KEYCODE_BUTTON_L2)
                 if (controllerBinding != null) {
                     handleInputEvent(
                         controllerBinding.binding,
                         controller.state.triggerL > 0f,
-                        controller.state.triggerL
+                        controller.state.triggerL,
+                        deviceId
                     )
                 }
 
@@ -134,12 +138,13 @@ class PhysicalControllerHandler(
                     handleInputEvent(
                         controllerBinding.binding,
                         controller.state.triggerR > 0f,
-                        controller.state.triggerR
+                        controller.state.triggerR,
+                        deviceId
                     )
                 }
 
                 // Process analog stick input
-                processJoystickInput(controller)
+                processJoystickInput(controller, deviceId)
                 return true
             }
         }
@@ -173,7 +178,7 @@ class PhysicalControllerHandler(
      * Process analog stick input and apply bindings.
      * Extracted from InputControlsView.processJoystickInput()
      */
-    private fun processJoystickInput(controller: ExternalController) {
+    private fun processJoystickInput(controller: ExternalController, deviceId: Int = -1) {
         // Reset mouse movement offset at the start - contributions will be added during processing
         mouseMoveOffset.set(0f, 0f)
 
@@ -202,27 +207,24 @@ class PhysicalControllerHandler(
                 val activeKey = ExternalControllerBinding.getKeyCodeForAxis(axes[i], Mathf.sign(values[i]))
                 val oppositeKey = if (activeKey == posKeyCode) negKeyCode else posKeyCode
 
-                // always send press (gamepad bindings need continuous offset updates)
                 activeAxisBindings.add(activeKey)
                 controller.getControllerBinding(activeKey)?.let {
-                    handleInputEvent(it.binding, true, values[i])
+                    handleInputEvent(it.binding, true, values[i], deviceId)
                 }
-                // release opposite direction (if it was active)
                 if (activeAxisBindings.remove(oppositeKey)) {
                     controller.getControllerBinding(oppositeKey)?.let {
-                        handleInputEvent(it.binding, false, 0f)
+                        handleInputEvent(it.binding, false, 0f, deviceId)
                     }
                 }
             } else {
-                // release both directions only if they were active
                 if (activeAxisBindings.remove(posKeyCode)) {
                     controller.getControllerBinding(posKeyCode)?.let {
-                        handleInputEvent(it.binding, false, 0f)
+                        handleInputEvent(it.binding, false, 0f, deviceId)
                     }
                 }
                 if (activeAxisBindings.remove(negKeyCode)) {
                     controller.getControllerBinding(negKeyCode)?.let {
-                        handleInputEvent(it.binding, false, 0f)
+                        handleInputEvent(it.binding, false, 0f, deviceId)
                     }
                 }
             }
@@ -233,78 +235,92 @@ class PhysicalControllerHandler(
      * Apply a binding to the virtual gamepad state and send to WinHandler.
      * Extracted from InputControlsView.handleInputEvent()
      */
-    // offset: analog axis value for presses; must be 0f for releases (triggers use offset > 0f
-    // to determine pressed state, sticks gate on isActionDown, everything else ignores offset)
-    private fun handleInputEvent(binding: Binding, isActionDown: Boolean, offset: Float = 0f) {
+    private fun handleInputEvent(binding: Binding, isActionDown: Boolean, offset: Float = 0f, deviceId: Int = -1) {
         if (binding.isGamepad) {
-            val winHandler = xServer?.winHandler
-            val state = profile?.gamepadState
+            val winHandler = xServer?.winHandler ?: return
+            val controllerManager = ControllerManager.getInstance()
 
-            if (state != null) {
-                val buttonIdx = binding.ordinal - Binding.GAMEPAD_BUTTON_A.ordinal
-                if (buttonIdx <= ExternalController.IDX_BUTTON_R2.toInt()) {
-                    when (buttonIdx) {
-                        ExternalController.IDX_BUTTON_L2.toInt() -> {
-                            state.triggerL = offset
-                            state.setPressed(ExternalController.IDX_BUTTON_L2.toInt(), offset > 0f)
-                        }
-                        ExternalController.IDX_BUTTON_R2.toInt() -> {
-                            state.triggerR = offset
-                            state.setPressed(ExternalController.IDX_BUTTON_R2.toInt(), offset > 0f)
-                        }
-                        else -> state.setPressed(buttonIdx, isActionDown)
-                    }
-                }
-                else {
-                    when (binding) {
-                        Binding.GAMEPAD_LEFT_THUMB_UP, Binding.GAMEPAD_LEFT_THUMB_DOWN -> {
-                            state.thumbLY = if (isActionDown) offset else 0f
-                        }
-                        Binding.GAMEPAD_LEFT_THUMB_LEFT, Binding.GAMEPAD_LEFT_THUMB_RIGHT -> {
-                            state.thumbLX = if (isActionDown) offset else 0f
-                        }
-                        Binding.GAMEPAD_RIGHT_THUMB_UP, Binding.GAMEPAD_RIGHT_THUMB_DOWN -> {
-                            state.thumbRY = if (isActionDown) offset else 0f
-                        }
-                        Binding.GAMEPAD_RIGHT_THUMB_LEFT, Binding.GAMEPAD_RIGHT_THUMB_RIGHT -> {
-                            state.thumbRX = if (isActionDown) offset else 0f
-                        }
-                        Binding.GAMEPAD_DPAD_UP  -> {
-                            state.dpad[0] = isActionDown
-                            if(isActionDown) {
-                                state.dpad[Binding.GAMEPAD_DPAD_DOWN.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal ] = false
-                            }
-                        }
-                        Binding.GAMEPAD_DPAD_DOWN -> {
-                            state.dpad[binding.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal] = isActionDown
-                            if(isActionDown) {
-                                state.dpad[0] = false
-                            }
-                        }
-                       Binding.GAMEPAD_DPAD_LEFT -> {
-                            state.dpad[binding.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal] = isActionDown
-                            if(isActionDown) {
-                              state.dpad[Binding.GAMEPAD_DPAD_RIGHT.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal ] = false
-                          }
-                        }
-                        Binding.GAMEPAD_DPAD_RIGHT -> {
-                            state.dpad[binding.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal] = isActionDown
-                            if(isActionDown) {
-                                state.dpad[Binding.GAMEPAD_DPAD_LEFT.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal ] = false
-                            }
-                        }
-                        else -> {}
-                    }
-                }
+            // Determine which player slot this device belongs to
+            val slot = if (deviceId >= 0) controllerManager.autoAssignDevice(deviceId) else 0
+            if (slot < 0) return
 
-                if (winHandler != null) {
-                    val controller = winHandler.currentController
-                    if (controller != null) {
-                        controller.state.copy(state)
+            // Ensure we have a controller in this slot
+            var slotController = winHandler.getControllerForSlot(slot)
+            if (slotController == null || (deviceId >= 0 && slotController.deviceId != deviceId)) {
+                val adopted = profile?.getController(deviceId)
+                    ?: ExternalController.getController(deviceId)
+                    ?: return
+                winHandler.setControllerForSlot(slot, adopted)
+                slotController = adopted
+            }
+
+            val state = slotController.state
+
+            val buttonIdx = binding.ordinal - Binding.GAMEPAD_BUTTON_A.ordinal
+            if (buttonIdx <= ExternalController.IDX_BUTTON_R2.toInt()) {
+                when (buttonIdx) {
+                    ExternalController.IDX_BUTTON_L2.toInt() -> {
+                        state.triggerL = offset
+                        state.setPressed(ExternalController.IDX_BUTTON_L2.toInt(), offset > 0f)
                     }
-                    winHandler.sendGamepadState()
-                    winHandler.sendVirtualGamepadState(state)
+                    ExternalController.IDX_BUTTON_R2.toInt() -> {
+                        state.triggerR = offset
+                        state.setPressed(ExternalController.IDX_BUTTON_R2.toInt(), offset > 0f)
+                    }
+                    else -> state.setPressed(buttonIdx, isActionDown)
                 }
+            }
+            else {
+                when (binding) {
+                    Binding.GAMEPAD_LEFT_THUMB_UP, Binding.GAMEPAD_LEFT_THUMB_DOWN -> {
+                        state.thumbLY = if (isActionDown) offset else 0f
+                    }
+                    Binding.GAMEPAD_LEFT_THUMB_LEFT, Binding.GAMEPAD_LEFT_THUMB_RIGHT -> {
+                        state.thumbLX = if (isActionDown) offset else 0f
+                    }
+                    Binding.GAMEPAD_RIGHT_THUMB_UP, Binding.GAMEPAD_RIGHT_THUMB_DOWN -> {
+                        state.thumbRY = if (isActionDown) offset else 0f
+                    }
+                    Binding.GAMEPAD_RIGHT_THUMB_LEFT, Binding.GAMEPAD_RIGHT_THUMB_RIGHT -> {
+                        state.thumbRX = if (isActionDown) offset else 0f
+                    }
+                    Binding.GAMEPAD_DPAD_UP  -> {
+                        state.dpad[0] = isActionDown
+                        if(isActionDown) {
+                            state.dpad[Binding.GAMEPAD_DPAD_DOWN.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal ] = false
+                        }
+                    }
+                    Binding.GAMEPAD_DPAD_DOWN -> {
+                        state.dpad[binding.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal] = isActionDown
+                        if(isActionDown) {
+                            state.dpad[0] = false
+                        }
+                    }
+                    Binding.GAMEPAD_DPAD_LEFT -> {
+                        state.dpad[binding.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal] = isActionDown
+                        if(isActionDown) {
+                            state.dpad[Binding.GAMEPAD_DPAD_RIGHT.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal ] = false
+                        }
+                    }
+                    Binding.GAMEPAD_DPAD_RIGHT -> {
+                        state.dpad[binding.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal] = isActionDown
+                        if(isActionDown) {
+                            state.dpad[Binding.GAMEPAD_DPAD_LEFT.ordinal - Binding.GAMEPAD_DPAD_UP.ordinal ] = false
+                        }
+                    }
+                    else -> {}
+                }
+            }
+
+            // Write state to the correct .mem buffer for this player slot
+            val buffer = winHandler.getBufferForSlot(slot)
+            if (buffer != null) winHandler.sendMemoryFileState(slotController, buffer)
+
+            // UDP and virtual gamepad only for P1 (slot 0) for backward compat
+            if (slot == 0) {
+                profile?.gamepadState?.copy(state)
+                winHandler.sendGamepadState()
+                winHandler.sendVirtualGamepadState(state)
             }
         } else {
             // Handle special bindings

--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -11,6 +11,8 @@ import android.view.KeyEvent;
 
 import app.gamenative.PrefManager;
 
+import com.winlator.winhandler.WinHandler;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,7 +46,7 @@ public class ControllerManager {
     private final SparseArray<String> slotAssignments = new SparseArray<>();
 
     // This tracks which of the 4 player slots are enabled by the user.
-    private final boolean[] enabledSlots = new boolean[4];
+    private final boolean[] enabledSlots = new boolean[WinHandler.MAX_PLAYERS];
 
     public static final String PREF_PLAYER_SLOT_PREFIX = "controller_slot_";
     public static final String PREF_ENABLED_SLOTS_PREFIX = "enabled_slot_";
@@ -87,7 +89,7 @@ public class ControllerManager {
      */
     private void loadAssignments() {
         slotAssignments.clear();
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < WinHandler.MAX_PLAYERS; i++) {
             // Load which device is assigned to this slot
             String prefKey = PREF_PLAYER_SLOT_PREFIX + i;
             String deviceIdentifier = preferences.getString(prefKey, null);
@@ -106,7 +108,7 @@ public class ControllerManager {
      */
     public void saveAssignments() {
         SharedPreferences.Editor editor = preferences.edit();
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < WinHandler.MAX_PLAYERS; i++) {
             // Save the assigned device identifier
             String deviceIdentifier = slotAssignments.get(i);
             String prefKey = PREF_PLAYER_SLOT_PREFIX + i;
@@ -202,13 +204,13 @@ public class ControllerManager {
      * @param device The physical InputDevice to assign.
      */
     public void assignDeviceToSlot(int slotIndex, InputDevice device) {
-        if (slotIndex < 0 || slotIndex >= 4) return;
+        if (slotIndex < 0 || slotIndex >= WinHandler.MAX_PLAYERS) return;
 
         String newDeviceIdentifier = getDeviceIdentifier(device);
         if (newDeviceIdentifier == null) return;
 
         // First, remove the new device from any slot it might already be in.
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < WinHandler.MAX_PLAYERS; i++) {
             if (newDeviceIdentifier.equals(slotAssignments.get(i))) {
                 slotAssignments.remove(i);
             }
@@ -224,7 +226,7 @@ public class ControllerManager {
      * @param slotIndex The player slot to un-assign (0-3).
      */
     public void unassignSlot(int slotIndex) {
-        if (slotIndex < 0 || slotIndex >= 4) return;
+        if (slotIndex < 0 || slotIndex >= WinHandler.MAX_PLAYERS) return;
         slotAssignments.remove(slotIndex);
         saveAssignments();
     }
@@ -277,13 +279,13 @@ public class ControllerManager {
      * @param isEnabled The new enabled state.
      */
     public void setSlotEnabled(int slotIndex, boolean isEnabled) {
-        if (slotIndex < 0 || slotIndex >= 4) return;
+        if (slotIndex < 0 || slotIndex >= WinHandler.MAX_PLAYERS) return;
         enabledSlots[slotIndex] = isEnabled;
         saveAssignments();
     }
 
     public boolean isSlotEnabled(int slotIndex) {
-        if (slotIndex < 0 || slotIndex >= 4) return false;
+        if (slotIndex < 0 || slotIndex >= WinHandler.MAX_PLAYERS) return false;
         return enabledSlots[slotIndex];
     }
 
@@ -302,7 +304,7 @@ public class ControllerManager {
         InputDevice device = inputManager.getInputDevice(deviceId);
         if (device == null || !isGameController(device)) return -1;
 
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < WinHandler.MAX_PLAYERS; i++) {
             if (slotAssignments.get(i) == null) {
                 assignDeviceToSlot(i, device);
                 setSlotEnabled(i, true);

--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -295,7 +295,9 @@ public class ControllerManager {
      */
     public int autoAssignDevice(int deviceId) {
         int existingSlot = getSlotForDevice(deviceId);
-        if (existingSlot >= 0) return existingSlot;
+        if (existingSlot >= 0) {
+            return isSlotEnabled(existingSlot) ? existingSlot : -1;
+        }
 
         InputDevice device = inputManager.getInputDevice(deviceId);
         if (device == null || !isGameController(device)) return -1;

--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -286,4 +286,27 @@ public class ControllerManager {
         if (slotIndex < 0 || slotIndex >= 4) return false;
         return enabledSlots[slotIndex];
     }
+
+    /**
+     * Auto-assigns a device to the first available slot.
+     * If the device is already assigned, returns its existing slot.
+     * @param deviceId The Android device ID from the input event.
+     * @return The slot index (0-3), or -1 if no slot available or device is not a controller.
+     */
+    public int autoAssignDevice(int deviceId) {
+        int existingSlot = getSlotForDevice(deviceId);
+        if (existingSlot >= 0) return existingSlot;
+
+        InputDevice device = inputManager.getInputDevice(deviceId);
+        if (device == null || !isGameController(device)) return -1;
+
+        for (int i = 0; i < 4; i++) {
+            if (slotAssignments.get(i) == null) {
+                assignDeviceToSlot(i, device);
+                setSlotEnabled(i, true);
+                return i;
+            }
+        }
+        return -1;
+    }
 }

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -595,6 +595,9 @@ public class WinHandler {
     }
 
     private void startRumblePoller() {
+        // poller skips case where controller is null and we
+        // do NOT vibrate phone as of now to prevent issues with docked users.
+        // TODO: add phone vibration option in upcoming ux when no controller device connected
         rumblePollerThread = new Thread(() -> {
             while (running) {
                 try {
@@ -607,13 +610,16 @@ public class WinHandler {
 
                         if (lowFreq != lastLowFreqs[slot] || highFreq != lastHighFreqs[slot]) {
                             ExternalController controller = getControllerForSlot(slot);
+
+                            // case: disable vibration, attempt to disable safely
                             if (lowFreq == 0 && highFreq == 0) {
                                 lastLowFreqs[slot] = lowFreq;
                                 lastHighFreqs[slot] = highFreq;
                                 stopVibrationForSlot(slot, controller);
-                            } else if (controller != null || slot == 0) {
-                                // Only mark as delivered when we can actually vibrate:
-                                // physical controller is available, or slot 0 has phone fallback
+
+                            // case: controller exists and vibration exists
+                            } else if (controller != null) {
+                                // Only mark as delivered when we can actually vibrate
                                 lastLowFreqs[slot] = lowFreq;
                                 lastHighFreqs[slot] = highFreq;
                                 startVibrationForSlot(slot, controller, lowFreq, highFreq);
@@ -645,53 +651,24 @@ public class WinHandler {
             stopVibrationForSlot(slot, controller);
             return;
         }
+        if (controller == null) return;
+        InputDevice device = InputDevice.getDevice(controller.getDeviceId());
+        if (device == null) return;
+        Vibrator controllerVibrator = device.getVibrator();
+        if (controllerVibrator == null || !controllerVibrator.hasVibrator()) return;
         isRumbling[slot] = true;
-        // Attempt to vibrate the physical controller first
-        if (controller != null) {
-            InputDevice device = InputDevice.getDevice(controller.getDeviceId());
-            if (device != null) {
-                Vibrator controllerVibrator = device.getVibrator();
-                if (controllerVibrator != null && controllerVibrator.hasVibrator()) {
-                    controllerVibrator.vibrate(VibrationEffect.createOneShot(50, amplitude));
-                    return;
-                }
-            }
-        }
-        // Fallback to phone vibration only for P1
-        if (slot == 0) {
-            Vibrator phoneVibrator = (Vibrator) activity.getSystemService(Context.VIBRATOR_SERVICE);
-            if (phoneVibrator != null && phoneVibrator.hasVibrator()) {
-                float normalizedAmplitude = (float) amplitude / 255.0f;
-                float curvedAmplitude = (float) Math.pow(normalizedAmplitude, 0.6f);
-                int finalPhoneAmplitude = (int) (curvedAmplitude * 255);
-                if (finalPhoneAmplitude > 255) finalPhoneAmplitude = 255;
-                if (finalPhoneAmplitude <= 1) finalPhoneAmplitude = 0;
-                if (finalPhoneAmplitude > 0) {
-                    phoneVibrator.vibrate(VibrationEffect.createOneShot(50, finalPhoneAmplitude));
-                }
-            }
-        }
+        controllerVibrator.vibrate(VibrationEffect.createOneShot(50, amplitude));
     }
 
     private void stopVibrationForSlot(int slot, ExternalController controller) {
         if (!isRumbling[slot]) return;
-        if (controller != null) {
-            InputDevice device = InputDevice.getDevice(controller.getDeviceId());
-            if (device != null) {
-                Vibrator vibrator = device.getVibrator();
-                if (vibrator != null && vibrator.hasVibrator()) {
-                    vibrator.cancel();
-                }
-            }
-        }
-        // Stop phone vibration only for P1
-        if (slot == 0) {
-            Vibrator phoneVibrator = (Vibrator) activity.getSystemService(Context.VIBRATOR_SERVICE);
-            if (phoneVibrator != null) {
-                phoneVibrator.cancel();
-            }
-        }
-        isRumbling[slot] = false;
+        isRumbling[slot] = false;  // handle before early returns - disconnected or null controller leaves slot, assures to disable
+        if (controller == null) return;
+        InputDevice device = InputDevice.getDevice(controller.getDeviceId());
+        if (device == null) return;
+        Vibrator controllerVibrator = device.getVibrator();
+        if (controllerVibrator == null || !controllerVibrator.hasVibrator()) return;
+        controllerVibrator.cancel();
     }
 
     public void sendGamepadState() {

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -156,6 +156,13 @@ public class WinHandler {
     }
 
     public void setControllerForSlot(int slot, ExternalController controller) {
+        if (slot < 0 || slot >= MAX_PLAYERS) return;
+        ExternalController old = getControllerForSlot(slot);
+        if (old != null && old != controller) {
+            stopVibrationForSlot(slot, old);
+            lastLowFreqs[slot] = 0;
+            lastHighFreqs[slot] = 0;
+        }
         if (slot == 0) { currentController = controller; return; }
         if (slot > 0 && slot <= extraControllers.length) extraControllers[slot - 1] = controller;
     }

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -51,7 +51,7 @@ public class WinHandler {
 
     private static final String TAG = "WinHandler";
     private final ControllerManager controllerManager;
-    public static final int MAX_PLAYERS = 1;
+    public static final int MAX_PLAYERS = 4;
     private final MappedByteBuffer[] extraGamepadBuffers = new MappedByteBuffer[MAX_PLAYERS - 1];
     private final ExternalController[] extraControllers = new ExternalController[MAX_PLAYERS - 1];
     private MappedByteBuffer gamepadBuffer;
@@ -77,14 +77,13 @@ public class WinHandler {
 
     private InputControlsView inputControlsView;
     private Thread rumblePollerThread;
-    private short lastLowFreq = 0;  // Use 'short' instead of uint16_t
-    private short lastHighFreq = 0; // Use 'short' instead of uint16_t
-    private boolean isRumbling = false;
+    private final short[] lastLowFreqs = new short[MAX_PLAYERS];
+    private final short[] lastHighFreqs = new short[MAX_PLAYERS];
+    private final boolean[] isRumbling = new boolean[MAX_PLAYERS];
     private boolean isShowingAssignDialog = false;
     private Context activity;
     private final java.util.Set<Integer> ignoredDeviceIds = new java.util.HashSet<>();
 
-    // Add method to set InputControlsView
     public void setInputControlsView(InputControlsView view) {
         this.inputControlsView = view;
     }
@@ -142,6 +141,23 @@ public class WinHandler {
                 Log.i(TAG, "Initialized Player " + (i + 2) + " with: " + extraDevice.getName());
             }
         }
+    }
+
+    public MappedByteBuffer getBufferForSlot(int slot) {
+        if (slot == 0) return gamepadBuffer;
+        if (slot > 0 && slot <= extraGamepadBuffers.length) return extraGamepadBuffers[slot - 1];
+        return null;
+    }
+
+    public ExternalController getControllerForSlot(int slot) {
+        if (slot == 0) return currentController;
+        if (slot > 0 && slot <= extraControllers.length) return extraControllers[slot - 1];
+        return null;
+    }
+
+    public void setControllerForSlot(int slot, ExternalController controller) {
+        if (slot == 0) { currentController = controller; return; }
+        if (slot > 0 && slot <= extraControllers.length) extraControllers[slot - 1] = controller;
     }
 
     private boolean sendPacket(int port) {
@@ -574,24 +590,29 @@ public class WinHandler {
     private void startRumblePoller() {
         rumblePollerThread = new Thread(() -> {
             while (running) {
-                // --- MODIFIED: Get the current profile state on EVERY loop iteration ---
                 try {
-                    // Always poll for rumble if gamepad buffer exists, regardless of controller state
-                    // This ensures vibration works with built-in controllers (like Ayn Odin 2)
-                    // even when virtual gamepad mode is disabled
-                    if (gamepadBuffer != null) {
-                        // Read the rumble values from the shared memory file.
-                        short lowFreq = gamepadBuffer.getShort(32);
-                        short highFreq = gamepadBuffer.getShort(34);
-                        // Check if the rumble state has changed
-                        if (lowFreq != lastLowFreq || highFreq != lastHighFreq) {
-                            lastLowFreq = lowFreq;
-                            lastHighFreq = highFreq;
+                    for (int slot = 0; slot < MAX_PLAYERS; slot++) {
+                        MappedByteBuffer buffer = getBufferForSlot(slot);
+                        if (buffer == null) continue;
+
+                        short lowFreq = buffer.getShort(32);
+                        short highFreq = buffer.getShort(34);
+
+                        if (lowFreq != lastLowFreqs[slot] || highFreq != lastHighFreqs[slot]) {
+                            ExternalController controller = getControllerForSlot(slot);
                             if (lowFreq == 0 && highFreq == 0) {
-                                stopVibration();
-                            } else {
-                                startVibration(lowFreq, highFreq);
+                                lastLowFreqs[slot] = lowFreq;
+                                lastHighFreqs[slot] = highFreq;
+                                stopVibrationForSlot(slot, controller);
+                            } else if (controller != null || slot == 0) {
+                                // Only mark as delivered when we can actually vibrate:
+                                // physical controller is available, or slot 0 has phone fallback
+                                lastLowFreqs[slot] = lowFreq;
+                                lastHighFreqs[slot] = highFreq;
+                                startVibrationForSlot(slot, controller, lowFreq, highFreq);
                             }
+                            // else: controller not yet adopted for this slot — don't update
+                            // lastFreqs so the poller retries on the next tick
                         }
                     }
                 } catch (Exception e) {
@@ -607,52 +628,48 @@ public class WinHandler {
         rumblePollerThread.start();
     }
 
-    private void startVibration(short lowFreq, short highFreq) {
-        // --- Step 1: Calculate the base amplitude once at the top ---
+    private void startVibrationForSlot(int slot, ExternalController controller, short lowFreq, short highFreq) {
         int unsignedLowFreq = lowFreq & 0xFFFF;
         int unsignedHighFreq = highFreq & 0xFFFF;
         int dominantRumble = Math.max(unsignedLowFreq, unsignedHighFreq);
-        // This is the raw amplitude for a physical X-Input device
         int amplitude = Math.round((float) dominantRumble / 65535.0f * 254.0f) + 1;
         if (amplitude > 255) amplitude = 255;
-        // If amplitude is negligible, just stop and exit.
         if (amplitude <= 1) {
-            stopVibration();
+            stopVibrationForSlot(slot, controller);
             return;
         }
-        isRumbling = true; // We know we are going to try to rumble.
-        // --- Step 2: Attempt to vibrate the physical controller first ---
-        if (currentController != null) {
-            InputDevice device = InputDevice.getDevice(currentController.getDeviceId());
+        isRumbling[slot] = true;
+        // Attempt to vibrate the physical controller first
+        if (controller != null) {
+            InputDevice device = InputDevice.getDevice(controller.getDeviceId());
             if (device != null) {
                 Vibrator controllerVibrator = device.getVibrator();
                 if (controllerVibrator != null && controllerVibrator.hasVibrator()) {
-                    // Vibrate the physical controller and then we are done.
                     controllerVibrator.vibrate(VibrationEffect.createOneShot(50, amplitude));
                     return;
                 }
             }
         }
-        // --- Step 3: Fallback to phone vibration if physical controller fails or doesn't exist ---
-        Log.w("WinHandler", "No physical controller vibrator found, falling back to device vibration.");
-        Vibrator phoneVibrator = (Vibrator) activity.getSystemService(Context.VIBRATOR_SERVICE);
-        if (phoneVibrator != null && phoneVibrator.hasVibrator()) {
-            // --- HAPTIC CURVE LOGIC to make phone vibration feel better ---
-            float normalizedAmplitude = (float) amplitude / 255.0f;
-            float curvedAmplitude = (float) Math.pow(normalizedAmplitude, 0.6f);
-            int finalPhoneAmplitude = (int) (curvedAmplitude * 255);
-            if (finalPhoneAmplitude > 255) finalPhoneAmplitude = 255;
-            if (finalPhoneAmplitude <= 1) finalPhoneAmplitude = 0;
-            if (finalPhoneAmplitude > 0) {
-                phoneVibrator.vibrate(VibrationEffect.createOneShot(50, finalPhoneAmplitude));
+        // Fallback to phone vibration only for P1
+        if (slot == 0) {
+            Vibrator phoneVibrator = (Vibrator) activity.getSystemService(Context.VIBRATOR_SERVICE);
+            if (phoneVibrator != null && phoneVibrator.hasVibrator()) {
+                float normalizedAmplitude = (float) amplitude / 255.0f;
+                float curvedAmplitude = (float) Math.pow(normalizedAmplitude, 0.6f);
+                int finalPhoneAmplitude = (int) (curvedAmplitude * 255);
+                if (finalPhoneAmplitude > 255) finalPhoneAmplitude = 255;
+                if (finalPhoneAmplitude <= 1) finalPhoneAmplitude = 0;
+                if (finalPhoneAmplitude > 0) {
+                    phoneVibrator.vibrate(VibrationEffect.createOneShot(50, finalPhoneAmplitude));
+                }
             }
         }
     }
-    private void stopVibration() {
-        if (!isRumbling) return; // Simplified check
-        // Attempt to stop the physical controller's vibration if it exists
-        if (currentController != null) {
-            InputDevice device = InputDevice.getDevice(currentController.getDeviceId());
+
+    private void stopVibrationForSlot(int slot, ExternalController controller) {
+        if (!isRumbling[slot]) return;
+        if (controller != null) {
+            InputDevice device = InputDevice.getDevice(controller.getDeviceId());
             if (device != null) {
                 Vibrator vibrator = device.getVibrator();
                 if (vibrator != null && vibrator.hasVibrator()) {
@@ -660,12 +677,14 @@ public class WinHandler {
                 }
             }
         }
-        // Always attempt to stop the phone's vibration
-        Vibrator phoneVibrator = (Vibrator) activity.getSystemService(Context.VIBRATOR_SERVICE);
-        if (phoneVibrator != null) {
-            phoneVibrator.cancel();
+        // Stop phone vibration only for P1
+        if (slot == 0) {
+            Vibrator phoneVibrator = (Vibrator) activity.getSystemService(Context.VIBRATOR_SERVICE);
+            if (phoneVibrator != null) {
+                phoneVibrator.cancel();
+            }
         }
-        isRumbling = false;
+        isRumbling[slot] = false;
     }
 
     public void sendGamepadState() {
@@ -695,80 +714,70 @@ public class WinHandler {
         }
     }
 
-    public boolean onGenericMotionEvent(MotionEvent event) {
-        boolean handled = false;
-        ExternalController externalController = this.currentController;
-        // Adopt newly connected controller if deviceId mismatches
-        if ((externalController == null || externalController.getDeviceId() != event.getDeviceId()) && ExternalController.isJoystickDevice(event)) {
+    /**
+     * Resolves (or adopts) an ExternalController for the given device into the correct player slot.
+     * Returns the slot index (0-3) or -1 if the device is not a game controller.
+     */
+    private int resolveControllerSlot(int deviceId) {
+        int slot = controllerManager.autoAssignDevice(deviceId);
+        if (slot < 0) return -1;
+
+        ExternalController controller = getControllerForSlot(slot);
+        if (controller == null || controller.getDeviceId() != deviceId) {
             ExternalController adopted = null;
-            // Try to get controller from profile first (has saved bindings)
             if (inputControlsView != null) {
                 ControlsProfile profile = inputControlsView.getProfile();
                 if (profile != null) {
-                    adopted = profile.getController(event.getDeviceId());
+                    adopted = profile.getController(deviceId);
                 }
             }
-            // Fallback to creating new controller if profile doesn't have one
             if (adopted == null) {
-                adopted = ExternalController.getController(event.getDeviceId());
+                adopted = ExternalController.getController(deviceId);
             }
-            if (adopted != null && "*".equals(adopted.getId())) {
-                this.currentController = adopted;
-                externalController = adopted;
-                Timber.d("WinHandler.onGenericMotionEvent: adopted controller %s(#%d)", adopted.getName(), adopted.getDeviceId());
-            }
-        }
-        if (externalController != null && externalController.getDeviceId() == event.getDeviceId() && (handled = this.currentController.updateStateFromMotionEvent(event))) {
-            if (handled) {
-                sendGamepadState();
-                sendMemoryFileState();
+            if (adopted != null) {
+                setControllerForSlot(slot, adopted);
+                Timber.d("WinHandler: adopted controller %s(#%d) to slot %d", adopted.getName(), adopted.getDeviceId(), slot);
             }
         }
-        return handled;
+        return slot;
+    }
+
+    public boolean onGenericMotionEvent(MotionEvent event) {
+        if (!ExternalController.isJoystickDevice(event)) return false;
+
+        int slot = resolveControllerSlot(event.getDeviceId());
+        if (slot < 0) return false;
+
+        ExternalController controller = getControllerForSlot(slot);
+        if (controller != null && controller.updateStateFromMotionEvent(event)) {
+            MappedByteBuffer buffer = getBufferForSlot(slot);
+            if (buffer != null) sendMemoryFileState(controller, buffer);
+            if (slot == 0) sendGamepadState();
+            return true;
+        }
+        return false;
     }
 
     public boolean onKeyEvent(KeyEvent event) {
-        MappedByteBuffer buffer = null;
-        boolean handled = false;
-        ExternalController externalController = this.currentController;
-        buffer = gamepadBuffer;
-        // If this is a gamepad event but our controller is null or mismatched, adopt it
         InputDevice device = event.getDevice();
-        if ((externalController == null || externalController.getDeviceId() != event.getDeviceId())
-                && device != null && ExternalController.isGameController(device)
-                && event.getRepeatCount() == 0) {
-            ExternalController adopted = null;
-            // Try to get controller from profile first (has saved bindings)
-            if (inputControlsView != null) {
-                ControlsProfile profile = inputControlsView.getProfile();
-                if (profile != null) {
-                    adopted = profile.getController(event.getDeviceId());
-                }
-            }
-            // Fallback to creating new controller if profile doesn't have one
-            if (adopted == null) {
-                adopted = ExternalController.getController(event.getDeviceId());
-            }
-            if (adopted != null && "*".equals(adopted.getId())) {
-                this.currentController = adopted;
-                externalController = adopted;
-                Timber.d("WinHandler.onKeyEvent: adopted controller %s(#%d)", adopted.getName(), adopted.getDeviceId());
-            }
+        if (device == null || !ExternalController.isGameController(device) || event.getRepeatCount() != 0) {
+            return false;
         }
 
+        int slot = resolveControllerSlot(event.getDeviceId());
+        if (slot < 0) return false;
 
-        if (externalController != null && externalController.getDeviceId() == event.getDeviceId() && event.getRepeatCount() == 0) {
-            int action = event.getAction();
-            if (action == KeyEvent.ACTION_DOWN) {
-                handled = this.currentController.updateStateFromKeyEvent(event);
-            } else if (action == KeyEvent.ACTION_UP) {
-                handled = this.currentController.updateStateFromKeyEvent(event);
-            }
-            sendMemoryFileState(this.currentController, buffer);
-            if (handled) {
-                sendGamepadState();
-            }
+        ExternalController controller = getControllerForSlot(slot);
+        if (controller == null) return false;
+
+        boolean handled = false;
+        int action = event.getAction();
+        if (action == KeyEvent.ACTION_DOWN || action == KeyEvent.ACTION_UP) {
+            handled = controller.updateStateFromKeyEvent(event);
         }
+        MappedByteBuffer buffer = getBufferForSlot(slot);
+        if (buffer != null) sendMemoryFileState(controller, buffer);
+        if (handled && slot == 0) sendGamepadState();
         return handled;
     }
 
@@ -785,11 +794,7 @@ public class WinHandler {
     }
 
 
-    private void sendMemoryFileState() {
-        sendMemoryFileState(currentController, gamepadBuffer);
-    }
-
-    private void sendMemoryFileState(ExternalController controller, MappedByteBuffer buffer) {
+    public void sendMemoryFileState(ExternalController controller, MappedByteBuffer buffer) {
         if (buffer == null || controller == null) {
             return;
         }

--- a/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
@@ -178,10 +178,9 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
 
     private int execGuestProgram() {
 
-        final int MAX_PLAYERS = 1; // old static method
-
-        // Get the number of enabled players directly from ControllerManager.
-        final int enabledPlayerCount = MAX_PLAYERS;
+        // Always pre-create all 4 mem files so controllers can be hot-plugged during gameplay.
+        // Unused gamepads just read zeroes (no-op in evshim).
+        final int enabledPlayerCount = 4;
         for (int i = 0; i < enabledPlayerCount; i++) {
             String memPath;
             if (i == 0) {

--- a/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
@@ -36,6 +36,7 @@ import com.winlator.fexcore.FEXCorePresetManager;
 import com.winlator.sysvshm.SysVSHMConnectionHandler;
 import com.winlator.sysvshm.SysVSHMRequestHandler;
 import com.winlator.sysvshm.SysVSharedMemory;
+import com.winlator.winhandler.WinHandler;
 import com.winlator.xconnector.UnixSocketConfig;
 import com.winlator.xconnector.XConnectorEpoll;
 import com.winlator.xenvironment.ImageFs;
@@ -180,7 +181,7 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
 
         // Always pre-create all 4 mem files so controllers can be hot-plugged during gameplay.
         // Unused gamepads just read zeroes (no-op in evshim).
-        final int enabledPlayerCount = 4;
+        final int enabledPlayerCount = WinHandler.MAX_PLAYERS;
         for (int i = 0; i < enabledPlayerCount; i++) {
             String memPath;
             if (i == 0) {

--- a/app/src/test/java/app/gamenative/input/MultiControllerTest.kt
+++ b/app/src/test/java/app/gamenative/input/MultiControllerTest.kt
@@ -1,0 +1,280 @@
+package app.gamenative.input
+
+import com.winlator.inputcontrols.ExternalController
+import com.winlator.inputcontrols.GamepadState
+import com.winlator.winhandler.WinHandler
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Unit tests for multi-controller support (Issue #565).
+ *
+ * Tests GamepadState independence and ExternalController isolation to verify
+ * that multiple controllers can maintain independent state simultaneously.
+ */
+class MultiControllerTest {
+
+    // ========================================================================
+    // GamepadState Independence
+    // ========================================================================
+
+    @Test
+    fun `GamepadState instances are independent - button press`() {
+        val state1 = GamepadState()
+        val state2 = GamepadState()
+
+        state1.setPressed(ExternalController.IDX_BUTTON_A.toInt(), true)
+
+        assertTrue(state1.isPressed(ExternalController.IDX_BUTTON_A.toInt()))
+        assertFalse(state2.isPressed(ExternalController.IDX_BUTTON_A.toInt()))
+    }
+
+    @Test
+    fun `GamepadState instances are independent - analog sticks`() {
+        val state1 = GamepadState()
+        val state2 = GamepadState()
+
+        state1.thumbLX = 0.75f
+        state1.thumbLY = -0.5f
+
+        assertEquals(0.75f, state1.thumbLX, 0.001f)
+        assertEquals(-0.5f, state1.thumbLY, 0.001f)
+        assertEquals(0f, state2.thumbLX, 0.001f)
+        assertEquals(0f, state2.thumbLY, 0.001f)
+    }
+
+    @Test
+    fun `GamepadState instances are independent - triggers`() {
+        val state1 = GamepadState()
+        val state2 = GamepadState()
+
+        state1.triggerL = 0.8f
+        state2.triggerR = 0.6f
+
+        assertEquals(0.8f, state1.triggerL, 0.001f)
+        assertEquals(0f, state1.triggerR, 0.001f)
+        assertEquals(0f, state2.triggerL, 0.001f)
+        assertEquals(0.6f, state2.triggerR, 0.001f)
+    }
+
+    @Test
+    fun `GamepadState instances are independent - dpad`() {
+        val state1 = GamepadState()
+        val state2 = GamepadState()
+
+        state1.dpad[0] = true // up
+
+        assertTrue(state1.dpad[0])
+        assertFalse(state2.dpad[0])
+    }
+
+    @Test
+    fun `GamepadState copy does not link instances`() {
+        val state1 = GamepadState()
+        val state2 = GamepadState()
+
+        state1.setPressed(ExternalController.IDX_BUTTON_A.toInt(), true)
+        state1.thumbLX = 0.5f
+        state2.copy(state1)
+
+        // Verify copy worked
+        assertTrue(state2.isPressed(ExternalController.IDX_BUTTON_A.toInt()))
+        assertEquals(0.5f, state2.thumbLX, 0.001f)
+
+        // Modify state1 after copy - state2 should not change
+        state1.setPressed(ExternalController.IDX_BUTTON_B.toInt(), true)
+        state1.thumbLX = -1f
+
+        assertFalse(state2.isPressed(ExternalController.IDX_BUTTON_B.toInt()))
+        assertEquals(0.5f, state2.thumbLX, 0.001f)
+    }
+
+    @Test
+    fun `multiple GamepadState instances can hold different simultaneous inputs`() {
+        val p1State = GamepadState()
+        val p2State = GamepadState()
+        val p3State = GamepadState()
+        val p4State = GamepadState()
+
+        p1State.setPressed(ExternalController.IDX_BUTTON_A.toInt(), true)
+        p1State.thumbLX = 1f
+
+        p2State.setPressed(ExternalController.IDX_BUTTON_B.toInt(), true)
+        p2State.thumbLY = -1f
+
+        p3State.setPressed(ExternalController.IDX_BUTTON_X.toInt(), true)
+        p3State.triggerL = 0.5f
+
+        p4State.setPressed(ExternalController.IDX_BUTTON_Y.toInt(), true)
+        p4State.dpad[2] = true // down
+
+        assertTrue(p1State.isPressed(ExternalController.IDX_BUTTON_A.toInt()))
+        assertFalse(p1State.isPressed(ExternalController.IDX_BUTTON_B.toInt()))
+        assertEquals(1f, p1State.thumbLX, 0.001f)
+
+        assertTrue(p2State.isPressed(ExternalController.IDX_BUTTON_B.toInt()))
+        assertFalse(p2State.isPressed(ExternalController.IDX_BUTTON_A.toInt()))
+        assertEquals(-1f, p2State.thumbLY, 0.001f)
+
+        assertTrue(p3State.isPressed(ExternalController.IDX_BUTTON_X.toInt()))
+        assertEquals(0.5f, p3State.triggerL, 0.001f)
+
+        assertTrue(p4State.isPressed(ExternalController.IDX_BUTTON_Y.toInt()))
+        assertTrue(p4State.dpad[2])
+        assertFalse(p1State.dpad[2])
+    }
+
+    // ========================================================================
+    // Slot Constants
+    // ========================================================================
+
+    @Test
+    fun `MAX_PLAYERS is 4`() {
+        assertEquals(4, WinHandler.MAX_PLAYERS)
+    }
+
+    // ========================================================================
+    // GamepadState writeTo - buffer layout used by sendGamepadState UDP path
+    // ========================================================================
+
+    @Test
+    fun `writeTo encodes sticks as signed shorts`() {
+        val state = GamepadState()
+        state.thumbLX = 1f
+        state.thumbLY = -1f
+
+        val buffer = ByteBuffer.allocate(32).order(ByteOrder.LITTLE_ENDIAN)
+        // writeTo format: buttons(2) + povHat(1) + sticks(8) + triggers(2)
+        state.writeTo(buffer)
+        buffer.flip()
+
+        buffer.getShort() // skip buttons
+        buffer.get()      // skip povHat
+        assertEquals(Short.MAX_VALUE, buffer.getShort()) // thumbLX = 1.0
+        assertEquals((-Short.MAX_VALUE).toShort(), buffer.getShort()) // thumbLY = -1.0
+    }
+
+    @Test
+    fun `writeTo encodes triggers as unsigned bytes`() {
+        val state = GamepadState()
+        state.triggerL = 1f
+        state.triggerR = 0.5f
+
+        val buffer = ByteBuffer.allocate(32).order(ByteOrder.LITTLE_ENDIAN)
+        state.writeTo(buffer)
+        buffer.flip()
+
+        // Skip: buttons(2) + povHat(1) + sticks(8) = 11 bytes
+        buffer.position(11)
+        assertEquals(255.toByte(), buffer.get()) // triggerL fully pressed
+        assertEquals(127.toByte(), buffer.get()) // triggerR half pressed
+    }
+
+    @Test
+    fun `writeTo encodes dpad as povHat`() {
+        val state = GamepadState()
+        state.dpad[0] = true // up
+
+        val buffer = ByteBuffer.allocate(32).order(ByteOrder.LITTLE_ENDIAN)
+        state.writeTo(buffer)
+        buffer.flip()
+
+        buffer.getShort() // skip buttons
+        val povHat = buffer.get()
+        assertEquals(0.toByte(), povHat) // up = 0 in POV hat convention
+    }
+
+    @Test
+    fun `writeTo dpad diagonal encodes correctly`() {
+        val state = GamepadState()
+        state.dpad[0] = true // up
+        state.dpad[1] = true // right
+
+        val buffer = ByteBuffer.allocate(32).order(ByteOrder.LITTLE_ENDIAN)
+        state.writeTo(buffer)
+        buffer.flip()
+
+        buffer.getShort() // skip buttons
+        val povHat = buffer.get()
+        assertEquals(1.toByte(), povHat) // up+right = 1
+    }
+
+    // ========================================================================
+    // GamepadState dpad helpers
+    // ========================================================================
+
+    @Test
+    fun `getDPadX returns correct direction`() {
+        val state = GamepadState()
+
+        // dpad[1] = right, dpad[3] = left
+        state.dpad[1] = true
+        assertEquals(1.toByte(), state.dPadX)
+
+        state.dpad[1] = false
+        state.dpad[3] = true
+        assertEquals((-1).toByte(), state.dPadX)
+
+        state.dpad[3] = false
+        assertEquals(0.toByte(), state.dPadX)
+    }
+
+    @Test
+    fun `getDPadY returns correct direction`() {
+        val state = GamepadState()
+
+        // dpad[0] = up (-1), dpad[2] = down (1)
+        state.dpad[0] = true
+        assertEquals((-1).toByte(), state.dPadY)
+
+        state.dpad[0] = false
+        state.dpad[2] = true
+        assertEquals(1.toByte(), state.dPadY)
+    }
+
+    // ========================================================================
+    // Button index constants match expected layout
+    // ========================================================================
+
+    @Test
+    fun `button indices are contiguous 0 through 11`() {
+        assertEquals(0, ExternalController.IDX_BUTTON_A.toInt())
+        assertEquals(1, ExternalController.IDX_BUTTON_B.toInt())
+        assertEquals(2, ExternalController.IDX_BUTTON_X.toInt())
+        assertEquals(3, ExternalController.IDX_BUTTON_Y.toInt())
+        assertEquals(4, ExternalController.IDX_BUTTON_L1.toInt())
+        assertEquals(5, ExternalController.IDX_BUTTON_R1.toInt())
+        assertEquals(6, ExternalController.IDX_BUTTON_SELECT.toInt())
+        assertEquals(7, ExternalController.IDX_BUTTON_START.toInt())
+        assertEquals(8, ExternalController.IDX_BUTTON_L3.toInt())
+        assertEquals(9, ExternalController.IDX_BUTTON_R3.toInt())
+        assertEquals(10, ExternalController.IDX_BUTTON_L2.toInt())
+        assertEquals(11, ExternalController.IDX_BUTTON_R2.toInt())
+    }
+
+    @Test
+    fun `all 12 buttons can be set independently`() {
+        val state = GamepadState()
+
+        // Press all buttons
+        for (i in 0..11) {
+            state.setPressed(i, true)
+        }
+        for (i in 0..11) {
+            assertTrue("Button $i should be pressed", state.isPressed(i))
+        }
+
+        // Release only button A
+        state.setPressed(ExternalController.IDX_BUTTON_A.toInt(), false)
+        assertFalse(state.isPressed(ExternalController.IDX_BUTTON_A.toInt()))
+        // All others still pressed
+        for (i in 1..11) {
+            assertTrue("Button $i should still be pressed", state.isPressed(i))
+        }
+    }
+}

--- a/app/src/test/java/com/winlator/inputcontrols/ControllerManagerTest.kt
+++ b/app/src/test/java/com/winlator/inputcontrols/ControllerManagerTest.kt
@@ -1,0 +1,59 @@
+package com.winlator.inputcontrols
+
+import android.view.InputDevice
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Verifies that [ControllerManager.getDeviceIdentifier] returns the correct
+ * identifier format per API level. Pre-Q (< 29) must use "vendor_X_product_Y";
+ * Q+ must use the device descriptor. Changing this breaks persisted slot
+ * assignments for existing installs.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ControllerManagerTest {
+
+    @Test
+    @Config(sdk = [28])
+    fun `pre-Q device uses vendor_product format`() {
+        val device = mockk<InputDevice> {
+            every { vendorId } returns 0x045E
+            every { productId } returns 0x028E
+        }
+        val id = ControllerManager.getDeviceIdentifier(device)
+        assertEquals("vendor_1118_product_654", id)
+    }
+
+    @Test
+    @Config(sdk = [29])
+    fun `Q device uses descriptor`() {
+        val descriptor = "usb-0000:00:14.0-2/input0"
+        val device = mockk<InputDevice> {
+            every { getDescriptor() } returns descriptor
+        }
+        val id = ControllerManager.getDeviceIdentifier(device)
+        assertEquals(descriptor, id)
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun `post-Q device uses descriptor`() {
+        val descriptor = "bluetooth-AB:CD:EF:12:34:56-input0"
+        val device = mockk<InputDevice> {
+            every { getDescriptor() } returns descriptor
+        }
+        val id = ControllerManager.getDeviceIdentifier(device)
+        assertEquals(descriptor, id)
+    }
+
+    @Test
+    fun `null device returns null`() {
+        assertNull(ControllerManager.getDeviceIdentifier(null))
+    }
+}


### PR DESCRIPTION

## Description
<!-- What changed and why? -->
- physical controller handler services now acommodate multi controller state management via deviceId
- slot 0 backwards compatible
- new autoassign func to get and/or assign device to specific slot
- windhandler accomodated MAX_PLAYERS = 4 suppot, multi-controller state management
- new MultiControllerTest.kt test suite

## Recording
<!-- Attach a short recording/GIF showing the change -->
[tested on a **retroid pocket 5** with **Steam** copy of **Cuphead**](https://drive.google.com/file/d/10qfibC_cECTo3wPnHRSA6kXhRk9OTWPX/view?usp=sharing)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-controller support for up to 4 players with auto device-to-slot assignment and per-slot input/rumble. UDP and virtual gamepad output remain on P1, and the phone vibration fallback is removed; we pre-create 4 `.mem` files for hot-plugging.

- **New Features**
  - Set `WinHandler.MAX_PLAYERS = 4` with per-slot controllers/buffers and accessors (`getBufferForSlot`, `getControllerForSlot`, `setControllerForSlot`); removed magic numbers across code.
  - `ControllerManager.autoAssignDevice(deviceId)` assigns to the first free enabled slot or returns the existing one.
  - `PhysicalControllerHandler` routes key/motion/binding updates by `deviceId` to the resolved slot and adopts controllers on demand; writes `.mem` per slot; UDP/virtual output only for P1; launcher uses `WinHandler.MAX_PLAYERS` to pre-create all `.mem` files.
  - Tests: `MultiControllerTest.kt` for state isolation and `ControllerManagerTest.kt` for device identifier behavior.

- **Bug Fixes**
  - Per-slot rumble poller that defers updates until a controller exists; resets rumble state when a slot adopts a new controller; removed phone vibration fallback.
  - `ControllerManager.getDeviceIdentifier` uses descriptor on Q+ and vendor/product on pre-Q; `autoAssignDevice` respects disabled slots.

<sup>Written for commit 2c6859ef7c6e0724bec991c64c10c552afd7c461. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for up to 4 simultaneous controllers with automatic device-to-player assignment and per-slot controller/buffer management
  * Per-player vibration and per-player memory-file state buffers; launcher now pre-creates multiple gamepad memory files

* **Behavior Change**
  * Input events are routed to explicit player slots; virtual/UDP gamepad output and phone-vibration fallback remain limited to player 1

* **Tests**
  * Added multi-controller, input-encoding, and device-identification tests across Android API levels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->