### PR TITLE
fix: ImageFsInstaller isImportedWineProton logic

### DIFF
--- a/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
@@ -214,9 +214,9 @@ public abstract class ImageFsInstaller {
     private static boolean isImportedWineProton(Context context, String fileName) {
         String lowerName = fileName.toLowerCase();
 
-        // Not a Wine/Proton directory
-        if (!lowerName.startsWith("wine-") && !lowerName.startsWith("proton-")) {
-            return false;
+        // Skip Wine/Proton directory
+        if (lowerName.startsWith("wine-") || lowerName.startsWith("proton-")) {
+            return true;
         }
 
         // Get bundled versions from resource arrays


### PR DESCRIPTION
## Description
Correct ImageFsInstaller to correctly skip wine / proton in clearOptDir logic

## Recording


## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix isImportedWineProton in ImageFsInstaller to treat directories starting with "wine-" or "proton-" as imported, so clearOptDir skips them and doesn’t delete Wine/Proton files.

<sup>Written for commit 981b24294821b282154a7d79040fdeb41991f0e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed detection and classification of custom wine/proton installations in system directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->