### PR TITLE
fix: filter out virtual devices and check axis from SOURCE_JOYSTICK instead of any source

### DIFF
--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -135,6 +135,9 @@ public class ControllerManager {
         if (device == null) return false;
         if (device.isVirtual()) return false;
 
+        String name = device.getName().toLowerCase();
+        if (name.contains("uinput")) return false;
+
         boolean isGamepad = device.supportsSource(InputDevice.SOURCE_GAMEPAD);
         boolean isJoystick = device.supportsSource(InputDevice.SOURCE_JOYSTICK);
 

--- a/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
@@ -364,6 +364,9 @@ public class ExternalController {
         if (device == null) return false;
         if (device.isVirtual()) return false;
 
+        String name = device.getName().toLowerCase();
+        if (name.contains("uinput")) return false;
+
         boolean isGamepad = device.supportsSource(InputDevice.SOURCE_GAMEPAD);
         boolean isJoystick = device.supportsSource(InputDevice.SOURCE_JOYSTICK);
 


### PR DESCRIPTION
## Description
some Xiaomi devices report built-in keyboard and gamepad and that conflicts with the auto-show/hide on-screen controller

## Recording

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes game controller misdetection on some Xiaomi devices by ignoring virtual and `uinput*` devices and tightening joystick axis checks. This restores correct auto-show/hide behavior for the on-screen controller.

- **Bug Fixes**
  - Filter out virtual and `uinput*` devices in controller detection (`ControllerManager`, `ExternalController`).
  - Require both X and Y axes from `SOURCE_JOYSTICK` when detecting controllers.

<sup>Written for commit d1bbb65825327775f2d67485ef3328c643f5814e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game controller detection: virtual devices and devices whose name contains "uinput" are now ignored, and joysticks must report both X and Y axis support to be recognized. This reduces false positives and improves input device classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->