### PR TITLE
Fix install size estimate using wrong language for depot selection

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.content.ContextCompat
+import app.gamenative.PrefManager
 import app.gamenative.PluviaApp
 
 import app.gamenative.R
@@ -896,7 +897,9 @@ class SteamAppScreen : BaseAppScreen() {
             }
             try {
                 val info = withContext(Dispatchers.IO) {
-                    val depots = SteamService.getDownloadableDepots(gameId)
+                    val container = ContainerManager(context).getContainerById("STEAM_$gameId")
+                    val language = container?.language ?: PrefManager.containerLanguage
+                    val depots = SteamService.getDownloadableDepots(gameId, language)
                     Timber.i("There are ${depots.size} depots belonging to ${libraryItem.appId}")
                     val branch = SteamService.getInstalledApp(gameId)?.branch ?: "public"
                     val availableBytes = StorageUtils.getAvailableSpace(SteamService.defaultStoragePath)


### PR DESCRIPTION
## Summary
- Size estimate now uses container language instead of global default, matching the download path
- Fixes incorrect depot count and download/install size shown for non-default language containers

## Test plan
- [ ] Set container language to non-English (e.g. Polish)
- [ ] Open a game with language-specific depots (e.g. Gothic)
- [ ] Verify size estimate matches what actually downloads

Fixes #1053

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install size estimate now uses the container's language when fetching depots, matching the download path. This fixes wrong depot counts and sizes for non-default language containers (fixes #1053).

<sup>Written for commit c4fe5a1891fda103be333905ebc9ec86e992904a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Steam app installation sizes are now calculated based on your configured language setting instead of a default option. This ensures installation and download size estimates more accurately reflect what you'll experience on your system, helping you make better storage and installation planning decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->