### PR TITLE
Don't show android bars by default, fix downloading overlay not corre…

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -935,7 +935,7 @@ object PrefManager {
     // Whether to hide the Android status bar when not in a game (in game list, settings, etc.)
     private val HIDE_STATUS_BAR_WHEN_NOT_IN_GAME = booleanPreferencesKey("hide_status_bar_when_not_in_game")
     var hideStatusBarWhenNotInGame: Boolean
-        get() = getPref(HIDE_STATUS_BAR_WHEN_NOT_IN_GAME, false)
+        get() = getPref(HIDE_STATUS_BAR_WHEN_NOT_IN_GAME, true)
         set(value) {
             setPref(HIDE_STATUS_BAR_WHEN_NOT_IN_GAME, value)
         }

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -76,6 +76,9 @@ import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.changedToDownIgnoreConsumed
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -506,6 +509,7 @@ internal fun AppScreenContent(
 
     // Track the original progress bar bounds for ambient mode morph animation
     var progressBarBounds by remember { mutableStateOf<Rect?>(null) }
+    var ambientInteractionCounter by remember { mutableStateOf(0) }
 
     // Focus requesters for gamepad navigation
     val playButtonFocusRequester = remember { FocusRequester() }
@@ -620,7 +624,22 @@ internal fun AppScreenContent(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .onKeyEvent { handleKeyEvent(it.nativeKeyEvent) },
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val pointerEvent = awaitPointerEvent(PointerEventPass.Initial)
+                        if (pointerEvent.changes.any { it.changedToDownIgnoreConsumed() }) {
+                            ambientInteractionCounter++
+                        }
+                    }
+                }
+            }
+            .onKeyEvent {
+                if (it.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
+                    ambientInteractionCounter++
+                }
+                handleKeyEvent(it.nativeKeyEvent)
+            },
     ) {
         Column(
             modifier = Modifier
@@ -1088,6 +1107,7 @@ internal fun AppScreenContent(
                 downloadProgress = downloadProgress,
                 iconUrl = displayInfo.iconUrl,
                 originBounds = progressBarBounds,
+                userInteractionCounter = ambientInteractionCounter,
             )
         }
     }

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/ambient/AmbientDownloadOverlay.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/ambient/AmbientDownloadOverlay.kt
@@ -1,5 +1,6 @@
 package app.gamenative.ui.screen.library.components.ambient
 
+import android.view.KeyEvent as AndroidKeyEvent
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.core.*
@@ -23,6 +24,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.util.lerp
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.changedToDownIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.alpha
@@ -57,6 +59,7 @@ internal fun AmbientDownloadOverlay(
     downloadProgress: Float,
     iconUrl: String? = null,
     originBounds: Rect? = null,
+    userInteractionCounter: Int = 0,
 ) {
     val activity = LocalActivity.current as? ComponentActivity ?: return
     val context = LocalContext.current
@@ -65,26 +68,34 @@ internal fun AmbientDownloadOverlay(
     var interactionCounter by remember { mutableIntStateOf(0) }
     var isIdle by remember { mutableStateOf(false) }
     var isDvdMode by remember { mutableStateOf(false) }
+    val registerInteraction = {
+        interactionCounter++
+        if (isIdle) isIdle = false
+        isDvdMode = false
+    }
 
     LaunchedEffect(interactionCounter) {
         delay(IDLE_TIMEOUT_MS)
         isIdle = true
     }
 
+    LaunchedEffect(userInteractionCounter) {
+        if (userInteractionCounter > 0) {
+            registerInteraction()
+        }
+    }
+
     DisposableEffect(Unit) {
         val keyListener: (AndroidEvent.KeyEvent) -> Boolean = {
-            if (isIdle) {
-                interactionCounter++
-                isIdle = false
-                isDvdMode = false
+            if (it.event.action == AndroidKeyEvent.ACTION_DOWN) {
+                registerInteraction()
             }
             false
         }
-        val motionListener: (AndroidEvent.MotionEvent) -> Boolean = {
-            if (isIdle) {
-                interactionCounter++
-                isIdle = false
-                isDvdMode = false
+        val motionListener: (AndroidEvent.MotionEvent) -> Boolean = { motionEvent ->
+            val event = motionEvent.event
+            if (event != null) {
+                registerInteraction()
             }
             false
         }
@@ -164,11 +175,9 @@ internal fun AmbientDownloadOverlay(
                 .pointerInput(Unit) {
                     awaitPointerEventScope {
                         while (true) {
-                            awaitPointerEvent(PointerEventPass.Initial)
-                            if (isIdle) {
-                                interactionCounter++
-                                isIdle = false
-                                isDvdMode = false
+                            val pointerEvent = awaitPointerEvent(PointerEventPass.Initial)
+                            if (pointerEvent.changes.any { it.changedToDownIgnoreConsumed() }) {
+                                registerInteraction()
                             }
                         }
                     }
@@ -182,7 +191,8 @@ internal fun AmbientDownloadOverlay(
                     iconUrl = iconUrl,
                 )
             } else {
-                val textAlpha = ((ambientAlpha - 0.7f) / 0.3f).coerceIn(0f, 1f) * AmbientModeConstants.TEXT_MAX_ALPHA
+                val textAlpha =
+                    ((ambientAlpha - 0.7f) / 0.3f).coerceIn(0f, 1f) * AmbientModeConstants.TEXT_MAX_ALPHA
 
                 if (textAlpha > 0f) {
                     Column(


### PR DESCRIPTION
…ctly registering touch inputs

## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Android status bar by default outside games, and fix the downloading ambient overlay so taps and key presses reliably exit idle mode.

- **Bug Fixes**
  - Overlay now detects interactions at `PointerEventPass.Initial` using `changedToDownIgnoreConsumed()` to catch consumed taps.
  - Counts only `ACTION_DOWN` key events for accurate interaction tracking.
  - Centralized interaction handling in `AmbientDownloadOverlay` via `registerInteraction` to reset idle/DVD modes consistently.
  - Propagates interactions from `LibraryAppScreen` to `AmbientDownloadOverlay` with `userInteractionCounter`, so overlay wakes even if children consume input.

<sup>Written for commit c56ce0f1d2c62d2426a5234c37655317f8dae4d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status bar now hides by default when the app is not running a game.

* **New Features**
  * Enhanced interaction detection system to better recognize when users are actively engaging with the app, preventing unintended idle mode activation during normal usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->