### PR TITLE
Removed duplicated downloading text

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -839,15 +839,6 @@ internal fun AppScreenContent(
                                     .padding(horizontal = 8.dp),
                                 verticalArrangement = Arrangement.Center,
                             ) {
-                                if (!downloadStatusMessage.isNullOrBlank()) {
-                                    Text(
-                                        text = downloadStatusMessage!!,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = Color.White,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
-                                }
                                 if (downloadSizeText.isNotEmpty()) {
                                     Text(
                                         text = downloadSizeText,
@@ -895,35 +886,21 @@ internal fun AppScreenContent(
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            if (!downloadStatusMessage.isNullOrBlank()) {
+                            if (downloadSizeText.isNotEmpty()) {
                                 Text(
-                                    text = downloadStatusMessage!!,
+                                    text = downloadSizeText,
                                     style = MaterialTheme.typography.bodySmall,
-                                    color = Color.White,
+                                    color = Color.White.copy(alpha = 0.9f),
                                     maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.weight(1f, fill = false),
                                 )
                             }
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            ) {
-                                if (downloadSizeText.isNotEmpty()) {
-                                    Text(
-                                        text = downloadSizeText,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = Color.White.copy(alpha = 0.9f),
-                                        maxLines = 1,
-                                    )
-                                }
-                                if (downloadTimeLeftText.isNotEmpty()) {
-                                    Text(
-                                        text = downloadTimeLeftText,
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = Color.White.copy(alpha = 0.65f),
-                                        maxLines = 1,
-                                    )
-                                }
+                            if (downloadTimeLeftText.isNotEmpty()) {
+                                Text(
+                                    text = downloadTimeLeftText,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = Color.White.copy(alpha = 0.65f),
+                                    maxLines = 1,
+                                )
                             }
                         }
                     }


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed duplicated downloading text in the Library screen to declutter the progress UI and show clear, single-line status info.

- **Bug Fixes**
  - Removed extra `downloadStatusMessage` render; show `downloadSizeText` and `downloadTimeLeftText` once.
  - Tweaked text layout and colors for consistent, readable status lines.

<sup>Written for commit d9924410dbb209f1a13b964bbd40e849e61144b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the download information display by removing status messages from both portrait and landscape layouts
  * Updated download size text styling to improve visual consistency across different screen orientations
  * Streamlined the download UI layout by removing unnecessary nested components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->