### PR TITLE
feat: Adds ability to import Steam games via custom paths

### DIFF
--- a/app/schemas/app.gamenative.db.PluviaDatabase/20.json
+++ b/app/schemas/app.gamenative.db.PluviaDatabase/20.json
@@ -1,0 +1,1267 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 20,
+    "identityHash": "bcaaca63252bc468a66722fea34d3abd",
+    "entities": [
+      {
+        "tableName": "app_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `is_downloaded` INTEGER NOT NULL, `downloaded_depots` TEXT NOT NULL, `dlc_depots` TEXT NOT NULL, `branch` TEXT NOT NULL DEFAULT 'public', `recovered_install_size_bytes` INTEGER NOT NULL DEFAULT 0, `custom_install_path` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "is_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedDepots",
+            "columnName": "downloaded_depots",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dlcDepots",
+            "columnName": "dlc_depots",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "branch",
+            "columnName": "branch",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'public'"
+          },
+          {
+            "fieldPath": "recoveredInstallSizeBytes",
+            "columnName": "recovered_install_size_bytes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customInstallPath",
+            "columnName": "custom_install_path",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_license",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `license_json` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseJson",
+            "columnName": "license_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "app_change_numbers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`appId` INTEGER, `changeNumber` INTEGER, PRIMARY KEY(`appId`))",
+        "fields": [
+          {
+            "fieldPath": "appId",
+            "columnName": "appId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "changeNumber",
+            "columnName": "changeNumber",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "appId"
+          ]
+        }
+      },
+      {
+        "tableName": "encrypted_app_ticket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`app_id` INTEGER NOT NULL, `result` INTEGER NOT NULL, `ticket_version_no` INTEGER NOT NULL, `crc_encrypted_ticket` INTEGER NOT NULL, `cb_encrypted_user_data` INTEGER NOT NULL, `cb_encrypted_app_ownership_ticket` INTEGER NOT NULL, `encrypted_ticket` BLOB NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`app_id`))",
+        "fields": [
+          {
+            "fieldPath": "appId",
+            "columnName": "app_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "result",
+            "columnName": "result",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ticketVersionNo",
+            "columnName": "ticket_version_no",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "crcEncryptedTicket",
+            "columnName": "crc_encrypted_ticket",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cbEncryptedUserData",
+            "columnName": "cb_encrypted_user_data",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cbEncryptedAppOwnershipTicket",
+            "columnName": "cb_encrypted_app_ownership_ticket",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encryptedTicket",
+            "columnName": "encrypted_ticket",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "app_id"
+          ]
+        }
+      },
+      {
+        "tableName": "app_file_change_lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`appId` INTEGER, `userFileInfo` TEXT NOT NULL, PRIMARY KEY(`appId`))",
+        "fields": [
+          {
+            "fieldPath": "appId",
+            "columnName": "appId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "userFileInfo",
+            "columnName": "userFileInfo",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "appId"
+          ]
+        }
+      },
+      {
+        "tableName": "steam_app",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `package_id` INTEGER NOT NULL, `owner_account_id` TEXT NOT NULL, `license_flags` INTEGER NOT NULL, `received_pics` INTEGER NOT NULL, `last_change_number` INTEGER NOT NULL, `ufs_parse_version` INTEGER NOT NULL DEFAULT 0, `depots` TEXT NOT NULL, `branches` TEXT NOT NULL, `name` TEXT NOT NULL, `type` INTEGER NOT NULL, `os_list` INTEGER NOT NULL, `release_state` INTEGER NOT NULL, `release_date` INTEGER NOT NULL, `metacritic_score` INTEGER NOT NULL, `metacritic_full_url` TEXT NOT NULL, `logo_hash` TEXT NOT NULL, `logo_small_hash` TEXT NOT NULL, `icon_hash` TEXT NOT NULL, `client_icon_hash` TEXT NOT NULL, `client_tga_hash` TEXT NOT NULL, `small_capsule` TEXT NOT NULL, `header_image` TEXT NOT NULL, `library_assets` TEXT NOT NULL, `primary_genre` INTEGER NOT NULL, `review_score` INTEGER NOT NULL, `review_percentage` INTEGER NOT NULL, `controller_support` INTEGER NOT NULL, `demo_of_app_id` INTEGER NOT NULL, `developer` TEXT NOT NULL, `publisher` TEXT NOT NULL, `homepage_url` TEXT NOT NULL, `game_manual_url` TEXT NOT NULL, `load_all_before_launch` INTEGER NOT NULL, `dlc_app_ids` TEXT NOT NULL, `is_free_app` INTEGER NOT NULL, `dlc_for_app_id` INTEGER NOT NULL, `must_own_app_to_purchase` INTEGER NOT NULL, `dlc_available_on_store` INTEGER NOT NULL, `optional_dlc` INTEGER NOT NULL, `game_dir` TEXT NOT NULL, `install_script` TEXT NOT NULL, `no_servers` INTEGER NOT NULL, `order` INTEGER NOT NULL, `primary_cache` INTEGER NOT NULL, `valid_os_list` INTEGER NOT NULL, `third_party_cd_key` INTEGER NOT NULL, `visible_only_when_installed` INTEGER NOT NULL, `visible_only_when_subscribed` INTEGER NOT NULL, `launch_eula_url` TEXT NOT NULL, `require_default_install_folder` INTEGER NOT NULL, `content_type` INTEGER NOT NULL, `install_dir` TEXT NOT NULL, `use_launch_cmd_line` INTEGER NOT NULL, `launch_without_workshop_updates` INTEGER NOT NULL, `use_mms` INTEGER NOT NULL, `install_script_signature` TEXT NOT NULL, `install_script_override` INTEGER NOT NULL, `config` TEXT NOT NULL, `ufs` TEXT NOT NULL, `workshop_mods` INTEGER NOT NULL DEFAULT 0, `enabled_workshop_item_ids` TEXT NOT NULL DEFAULT '', `workshop_download_pending` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageId",
+            "columnName": "package_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerAccountId",
+            "columnName": "owner_account_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseFlags",
+            "columnName": "license_flags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedPICS",
+            "columnName": "received_pics",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChangeNumber",
+            "columnName": "last_change_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ufsParseVersion",
+            "columnName": "ufs_parse_version",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "depots",
+            "columnName": "depots",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "branches",
+            "columnName": "branches",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "osList",
+            "columnName": "os_list",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseState",
+            "columnName": "release_state",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "release_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metacriticScore",
+            "columnName": "metacritic_score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metacriticFullUrl",
+            "columnName": "metacritic_full_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoHash",
+            "columnName": "logo_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoSmallHash",
+            "columnName": "logo_small_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconHash",
+            "columnName": "icon_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientIconHash",
+            "columnName": "client_icon_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientTgaHash",
+            "columnName": "client_tga_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smallCapsule",
+            "columnName": "small_capsule",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "headerImage",
+            "columnName": "header_image",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryAssets",
+            "columnName": "library_assets",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryGenre",
+            "columnName": "primary_genre",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reviewScore",
+            "columnName": "review_score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reviewPercentage",
+            "columnName": "review_percentage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "controllerSupport",
+            "columnName": "controller_support",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "demoOfAppId",
+            "columnName": "demo_of_app_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "developer",
+            "columnName": "developer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "homepageUrl",
+            "columnName": "homepage_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gameManualUrl",
+            "columnName": "game_manual_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loadAllBeforeLaunch",
+            "columnName": "load_all_before_launch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dlcAppIds",
+            "columnName": "dlc_app_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFreeApp",
+            "columnName": "is_free_app",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dlcForAppId",
+            "columnName": "dlc_for_app_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mustOwnAppToPurchase",
+            "columnName": "must_own_app_to_purchase",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dlcAvailableOnStore",
+            "columnName": "dlc_available_on_store",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optionalDlc",
+            "columnName": "optional_dlc",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gameDir",
+            "columnName": "game_dir",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installScript",
+            "columnName": "install_script",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noServers",
+            "columnName": "no_servers",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryCache",
+            "columnName": "primary_cache",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "validOSList",
+            "columnName": "valid_os_list",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thirdPartyCdKey",
+            "columnName": "third_party_cd_key",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibleOnlyWhenInstalled",
+            "columnName": "visible_only_when_installed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibleOnlyWhenSubscribed",
+            "columnName": "visible_only_when_subscribed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchEulaUrl",
+            "columnName": "launch_eula_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requireDefaultInstallFolder",
+            "columnName": "require_default_install_folder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "content_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installDir",
+            "columnName": "install_dir",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useLaunchCmdLine",
+            "columnName": "use_launch_cmd_line",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchWithoutWorkshopUpdates",
+            "columnName": "launch_without_workshop_updates",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useMms",
+            "columnName": "use_mms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installScriptSignature",
+            "columnName": "install_script_signature",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installScriptOverride",
+            "columnName": "install_script_override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "config",
+            "columnName": "config",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ufs",
+            "columnName": "ufs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workshopMods",
+            "columnName": "workshop_mods",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "enabledWorkshopItemIds",
+            "columnName": "enabled_workshop_item_ids",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "workshopDownloadPending",
+            "columnName": "workshop_download_pending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "steam_license",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageId` INTEGER NOT NULL, `last_change_number` INTEGER NOT NULL, `time_created` INTEGER NOT NULL, `time_next_process` INTEGER NOT NULL, `minute_limit` INTEGER NOT NULL, `minutes_used` INTEGER NOT NULL, `payment_method` INTEGER NOT NULL, `license_flags` INTEGER NOT NULL, `purchase_code` TEXT NOT NULL, `license_type` INTEGER NOT NULL, `territory_code` INTEGER NOT NULL, `access_token` INTEGER NOT NULL, `owner_account_id` TEXT NOT NULL, `master_package_id` INTEGER NOT NULL, `app_ids` TEXT NOT NULL, `depot_ids` TEXT NOT NULL, PRIMARY KEY(`packageId`))",
+        "fields": [
+          {
+            "fieldPath": "packageId",
+            "columnName": "packageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChangeNumber",
+            "columnName": "last_change_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeCreated",
+            "columnName": "time_created",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeNextProcess",
+            "columnName": "time_next_process",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minuteLimit",
+            "columnName": "minute_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minutesUsed",
+            "columnName": "minutes_used",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentMethod",
+            "columnName": "payment_method",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseFlags",
+            "columnName": "license_flags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "purchaseCode",
+            "columnName": "purchase_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseType",
+            "columnName": "license_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "territoryCode",
+            "columnName": "territory_code",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "access_token",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerAccountId",
+            "columnName": "owner_account_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "masterPackageID",
+            "columnName": "master_package_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appIds",
+            "columnName": "app_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "depotIds",
+            "columnName": "depot_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageId"
+          ]
+        }
+      },
+      {
+        "tableName": "gog_games",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `slug` TEXT NOT NULL, `download_size` INTEGER NOT NULL, `install_size` INTEGER NOT NULL, `is_installed` INTEGER NOT NULL, `install_path` TEXT NOT NULL, `image_url` TEXT NOT NULL, `icon_url` TEXT NOT NULL, `background_url` TEXT NOT NULL DEFAULT '', `description` TEXT NOT NULL, `release_date` TEXT NOT NULL, `developer` TEXT NOT NULL, `publisher` TEXT NOT NULL, `genres` TEXT NOT NULL, `languages` TEXT NOT NULL, `last_played` INTEGER NOT NULL, `play_time` INTEGER NOT NULL, `type` INTEGER NOT NULL, `exclude` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadSize",
+            "columnName": "download_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installSize",
+            "columnName": "install_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInstalled",
+            "columnName": "is_installed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installPath",
+            "columnName": "install_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "icon_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundUrl",
+            "columnName": "background_url",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "release_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "developer",
+            "columnName": "developer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "languages",
+            "columnName": "languages",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayed",
+            "columnName": "last_played",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playTime",
+            "columnName": "play_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exclude",
+            "columnName": "exclude",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "epic_games",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `catalog_id` TEXT NOT NULL, `app_name` TEXT NOT NULL, `title` TEXT NOT NULL, `namespace` TEXT NOT NULL, `developer` TEXT NOT NULL, `publisher` TEXT NOT NULL, `is_installed` INTEGER NOT NULL, `install_path` TEXT NOT NULL, `platform` TEXT NOT NULL, `version` TEXT NOT NULL, `executable` TEXT NOT NULL, `install_size` INTEGER NOT NULL, `download_size` INTEGER NOT NULL, `art_cover` TEXT NOT NULL, `art_square` TEXT NOT NULL, `art_logo` TEXT NOT NULL, `art_portrait` TEXT NOT NULL, `can_run_offline` INTEGER NOT NULL, `requires_ot` INTEGER NOT NULL, `cloud_save_enabled` INTEGER NOT NULL, `save_folder` TEXT NOT NULL, `third_party_managed_app` TEXT NOT NULL, `is_ea_managed` INTEGER NOT NULL, `is_dlc` INTEGER NOT NULL, `base_game_app_name` TEXT NOT NULL, `description` TEXT NOT NULL, `release_date` TEXT NOT NULL, `genres` TEXT NOT NULL, `tags` TEXT NOT NULL, `last_played` INTEGER NOT NULL, `play_time` INTEGER NOT NULL, `type` INTEGER NOT NULL, `eos_catalog_item_id` TEXT NOT NULL, `eos_app_id` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogId",
+            "columnName": "catalog_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appName",
+            "columnName": "app_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "namespace",
+            "columnName": "namespace",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "developer",
+            "columnName": "developer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInstalled",
+            "columnName": "is_installed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installPath",
+            "columnName": "install_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "executable",
+            "columnName": "executable",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installSize",
+            "columnName": "install_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadSize",
+            "columnName": "download_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artCover",
+            "columnName": "art_cover",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artSquare",
+            "columnName": "art_square",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artLogo",
+            "columnName": "art_logo",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artPortrait",
+            "columnName": "art_portrait",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canRunOffline",
+            "columnName": "can_run_offline",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requiresOT",
+            "columnName": "requires_ot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cloudSaveEnabled",
+            "columnName": "cloud_save_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveFolder",
+            "columnName": "save_folder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thirdPartyManagedApp",
+            "columnName": "third_party_managed_app",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEAManaged",
+            "columnName": "is_ea_managed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDLC",
+            "columnName": "is_dlc",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseGameAppName",
+            "columnName": "base_game_app_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "release_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayed",
+            "columnName": "last_played",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playTime",
+            "columnName": "play_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eosCatalogItemId",
+            "columnName": "eos_catalog_item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eosAppId",
+            "columnName": "eos_app_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "amazon_games",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`app_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `product_id` TEXT NOT NULL, `entitlement_id` TEXT NOT NULL DEFAULT '', `title` TEXT NOT NULL, `is_installed` INTEGER NOT NULL, `install_path` TEXT NOT NULL, `art_url` TEXT NOT NULL, `hero_url` TEXT NOT NULL DEFAULT '', `purchased_date` TEXT NOT NULL, `developer` TEXT NOT NULL DEFAULT '', `publisher` TEXT NOT NULL DEFAULT '', `release_date` TEXT NOT NULL DEFAULT '', `download_size` INTEGER NOT NULL DEFAULT 0, `install_size` INTEGER NOT NULL DEFAULT 0, `version_id` TEXT NOT NULL DEFAULT '', `product_sku` TEXT NOT NULL DEFAULT '', `last_played` INTEGER NOT NULL DEFAULT 0, `play_time_minutes` INTEGER NOT NULL DEFAULT 0, `product_json` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "appId",
+            "columnName": "app_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "product_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entitlementId",
+            "columnName": "entitlement_id",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInstalled",
+            "columnName": "is_installed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installPath",
+            "columnName": "install_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artUrl",
+            "columnName": "art_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "heroUrl",
+            "columnName": "hero_url",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "purchasedDate",
+            "columnName": "purchased_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "developer",
+            "columnName": "developer",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "release_date",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "downloadSize",
+            "columnName": "download_size",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "installSize",
+            "columnName": "install_size",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "versionId",
+            "columnName": "version_id",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "productSku",
+            "columnName": "product_sku",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "lastPlayed",
+            "columnName": "last_played",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "playTimeMinutes",
+            "columnName": "play_time_minutes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "productJson",
+            "columnName": "product_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "app_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_amazon_games_product_id",
+            "unique": false,
+            "columnNames": [
+              "product_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_amazon_games_product_id` ON `${TABLE_NAME}` (`product_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "downloading_app_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`appId` INTEGER NOT NULL, `dlcAppIds` TEXT NOT NULL, `branch` TEXT NOT NULL DEFAULT 'public', PRIMARY KEY(`appId`))",
+        "fields": [
+          {
+            "fieldPath": "appId",
+            "columnName": "appId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dlcAppIds",
+            "columnName": "dlcAppIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "branch",
+            "columnName": "branch",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'public'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "appId"
+          ]
+        }
+      },
+      {
+        "tableName": "steam_unlocked_branch",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`appId` INTEGER NOT NULL, `branchName` TEXT NOT NULL, `password` TEXT NOT NULL, PRIMARY KEY(`appId`, `branchName`))",
+        "fields": [
+          {
+            "fieldPath": "appId",
+            "columnName": "appId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "branchName",
+            "columnName": "branchName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "appId",
+            "branchName"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bcaaca63252bc468a66722fea34d3abd')"
+    ]
+  }
+}

--- a/app/src/main/java/app/gamenative/data/AppInfo.kt
+++ b/app/src/main/java/app/gamenative/data/AppInfo.kt
@@ -17,4 +17,9 @@ data class AppInfo (
     val branch: String = "public",
     @ColumnInfo(name = "recovered_install_size_bytes", defaultValue = "0")
     val recoveredInstallSizeBytes: Long = 0L,
-)
+    @ColumnInfo("custom_install_path", defaultValue = "")
+    val customInstallPath: String = "",
+) {
+    val isImported: Boolean
+        get() = customInstallPath != ""
+}

--- a/app/src/main/java/app/gamenative/db/PluviaDatabase.kt
+++ b/app/src/main/java/app/gamenative/db/PluviaDatabase.kt
@@ -53,7 +53,7 @@ const val DATABASE_NAME = "pluvia.db"
         DownloadingAppInfo::class,
         SteamUnlockedBranch::class,
     ],
-    version = 19,
+    version = 20,
     // For db migration, visit https://developer.android.com/training/data-storage/room/migrating-db-versions for more information
     exportSchema = true, // It is better to handle db changes carefully, as GN is getting much more users.
     autoMigrations = [
@@ -72,6 +72,7 @@ const val DATABASE_NAME = "pluvia.db"
         // v16 users will fallback to destructive migration (only cached Steam data, re-fetched on login)
         AutoMigration(from = 17, to = 18), // Added workshop_mods, enabled_workshop_item_ids, workshop_download_pending to steam_app
         AutoMigration(from = 18, to = 19), // Added recovered_install_size_bytes to app_info
+        AutoMigration(from = 19, to = 20), // Added custom_install_path to app_info
     ]
 )
 @TypeConverters(

--- a/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
@@ -155,4 +155,7 @@ interface SteamAppDao {
 
     @Query("SELECT * FROM steam_app WHERE config LIKE '%\"installDir\":\"' || :dirName || '\",%'")
     suspend fun findSteamAppWithInstallDir(dirName: String): List<SteamApp>
+
+    @Query("SELECT * FROM steam_app WHERE id IN (:appIds)")
+    suspend fun findSteamAppWithAppIds(appIds: List<Int>): List<SteamApp>
 }

--- a/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
@@ -152,4 +152,7 @@ interface SteamAppDao {
 
     @Query("UPDATE steam_app SET workshop_mods = 0, enabled_workshop_item_ids = '', workshop_download_pending = 0 WHERE id = :appId")
     suspend fun clearWorkshopState(appId: Int)
+
+    @Query("SELECT * FROM steam_app WHERE config LIKE '%\"installDir\":\"' || :dirName || '\",%'")
+    suspend fun findSteamAppWithInstallDir(dirName: String): List<SteamApp>
 }

--- a/app/src/main/java/app/gamenative/service/DownloadService.kt
+++ b/app/src/main/java/app/gamenative/service/DownloadService.kt
@@ -65,15 +65,6 @@ object DownloadService {
                 dirs += getSubdirectories(installPath)
             }
 
-            SteamService.getAllInstalledApps()?.forEach { installedApp ->
-                if (installedApp.isImported) {
-                    val steamApp = SteamService.getAppInfoOf(installedApp.id)
-                    if (steamApp != null) {
-                        dirs += SteamService.getAppDirName(steamApp)
-                    }
-                }
-            }
-
             downloadDirectoryApps = dirs.toMutableList()
         }
 

--- a/app/src/main/java/app/gamenative/service/DownloadService.kt
+++ b/app/src/main/java/app/gamenative/service/DownloadService.kt
@@ -65,6 +65,15 @@ object DownloadService {
                 dirs += getSubdirectories(installPath)
             }
 
+            SteamService.getAllInstalledApps()?.forEach { installedApp ->
+                if (installedApp.isImported) {
+                    val steamApp = SteamService.getAppInfoOf(installedApp.id)
+                    if (steamApp != null) {
+                        dirs += SteamService.getAppDirName(steamApp)
+                    }
+                }
+            }
+
             downloadDirectoryApps = dirs.toMutableList()
         }
 

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -612,6 +612,21 @@ class SteamService : Service(), IChallengeUrlChanged {
             return runBlocking(Dispatchers.IO) { instance?.appInfoDao?.getAll() }
         }
 
+        fun getImportedAppDirs(): List<String> {
+            val dirs = mutableSetOf<String>()
+
+            getAllInstalledApps()?.forEach { installedApp ->
+                if (installedApp.isImported) {
+                    val steamApp = getAppInfoOf(installedApp.id)
+                    if (steamApp != null) {
+                        dirs += getAppDirName(steamApp)
+                    }
+                }
+            }
+
+            return dirs.toList()
+        }
+
         fun findSteamAppWithInstallDir(dirName: String): List<SteamApp>? {
             return runBlocking(Dispatchers.IO) { instance?.appDao?.findSteamAppWithInstallDir(dirName) }
         }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -612,18 +612,20 @@ class SteamService : Service(), IChallengeUrlChanged {
             return runBlocking(Dispatchers.IO) { instance?.appInfoDao?.getAll() }
         }
 
+        fun findSteamAppWithAppIds(appIds: List<Int>): List<SteamApp>? {
+            return runBlocking(Dispatchers.IO) { instance?.appDao?.findSteamAppWithAppIds(appIds) }
+        }
+
         fun getImportedAppDirs(): List<String> {
             val dirs = mutableSetOf<String>()
-
-            getAllInstalledApps()?.forEach { installedApp ->
-                if (installedApp.isImported) {
-                    val steamApp = getAppInfoOf(installedApp.id)
-                    if (steamApp != null) {
-                        dirs += getAppDirName(steamApp)
-                    }
+            val installedApps = getAllInstalledApps()
+            val importedAppIds = installedApps?.filter { it.isImported }?.map { it.id }
+            if (importedAppIds != null) {
+                val steamApps = findSteamAppWithAppIds(importedAppIds)
+                steamApps?.forEach { steamApp ->
+                    dirs += getAppDirName(steamApp)
                 }
             }
-
             return dirs.toList()
         }
 

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -174,6 +174,7 @@ import app.gamenative.statsgen.StatType
 import app.gamenative.statsgen.StatsAchievementsGenerator
 import app.gamenative.statsgen.VdfParser
 import app.gamenative.utils.DownloadSpeedConfig
+import app.gamenative.utils.CustomGameScanner
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -601,6 +602,10 @@ class SteamService : Service(), IChallengeUrlChanged {
             return runBlocking(Dispatchers.IO) { instance?.appInfoDao?.getInstalledApp(appId) }
         }
 
+        fun findSteamAppWithInstallDir(dirName: String): List<SteamApp>? {
+            return runBlocking(Dispatchers.IO) { instance?.appDao?.findSteamAppWithInstallDir(dirName) }
+        }
+
         fun getInstalledDepotsOf(appId: Int): List<Int>? {
             return getInstalledApp(appId)?.downloadedDepots
         }
@@ -935,6 +940,13 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         fun getAppDirPath(gameId: Int): String {
             val info = getAppInfoOf(gameId)
+
+            // For installed game, check whether it has customInstallPath and return it
+            val appInfo = getInstalledApp(gameId)
+            if (appInfo != null && appInfo.isImported) {
+                return appInfo.customInstallPath
+            }
+
             val appName = getAppDirName(info)
             val oldName = info?.name.orEmpty()
             val names = if (oldName.isNotEmpty() && oldName != appName) listOf(appName, oldName) else listOf(appName)
@@ -1168,8 +1180,30 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         fun deleteApp(appId: Int): Boolean {
             // snapshot path before marker removal (removing the marker changes resolution)
-            val appDirPath = getAppDirPath(appId)
-            MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+            val appInfo = getInstalledApp(appId)
+            val result = if (appInfo?.isImported == true) {
+                // For imported game, do cleanup
+                // Remove from manual folders list and invalidate cache
+                val folderPath = appInfo.customInstallPath
+                val manualFolders = PrefManager.customGameManualFolders.toMutableSet()
+                manualFolders.remove(folderPath)
+                PrefManager.customGameManualFolders = manualFolders
+                CustomGameScanner.invalidateCache()
+
+                MarkerUtils.removeMarker(folderPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+
+                true
+            } else {
+                val appDirPath = getAppDirPath(appId)
+                val appDir = File(appDirPath)
+
+                if (appDir.exists()) {
+                    MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+                }
+
+                File(appDirPath).deleteRecursively()
+            }
+
             // Remove from DB
             workshopPausedApps.remove(appId)
             with(instance!!) {
@@ -1191,7 +1225,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                 }
             }
 
-            return File(appDirPath).deleteRecursively()
+            return result
         }
 
         fun downloadApp(appId: Int): DownloadInfo? {
@@ -1930,8 +1964,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                 val updatedDlcDepots = (appInfo.dlcDepots + selectedDlcAppIds).distinct()
 
                 instance?.appInfoDao?.update(
-                    AppInfo(
-                        downloadingAppId,
+                    appInfo.copy(
                         isDownloaded = true,
                         downloadedDepots = updatedDownloadedDepots.sorted(),
                         dlcDepots = updatedDlcDepots.sorted(),

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -621,7 +621,9 @@ class SteamService : Service(), IChallengeUrlChanged {
             val installedApps = getAllInstalledApps()
             val importedAppIds = installedApps?.filter { it.isImported }?.map { it.id }
             if (importedAppIds != null) {
-                val steamApps = findSteamAppWithAppIds(importedAppIds)
+                val steamApps = importedAppIds
+                    .chunked(900)
+                    .flatMap { ids -> findSteamAppWithAppIds(ids).orEmpty() }
                 steamApps?.forEach { steamApp ->
                     dirs += getAppDirName(steamApp)
                 }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -540,6 +540,12 @@ class SteamService : Service(), IChallengeUrlChanged {
             }
         }
 
+        fun isAppLicensed(packageId: Int): Boolean {
+            return runBlocking(Dispatchers.IO) {
+                instance?.licenseDao?.findLicense(packageId) != null
+            }
+        }
+
         fun getPkgInfoOf(appId: Int): SteamLicense? {
             return runBlocking(Dispatchers.IO) {
                 instance?.licenseDao?.findLicense(

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -602,6 +602,10 @@ class SteamService : Service(), IChallengeUrlChanged {
             return runBlocking(Dispatchers.IO) { instance?.appInfoDao?.getInstalledApp(appId) }
         }
 
+        fun getAllInstalledApps(): List<AppInfo>? {
+            return runBlocking(Dispatchers.IO) { instance?.appInfoDao?.getAll() }
+        }
+
         fun findSteamAppWithInstallDir(dirName: String): List<SteamApp>? {
             return runBlocking(Dispatchers.IO) { instance?.appDao?.findSteamAppWithInstallDir(dirName) }
         }

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -376,7 +376,7 @@ class LibraryViewModel @Inject constructor(
             val currentFilter = AppFilter.getAppType(currentState.appInfoSortType)
 
             // Fetch download directory apps once on IO thread and cache as a HashSet for O(1) lookups
-            val downloadDirectoryApps = DownloadService.getDownloadDirectoryApps()
+            val downloadDirectoryApps = DownloadService.getDownloadDirectoryApps() + SteamService.getImportedAppDirs()
             val downloadDirectorySet = downloadDirectoryApps.toHashSet()
 
             fun passesCompatibleFilter(gameName: String): Boolean {
@@ -447,6 +447,10 @@ class LibraryViewModel @Inject constructor(
             // Map Steam apps to UI items
             data class LibraryEntry(val item: LibraryItem, val isInstalled: Boolean)
             val licensedDepotMap = SteamService.buildLicensedDepotMap(filteredSteamApps)
+
+            // Added this to avoid duplicate from custom imported steam game
+            val steamEntriesAppIds = mutableListOf<String>()
+
             val steamEntries: List<LibraryEntry> = filteredSteamApps.map { item ->
                 val isInstalled = downloadDirectorySet.contains(SteamService.getAppDirName(item))
                 val installedBranch = if (isInstalled) {
@@ -460,10 +464,15 @@ class LibraryViewModel @Inject constructor(
                 val totalSizeBytes = resolved.values.sumOf { depot ->
                     depot.manifests[installedBranch]?.size ?: depot.manifests.values.firstOrNull()?.size ?: 0L
                 }
+
+                // Move appId here
+                val appId = "${GameSource.STEAM.name}_${item.id}"
+                steamEntriesAppIds.add(appId)
+
                 LibraryEntry(
                     item = LibraryItem(
                         index = 0, // temporary, will be re-indexed after combining and paginating
-                        appId = "${GameSource.STEAM.name}_${item.id}",
+                        appId = appId,
                         name = item.name,
                         iconHash = item.clientIconHash,
                         capsuleImageUrl = item.getCapsuleUrl(),
@@ -487,6 +496,7 @@ class LibraryViewModel @Inject constructor(
             }
             val customEntries = customGameItems
                 .filter { passesCompatibleFilter(it.name) }
+                .filter { !steamEntriesAppIds.contains(it.appId) } // Filter out imported steam appId
                 .map { LibraryEntry(it, true) }
 
             // Filter GOG games

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -449,7 +449,7 @@ class LibraryViewModel @Inject constructor(
             val licensedDepotMap = SteamService.buildLicensedDepotMap(filteredSteamApps)
 
             // Added this to avoid duplicate from custom imported steam game
-            val steamEntriesAppIds = mutableListOf<String>()
+            val steamEntriesAppIds = mutableSetOf<String>()
 
             val steamEntries: List<LibraryEntry> = filteredSteamApps.map { item ->
                 val isInstalled = downloadDirectorySet.contains(SteamService.getAppDirName(item))

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -59,6 +59,7 @@ import app.gamenative.utils.SteamUtils
 import app.gamenative.utils.StorageUtils
 import app.gamenative.workshop.WorkshopManager
 import app.gamenative.NetworkMonitor
+import app.gamenative.service.SteamService.Companion.getInstalledApp
 import com.google.android.play.core.splitcompat.SplitCompat
 import com.posthog.PostHog
 import com.winlator.container.ContainerData
@@ -79,6 +80,7 @@ import app.gamenative.ui.component.dialog.state.GameManagerDialogState
 import app.gamenative.ui.util.SnackbarManager
 import app.gamenative.ui.util.SteamSaveTransfer
 import app.gamenative.utils.ContainerUtils.getContainer
+import app.gamenative.utils.CustomGameScanner
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import timber.log.Timber
@@ -1223,6 +1225,8 @@ class SteamAppScreen : BaseAppScreen() {
                             hideUninstallDialog(libraryItem.appId)
 
                             CoroutineScope(Dispatchers.IO).launch {
+                                val installedAppInfo = getInstalledApp(libraryItem.gameId)!!
+
                                 val success = SteamService.deleteApp(gameId)
                                 DownloadService.invalidateCache()
                                 withContext(Dispatchers.Main) {
@@ -1243,6 +1247,13 @@ class SteamAppScreen : BaseAppScreen() {
                                         )
                                     } else {
                                         SnackbarManager.show(context.getString(R.string.steam_uninstall_failed))
+                                    }
+                                }
+
+                                // Back to home screen as the game is imported
+                                if (success && installedAppInfo.isImported) {
+                                    withContext(Dispatchers.Main) {
+                                        onBack()
                                     }
                                 }
                             }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -1225,7 +1225,7 @@ class SteamAppScreen : BaseAppScreen() {
                             hideUninstallDialog(libraryItem.appId)
 
                             CoroutineScope(Dispatchers.IO).launch {
-                                val installedAppInfo = getInstalledApp(libraryItem.gameId)!!
+                                val installedAppInfo = getInstalledApp(libraryItem.gameId)
 
                                 val success = SteamService.deleteApp(gameId)
                                 DownloadService.invalidateCache()
@@ -1251,7 +1251,7 @@ class SteamAppScreen : BaseAppScreen() {
                                 }
 
                                 // Back to home screen as the game is imported
-                                if (success && installedAppInfo.isImported) {
+                                if (success && installedAppInfo?.isImported == true) {
                                     withContext(Dispatchers.Main) {
                                         onBack()
                                     }

--- a/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
+++ b/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
@@ -465,9 +465,7 @@ object CustomGameScanner {
 
                 val manualItem = createLibraryItemFromFolder(manualPath)
                 if (manualItem != null && existingAppIds.add(manualItem.appId)) {
-                    if (manualItem.gameSource != GameSource.STEAM) {
-                        items.add(manualItem.copy(index = indexCounter++))
-                    }
+                    items.add(manualItem.copy(index = indexCounter++))
                 }
             }
         }

--- a/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
+++ b/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
@@ -465,7 +465,9 @@ object CustomGameScanner {
 
                 val manualItem = createLibraryItemFromFolder(manualPath)
                 if (manualItem != null && existingAppIds.add(manualItem.appId)) {
-                    items.add(manualItem.copy(index = indexCounter++))
+                    if (manualItem.gameSource != GameSource.STEAM) {
+                        items.add(manualItem.copy(index = indexCounter++))
+                    }
                 }
             }
         }

--- a/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
+++ b/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
@@ -513,46 +513,46 @@ object CustomGameScanner {
             val steamApps = SteamService.findSteamAppWithInstallDir(dirName = folder.name)
             if (steamApps?.size == 1) {
                 val steamApp = steamApps[0]
+                if (SteamService.isAppLicensed(steamApp.packageId)) {
+                    if (SteamService.getInstalledApp(steamApp.id) == null) {
+                        val preferredLanguage = PrefManager.containerLanguage
+                        val mainDepots = getMainAppDepots(steamApp.id, preferredLanguage)
+                        val mainAppDepots = mainDepots.filter { (_, depot) ->
+                            depot.dlcAppId == INVALID_APP_ID
+                        }
+                        val mainAppDepotIds = mainAppDepots.keys.sorted()
 
-                if (SteamService.isAppLicensed(steamApp.packageId) &&
-                    SteamService.getInstalledApp(steamApp.id) == null) {
-                    val preferredLanguage = PrefManager.containerLanguage
-                    val mainDepots = getMainAppDepots(steamApp.id, preferredLanguage)
-                    val mainAppDepots = mainDepots.filter { (_, depot) ->
-                        depot.dlcAppId == INVALID_APP_ID
+                        runBlocking {
+                            SteamService.instance?.appInfoDao?.insert(
+                                AppInfo(
+                                    steamApp.id,
+                                    isDownloaded = true,
+                                    downloadedDepots = mainAppDepotIds,
+                                    dlcDepots = emptyList(),
+                                    branch = "public",
+                                    customInstallPath = folderPath
+                                ),
+                            )
+                        }
+
+                        MarkerUtils.addMarker(folderPath, Marker.DOWNLOAD_COMPLETE_MARKER)
                     }
-                    val mainAppDepotIds = mainAppDepots.keys.sorted()
 
-                    runBlocking {
-                        SteamService.instance?.appInfoDao?.insert(
-                            AppInfo(
-                                steamApp.id,
-                                isDownloaded = true,
-                                downloadedDepots = mainAppDepotIds,
-                                dlcDepots = emptyList(),
-                                branch = "public",
-                                customInstallPath = folderPath
-                            ),
-                        )
-                    }
+                    val idPart = steamApp.id
+                    val appId = "${GameSource.STEAM.name}_$idPart"
 
-                    MarkerUtils.addMarker(folderPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+                    return LibraryItem(
+                        index = 0,
+                        appId = appId,
+                        name = steamApp.name,
+                        iconHash = steamApp.clientIconHash,
+                        capsuleImageUrl = steamApp.getCapsuleUrl(),
+                        headerImageUrl = steamApp.getHeaderImageUrl().orEmpty().ifEmpty { steamApp.headerUrl },
+                        heroImageUrl = steamApp.getHeroUrl().ifEmpty { steamApp.headerUrl },
+                        isShared = false,
+                        gameSource = GameSource.STEAM,
+                    )
                 }
-
-                val idPart = steamApp.id
-                val appId = "${GameSource.STEAM.name}_$idPart"
-
-                return LibraryItem(
-                    index = 0,
-                    appId = appId,
-                    name = steamApp.name,
-                    iconHash = steamApp.clientIconHash,
-                    capsuleImageUrl = steamApp.getCapsuleUrl(),
-                    headerImageUrl = steamApp.getHeaderImageUrl().orEmpty().ifEmpty { steamApp.headerUrl },
-                    heroImageUrl = steamApp.getHeroUrl().ifEmpty { steamApp.headerUrl },
-                    isShared = false,
-                    gameSource = GameSource.STEAM,
-                )
             }
         }
 

--- a/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
+++ b/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
@@ -10,17 +10,26 @@ import android.provider.Settings
 import androidx.core.content.ContextCompat
 import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
+import app.gamenative.data.AppInfo
 import app.gamenative.data.GameSource
 import app.gamenative.data.LibraryItem
+import app.gamenative.enums.Marker
 import app.gamenative.events.AndroidEvent
 import app.gamenative.service.DownloadService
+import app.gamenative.service.SteamService
+import app.gamenative.service.SteamService.Companion.INVALID_APP_ID
+import app.gamenative.service.SteamService.Companion.getMainAppDepots
 import com.winlator.container.Container
 import com.winlator.container.ContainerManager
 import java.io.File
 import kotlin.math.abs
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import timber.log.Timber
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.text.ifEmpty
 
 object CustomGameScanner {
 
@@ -498,6 +507,52 @@ object CustomGameScanner {
         if (!folder.exists() || !folder.isDirectory) {
             Timber.tag("CustomGameScanner").w("Folder does not exist or is not a directory: $folderPath")
             return null
+        }
+
+        if (SteamService.instance != null) {
+            val steamApps = SteamService.findSteamAppWithInstallDir(dirName = folder.name)
+            if (steamApps?.size == 1) {
+                val steamApp = steamApps[0]
+
+                if (SteamService.getInstalledApp(steamApp.id) == null) {
+                    val preferredLanguage = PrefManager.containerLanguage
+                    val mainDepots = getMainAppDepots(steamApp.id, preferredLanguage)
+                    val mainAppDepots = mainDepots.filter { (_, depot) ->
+                        depot.dlcAppId == INVALID_APP_ID
+                    }
+                    val mainAppDepotIds = mainAppDepots.keys.sorted()
+
+                    runBlocking {
+                        SteamService.instance?.appInfoDao?.insert(
+                            AppInfo(
+                                steamApp.id,
+                                isDownloaded = true,
+                                downloadedDepots = mainAppDepotIds,
+                                dlcDepots = emptyList(),
+                                branch = "public",
+                                customInstallPath = folderPath
+                            ),
+                        )
+                    }
+
+                    MarkerUtils.addMarker(folderPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+                }
+
+                val idPart = steamApp.id
+                val appId = "${GameSource.STEAM.name}_$idPart"
+
+                return LibraryItem(
+                    index = 0,
+                    appId = appId,
+                    name = steamApp.name,
+                    iconHash = steamApp.clientIconHash,
+                    capsuleImageUrl = steamApp.getCapsuleUrl(),
+                    headerImageUrl = steamApp.getHeaderImageUrl().orEmpty().ifEmpty { steamApp.headerUrl },
+                    heroImageUrl = steamApp.getHeroUrl().ifEmpty { steamApp.headerUrl },
+                    isShared = false,
+                    gameSource = GameSource.STEAM,
+                )
+            }
         }
 
         val idPart = getOrGenerateGameId(folder)

--- a/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
+++ b/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
@@ -516,7 +516,8 @@ object CustomGameScanner {
             if (steamApps?.size == 1) {
                 val steamApp = steamApps[0]
 
-                if (SteamService.getInstalledApp(steamApp.id) == null) {
+                if (SteamService.isAppLicensed(steamApp.packageId) &&
+                    SteamService.getInstalledApp(steamApp.id) == null) {
                     val preferredLanguage = PrefManager.containerLanguage
                     val mainDepots = getMainAppDepots(steamApp.id, preferredLanguage)
                     val mainAppDepots = mainDepots.filter { (_, depot) ->

--- a/app/src/main/java/com/winlator/core/WineUtils.java
+++ b/app/src/main/java/com/winlator/core/WineUtils.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 
+import app.gamenative.PrefManager;
 import timber.log.Timber;
 
 public abstract class WineUtils {
@@ -63,8 +64,12 @@ public abstract class WineUtils {
             FileUtils.symlink(path, dosdevicesPath+"/"+drive[0].toLowerCase(Locale.ENGLISH)+":");
 
             // Check if this is the A: drive (game directory)
-            if (drive[0].equals("A") && path.contains("/Steam/steamapps/common/")) {
-                gameDirectoryPath = path;
+            if (drive[0].equals("A")) {
+                if (path.contains("/Steam/steamapps/common/")) {
+                    gameDirectoryPath = path;
+                } else if (PrefManager.INSTANCE.getCustomGameManualFolders().contains(path)) {
+                    gameDirectoryPath = path;
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Increments the database version to 19, introducing a `custom_install_path` field to the `app_info` table for tracking user-defined installation locations.

Enhances the custom game scanner to identify and import existing Steam games by matching installation directories. Imported Steam games will now leverage existing metadata and be managed as native Steam entries.

Updates `SteamService` to use the `custom_install_path` for installed imported games and modifies the uninstall process for imported games to only remove database entries, preserving the game files.

Adjusts `WineUtils` to recognize custom game folders as valid game directories, ensuring correct drive mounting for imported titles.

## Recording
- Check Discord video

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Import Steam games from custom install folders so they show as native entries in the Steam tab with full metadata and license validation. Also fixes a crash in the import/uninstall flow and ensures imported games appear on first load without duplicates.

- **New Features**
  - DB v20: add `custom_install_path` to `app_info`; `AppInfo.isImported` derives from it.
  - Scanner: match folder name to Steam `installDir`; import only if licensed; mark main depots downloaded; add `DOWNLOAD_COMPLETE`; save the path; imported titles appear under Steam, not Custom.
  - Service/DAO: add `SteamAppDao.findSteamAppWithInstallDir` and `findSteamAppWithAppIds`; `getImportedAppDirs` enables first-load visibility; `getAppDirPath` returns `custom_install_path` for imported games; uninstall preserves files, removes the folder from custom folders, cleans DB, removes the marker, and invalidates scanner cache.
  - Library/UI: treat imported Steam dirs as installed, de-dupe by app ID, and navigate back after uninstall of an imported game.
  - WineUtils: accept custom manual folders as valid A: game dirs for proper mounting.

- **Migration**
  - Auto-migrates 19 → 20.
  - To import, add the install folder to custom game folders; the folder name must match the Steam `installDir`.

<sup>Written for commit cf5454341ce17d36fad61ac81406f5c121b83111. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking games installed at custom paths outside default locations.
  * Enabled Steam auto-detection when scanning custom-installed games.
  * Improved game directory scanning to better recognize manually installed games.

* **Bug Fixes**
  * Enhanced uninstall experience for custom-installed games with improved navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->