### PR TITLE
fix: restore carousel scroll position on back when navigating by touch

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
@@ -484,7 +484,10 @@ internal fun LibraryCarouselPane(
                                         AppItem(
                                             modifier = appItemModifier,
                                             appInfo = item,
-                                            onClick = { onNavigate(item.appId) },
+                                            onClick = {
+                                                onFocusedIndexChanged(listIndex)
+                                                onNavigate(item.appId)
+                                            },
                                             onFocus = {
                                                 onFocusedIndexChanged(listIndex)
                                             },


### PR DESCRIPTION
## Description

focused index change only wired to onFocus, so focus targe never updated in touch nav. On back, requestCarouselFocusOrDefer always resolved to first item in index instead of the tapped item.

Fix: also call onFocusedIndexChanged in onClick so the index is recorded before navigating regardless of input method.

<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed app item selection in the library carousel to properly synchronize the focused state when clicked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->