### PR TITLE
Added uplay support on top of ubisoft connect

### DIFF
--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/UbisoftConnectStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/UbisoftConnectStep.kt
@@ -9,9 +9,8 @@ import timber.log.Timber
 
 object UbisoftConnectStep : PreInstallStep {
     private const val TAG = "UbisoftConnectStep"
-    private const val INSTALLER_NAME = "UbisoftConnectInstaller.exe"
+    private val INSTALLER_NAMES = listOf("UbisoftConnectInstaller.exe", "UplayInstaller.exe")
     private const val COMMON_REDIST_SUBDIR = "_CommonRedist/UbisoftConnect"
-    private const val WINE_INSTALLER_PATH = "A:\\_CommonRedist\\UbisoftConnect\\UbisoftConnectInstaller.exe"
 
     override val marker: Marker = Marker.UBISOFT_CONNECT_INSTALLED
 
@@ -32,20 +31,27 @@ object UbisoftConnectStep : PreInstallStep {
         gameDir: File,
         gameDirPath: String,
     ): String? {
-        val rootInstaller = File(gameDir, INSTALLER_NAME)
         val commonRedistDir = File(gameDir, COMMON_REDIST_SUBDIR)
-        val commonRedistInstaller = File(commonRedistDir, INSTALLER_NAME)
+        val installerName =
+            INSTALLER_NAMES.firstOrNull { installer ->
+                ensureInstallerAtCommonRedist(
+                    rootInstaller = File(gameDir, installer),
+                    commonRedistDir = commonRedistDir,
+                    commonRedistInstaller = File(commonRedistDir, installer),
+                )
+            }
 
-        if (!ensureInstallerAtCommonRedist(rootInstaller, commonRedistDir, commonRedistInstaller)) {
+        if (installerName == null) {
             Timber.tag(TAG).i(
-                "Ubisoft Connect installer not present at expected _CommonRedist path for game at %s",
+                "Ubisoft installer not present at expected _CommonRedist path for game at %s",
                 gameDirPath,
             )
             return null
         }
 
-        val command = "$WINE_INSTALLER_PATH /S"
-        Timber.tag(TAG).i("Using Ubisoft Connect installer (silent): %s", command)
+        val wineInstallerPath = "A:\\_CommonRedist\\UbisoftConnect\\$installerName"
+        val command = "$wineInstallerPath /S"
+        Timber.tag(TAG).i("Using Ubisoft installer (silent): %s", command)
 
         return command
     }
@@ -68,7 +74,7 @@ object UbisoftConnectStep : PreInstallStep {
             Files.createSymbolicLink(commonRedistInstaller.toPath(), rootInstaller.toPath())
             return commonRedistInstaller.exists()
         } catch (t: Throwable) {
-            Timber.tag(TAG).w(t, "Failed creating Ubisoft Connect symlink")
+            Timber.tag(TAG).w(t, "Failed creating Ubisoft symlink")
             return false
         }
     }


### PR DESCRIPTION
## Description
Now searches for the older uplayinstaller.exe as well.

## Recording

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the legacy `UplayInstaller.exe` in the Ubisoft Connect pre-install step so older game bundles install silently without manual intervention.

- **New Features**
  - Detects both `UbisoftConnectInstaller.exe` and `UplayInstaller.exe`.
  - Symlinks the found installer into `_CommonRedist/UbisoftConnect` and runs it with `/S`.
  - Generalizes logging and path handling to “Ubisoft” to cover both installers.

<sup>Written for commit 2621b3b8ca055b6d82198365d0347e540cbbbce6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ubisoft Connect installation robustness by supporting multiple installer variants. The system now automatically detects and applies the correct installer version when available, enhancing compatibility across different game installations and reducing potential installation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->