### PR TITLE
fix/feat: allow config dxvk and vkd3d version together

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -739,18 +739,15 @@ fun ContainerConfigDialog(
                 if (context.isVortekLike) "async-1.10.3" else DefaultVersion.DXVK
             } else selectedVersion
             val envSet = EnvVars(config.envVars)
-            // Update dxwrapperConfig version only when DXVK wrapper selected
-            val wrapperIsDxvk = StringUtils.parseIdentifier(dxWrappers[dxWrapperIndex]) == "dxvk"
+            // Update dxwrapperConfig version regardless of wrapper type (allows DXVK config even when VKD3D is selected)
             val kvs = KeyValueSet(config.dxwrapperConfig)
             val currentVersion = kvs.get("version")
-            // Only update if the version actually changed (don't overwrite on initial load if it matches)
-            if (wrapperIsDxvk) {
-                // Check if we need to update - only if current version doesn't match selected version
-                val needsUpdate = currentVersion.isEmpty() ||
-                    (currentVersion != version && StringUtils.parseIdentifier(currentVersion) != StringUtils.parseIdentifier(version))
-                if (needsUpdate) {
-                    kvs.put("version", version)
-                }
+            // Always allow DXVK version updates (removed wrapper type restriction)
+            // Check if we need to update - only if current version doesn't match selected version
+            val needsUpdate = currentVersion.isEmpty() ||
+                (currentVersion != version && StringUtils.parseIdentifier(currentVersion) != StringUtils.parseIdentifier(version))
+            if (needsUpdate) {
+                kvs.put("version", version)
             }
             if (version.contains("async", ignoreCase = true)) {
                 kvs.put("async", "1")

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GraphicsTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GraphicsTab.kt
@@ -337,61 +337,50 @@ private fun DxWrapperSection(state: ContainerConfigState) {
             state.config.value = config.copy(dxwrapper = StringUtils.parseIdentifier(state.dxWrappers[it]))
         },
     )
-    // DXVK Version Dropdown (conditionally visible and constrained)
+    // DXVK Version Dropdown (always visible - allows configuration even when VKD3D is selected)
     run {
         val context = state.currentDxvkContext()
-        val isVKD3D = StringUtils.parseIdentifier(state.dxWrappers.getOrNull(state.dxWrapperIndex.value).orEmpty()) == "vkd3d"
-        if (!isVKD3D) {
-            val items = context.labels
-            val itemIds = context.ids
-            val itemMuted = context.muted
-            SettingsListDropdown(
-                colors = settingsTileColors(),
-                title = { Text(text = stringResource(R.string.dxvk_version)) },
-                value = state.dxvkVersionIndex.value.coerceIn(0, (items.size - 1).coerceAtLeast(0)),
-                items = items,
-                itemMuted = itemMuted,
-                onItemSelected = {
-                    state.dxvkVersionIndex.value = it
-                    val selectedId = itemIds.getOrNull(it).orEmpty()
-                    val isManifestNotInstalled = state.isBionicVariant && itemMuted?.getOrNull(it) == true
-                    val manifestEntry = if (state.isBionicVariant) state.dxvkManifestById[selectedId] else null
-                    if (isManifestNotInstalled && manifestEntry != null) {
-                        state.launchManifestContentInstall(
-                            manifestEntry,
-                            ContentProfile.ContentType.CONTENT_TYPE_DXVK,
-                        ) {
-                            val currentConfig = KeyValueSet(config.dxwrapperConfig)
-                            currentConfig.put("version", selectedId)
-                            if (selectedId.contains("async", ignoreCase = true)) currentConfig.put("async", "1")
-                            else currentConfig.put("async", "0")
-                            if (selectedId.contains("gplasync", ignoreCase = true)) currentConfig.put("asyncCache", "1")
-                            else currentConfig.put("asyncCache", "0")
-                            state.config.value = config.copy(dxwrapperConfig = currentConfig.toString())
-                        }
-                        return@SettingsListDropdown
+        val items = context.labels
+        val itemIds = context.ids
+        val itemMuted = context.muted
+        SettingsListDropdown(
+            colors = settingsTileColors(),
+            title = { Text(text = stringResource(R.string.dxvk_version)) },
+            value = state.dxvkVersionIndex.value.coerceIn(0, (items.size - 1).coerceAtLeast(0)),
+            items = items,
+            itemMuted = itemMuted,
+            onItemSelected = {
+                state.dxvkVersionIndex.value = it
+                val selectedId = itemIds.getOrNull(it).orEmpty()
+                val isManifestNotInstalled = state.isBionicVariant && itemMuted?.getOrNull(it) == true
+                val manifestEntry = if (state.isBionicVariant) state.dxvkManifestById[selectedId] else null
+                if (isManifestNotInstalled && manifestEntry != null) {
+                    state.launchManifestContentInstall(
+                        manifestEntry,
+                        ContentProfile.ContentType.CONTENT_TYPE_DXVK,
+                    ) {
+                        val currentConfig = KeyValueSet(config.dxwrapperConfig)
+                        currentConfig.put("version", selectedId)
+                        if (selectedId.contains("async", ignoreCase = true)) currentConfig.put("async", "1")
+                        else currentConfig.put("async", "0")
+                        if (selectedId.contains("gplasync", ignoreCase = true)) currentConfig.put("asyncCache", "1")
+                        else currentConfig.put("asyncCache", "0")
+                        state.config.value = config.copy(dxwrapperConfig = currentConfig.toString())
                     }
-                    val version = selectedId.ifEmpty { StringUtils.parseIdentifier(items.getOrNull(it).orEmpty()) }
-                    val currentConfig = KeyValueSet(config.dxwrapperConfig)
-                    currentConfig.put("version", version)
-                    val envVarsSet = EnvVars(config.envVars)
-                    if (version.contains("async", ignoreCase = true)) currentConfig.put("async", "1")
-                    else currentConfig.put("async", "0")
-                    if (version.contains("gplasync", ignoreCase = true)) currentConfig.put("asyncCache", "1")
-                    else currentConfig.put("asyncCache", "0")
-                    state.config.value =
-                        config.copy(dxwrapperConfig = currentConfig.toString(), envVars = envVarsSet.toString())
-                },
-            )
-        } else {
-            // Ensure default version for vortek-like when hidden
-            val driverType = StringUtils.parseIdentifier(state.graphicsDrivers.value.getOrNull(state.graphicsDriverIndex.value).orEmpty())
-            val isVortekLike = config.containerVariant.equals(Container.GLIBC) && (driverType == "vortek" || driverType == "adreno" || driverType == "sd-8-elite")
-            val version = if (isVortekLike) "1.10.3" else "2.4.1"
-            val currentConfig = KeyValueSet(config.dxwrapperConfig)
-            currentConfig.put("version", version)
-            state.config.value = config.copy(dxwrapperConfig = currentConfig.toString())
-        }
+                    return@SettingsListDropdown
+                }
+                val version = selectedId.ifEmpty { StringUtils.parseIdentifier(items.getOrNull(it).orEmpty()) }
+                val currentConfig = KeyValueSet(config.dxwrapperConfig)
+                currentConfig.put("version", version)
+                val envVarsSet = EnvVars(config.envVars)
+                if (version.contains("async", ignoreCase = true)) currentConfig.put("async", "1")
+                else currentConfig.put("async", "0")
+                if (version.contains("gplasync", ignoreCase = true)) currentConfig.put("asyncCache", "1")
+                else currentConfig.put("asyncCache", "0")
+                state.config.value =
+                    config.copy(dxwrapperConfig = currentConfig.toString(), envVars = envVarsSet.toString())
+            },
+        )
     }
     // VKD3D Version UI (visible only when VKD3D selected)
     run {

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -4019,7 +4019,7 @@ private fun extractDXWrapperFiles(
             val dxvkVersion = dxwrapperConfig.get("version", dxvkMinVersion)
             val dxvkVersionForVkd3d = if (vortekLike && GPUHelper.vkGetApiVersionSafe() < GPUHelper.vkMakeVersion(1, 3, 0)) {
                 "1.10.3"
-            } else if (ManifestComponentHelper.isAtLeastVersion(dxvkVersion, 2, 6, 1)) {
+            } else if (ManifestComponentHelper.isAtLeastVersion(dxvkVersion, 2, 1, 0)) {
                 dxvkVersion
             } else {
                 dxvkMinVersion

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -4015,7 +4015,7 @@ private fun extractDXWrapperFiles(
             // Determine graphics driver to choose DXVK version
             val vortekLike = container.graphicsDriver == "vortek" || container.graphicsDriver == "adreno" || container.graphicsDriver == "sd-8-elite"
             val dxvkMinVersion = "2.6.1-gplasync"
-            val dxwrapperConfig = DXVKHelper.parseConfig(container.getExtra("dxwrapperConfig") as String)
+            val dxwrapperConfig = DXVKHelper.parseConfig(container.dxWrapperConfig)
             val dxvkVersion = dxwrapperConfig.get("version", dxvkMinVersion)
             val dxvkVersionForVkd3d = if (vortekLike && GPUHelper.vkGetApiVersionSafe() < GPUHelper.vkMakeVersion(1, 3, 0)) {
                 "1.10.3"

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -96,6 +96,7 @@ import app.gamenative.ui.widget.PerformanceHudView
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.CustomGameScanner
 import app.gamenative.utils.ExecutableSelectionUtils
+import app.gamenative.utils.ManifestComponentHelper
 import app.gamenative.utils.PreInstallSteps
 import app.gamenative.utils.SteamTokenLogin
 import app.gamenative.utils.SteamUtils
@@ -4013,7 +4014,13 @@ private fun extractDXWrapperFiles(
             val profile: ContentProfile? = contentsManager.getProfileByEntryName(dxwrapper)
             // Determine graphics driver to choose DXVK version
             val vortekLike = container.graphicsDriver == "vortek" || container.graphicsDriver == "adreno" || container.graphicsDriver == "sd-8-elite"
-            val dxvkVersionForVkd3d = if (vortekLike && GPUHelper.vkGetApiVersionSafe() < GPUHelper.vkMakeVersion(1, 3, 0)) "1.10.3" else "2.4.1"
+            val dxvkVersionForVkd3d = if (vortekLike && GPUHelper.vkGetApiVersionSafe() < GPUHelper.vkMakeVersion(1, 3, 0)) {
+                "1.10.3"
+            } else if (ManifestComponentHelper.isAtLeastVersion(dxwrapper, 2, 6, 1)) {
+                dxwrapper
+            } else {
+                "2.6.1-gplasync"
+            }
             Timber.i("Extracting VKD3D DX version for dxwrapper: $dxvkVersionForVkd3d")
             TarCompressorUtils.extract(
                 TarCompressorUtils.Type.ZSTD, context.assets,

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -4014,12 +4014,15 @@ private fun extractDXWrapperFiles(
             val profile: ContentProfile? = contentsManager.getProfileByEntryName(dxwrapper)
             // Determine graphics driver to choose DXVK version
             val vortekLike = container.graphicsDriver == "vortek" || container.graphicsDriver == "adreno" || container.graphicsDriver == "sd-8-elite"
+            val dxvkMinVersion = "2.6.1-gplasync"
+            val dxwrapperConfig = DXVKHelper.parseConfig(container.getExtra("dxwrapperConfig") as String)
+            val dxvkVersion = dxwrapperConfig.get("version", dxvkMinVersion)
             val dxvkVersionForVkd3d = if (vortekLike && GPUHelper.vkGetApiVersionSafe() < GPUHelper.vkMakeVersion(1, 3, 0)) {
                 "1.10.3"
-            } else if (ManifestComponentHelper.isAtLeastVersion(dxwrapper, 2, 6, 1)) {
-                dxwrapper
+            } else if (ManifestComponentHelper.isAtLeastVersion(dxvkVersion, 2, 6, 1)) {
+                dxvkVersion
             } else {
-                "2.6.1-gplasync"
+                dxvkMinVersion
             }
             Timber.i("Extracting VKD3D DX version for dxwrapper: $dxvkVersionForVkd3d")
             TarCompressorUtils.extract(

--- a/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
+++ b/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
@@ -11,6 +11,23 @@ import kotlinx.coroutines.withContext
 import java.util.Locale
 
 object ManifestComponentHelper {
+    private fun parseSemVerTriplet(value: String): Triple<Int, Int, Int>? {
+        val match = Regex("(\\d+)\\.(\\d+)(?:\\.(\\d+))?").find(value) ?: return null
+        val major = match.groupValues.getOrNull(1)?.toIntOrNull() ?: return null
+        val minor = match.groupValues.getOrNull(2)?.toIntOrNull() ?: return null
+        val patch = match.groupValues.getOrNull(3)?.toIntOrNull() ?: 0
+        return Triple(major, minor, patch)
+    }
+
+    private fun isAtLeastVersion(value: String, minMajor: Int, minMinor: Int, minPatch: Int): Boolean {
+        val (major, minor, patch) = parseSemVerTriplet(value) ?: return false
+        return when {
+            major != minMajor -> major > minMajor
+            minor != minMinor -> minor > minMinor
+            else -> patch >= minPatch
+        }
+    }
+
     data class InstalledContentLists(
         val dxvk: List<String>,
         val vkd3d: List<String>,
@@ -180,6 +197,9 @@ object ManifestComponentHelper {
         val isVortekLike = containerVariant.equals("glibc", ignoreCase = true) &&
             driverType in listOf("vortek", "adreno", "sd-8-elite")
 
+        val isVKD3D = StringUtils.parseIdentifier(
+            dxWrappers.getOrNull(dxWrapperIndex).orEmpty(),
+        ) == "vkd3d"
         val constrainedLabels = listOf("1.10.3", "1.10.9-sarek", "1.9.2", "async-1.10.3")
         val constrainedIds = constrainedLabels.map { StringUtils.parseIdentifier(it) }
         val useConstrained =
@@ -199,8 +219,25 @@ object ManifestComponentHelper {
             else if (isBionicVariant) dxvkOptions.muted
             else emptyList()
 
+        val (finalLabels, finalIds, finalMuted) = if (isVKD3D) {
+            val allowedIndices = ids.mapIndexedNotNull { index, id ->
+                if (isAtLeastVersion(id, 2, 6, 1)) index else null
+            }
+            if (allowedIndices.isNotEmpty()) {
+                Triple(
+                    allowedIndices.map { labels[it] },
+                    allowedIndices.map { ids[it] },
+                    if (muted.isNotEmpty()) allowedIndices.map { muted[it] } else emptyList(),
+                )
+            } else {
+                Triple(labels, ids, muted)
+            }
+        } else {
+            Triple(labels, ids, muted)
+        }
+
         // Always return DXVK options regardless of wrapper selection (allows DXVK config even when VKD3D is selected)
-        return DxvkContext(isVortekLike, labels, ids, muted)
+        return DxvkContext(isVortekLike, finalLabels, finalIds, finalMuted)
     }
 
     fun versionExists(version: String, available: List<String>): Boolean {

--- a/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
+++ b/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.withContext
 import java.util.Locale
 
 object ManifestComponentHelper {
-    private fun parseSemVerTriplet(value: String): Triple<Int, Int, Int>? {
+    fun parseSemVerTriplet(value: String): Triple<Int, Int, Int>? {
         val match = Regex("(\\d+)\\.(\\d+)(?:\\.(\\d+))?").find(value) ?: return null
         val major = match.groupValues.getOrNull(1)?.toIntOrNull() ?: return null
         val minor = match.groupValues.getOrNull(2)?.toIntOrNull() ?: return null
@@ -19,7 +19,7 @@ object ManifestComponentHelper {
         return Triple(major, minor, patch)
     }
 
-    private fun isAtLeastVersion(value: String, minMajor: Int, minMinor: Int, minPatch: Int): Boolean {
+    fun isAtLeastVersion(value: String, minMajor: Int, minMinor: Int, minPatch: Int): Boolean {
         val (major, minor, patch) = parseSemVerTriplet(value) ?: return false
         return when {
             major != minMajor -> major > minMajor

--- a/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
+++ b/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
@@ -180,9 +180,6 @@ object ManifestComponentHelper {
         val isVortekLike = containerVariant.equals("glibc", ignoreCase = true) &&
             driverType in listOf("vortek", "adreno", "sd-8-elite")
 
-        val isVKD3D = StringUtils.parseIdentifier(
-            dxWrappers.getOrNull(dxWrapperIndex).orEmpty(),
-        ) == "vkd3d"
         val constrainedLabels = listOf("1.10.3", "1.10.9-sarek", "1.9.2", "async-1.10.3")
         val constrainedIds = constrainedLabels.map { StringUtils.parseIdentifier(it) }
         val useConstrained =
@@ -202,11 +199,8 @@ object ManifestComponentHelper {
             else if (isBionicVariant) dxvkOptions.muted
             else emptyList()
 
-        return if (isVKD3D) {
-            DxvkContext(isVortekLike, emptyList(), emptyList(), emptyList())
-        } else {
-            DxvkContext(isVortekLike, labels, ids, muted)
-        }
+        // Always return DXVK options regardless of wrapper selection (allows DXVK config even when VKD3D is selected)
+        return DxvkContext(isVortekLike, labels, ids, muted)
     }
 
     fun versionExists(version: String, available: List<String>): Boolean {

--- a/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
+++ b/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
@@ -221,7 +221,7 @@ object ManifestComponentHelper {
 
         val (finalLabels, finalIds, finalMuted) = if (isVKD3D) {
             val allowedIndices = ids.mapIndexedNotNull { index, id ->
-                if (isAtLeastVersion(id, 2, 6, 1)) index else null
+                if (isAtLeastVersion(id, 2, 1, 0)) index else null
             }
             if (allowedIndices.isNotEmpty()) {
                 Triple(


### PR DESCRIPTION
## Description
For some Games, it may use both directx 11 and 12 together, so setting dxvk version on a vkd3d is very useful.
It fixes Lies of P running in Odin 3.

## Recording
- Check Discord

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow configuring DXVK and VKD3D versions together. The DXVK dropdown stays visible (including with VKD3D) and filters to 2.1.0+; runtime extraction reads the correct `dxWrapperConfig` and prefers the selected version (>=2.1.0) or falls back to `2.6.1-gplasync` (`1.10.3` for Vortek-like GPUs on Vulkan < 1.3), fixing DX11+DX12 games like Lies of P on Odin 3.

- **Bug Fixes**
  - Always show the DXVK version dropdown and persist `dxwrapperConfig.version` regardless of wrapper; update only on change.
  - Under VKD3D, show only DXVK 2.1.0+; set `async`/`asyncCache` from the selected version and during DXVK manifest installs; avoid resets when switching wrappers.
  - During VKD3D extraction, read the correct `dxWrapperConfig`; use the chosen DXVK if ≥2.1.0 or fallback to `2.6.1-gplasync` (`1.10.3` for Vortek-like GPUs on Vulkan < 1.3).

<sup>Written for commit a65b92c6f6d9b819c02a664064b9961387372df3. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1083?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DXVK version selector is always visible and reliably saves when changed or left empty.
  * Version selections now persist and apply consistently across all graphics wrapper choices.
  * Removed cases where version updates were previously skipped for specific wrapper types.

* **Refactor**
  * Simplified wrapper detection and manifest preparation for more predictable version handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->