### PR TITLE
fix: mouse movement in games that use raw mouse input and clipcursor

### DIFF
--- a/app/src/main/java/com/winlator/xconnector/XOutputStream.java
+++ b/app/src/main/java/com/winlator/xconnector/XOutputStream.java
@@ -13,6 +13,7 @@ public class XOutputStream {
     public final ClientSocket clientSocket;
     private final ReentrantLock lock = new ReentrantLock();
     private int ancillaryFd = -1;
+    private static final double FP3232_SCALE = 4294967296.0;
 
     public XOutputStream(int initialCapacity) {
         this(null, initialCapacity);
@@ -49,6 +50,30 @@ public class XOutputStream {
     public void writeLong(long value) {
         ensureSpaceIsAvailable(8);
         buffer.putLong(value);
+    }
+
+    public void writeFP3232(double value) {
+        if (Double.isNaN(value) || Double.isInfinite(value)) {
+            throw new IllegalArgumentException("FP3232 value must be finite");
+        }
+
+        long fixed = Math.round(value * FP3232_SCALE);
+
+        int integral = (int) (fixed >> 32);
+        int frac = (int) fixed;
+
+        // FP3232 is a struct { int32_t integral; uint32_t frac; } in X11.
+        writeInt(integral);
+        writeInt(frac);
+    }
+
+    public void writeFP3232(int integerPart, long fractionalPart) {
+        if (fractionalPart < 0L || fractionalPart > 0xFFFFFFFFL) {
+            throw new IllegalArgumentException("fractionalPart must be in range 0 .. 0xFFFFFFFF");
+        }
+
+        writeInt(integerPart);
+        writeInt((int) fractionalPart);
     }
 
     public void writeString8(String str) {

--- a/app/src/main/java/com/winlator/xserver/Bitmask.java
+++ b/app/src/main/java/com/winlator/xserver/Bitmask.java
@@ -5,15 +5,15 @@ import androidx.annotation.NonNull;
 import java.util.Iterator;
 
 public class Bitmask implements Iterable<Integer> {
-    private int bits = 0;
+    private long bits = 0;
 
     public Bitmask() {}
 
-    public Bitmask(int bits) {
+    public Bitmask(long bits) {
         this.bits = bits;
     }
 
-    public boolean isSet(int flag) {
+    public boolean isSet(long flag) {
         return (flag & this.bits) != 0;
     }
 
@@ -21,18 +21,18 @@ public class Bitmask implements Iterable<Integer> {
         return (mask.bits & this.bits) != 0;
     }
 
-    public void set(int flag) {
+    public void set(long flag) {
         bits |= flag;
     }
 
-    public void set(int flag, boolean value) {
+    public void set(long flag, boolean value) {
         if (value) {
             set(flag);
         }
         else unset(flag);
     }
 
-    public void unset(int flag) {
+    public void unset(long flag) {
         bits &= ~flag;
     }
 
@@ -40,7 +40,7 @@ public class Bitmask implements Iterable<Integer> {
         return bits == 0;
     }
 
-    public int getBits() {
+    public long getBits() {
         return bits;
     }
 
@@ -51,7 +51,7 @@ public class Bitmask implements Iterable<Integer> {
     @NonNull
     @Override
     public Iterator<Integer> iterator() {
-        final int[] bits = {this.bits};
+        final long[] bits = {this.bits};
         return new Iterator<Integer>() {
             @Override
             public boolean hasNext() {
@@ -60,15 +60,15 @@ public class Bitmask implements Iterable<Integer> {
 
             @Override
             public Integer next() {
-                int index = Integer.lowestOneBit(bits[0]);
+                long index = Long.lowestOneBit(bits[0]);
                 bits[0] &= ~index;
-                return index;
+                return (int) index;
             }
         };
     }
 
     @Override
     public int hashCode() {
-        return bits;
+        return Long.hashCode(bits);
     }
 }

--- a/app/src/main/java/com/winlator/xserver/GrabManager.java
+++ b/app/src/main/java/com/winlator/xserver/GrabManager.java
@@ -1,10 +1,13 @@
 package com.winlator.xserver;
 
+import android.graphics.Rect;
+
 import com.winlator.xserver.events.Event;
 import com.winlator.xserver.events.PointerWindowEvent;
 
 public class GrabManager implements WindowManager.OnWindowModificationListener {
     private Window window;
+    private Window confineToWindow;
     private boolean ownerEvents;
     private boolean releaseWithButtons;
     private EventListener eventListener;
@@ -42,15 +45,21 @@ public class GrabManager implements WindowManager.OnWindowModificationListener {
         return eventListener != null ? eventListener.client : null;
     }
 
+    public Rect getConfinementBounds() {
+        if (confineToWindow == null) return null;
+        return confineToWindow.getAbsoluteBounds();
+    }
+
     public void deactivatePointerGrab() {
         if (window != null) {
             xServer.inputDeviceManager.sendEnterLeaveNotify(window, xServer.inputDeviceManager.getPointWindow(), PointerWindowEvent.Mode.UNGRAB);
             window = null;
             eventListener = null;
+            confineToWindow = null;
         }
     }
 
-    private void activatePointerGrab(Window window, EventListener eventListener, boolean ownerEvents, boolean releaseWithButtons) {
+    private void activatePointerGrab(Window window, EventListener eventListener, boolean ownerEvents, boolean releaseWithButtons, Window confineToWindow) {
         if (this.window == null) {
             xServer.inputDeviceManager.sendEnterLeaveNotify(xServer.inputDeviceManager.getPointWindow(), window, PointerWindowEvent.Mode.GRAB);
         }
@@ -58,14 +67,15 @@ public class GrabManager implements WindowManager.OnWindowModificationListener {
         this.releaseWithButtons = releaseWithButtons;
         this.ownerEvents = ownerEvents;
         this.eventListener = eventListener;
+        this.confineToWindow = confineToWindow;
     }
 
-    public void activatePointerGrab(Window window, boolean ownerEvents, Bitmask eventMask, XClient client) {
-        activatePointerGrab(window, new EventListener(client, eventMask), ownerEvents, false);
+    public void activatePointerGrab(Window window, boolean ownerEvents, Bitmask eventMask, XClient client, Window confineToWindow) {
+        activatePointerGrab(window, new EventListener(client, eventMask), ownerEvents, false, confineToWindow);
     }
 
     public void activatePointerGrab(Window window) {
         EventListener eventListener = window.getButtonPressListener();
-        activatePointerGrab(window, eventListener, eventListener.isInterestedIn(Event.OWNER_GRAB_BUTTON), true);
+        activatePointerGrab(window, eventListener, eventListener.isInterestedIn(Event.OWNER_GRAB_BUTTON), true, null);
     }
 }

--- a/app/src/main/java/com/winlator/xserver/Window.java
+++ b/app/src/main/java/com/winlator/xserver/Window.java
@@ -1,5 +1,6 @@
 package com.winlator.xserver;
 
+import android.graphics.Rect;
 import android.util.SparseArray;
 
 import com.winlator.xserver.events.Event;
@@ -329,6 +330,12 @@ public class Window extends XResource {
             window = window.parent;
         }
         return rootY;
+    }
+
+    public Rect getAbsoluteBounds() {
+        short rootX = getRootX();
+        short rootY = getRootY();
+        return new Rect(rootX, rootY, rootX + width, rootY + height);
     }
 
     public Window getAncestorWithEventMask(Bitmask eventMask) {

--- a/app/src/main/java/com/winlator/xserver/XClient.java
+++ b/app/src/main/java/com/winlator/xserver/XClient.java
@@ -5,6 +5,7 @@ import androidx.collection.ArrayMap;
 import com.winlator.xconnector.XInputStream;
 import com.winlator.xconnector.XOutputStream;
 import com.winlator.xserver.events.Event;
+import com.winlator.xserver.extensions.XInput2Extension;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -100,6 +101,9 @@ public class XClient implements XResourceManager.OnResourceLifecycleListener {
             xServer.cursorManager.removeOnResourceLifecycleListener(this);
             xServer.resourceIDs.free(resourceIDBase);
         }
+
+        XInput2Extension xi2 = xServer.getExtension(XInput2Extension.MAJOR_OPCODE);
+        xi2.onClientDisconnected(this);
     }
 
     public void generateSequenceNumber() {

--- a/app/src/main/java/com/winlator/xserver/XClientRequestHandler.java
+++ b/app/src/main/java/com/winlator/xserver/XClientRequestHandler.java
@@ -24,6 +24,8 @@ import com.winlator.xserver.requests.WindowRequests;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
+import timber.log.Timber;
+
 public class XClientRequestHandler implements RequestHandler {
     public static final byte RESPONSE_CODE_ERROR = 0;
     public static final byte RESPONSE_CODE_SUCCESS = 1;
@@ -447,15 +449,19 @@ public class XClientRequestHandler implements RequestHandler {
                 default:
                     if (opcode < 0) {
                         Extension extension = client.xServer.extensions.get(opcode);
-                        if (extension != null) extension.handleRequest(client, inputStream, outputStream);
+                        if (extension != null)
+                            extension.handleRequest(client, inputStream, outputStream);
+                        else
+                            Timber.w("handleNormalRequest: unhandled opcode=%d, requestData=%d, requestLength=%d", opcode, requestData, requestLength);
+
                     }
-                    else Log.d("XClientRequestHandler", "Unsupported opcode " + opcode);
+                    else Timber.w("handleNormalRequest: unsupported opcode " + opcode);
                     break;
             }
         }
         catch (XRequestError e) {
             client.skipRequest();
-            Log.w("XClientRequestHandler", "handleNormalRequest error " + e);
+            Timber.e("handleNormalRequest: XRequestError for opcode=%d: %s", opcode, e);
             e.sendError(client, opcode);
         }
 

--- a/app/src/main/java/com/winlator/xserver/XClientRequestHandler.java
+++ b/app/src/main/java/com/winlator/xserver/XClientRequestHandler.java
@@ -84,7 +84,7 @@ public class XClientRequestHandler implements RequestHandler {
             outputStream.writeInt(0);
             outputStream.writeInt(0xffffff);
             outputStream.writeInt(0x000000);
-            outputStream.writeInt(client.xServer.windowManager.rootWindow.getAllEventMasks().getBits());
+            outputStream.writeInt((int)client.xServer.windowManager.rootWindow.getAllEventMasks().getBits());
             outputStream.writeShort(client.xServer.screenInfo.width);
             outputStream.writeShort(client.xServer.screenInfo.height);
             outputStream.writeShort(client.xServer.screenInfo.getWidthInMillimeters());

--- a/app/src/main/java/com/winlator/xserver/XServer.java
+++ b/app/src/main/java/com/winlator/xserver/XServer.java
@@ -168,8 +168,8 @@ public class XServer {
             if (confinement != null) {
                 minX = Math.max(minX, confinement.left);
                 minY = Math.max(minY, confinement.top);
-                maxX = Math.min(maxX, confinement.right);
-                maxY = Math.min(maxY, confinement.bottom);
+                maxX = Math.min(maxX, confinement.right - 1);
+                maxY = Math.min(maxY, confinement.bottom - 1);
 
                 clampedX = (short) Mathf.clamp(pointer.getX() + dx, minX, maxX);
                 clampedY = (short) Mathf.clamp(pointer.getY() + dy, minY, maxY);

--- a/app/src/main/java/com/winlator/xserver/XServer.java
+++ b/app/src/main/java/com/winlator/xserver/XServer.java
@@ -1,9 +1,10 @@
 package com.winlator.xserver;
 
+import android.graphics.Rect;
 import android.util.Log;
 import android.util.SparseArray;
 
-import com.winlator.core.CursorLocker;
+import com.winlator.math.Mathf;
 import com.winlator.renderer.GLRenderer;
 import com.winlator.winhandler.WinHandler;
 import com.winlator.xserver.extensions.BigReqExtension;
@@ -12,6 +13,7 @@ import com.winlator.xserver.extensions.Extension;
 import com.winlator.xserver.extensions.MITSHMExtension;
 import com.winlator.xserver.extensions.PresentExtension;
 import com.winlator.xserver.extensions.SyncExtension;
+import com.winlator.xserver.extensions.XInput2Extension;
 
 import java.nio.charset.Charset;
 import java.util.EnumMap;
@@ -37,7 +39,6 @@ public class XServer {
     public final GrabManager grabManager;
     private boolean isGrabbed = false;
     private XClient grabbingClient = null;
-    public final CursorLocker cursorLocker;
     private SHMSegmentManager shmSegmentManager;
     private GLRenderer renderer;
     private WinHandler winHandler;
@@ -48,7 +49,6 @@ public class XServer {
     public XServer(ScreenInfo screenInfo) {
         Log.d("XServer", "Creating xServer " + screenInfo);
         this.screenInfo = screenInfo;
-        cursorLocker = new CursorLocker(this);
         for (Lockable lockable : Lockable.values()) locks.put(lockable, new ReentrantLock());
 
         pixmapManager = new PixmapManager();
@@ -68,7 +68,6 @@ public class XServer {
     }
 
     public void setRelativeMouseMovement(boolean relativeMouseMovement) {
-        cursorLocker.setEnabled(!relativeMouseMovement);
         this.relativeMouseMovement = relativeMouseMovement;
     }
 
@@ -160,19 +159,74 @@ public class XServer {
 
     public void injectPointerMoveDelta(int dx, int dy) {
         try (XLock lock = lock(Lockable.WINDOW_MANAGER, Lockable.INPUT_DEVICE)) {
-            pointer.setPosition(pointer.getX() + dx, pointer.getY() + dy);
+            int minX = 0, minY = 0;
+            int maxX = screenInfo.width - 1, maxY = screenInfo.height - 1;
+            short clampedX = 0, clampedY = 0;
+
+            // ClipCursor
+            Rect confinement = grabManager.getConfinementBounds();
+            if (confinement != null) {
+                minX = Math.max(minX, confinement.left);
+                minY = Math.max(minY, confinement.top);
+                maxX = Math.min(maxX, confinement.right);
+                maxY = Math.min(maxY, confinement.bottom);
+
+                clampedX = (short) Mathf.clamp(pointer.getX() + dx, minX, maxX);
+                clampedY = (short) Mathf.clamp(pointer.getY() + dy, minY, maxY);
+
+                pointer.setPosition(clampedX, clampedY);
+            } else {
+                // Legacy path for old Proton builds with broken ClipCursor
+                // Do NOT remove without confirming no regressions with:
+                // - Games that rely on XWarpPointer (see WindowRequests.java:warpPointer)
+                // - Games that call ClipCursor and happen to work well with this workaround
+                short softMarginX = (short)(screenInfo.width * 0.05f);
+                short softMarginY = (short)(screenInfo.height * 0.05f);
+                short x = (short)Mathf.clamp(pointer.getX() + dx, -softMarginX, screenInfo.width - 1 + softMarginX);
+                short y = (short)Mathf.clamp(pointer.getY() + dy, -softMarginY, screenInfo.height - 1 + softMarginY);
+
+                pointer.setPosition(x, y);
+
+                clampedX = x;
+                clampedY = y;
+
+                if (x < 0) {
+                    clampedX = 0;
+                }
+                else if (x > screenInfo.width - 1) {
+                    clampedX = (short) (screenInfo.width - 1);
+                }
+                if (y < 0) {
+                    clampedY = 0;
+                }
+                else if (y > screenInfo.height - 1) {
+                    clampedY = (short) (screenInfo.height - 1);
+                }
+
+                pointer.setX(clampedX);
+                pointer.setY(clampedY);
+            }
+
+            XInput2Extension xi = getExtension(XInput2Extension.MAJOR_OPCODE);
+            xi.emitRawMotion(2, dx, dy);
         }
     }
 
     public void injectPointerButtonPress(Pointer.Button buttonCode) {
         try (XLock lock = lock(Lockable.WINDOW_MANAGER, Lockable.INPUT_DEVICE)) {
             pointer.setButton(buttonCode, true);
+
+            XInput2Extension xi = getExtension(XInput2Extension.MAJOR_OPCODE);
+            xi.emitRawButton(2, buttonCode.code(), true);
         }
     }
 
     public void injectPointerButtonRelease(Pointer.Button buttonCode) {
         try (XLock lock = lock(Lockable.WINDOW_MANAGER, Lockable.INPUT_DEVICE)) {
             pointer.setButton(buttonCode, false);
+
+            XInput2Extension xi = getExtension(XInput2Extension.MAJOR_OPCODE);
+            xi.emitRawButton(2, buttonCode.code(), false);
         }
     }
 

--- a/app/src/main/java/com/winlator/xserver/XServer.java
+++ b/app/src/main/java/com/winlator/xserver/XServer.java
@@ -192,12 +192,28 @@ public class XServer {
         }
     }
 
+    private void registerExtension(Extension ext, int[] nextEventId, int[] nextErrorId) {
+        if (ext.getNumEvents() > 0) {
+            ext.setFirstEventId((byte) nextEventId[0]);
+            nextEventId[0] += ext.getNumEvents();
+        }
+        if (ext.getNumErrors() > 0) {
+            ext.setFirstErrorId((byte) nextErrorId[0]);
+            nextErrorId[0] += ext.getNumErrors();
+        }
+        extensions.put(ext.getMajorOpcode(), ext);
+    }
+
     private void setupExtensions() {
-        extensions.put(BigReqExtension.MAJOR_OPCODE, new BigReqExtension());
-        extensions.put(MITSHMExtension.MAJOR_OPCODE, new MITSHMExtension());
-        extensions.put(DRI3Extension.MAJOR_OPCODE, new DRI3Extension());
-        extensions.put(PresentExtension.MAJOR_OPCODE, new PresentExtension());
-        extensions.put(SyncExtension.MAJOR_OPCODE, new SyncExtension());
+        int[] nextEventId = {64};
+        int[] nextErrorId = {128};
+
+        registerExtension(new BigReqExtension(),    nextEventId, nextErrorId);
+        registerExtension(new MITSHMExtension(),    nextEventId, nextErrorId);
+        registerExtension(new DRI3Extension(),      nextEventId, nextErrorId);
+        registerExtension(new PresentExtension(),   nextEventId, nextErrorId);
+        registerExtension(new SyncExtension(),      nextEventId, nextErrorId);
+        registerExtension(new XInput2Extension(),   nextEventId, nextErrorId);
     }
 
     public <T extends Extension> T getExtension(int opcode) {

--- a/app/src/main/java/com/winlator/xserver/events/XIRawButtonPressNotify.java
+++ b/app/src/main/java/com/winlator/xserver/events/XIRawButtonPressNotify.java
@@ -1,0 +1,46 @@
+package com.winlator.xserver.events;
+
+import com.winlator.xconnector.XOutputStream;
+import com.winlator.xconnector.XStreamLock;
+import com.winlator.xserver.Window;
+
+import java.io.IOException;
+
+import timber.log.Timber;
+
+public class XIRawButtonPressNotify extends Event {
+    public static final int GENERIC_EVENT_CODE = 35;
+    private static final short XI_RAWBUTTONPRESS_EVTYPE = 15;
+
+    private final byte extensionOpcode;
+    private final int deviceId;
+    private final int buttonNumber;
+
+    public XIRawButtonPressNotify(int deviceId, byte extensionOpcode, int buttonNumber) {
+        super(GENERIC_EVENT_CODE);
+        this.deviceId = deviceId;
+        this.extensionOpcode = extensionOpcode;
+        this.buttonNumber = buttonNumber;
+    }
+
+    @Override
+    public void send(short sequenceNumber, XOutputStream outputStream) throws IOException {
+        try (XStreamLock lock = outputStream.lock()) {
+            // Raw button events do not need valuator payload for a basic mouse button press.
+            // Extra payload length = 0.
+            outputStream.writeByte(this.code);                     // [0] GenericEvent = 35
+            outputStream.writeByte(extensionOpcode);               // [1] extension opcode
+            outputStream.writeShort(sequenceNumber);               // [2-3] sequence number
+            outputStream.writeInt(0);                              // [4-7] extra payload length = 0
+
+            outputStream.writeShort(XI_RAWBUTTONPRESS_EVTYPE);     // [8-9] evtype = 15
+            outputStream.writeShort((short) deviceId);             // [10-11] deviceid
+            outputStream.writeInt((int) System.currentTimeMillis());// [12-15] time
+            outputStream.writeInt(buttonNumber);                   // [16-19] detail = button number
+            outputStream.writeShort((short) deviceId);             // [20-21] sourceid
+            outputStream.writeShort((short) 0);                    // [22-23] valuators_len = 0
+            outputStream.writeInt(0);                              // [24-27] flags
+            outputStream.writePad(4);                              // [28-31] padding
+        }
+    }
+}

--- a/app/src/main/java/com/winlator/xserver/events/XIRawButtonReleaseNotify.java
+++ b/app/src/main/java/com/winlator/xserver/events/XIRawButtonReleaseNotify.java
@@ -1,0 +1,43 @@
+package com.winlator.xserver.events;
+
+import com.winlator.xconnector.XOutputStream;
+import com.winlator.xconnector.XStreamLock;
+import com.winlator.xserver.Window;
+
+import java.io.IOException;
+
+public class XIRawButtonReleaseNotify extends Event {
+    public static final int GENERIC_EVENT_CODE = 35;
+    private static final short XI_RAWBUTTONRELEASE_EVTYPE = 16;
+
+    private final byte extensionOpcode;
+    private final int deviceId;
+    private final int buttonNumber;
+
+    public XIRawButtonReleaseNotify(int deviceId, byte extensionOpcode, int buttonNumber) {
+        super(GENERIC_EVENT_CODE);
+        this.deviceId = deviceId;
+        this.extensionOpcode = extensionOpcode;
+        this.buttonNumber = buttonNumber;
+    }
+
+    @Override
+    public void send(short sequenceNumber, XOutputStream outputStream) throws IOException {
+        try (XStreamLock lock = outputStream.lock()) {
+            // Extra payload length = 0.
+            outputStream.writeByte(this.code);                      // [0] GenericEvent = 35
+            outputStream.writeByte(extensionOpcode);                // [1] extension opcode
+            outputStream.writeShort(sequenceNumber);                // [2-3] sequence number
+            outputStream.writeInt(0);                               // [4-7] extra payload length = 0
+
+            outputStream.writeShort(XI_RAWBUTTONRELEASE_EVTYPE);    // [8-9] evtype = 16
+            outputStream.writeShort((short) deviceId);              // [10-11] deviceid
+            outputStream.writeInt((int) System.currentTimeMillis());// [12-15] time
+            outputStream.writeInt(buttonNumber);                    // [16-19] detail = button number
+            outputStream.writeShort((short) deviceId);              // [20-21] sourceid
+            outputStream.writeShort((short) 0);                     // [22-23] valuators_len = 0
+            outputStream.writeInt(0);                               // [24-27] flags
+            outputStream.writePad(4);                               // [28-31] padding
+        }
+    }
+}

--- a/app/src/main/java/com/winlator/xserver/events/XIRawMotionNotify.java
+++ b/app/src/main/java/com/winlator/xserver/events/XIRawMotionNotify.java
@@ -1,0 +1,80 @@
+package com.winlator.xserver.events;
+
+import com.winlator.xconnector.XOutputStream;
+import com.winlator.xconnector.XStreamLock;
+import com.winlator.xserver.Window;
+
+import java.io.IOException;
+
+public class XIRawMotionNotify extends Event {
+    public static final int GENERIC_EVENT_CODE = 35;
+    private static final short XI_RAWMOTION_EVTYPE = 17;
+
+    private final byte extensionOpcode;
+    private final int deviceId;
+    private final double[] valuators;
+    private final int valuatorMask;
+
+    public XIRawMotionNotify(int deviceId,
+                             byte extensionOpcode,
+                             double[] valuators,
+                             int valuatorMask) {
+        super(GENERIC_EVENT_CODE);
+        this.deviceId = deviceId;
+        this.extensionOpcode = extensionOpcode;
+        this.valuators = valuators;
+        this.valuatorMask = valuatorMask;
+    }
+
+    @Override
+    public void send(short sequenceNumber, XOutputStream outputStream) throws IOException {
+        try (XStreamLock lock = outputStream.lock()) {
+
+            // Mask length in 4-byte units. We need 1 unit to hold our X/Y bits (0x03).
+            short maskLenUnits = 1;
+
+            int numAxes = valuators.length;
+            int payloadBytes =
+                4 +                    // mask
+                (numAxes * 8) +        // axisvalues
+                (numAxes * 8);         // axisvalues_raw
+
+            int payloadLengthUnits = payloadBytes / 4;
+
+            // --------------------------------------------------------
+            // 1. STANDARD GENERIC EVENT HEADER (32 bytes)
+            // --------------------------------------------------------
+            outputStream.writeByte(this.code);               // [0] type = 35 (GenericEvent)
+            outputStream.writeByte(extensionOpcode);         // [1] extension opcode
+            outputStream.writeShort(sequenceNumber);         // [2-3] sequence number (passed from XClient)
+            outputStream.writeInt(payloadLengthUnits);       // [4-7] length of extra payload
+            outputStream.writeShort(XI_RAWMOTION_EVTYPE);    // [8-9] evtype = 17
+            outputStream.writeShort((short) deviceId);       // [10-11] deviceid
+            outputStream.writeInt((int) System.currentTimeMillis()); // [12-15] time
+            outputStream.writeInt(0);                        // [16-19] detail (0 for motion)
+            outputStream.writeShort((short) deviceId);       // [20-21] sourceid
+            outputStream.writeShort(maskLenUnits);           // [22-23] valuators_len
+            outputStream.writeInt(0);                        // [24-27] flags
+            outputStream.writePad(4);                        // [28-31] padding to complete 32 bytes
+
+            // --------------------------------------------------------
+            // 2. PAYLOAD: MASK (4 bytes)
+            // --------------------------------------------------------
+            outputStream.writeInt(valuatorMask);
+
+            // --------------------------------------------------------
+            // 3. PAYLOAD: AXISVALUES (16 bytes)
+            // --------------------------------------------------------
+            for (double v : valuators) {
+                outputStream.writeFP3232(v);
+            }
+
+            // --------------------------------------------------------
+            // 4. PAYLOAD: AXISVALUES_RAW (16 bytes)
+            // --------------------------------------------------------
+            for (double v : valuators) {
+                outputStream.writeFP3232(v);
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/winlator/xserver/extensions/BigReqExtension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/BigReqExtension.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 public class BigReqExtension implements Extension {
     public static final byte MAJOR_OPCODE = -100;
     private static final int MAX_REQUEST_LENGTH = 4194303;
+    private byte firstEventId = 0;
+    private byte firstErrorId = 0;
 
     @Override
     public String getName() {
@@ -24,14 +26,22 @@ public class BigReqExtension implements Extension {
     }
 
     @Override
-    public byte getFirstErrorId() {
-        return 0;
-    }
+    public int getNumEvents() { return 0; }
 
     @Override
-    public byte getFirstEventId() {
-        return 0;
-    }
+    public int getNumErrors() { return 0; }
+
+    @Override
+    public void setFirstEventId(byte id) { this.firstEventId = id; }
+
+    @Override
+    public void setFirstErrorId(byte id) { this.firstErrorId = id; }
+
+    @Override
+    public byte getFirstEventId() { return firstEventId; }
+
+    @Override
+    public byte getFirstErrorId() { return firstErrorId; }
 
     @Override
     public void handleRequest(XClient client, XInputStream inputStream, XOutputStream outputStream) throws IOException {

--- a/app/src/main/java/com/winlator/xserver/extensions/DRI3Extension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/DRI3Extension.java
@@ -34,6 +34,8 @@ import java.util.Objects;
 
 public class DRI3Extension implements Extension {
     public static final byte MAJOR_OPCODE = -102;
+    private byte firstEventId = 0;
+    private byte firstErrorId = 0;
     private final Callback<Drawable> onDestroyDrawableListener = (drawable) -> {
         ByteBuffer data = drawable.getData();
         SysVSharedMemory.unmapSHMSegment(data, data.capacity());
@@ -57,14 +59,22 @@ public class DRI3Extension implements Extension {
     }
 
     @Override
-    public byte getFirstErrorId() {
-        return 0;
-    }
+    public int getNumEvents() { return 0; }
 
     @Override
-    public byte getFirstEventId() {
-        return 0;
-    }
+    public int getNumErrors() { return 0; }
+
+    @Override
+    public void setFirstEventId(byte id) { this.firstEventId = id; }
+
+    @Override
+    public void setFirstErrorId(byte id) { this.firstErrorId = id; }
+
+    @Override
+    public byte getFirstEventId() { return firstEventId; }
+
+    @Override
+    public byte getFirstErrorId() { return firstErrorId; }
 
     private void queryVersion(XClient client, XInputStream inputStream, XOutputStream outputStream) throws IOException, XRequestError {
         inputStream.skip(8);

--- a/app/src/main/java/com/winlator/xserver/extensions/Extension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/Extension.java
@@ -16,5 +16,11 @@ public interface Extension {
 
     byte getFirstEventId();
 
+    default int getNumEvents() { return 0; }
+    default int getNumErrors() { return 0; }
+
+    default void setFirstEventId(byte firstEventId) {}
+    default void setFirstErrorId(byte firstErrorId) {}
+
     void handleRequest(XClient client, XInputStream inputStream, XOutputStream outputStream) throws IOException, XRequestError;
 }

--- a/app/src/main/java/com/winlator/xserver/extensions/MITSHMExtension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/MITSHMExtension.java
@@ -21,6 +21,8 @@ import java.nio.ByteBuffer;
 
 public class MITSHMExtension implements Extension {
     public static final byte MAJOR_OPCODE = -101;
+    private byte firstEventId = 0;
+    private byte firstErrorId = 0;
 
     private static abstract class ClientOpcodes {
         private static final byte QUERY_VERSION = 0;
@@ -40,14 +42,22 @@ public class MITSHMExtension implements Extension {
     }
 
     @Override
-    public byte getFirstErrorId() {
-        return Byte.MIN_VALUE;
-    }
+    public int getNumEvents() { return 1; }
 
     @Override
-    public byte getFirstEventId() {
-        return 64;
-    }
+    public int getNumErrors() { return 1; }
+
+    @Override
+    public void setFirstEventId(byte id) { this.firstEventId = id; }
+
+    @Override
+    public void setFirstErrorId(byte id) { this.firstErrorId = id; }
+
+    @Override
+    public byte getFirstEventId() { return firstEventId; }
+
+    @Override
+    public byte getFirstErrorId() { return firstErrorId; }
 
     private static void queryVersion(XClient client, XInputStream inputStream, XOutputStream outputStream) throws IOException, XRequestError {
         try (XStreamLock lock = outputStream.lock()) {

--- a/app/src/main/java/com/winlator/xserver/extensions/PresentExtension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/PresentExtension.java
@@ -36,6 +36,8 @@ public class PresentExtension implements Extension {
     public enum Mode {COPY, FLIP, SKIP}
     private final SparseArray<Event> events = new SparseArray<>();
     private SyncExtension syncExtension;
+    private byte firstEventId = 0;
+    private byte firstErrorId = 0;
 
     private static abstract class ClientOpcodes {
         private static final byte QUERY_VERSION = 0;
@@ -61,14 +63,22 @@ public class PresentExtension implements Extension {
     }
 
     @Override
-    public byte getFirstErrorId() {
-        return 0;
-    }
+    public int getNumEvents() { return 2; }
 
     @Override
-    public byte getFirstEventId() {
-        return 0;
-    }
+    public int getNumErrors() { return 0; }
+
+    @Override
+    public void setFirstEventId(byte id) { this.firstEventId = id; }
+
+    @Override
+    public void setFirstErrorId(byte id) { this.firstErrorId = id; }
+
+    @Override
+    public byte getFirstEventId() { return firstEventId; }
+
+    @Override
+    public byte getFirstErrorId() { return firstErrorId; }
 
     private void sendIdleNotify(Window window, Pixmap pixmap, int serial, int idleFence) {
         if (idleFence != 0) syncExtension.setTriggered(idleFence);

--- a/app/src/main/java/com/winlator/xserver/extensions/SyncExtension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/SyncExtension.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 public class SyncExtension implements Extension {
     public static final byte MAJOR_OPCODE = -104;
     private final SparseBooleanArray fences = new SparseBooleanArray();
+    private byte firstEventId = 0;
+    private byte firstErrorId = 0;
 
     private static abstract class ClientOpcodes {
         private static final byte CREATE_FENCE = 14;
@@ -36,14 +38,22 @@ public class SyncExtension implements Extension {
     }
 
     @Override
-    public byte getFirstErrorId() {
-        return Byte.MIN_VALUE;
-    }
+    public int getNumEvents() { return 2; }
 
     @Override
-    public byte getFirstEventId() {
-        return 0;
-    }
+    public int getNumErrors() { return 2; }
+
+    @Override
+    public void setFirstEventId(byte id) { this.firstEventId = id; }
+
+    @Override
+    public void setFirstErrorId(byte id) { this.firstErrorId = id; }
+
+    @Override
+    public byte getFirstEventId() { return firstEventId; }
+
+    @Override
+    public byte getFirstErrorId() { return firstErrorId; }
 
     public void setTriggered(int id) {
         synchronized (fences) {

--- a/app/src/main/java/com/winlator/xserver/extensions/XInput2Extension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/XInput2Extension.java
@@ -1,0 +1,470 @@
+package com.winlator.xserver.extensions;
+
+import static com.winlator.xserver.XClientRequestHandler.RESPONSE_CODE_SUCCESS;
+
+import com.winlator.xserver.Bitmask;
+import com.winlator.xserver.Window;
+import com.winlator.xserver.XClient;
+import com.winlator.xserver.XLock;
+import com.winlator.xserver.XServer;
+import com.winlator.xconnector.XInputStream;
+import com.winlator.xconnector.XOutputStream;
+import com.winlator.xconnector.XStreamLock;
+import com.winlator.xserver.errors.BadImplementation;
+import com.winlator.xserver.errors.BadWindow;
+import com.winlator.xserver.errors.XRequestError;
+import com.winlator.xserver.events.XIRawButtonPressNotify;
+import com.winlator.xserver.events.XIRawButtonReleaseNotify;
+import com.winlator.xserver.events.XIRawMotionNotify;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import timber.log.Timber;
+
+public class XInput2Extension implements Extension {
+    public static final byte MAJOR_OPCODE = -105;
+    private byte firstEventId = 0;
+    private byte firstErrorId = 0;
+
+    private static final int XI_MAJOR = 2;
+    private static final int XI_MINOR = 2;
+    private static final int XI_ALL_DEVICES = 0;
+    private static final int XI_ALL_MASTER_DEVICES = 1;
+    private static final int MASTER_POINTER_ID = 2;
+    private static final int MASTER_KEYBOARD_ID = 3;
+    private static final int XI_BUTTON_CLASS = 1;
+    private static final int XI_VALUATOR_CLASS = 2;
+    private static final int XI_RawButtonPress_MASK = 1 << 15;
+    private static final int XI_RawButtonRelease_MASK = 1 << 16;
+    private static final int XI_RawMotion_MASK  = 1 << 17;
+    // advertise enough buttons to cover a normal mouse + wheel buttons
+    private static final int RawMotion_XY_MASK = (1 << 0) | (1 << 1);
+    private static final int POINTER_BUTTON_COUNT = 7;
+
+    private final List<Selection> selections = new CopyOnWriteArrayList<>();
+
+    private static abstract class ClientOpcodes {
+        private static final byte GET_EXTENSION_VERSION = 1;  // X_GetExtensionVersion (XI 1.x)
+        private static final byte GET_CLIENT_POINTER    = 45; // X_XIGetClientPointer (XI 2.x)
+        private static final byte SELECT_EVENTS         = 46; // X_XISelectEvents (XI 2.x)
+        private static final byte QUERY_VERSION         = 47; // X_XIQueryVersion (XI 2.x)
+        private static final byte QUERY_DEVICE          = 48; // X_XIQueryDevice (XI 2.x)
+    }
+
+    private static class Selection {
+        Window window;
+        XClient client;
+        int id;
+        Bitmask mask;
+        int deviceId;
+    }
+
+    @Override
+    public String getName() {
+        return "XInputExtension";
+    }
+
+    @Override
+    public byte getMajorOpcode() {
+        return MAJOR_OPCODE;
+    }
+
+    @Override
+    public int getNumEvents() { return 24; }
+
+    @Override
+    public int getNumErrors() { return 5; }
+
+    @Override
+    public void setFirstEventId(byte id) { this.firstEventId = id; }
+
+    @Override
+    public void setFirstErrorId(byte id) { this.firstErrorId = id; }
+
+    @Override
+    public byte getFirstEventId() { return firstEventId; }
+
+    @Override
+    public byte getFirstErrorId() { return firstErrorId; }
+
+    private boolean isMasterDevice(int deviceId) {
+        return deviceId == MASTER_POINTER_ID || deviceId == MASTER_KEYBOARD_ID;
+    }
+
+    private boolean matchesSelection(Selection sel, int deviceId) {
+        return sel.deviceId == XI_ALL_DEVICES
+                || (sel.deviceId == XI_ALL_MASTER_DEVICES && isMasterDevice(deviceId))
+                || sel.deviceId == deviceId;
+    }
+
+    /*
+     XInput2 wire format located on termuxfs /usr/include/X11/extensions
+     XIproto.h and XI2proto.h for the struct definitions
+     */
+
+    private static void getExtensionVersion(XClient client, XInputStream inputStream, XOutputStream outputStream) throws IOException {
+        inputStream.skip(client.getRemainingRequestLength());
+
+        try (XStreamLock lock = outputStream.lock()) {
+            // typedef struct
+            //    CARD8	repType;	/* X_Reply */
+            //    CARD8	RepType;	/* always X_GetExtensionVersion */
+            //    CARD16	sequenceNumber;
+            //    CARD32	length;
+            //    CARD16	major_version;
+            //    CARD16	minor_version;
+            //    BOOL	present;
+            //    CARD8	pad1, pad2, pad3;
+            //    CARD32	pad01;
+            //    CARD32	pad02;
+            //    CARD32	pad03;
+            //    CARD32	pad04;
+            // xGetExtensionVersionReply;
+            outputStream.writeByte(RESPONSE_CODE_SUCCESS);
+            outputStream.writeByte((byte) 0);
+            outputStream.writeShort(client.getSequenceNumber());
+            outputStream.writeInt(0);
+
+            outputStream.writeShort((short) 2);
+            outputStream.writeShort((short) 0);
+            outputStream.writeByte((byte) 1);
+            outputStream.writePad(19);
+        }
+    }
+
+    private static void getClientPointer(XClient client, XInputStream inputStream, XOutputStream outputStream) throws IOException {
+        inputStream.skip(client.getRemainingRequestLength());
+
+        try (XStreamLock lock = outputStream.lock()) {
+            // typedef struct
+            //    uint8_t     repType;                /**< Input extension major opcode */
+            //    uint8_t     RepType;                /**< Always ::X_GetClientPointer */
+            //    uint16_t    sequenceNumber;
+            //    uint32_t    length;
+            //    BOOL        set;                    /**< client pointer is set? */
+            //    uint8_t     pad0;
+            //    uint16_t    deviceid;
+            //    uint32_t    pad1;
+            //    uint32_t    pad2;
+            //    uint32_t    pad3;
+            //    uint32_t    pad4;
+            //    uint32_t    pad5;
+            // xXIGetClientPointerReply;
+            outputStream.writeByte(RESPONSE_CODE_SUCCESS);
+            outputStream.writeByte((byte) 0);
+            outputStream.writeShort(client.getSequenceNumber());
+            outputStream.writeInt(0);
+
+            outputStream.writeByte((byte) 1);
+            outputStream.writeByte((byte) 0);
+            outputStream.writeShort((short) 2);
+
+            outputStream.writePad(20);
+        }
+    }
+
+    private static void queryVersion(XClient client, XInputStream inputStream, XOutputStream outputStream) throws IOException {
+        short clientMajor = (short)(inputStream.readShort() & 0xFFFF);
+        short clientMinor = (short)(inputStream.readShort() & 0xFFFF);
+
+        inputStream.skip(client.getRemainingRequestLength());
+
+        short negotiatedMajor;
+        short negotiatedMinor;
+
+        if (clientMajor < XI_MAJOR || (clientMajor == XI_MAJOR && clientMinor < XI_MINOR)) {
+            negotiatedMajor = clientMajor;
+            negotiatedMinor = clientMinor;
+        } else {
+            negotiatedMajor = XI_MAJOR;
+            negotiatedMinor = XI_MINOR;
+        }
+
+        try (XStreamLock lock = outputStream.lock()) {
+            // typedef struct
+            //    uint8_t     repType;                /**< ::X_Reply */
+            //    uint8_t     RepType;                /**< Always ::X_XIQueryVersion */
+            //    uint16_t    sequenceNumber;
+            //    uint32_t    length;
+            //    uint16_t    major_version;
+            //    uint16_t    minor_version;
+            //    uint32_t    pad1;
+            //    uint32_t    pad2;
+            //    uint32_t    pad3;
+            //    uint32_t    pad4;
+            //    uint32_t    pad5;
+            // xXIQueryVersionReply;
+            outputStream.writeByte(RESPONSE_CODE_SUCCESS);
+            outputStream.writeByte((byte)0);
+            outputStream.writeShort(client.getSequenceNumber());
+            outputStream.writeInt(0);
+
+            outputStream.writeShort(negotiatedMajor);
+            outputStream.writeShort(negotiatedMinor);
+
+            outputStream.writePad(20);
+        }
+    }
+
+    private void writeButtonClass(XOutputStream outputStream, int sourceId, int numButtons) throws IOException {
+        int stateBytes = Math.max(4, ((numButtons + 31) / 32) * 4);
+        int labelsBytes = numButtons * 4;
+        int totalBytes = 8 + stateBytes + labelsBytes;
+        int length = totalBytes / 4;
+
+        // typedef struct
+        //    uint16_t    type;           /**< Always ButtonClass */
+        //    uint16_t    length;         /**< Length in 4 byte units */
+        //    uint16_t    sourceid;       /**< source device for this class */
+        //    uint16_t    num_buttons;    /**< Number of buttons provided */
+        // xXIButtonInfo;
+        outputStream.writeShort((short) XI_BUTTON_CLASS);   // type
+        outputStream.writeShort((short) length);            // length
+        outputStream.writeShort((short) sourceId);          // sourceid
+        outputStream.writeShort((short) numButtons);        // num_buttons
+
+        // Struct is followed by a button bit-mask (padded to four byte chunks) and
+        // then num_buttons * Atom that names the buttons in the device-native setup
+
+        // button state mask, all released by default
+        outputStream.writeInt(0);
+        if (stateBytes > 4) {
+            outputStream.writePad(stateBytes - 4);
+        }
+
+        // labels: one Atom per button; 0 == None/unlabeled
+        for (int i = 0; i < numButtons; i++) {
+            outputStream.writeInt(0);
+        }
+    }
+
+    private void writeValuatorClass(XOutputStream outputStream, int axisNumber) throws IOException {
+        // typedef struct
+        //    uint16_t    type;           /**< Always ValuatorClass       */
+        //    uint16_t    length;         /**< Length in 4 byte units */
+        //    uint16_t    sourceid;       /**< source device for this class */
+        //    uint16_t    number;         /**< Valuator number            */
+        //    Atom        label;          /**< Axis label                 */
+        //    FP3232      min;            /**< Min value                  */
+        //    FP3232      max;            /**< Max value                  */
+        //    FP3232      value;          /**< Last published value       */
+        //    uint32_t    resolution;     /**< Resolutions in units/m     */
+        //    uint8_t     mode;           /**< ModeRelative or ModeAbsolute */
+        //    uint8_t     pad1;
+        //    uint16_t    pad2;
+        // xXIValuatorInfo;
+        // length = 44 bytes / 4 = 11 units
+        outputStream.writeShort((short) XI_VALUATOR_CLASS); // type: 2 = XIValuatorClass
+        outputStream.writeShort((short) 11);                // length
+        outputStream.writeShort((short) MASTER_POINTER_ID); // sourceid
+        outputStream.writeShort((short) axisNumber);        // number (Axis 0 for X, 1 for Y)
+
+        outputStream.writeInt(0); // label
+
+        // min/max: valid range for Absolute axes; conventionally 0 for Relative axes
+        outputStream.writeFP3232(0);  // min
+        outputStream.writeFP3232(0);  // max
+
+        // value: current axis position; 0 at initialisation
+        outputStream.writeFP3232(0);
+
+        // resolution: units per meter, used by absolute axes; 0 for relative
+        outputStream.writeInt(0);
+
+        // mode: 0 = Relative (delta per event), 1 = Absolute (position in min/max range)
+        outputStream.writeByte((byte) 0);
+        outputStream.writePad(3);  // pad1 (1 byte) + pad2 (2 bytes)
+    }
+
+    private void queryDevice(XClient client, XInputStream inputStream, XOutputStream outputStream) throws IOException {
+        inputStream.skip(client.getRemainingRequestLength());
+
+        final int masterPointerId = 2; // Standard ID for the main mouse
+        final String name = "Virtual Core Pointer";
+        final byte[] nameBytes = name.getBytes();
+        final int nameLen = nameBytes.length; // 20
+        final int namePad = (nameLen + 3) & ~3; // Padded to 4-byte boundary (20)
+
+        final int numButtons = POINTER_BUTTON_COUNT;
+        final int buttonStateBytes = Math.max(4, ((numButtons + 31) / 32) * 4);
+        final int buttonClassBytes = 8 + buttonStateBytes + (numButtons * 4);
+
+        final int numValuators = 2;
+        final int numClasses = 1 + numValuators; // Button + 2 valuators
+
+        // Payload Size
+        int deviceInfoSize =
+                12 + // xXIDeviceInfo size
+                namePad +
+                buttonClassBytes +
+                (44 * numValuators);
+
+        int length = deviceInfoSize / 4; // payload length in 4-byte units (30)
+
+        try (XStreamLock lock = outputStream.lock()) {
+            // typedef struct
+            //    uint8_t     repType;                /**< ::X_Reply */
+            //    uint8_t     RepType;                /**< Always ::X_XIQueryDevice */
+            //    uint16_t    sequenceNumber;
+            //    uint32_t    length;
+            //    uint16_t    num_devices;
+            //    uint16_t    pad0;
+            //    uint32_t    pad1;
+            //    uint32_t    pad2;
+            //    uint32_t    pad3;
+            //    uint32_t    pad4;
+            //    uint32_t    pad5;
+            // xXIQueryDeviceReply;
+            outputStream.writeByte(RESPONSE_CODE_SUCCESS);      // repType
+            outputStream.writeByte((byte)0);                    // RepType
+            outputStream.writeShort(client.getSequenceNumber());// sequenceNumber
+            outputStream.writeInt(length);                      // length
+            outputStream.writeShort((short)1);                  // num_devices
+            outputStream.writePad(22);                    // padding
+
+            // typedef struct
+            //    uint16_t    deviceid;
+            //    uint16_t    use;            /**< ::XIMasterPointer, ::XIMasterKeyboard,
+            //                                     ::XISlavePointer, ::XISlaveKeyboard,
+            //                                     ::XIFloatingSlave */
+            //    uint16_t    attachment;     /**< Current attachment or pairing.*/
+            //    uint16_t    num_classes;    /**< Number of classes following this struct. */
+            //    uint16_t    name_len;       /**< Length of name in bytes. */
+            //    uint8_t     enabled;        /**< TRUE if device is enabled. */
+            //    uint8_t     pad;
+            // xXIDeviceInfo;
+            outputStream.writeShort((short)masterPointerId); // deviceid
+            outputStream.writeShort((short)1);               // use (1 = MasterPointer)
+            outputStream.writeShort((short)0);               // attachment
+            outputStream.writeShort((short)numClasses);      // num_classes
+            outputStream.writeShort((short)nameLen);         // name_len
+            outputStream.writeByte((byte)1);                 // enabled
+            outputStream.writeByte((byte)0);                 // pad1
+
+            // Device Name
+            outputStream.write(nameBytes);
+            outputStream.writePad(namePad - nameLen);
+
+            // Classes
+            writeButtonClass(outputStream, masterPointerId, numButtons);
+            writeValuatorClass(outputStream, 0);
+            writeValuatorClass(outputStream, 1);
+        }
+    }
+
+    private void selectEvents(XClient client, XInputStream inputStream, XOutputStream outputStream) throws IOException, XRequestError {
+        int windowId = inputStream.readInt();
+        int numMasks = inputStream.readShort() & 0xFFFF;
+        inputStream.readShort();
+
+        Window window = client.xServer.windowManager.getWindow(windowId);
+
+        if (window == null) {
+            inputStream.skip(client.getRemainingRequestLength());
+            throw new BadWindow(windowId);
+        }
+
+        for (int i = 0; i < numMasks; i++) {
+            int deviceId = inputStream.readShort() & 0xFFFF;
+            int maskLen = inputStream.readShort() & 0xFFFF;
+
+            Bitmask mask = new Bitmask(inputStream.readInt());
+
+            Selection sel = new Selection();
+            sel.client = client;
+            sel.window = window;
+            sel.deviceId = deviceId;
+            sel.mask = mask;
+            sel.id = windowId;
+
+            // XISelectEvents overwrites the previous mask for the same client/window/device
+            selections.removeIf(old ->
+                    old.client == client &&
+                            old.id == windowId &&
+                            old.deviceId == deviceId);
+
+            selections.add(sel);
+        }
+
+        inputStream.skip(client.getRemainingRequestLength());
+    }
+
+    @Override
+    public void handleRequest(XClient client, XInputStream inputStream, XOutputStream outputStream)
+            throws IOException, XRequestError {
+        int opcode = client.getRequestData();
+
+        switch (opcode) {
+            case ClientOpcodes.GET_EXTENSION_VERSION:
+                getExtensionVersion(client, inputStream, outputStream);
+                break;
+            case ClientOpcodes.GET_CLIENT_POINTER:
+                getClientPointer(client, inputStream, outputStream);
+                break;
+            case ClientOpcodes.SELECT_EVENTS:
+                try (XLock lock = client.xServer.lock(XServer.Lockable.WINDOW_MANAGER)) {
+                    selectEvents(client, inputStream, outputStream);
+                }
+                break;
+            case ClientOpcodes.QUERY_VERSION:
+                queryVersion(client, inputStream, outputStream);
+                break;
+            case ClientOpcodes.QUERY_DEVICE:
+                queryDevice(client, inputStream, outputStream);
+                break;
+            default:
+                Timber.w("XInput2Extension: unhandled minor opcode=%d, requestData=%d, requestLength=%d",
+                        opcode, client.getRequestData(), client.getRemainingRequestLength());
+                inputStream.skip(client.getRemainingRequestLength());
+                // throw new BadImplementation();
+                break;
+        }
+    }
+
+    public void onClientDisconnected(XClient client) {
+        selections.removeIf(sel -> sel.client == client);
+    }
+
+    public void emitRawMotion(int deviceId, double deltaX, double deltaY) {
+        for (Selection sel : selections) {
+            if (!matchesSelection(sel, deviceId)) continue;
+            if (!sel.mask.isSet(XI_RawMotion_MASK)) continue;
+
+            try {
+                sendXIRawMotionToClient(sel.client, deviceId, deltaX, deltaY);
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    public void emitRawButton(int deviceId, int buttonNumber, boolean pressed) {
+        int maskBit = pressed ? XI_RawButtonPress_MASK : XI_RawButtonRelease_MASK;
+
+        for (Selection sel : selections) {
+            if (!matchesSelection(sel, deviceId)) continue;
+            if (!sel.mask.isSet(maskBit)) continue;
+
+            try {
+                sendXIRawButtonToClient(sel.client, deviceId, buttonNumber, pressed);
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    private void sendXIRawMotionToClient(XClient client, int deviceId, double deltaX, double deltaY) throws IOException {
+        client.sendEvent(new XIRawMotionNotify(deviceId, MAJOR_OPCODE,
+                new double[] {deltaX, deltaY},
+                RawMotion_XY_MASK
+        ));
+    }
+
+    private void sendXIRawButtonToClient(XClient client, int deviceId, int buttonNumber, boolean pressed) throws IOException {
+        if (pressed) {
+            client.sendEvent(new XIRawButtonPressNotify(deviceId, MAJOR_OPCODE, buttonNumber));
+        } else {
+            client.sendEvent(new XIRawButtonReleaseNotify(deviceId, MAJOR_OPCODE, buttonNumber));
+        }
+    }
+}

--- a/app/src/main/java/com/winlator/xserver/extensions/XInput2Extension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/XInput2Extension.java
@@ -357,6 +357,12 @@ public class XInput2Extension implements Extension {
     private void selectEvents(XClient client, XInputStream inputStream, XOutputStream outputStream) throws IOException, XRequestError {
         int windowId = inputStream.readInt();
         int numMasks = inputStream.readShort() & 0xFFFF;
+
+        if (numMasks == 0) {
+            inputStream.skip(client.getRemainingRequestLength());
+            throw new BadValue(numMasks);
+        }
+
         inputStream.readShort();
 
         Window window = client.xServer.windowManager.getWindow(windowId);

--- a/app/src/main/java/com/winlator/xserver/extensions/XInput2Extension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/XInput2Extension.java
@@ -11,6 +11,7 @@ import com.winlator.xconnector.XInputStream;
 import com.winlator.xconnector.XOutputStream;
 import com.winlator.xconnector.XStreamLock;
 import com.winlator.xserver.errors.BadImplementation;
+import com.winlator.xserver.errors.BadValue;
 import com.winlator.xserver.errors.BadWindow;
 import com.winlator.xserver.errors.XRequestError;
 import com.winlator.xserver.events.XIRawButtonPressNotify;
@@ -376,7 +377,12 @@ public class XInput2Extension implements Extension {
             int deviceId = inputStream.readShort() & 0xFFFF;
             int maskLen = inputStream.readShort() & 0xFFFF;
 
-            Bitmask mask = new Bitmask(inputStream.readInt());
+            Bitmask mask = new Bitmask(0);
+
+            for (int word = 0; word < maskLen; word++) {
+                long value = inputStream.readUnsignedInt();
+                mask.set(value << (word * 32));
+            }
 
             Selection sel = new Selection();
             sel.client = client;

--- a/app/src/main/java/com/winlator/xserver/requests/CursorRequests.java
+++ b/app/src/main/java/com/winlator/xserver/requests/CursorRequests.java
@@ -55,15 +55,23 @@ public abstract class CursorRequests {
 
     public static void getPointerMapping(XClient client, XInputStream inputStream, XOutputStream outputStream) throws XRequestError, IOException {
         try (XStreamLock lock = outputStream.lock()) {
-            byte[] buttonsMap = {1, 2, 3};
-            byte length = (byte) buttonsMap.length;
+            // Fix scroll when using XInput2 extension
+            byte[] buttonsMap = { 1, 2, 3, 4, 5, 6, 7 };
+            int nElts = buttonsMap.length;
+
+            int lengthUnits = (nElts + 3) / 4;
+
             outputStream.writeByte(RESPONSE_CODE_SUCCESS);
-            outputStream.writeByte(length);
+            outputStream.writeByte((byte) nElts);
             outputStream.writeShort(client.getSequenceNumber());
-            outputStream.writeInt((length + 3) / 4);
+            outputStream.writeInt(lengthUnits);
             outputStream.writePad(24);
             outputStream.write(buttonsMap);
-            outputStream.writePad(3 & (-length));
+
+            int pad = (-nElts) & 3;
+            if (pad > 0) {
+                outputStream.writePad(pad);
+            }
         }
     }
 }

--- a/app/src/main/java/com/winlator/xserver/requests/ExtensionRequests.java
+++ b/app/src/main/java/com/winlator/xserver/requests/ExtensionRequests.java
@@ -11,12 +11,15 @@ import com.winlator.xserver.extensions.Extension;
 
 import java.io.IOException;
 
+import timber.log.Timber;
+
 public abstract class ExtensionRequests {
     public static void queryExtension(XClient client, XInputStream inputStream, XOutputStream outputStream) throws IOException, XRequestError {
         short length = inputStream.readShort();
         inputStream.skip(2);
         String name = inputStream.readString8(length);
         Extension extension = client.xServer.getExtensionByName(name);
+        Timber.d("QueryExtension: name=%s present=%b opcode=%d", name, extension != null, extension != null ? extension.getMajorOpcode() : -1);
         try (XStreamLock lock = outputStream.lock()) {
             outputStream.writeByte(RESPONSE_CODE_SUCCESS);
             outputStream.writeByte((byte)0);

--- a/app/src/main/java/com/winlator/xserver/requests/GrabRequests.java
+++ b/app/src/main/java/com/winlator/xserver/requests/GrabRequests.java
@@ -2,7 +2,9 @@ package com.winlator.xserver.requests;
 
 import static com.winlator.xserver.XClientRequestHandler.RESPONSE_CODE_SUCCESS;
 
-import com.winlator.core.CursorLocker;
+import android.graphics.Rect;
+import android.util.Log;
+
 import com.winlator.xconnector.XInputStream;
 import com.winlator.xconnector.XOutputStream;
 import com.winlator.xconnector.XStreamLock;
@@ -36,7 +38,13 @@ public abstract class GrabRequests {
         if (window == null) throw new BadWindow(windowId);
 
         Bitmask eventMask = new Bitmask(inputStream.readShort());
-        inputStream.skip(14);
+        byte pointerMode = inputStream.readByte();
+        byte keyboardMode = inputStream.readByte();
+        int confineToWindowId = inputStream.readInt();
+        int cursorId = inputStream.readInt();
+        int time = inputStream.readInt();
+
+        Window confineToWindow = null;
 
         Status status;
         if (client.xServer.grabManager.getWindow() != null && client.xServer.grabManager.getClient() != client) {
@@ -47,7 +55,14 @@ public abstract class GrabRequests {
         }
         else {
             status = Status.SUCCESS;
-            client.xServer.grabManager.activatePointerGrab(window, ownerEvents, eventMask, client);
+            if (confineToWindowId != 0) {
+                confineToWindow = client.xServer.windowManager.getWindow(confineToWindowId);
+                // Per X11 spec: silently ignore if not viewable, not a BadWindow error
+                if (confineToWindow != null && confineToWindow.getMapState() != Window.MapState.VIEWABLE) {
+                    confineToWindow = null;
+                }
+            }
+            client.xServer.grabManager.activatePointerGrab(window, ownerEvents, eventMask, client, confineToWindow);
         }
 
         try (XStreamLock lock = outputStream.lock()) {

--- a/app/src/main/java/com/winlator/xserver/requests/WindowRequests.java
+++ b/app/src/main/java/com/winlator/xserver/requests/WindowRequests.java
@@ -76,8 +76,8 @@ public abstract class WindowRequests {
             outputStream.writeByte((byte)window.getMapState().ordinal());
             outputStream.writeByte((byte)(window.attributes.isOverrideRedirect() ? 1 : 0));
             outputStream.writeInt(0);
-            outputStream.writeInt(window.getAllEventMasks().getBits());
-            outputStream.writeInt(client.getEventMaskForWindow(window).getBits());
+            outputStream.writeInt((int)window.getAllEventMasks().getBits());
+            outputStream.writeInt((int)client.getEventMaskForWindow(window).getBits());
             outputStream.writeShort((short)window.attributes.getDoNotPropagateMask().getBits());
             outputStream.writeShort((short)0);
         }

--- a/app/src/main/java/com/winlator/xserver/requests/WindowRequests.java
+++ b/app/src/main/java/com/winlator/xserver/requests/WindowRequests.java
@@ -2,7 +2,6 @@ package com.winlator.xserver.requests;
 
 import static com.winlator.xserver.XClientRequestHandler.RESPONSE_CODE_SUCCESS;
 
-import com.winlator.core.CursorLocker;
 import com.winlator.xconnector.XInputStream;
 import com.winlator.xconnector.XOutputStream;
 import com.winlator.xconnector.XStreamLock;
@@ -336,7 +335,14 @@ public abstract class WindowRequests {
             if (srcHeight == 0) srcHeight = (short)(srcWindow.getHeight() - srcY);
 
             short[] localPoint = srcWindow.rootPointToLocal(client.xServer.pointer.getX(), client.xServer.pointer.getY());
-            boolean isContained = localPoint[0] >= srcX && localPoint[1] >= srcY && localPoint[0] < (srcX + srcWidth) && localPoint[1] < (srcY + srcHeight);
+            // Allow XWarpPointer to work with legacy soft-bounds
+            // (see XServer.java:injectPointerMoveDelta)
+            short x = localPoint[0];
+            short y = localPoint[1];
+            short softMarginX = (short)(client.xServer.screenInfo.width * 0.05f);
+            short softMarginY = (short)(client.xServer.screenInfo.height * 0.05f);
+            boolean isContained = x >= srcX - softMarginX && y >= srcY - softMarginY &&
+                                  x < (srcX + srcWidth + softMarginX) && y < (srcY + srcHeight + softMarginY);
             if (!isContained) return;
         }
 


### PR DESCRIPTION
## Description
Fixes https://discord.com/channels/1378308569287622737/1485460478040866926
Implement XInput2 and ClipCursor, along with a small refactoring of all extensions and the extension registering method

As of now, with this code change, Raw Mouse Input will only work with Proton 9.0 x86_64
Games that rely on ClipCursor might not work well
Megabonk happens to work fine but Barony doesn't

For both Raw Mouse Input and ClipCursor, GameNative Proton 10.0-4 arm64 and x86_64 will be required with this [PR](https://github.com/GameNative/proton-wine/pull/10) applied

## Recording

All clips recorded using GameNative Proton 10.0-4 arm64ec

#### Raw Mouse Input

https://github.com/user-attachments/assets/a02b150f-2a81-4c26-ac5d-c4127b1ec1f8


https://github.com/user-attachments/assets/9001c300-ce3f-43cc-9b1e-40771a7a1f77


https://github.com/user-attachments/assets/39b0cb93-787f-4496-b54a-4955e199de89


https://github.com/user-attachments/assets/19a51fc9-d458-4df8-b9ba-656e946ccac0

#### ClipCursor

https://github.com/user-attachments/assets/dfd8437e-61c4-4b43-b30d-a2d55c0b4861


https://github.com/user-attachments/assets/8772592b-581a-42f9-80d5-14c6dd7e0135



## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `XInput2` raw mouse support and ClipCursor confinement to fix mouse movement in games that rely on raw input and cursor clipping. Also updates extension registration and pointer mapping to improve compatibility (e.g., scroll wheel), and tightens confinement and XI2 mask handling.

- New Features
  - Implemented `XInput2` with raw motion and button events; emits on pointer deltas and presses/releases.
  - Added ClipCursor confinement via `GrabManager`; pointer is clamped to the grab window with a soft-margin fallback.
  - Expanded pointer mapping to 7 buttons to fix scroll wheel.
  - Added FP3232 encoding in `XOutputStream` for XI valuators.

- Bug Fixes
  - Fixed confinement off-by-one in pointer clamping.
  - `XISelectEvents` now throws `BadValue` when no masks are provided (per XI2 spec).
  - Switched `Bitmask` to 64-bit to correctly read XI2 event masks.

<sup>Written for commit 417edde1c96ae31959dd78597333376d50098da1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XInput2 support with raw motion and raw button event notifications.
  * Pointer grab can now optionally confine the pointer to a window.

* **Bug Fixes**
  * Improved pointer tracking, clamping, and raw event emission.
  * Expanded pointer/button mapping and alignment in cursor responses.
  * Relaxed warp-pointer containment checks (soft margins).

* **Chores**
  * Removed legacy cursor-locking behavior.
  * Standardized logging across request handlers.
  * Made extension event/error ID allocation configurable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->