### PR TITLE
fix: remove 30s brightness blackout from ambient download overlay

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/components/ambient/AmbientDownloadOverlay.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/ambient/AmbientDownloadOverlay.kt
@@ -46,7 +46,6 @@ import app.gamenative.ui.screen.library.components.ambient.AmbientModeConstants.
 import app.gamenative.ui.screen.library.components.ambient.AmbientModeConstants.SHIMMER_PERIOD_MS
 import app.gamenative.ui.screen.library.components.ambient.AmbientModeConstants.SHIMMER_WIDTH_FRACTION
 import app.gamenative.ui.theme.BrandGradient
-import app.gamenative.utils.BrightnessManager
 import app.gamenative.utils.ShakeDetector
 import kotlinx.coroutines.delay
 
@@ -63,7 +62,6 @@ internal fun AmbientDownloadOverlay(
 ) {
     val activity = LocalActivity.current as? ComponentActivity ?: return
     val context = LocalContext.current
-    val brightnessManager = remember { BrightnessManager(activity, AmbientModeConstants.MIN_BRIGHTNESS) }
 
     var interactionCounter by remember { mutableIntStateOf(0) }
     var isIdle by remember { mutableStateOf(false) }
@@ -130,19 +128,6 @@ internal fun AmbientDownloadOverlay(
         ),
         label = "ambientAlpha",
     )
-
-    LaunchedEffect(isIdle) {
-        if (isIdle) {
-            delay(AmbientModeConstants.BRIGHTNESS_DIM_DELAY_MS)
-            brightnessManager.dim()
-        } else {
-            brightnessManager.restore()
-        }
-    }
-
-    DisposableEffect(Unit) {
-        onDispose { brightnessManager.restore() }
-    }
 
     if (ambientAlpha > 0f) {
         val infiniteTransition = rememberInfiniteTransition(label = "ambient")

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/ambient/AmbientModeConstants.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/ambient/AmbientModeConstants.kt
@@ -7,8 +7,6 @@ internal object AmbientModeConstants {
     const val SHIMMER_PERIOD_MS = 2_000
     const val DRIFT_PERIOD_MS = 30_000
     const val DRIFT_AMPLITUDE_PX = 16f
-    const val BRIGHTNESS_DIM_DELAY_MS = 30_000L
-    const val MIN_BRIGHTNESS = 0.01f
     const val BAR_HEIGHT_DP = 4f
     const val BAR_BASE_ALPHA = 0.25f
     const val BAR_TRACK_ALPHA = 0.15f


### PR DESCRIPTION

## Description
<!-- What changed and why? -->


> @Producdevity for the minimal dl progress thing, is it supposed to fade out to fully black after like 30 sec? id prefer we just keep having the progress bar personally, or, when i tap once then go back to black with moving bar, tap one more time to get all the way back to full app. what do you think


Producdevity

> Thinking about it, I agree. We probably can get rid of the full blackout after 30 seconds. The bar and texts do shift slightly so showing those even for a long period of time shouldn’t burn-in OLED screens


this is the pr which does the agreed upon, remove the fade to full black but preserve the minimalist fade out while downloading after 10 sec.

## Recording
<!-- Attach a short recording/GIF showing the change -->

imagine in your minds eye, the thing that was happening, not happening now

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic screen brightness dimming behavior from the ambient download overlay. The overlay now manages visual appearance and user interactions only, without adjusting system brightness settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->