### PR TITLE
fix: exempt systemDefined depots from license check

### DIFF
--- a/app/src/main/java/app/gamenative/data/DepotInfo.kt
+++ b/app/src/main/java/app/gamenative/data/DepotInfo.kt
@@ -21,6 +21,7 @@ data class DepotInfo(
     val encryptedManifests: Map<String, ManifestInfo>,
     val language: String = "",
     val realm: String = "",
+    val systemDefined: Boolean = false,
     val steamDeck: Boolean = false,
 ) {
     /** Windows or OS-untagged (neither Linux nor macOS) */

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -760,8 +760,8 @@ class SteamService : Service(), IChallengeUrlChanged {
             if (depot.language.isNotEmpty() && depot.language != preferredLanguage)
                 return false
             // 6. Package grants this depot — prevents grabbing region depots the user has no license for.
-            //    Skip for DLC depots: they're licensed via their own package, already validated by check 4.
-            if (depot.dlcAppId == INVALID_APP_ID && licensedDepotIds != null && depot.depotId !in licensedDepotIds)
+            //    Skip for DLC and systemDefined depots: DLC licensed via own package (check 4), systemDefined always granted.
+            if (depot.dlcAppId == INVALID_APP_ID && !depot.systemDefined && licensedDepotIds != null && depot.depotId !in licensedDepotIds)
                 return false
             // 7. Prefer non-Steam-Deck depot when both exist (we're on Android, not Deck)
             if (depot.steamDeck && preferNonDeckWindows)
@@ -860,6 +860,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                             language = depot.language,
                             manifests = depot.manifests,
                             encryptedManifests = depot.encryptedManifests,
+                            systemDefined = depot.systemDefined,
                             steamDeck = depot.steamDeck,
                         )
                     }

--- a/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
@@ -58,6 +58,7 @@ fun KeyValue.generateSteamApp(): SteamApp {
                     encryptedManifests = encryptedManifests,
                     language = currentDepot["config"]["language"].value.orEmpty(),
                     realm = currentDepot["config"]["realm"].value.orEmpty(),
+                    systemDefined = currentDepot["systemdefined"].asBoolean(),
                     optionalDlcId = currentDepot["config"]["optionaldlc"].asInteger(INVALID_APP_ID),
                     steamDeck = currentDepot["config"]["steamdeck"].asBoolean(false),
                 )

--- a/app/src/test/java/app/gamenative/service/DepotFilteringTest.kt
+++ b/app/src/test/java/app/gamenative/service/DepotFilteringTest.kt
@@ -19,6 +19,7 @@ class DepotFilteringTest {
         osArch: OSArch = OSArch.Arch64,
         dlcAppId: Int = SteamService.INVALID_APP_ID,
         language: String = "",
+        systemDefined: Boolean = false,
         steamDeck: Boolean = false,
     ) = DepotInfo(
         depotId = depotId,
@@ -30,6 +31,7 @@ class DepotFilteringTest {
         manifests = manifests,
         encryptedManifests = encryptedManifests,
         language = language,
+        systemDefined = systemDefined,
         steamDeck = steamDeck,
     )
 
@@ -117,6 +119,18 @@ class DepotFilteringTest {
     fun `null licensedDepotIds skips license check`() {
         val d = depot(depotId = 100, manifests = mapOf("public" to manifest()))
         assertTrue(SteamService.filterForDownloadableDepots(d, true, false, "english", null, null))
+    }
+
+    @Test
+    fun `systemDefined depot bypasses license check`() {
+        val d = depot(depotId = 551, manifests = mapOf("public" to manifest()), systemDefined = true)
+        assertTrue(SteamService.filterForDownloadableDepots(d, true, false, "english", null, setOf(552, 553)))
+    }
+
+    @Test
+    fun `non-systemDefined depot still rejected when unlicensed`() {
+        val d = depot(depotId = 100, manifests = mapOf("public" to manifest()), systemDefined = false)
+        assertFalse(SteamService.filterForDownloadableDepots(d, true, false, "english", null, setOf(200, 300)))
     }
 
     // -- Steam Deck depot filtering --


### PR DESCRIPTION
Steam packages don't list systemDefined depots in their depotids, causing them to be filtered out (e.g. L4D2 depot 551 = 5.2GB main content).

## Description
Parse `systemdefined` flag from PICS depot data into `DepotInfo` and skip the license depot-list check for those depots. Fixes utkarshdalal/GameNative#1087.

- L4D2 size now reports ~14.65GB (was ~4GB)
- Unit tests added for systemDefined bypass and non-systemDefined rejection

## Recording
n/a

## Test plan
- Unit tests added for systemDefined bypass and non-systemDefined rejection
- Verified on-device: L4D2 size now reports correctly (~14.65GB vs ~4GB)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip license filtering for `systemDefined` depots and plumb the flag from PICS into `DepotInfo`. Fixes underreported install sizes by including system-defined depots (e.g., L4D2 now ~14.65GB instead of ~4GB).

- **Bug Fixes**
  - Parse PICS `systemdefined` into `DepotInfo.systemDefined` via `KeyValueUtils`.
  - In `SteamService`, skip the license depot-list check when `systemDefined` is true (DLC exception unchanged).
  - Add unit tests for the bypass and for rejecting unlicensed, non-`systemDefined` depots.

<sup>Written for commit d0f1879b0a5cf2e5d22f0c0ba54bf58cb2c9f755. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for identifying and managing system-defined game depots.

* **Improvements**
  * Enhanced depot filtering and licensing logic to properly handle system-defined content packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->