### PR TITLE
feat: streaming download+assembly for Epic/GOG to reduce disk usage

### DIFF
--- a/app/src/main/java/app/gamenative/service/StreamingAssembly.kt
+++ b/app/src/main/java/app/gamenative/service/StreamingAssembly.kt
@@ -1,0 +1,54 @@
+package app.gamenative.service
+
+// pure logic for streaming download+assembly, decoupled from Epic/GOG types.
+// TODO: overlap assembly with download in a separate coroutine for better throughput
+object StreamingAssembly {
+
+    // deduplicated chunk-ID queue ordered by file appearance
+    fun buildOrderedChunkQueue(fileChunkIds: List<List<String>>): List<String> {
+        val seen = mutableSetOf<String>()
+        val queue = mutableListOf<String>()
+        for (chunks in fileChunkIds) {
+            for (id in chunks) {
+                if (seen.add(id)) queue.add(id)
+            }
+        }
+        return queue
+    }
+
+    // last file index per chunk — chunk is safe to delete once that file is assembled
+    fun buildChunkLastFileMap(fileChunkIds: List<List<String>>): Map<String, Int> {
+        val map = mutableMapOf<String, Int>()
+        fileChunkIds.forEachIndexed { i, chunks ->
+            for (id in chunks) { map[id] = i }
+        }
+        return map
+    }
+
+    // used by tests
+    fun countReadyFiles(
+        fileChunkIds: List<List<String>>,
+        downloadedChunkIds: Set<String>,
+        nextFileIndex: Int,
+    ): Int {
+        require(nextFileIndex >= 0) { "nextFileIndex must be non-negative" }
+        var ready = 0
+        var i = nextFileIndex
+        while (i < fileChunkIds.size) {
+            if (!fileChunkIds[i].all { it in downloadedChunkIds }) break
+            ready++
+            i++
+        }
+        return ready
+    }
+
+    // used by tests
+    fun chunksToDelete(
+        fileChunkIds: List<List<String>>,
+        chunkLastFile: Map<String, Int>,
+        fileIndex: Int,
+    ): List<String> {
+        require(fileIndex in fileChunkIds.indices) { "fileIndex out of bounds" }
+        return fileChunkIds[fileIndex].filter { chunkLastFile[it] == fileIndex }
+    }
+}

--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -143,9 +143,8 @@ class EpicDownloadManager @Inject constructor(
 
             val chunkDir = manifest.getChunkDir()
 
-            if (chunks.isEmpty()) {
-                return@withContext Result.failure(Exception("No chunk data in manifest"))
-            }
+            // chunks can be empty when every file is zero-chunk (e.g. empty
+            // config stubs); files.isEmpty() is the real error condition
             if (files.isEmpty()) {
                 val msg = if (selectedTags.isNotEmpty()) {
                     "No files found for the selected language. This game may not support this language."

--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -6,6 +6,7 @@ import app.gamenative.data.DownloadInfo
 import app.gamenative.enums.Marker
 import app.gamenative.utils.MarkerUtils
 import app.gamenative.data.EpicGame
+import app.gamenative.service.StreamingAssembly
 import app.gamenative.service.epic.manifest.EpicManifest
 import app.gamenative.service.epic.manifest.ManifestUtils
 import java.io.ByteArrayInputStream
@@ -223,80 +224,20 @@ class EpicDownloadManager @Inject constructor(
                 """.trimMargin(),
             )
 
-            // Download chunks in batches to avoid overwhelming the system
-            var downloadedChunks = 0
-            val totalChunks = chunks.size
-
-            // Initialize progress tracking
-            downloadInfo.setProgress(0.0f)
-            downloadInfo.emitProgressChange()
-
-            chunks.chunked(MAX_PARALLEL_DOWNLOADS).forEach { chunkBatch ->
-                if (!downloadInfo.isActive()) {
-                    Timber.tag("Epic").w("Download cancelled by user")
-                    return@withContext Result.failure(Exception("Download cancelled"))
-                }
-
-                // Download batch in parallel
-                val results = chunkBatch.map { chunk ->
-                    async {
-                        downloadChunkWithRetry(chunk, chunkCacheDir, chunkDir, cdnUrls, downloadInfo)
-                    }
-                }.awaitAll()
-
-                // Check if any download failed
-                results.firstOrNull { it.isFailure }?.let { failedResult ->
-                    return@withContext Result.failure(
-                        failedResult.exceptionOrNull() ?: Exception("Failed to download chunk"),
-                    )
-                }
-
-                // Update progress after each batch completes
-                downloadedChunks += chunkBatch.size
-                val progress = downloadedChunks.toFloat() / totalChunks
-                downloadInfo.setProgress(progress)
-                val statusMsg = if (dlcManifestData.isNotEmpty()) {
-                    "Downloading base game ($downloadedChunks/$totalChunks chunks)"
-                } else {
-                    "Downloading chunks ($downloadedChunks/$totalChunks)"
-                }
-                downloadInfo.updateStatusMessage(statusMsg)
-                downloadInfo.emitProgressChange()
-
-                Timber.tag("Epic").d("Download progress: $downloadedChunks/$totalChunks chunks (${(progress * 100).toInt()}%)")
-            }
-
-            downloadInfo.updateStatusMessage("Assembling files...")
-
-            // Assemble files from chunks in parallel batches
+            // Build file-ordered chunk queue and run streaming download + assembly
+            val fileChunkIds = files.map { f -> f.chunkParts.map { it.guidStr } }
+            val chunkQueue = buildFileOrderedChunkQueue(manifest, fileChunkIds)
+            val chunkLastFile = StreamingAssembly.buildChunkLastFileMap(fileChunkIds)
             val installDir = File(installPath)
             installDir.mkdirs()
 
-            var assembledFiles = 0
-            val totalFiles = files.size
-
-            // Process files in batches for better parallelism
-            files.chunked(4).forEach { fileBatch ->
-                val assembleResults = fileBatch.map { fileManifest ->
-                    async {
-                        assembleFile(fileManifest, chunkCacheDir, installDir)
-                    }
-                }.awaitAll()
-
-                // Check if any assembly failed
-                assembleResults.firstOrNull { it.isFailure }?.let { failedResult ->
-                    return@withContext Result.failure(
-                        failedResult.exceptionOrNull() ?: Exception("Failed to assemble file"),
-                    )
-                }
-
-                assembledFiles += fileBatch.size
-                val assemblyProgress = assembledFiles.toFloat() / totalFiles
-                downloadInfo.updateStatusMessage("Assembling files ($assembledFiles/$totalFiles)")
-                Timber.tag("Epic").d("File assembly progress: $assembledFiles/$totalFiles (${(assemblyProgress * 100).toInt()}%)")
+            val downloadResult = downloadAndAssembleEpicChunks(
+                chunkQueue, files, chunkLastFile, chunkCacheDir, chunkDir, cdnUrls, installDir, downloadInfo,
+            )
+            if (downloadResult.isFailure) {
+                return@withContext downloadResult
             }
 
-            // Cleanup chunk directory
             chunkCacheDir.deleteRecursively()
 
             // Log final directory structure
@@ -323,8 +264,10 @@ class EpicDownloadManager @Inject constructor(
                             )
 
                             if (dlcResult.isFailure) {
+                                if (!downloadInfo.isActive()) {
+                                    return@withContext dlcResult
+                                }
                                 Timber.tag("Epic").w("Failed to download DLC ${dlc.title}: ${dlcResult.exceptionOrNull()?.message}")
-                                // Continue with other DLCs even if one fails
                             } else {
                                 Timber.tag("Epic").i("Successfully downloaded DLC: ${dlc.title}")
                             }
@@ -412,57 +355,23 @@ class EpicDownloadManager @Inject constructor(
             val fileManifestList = manifest.fileManifestList
                 ?: return@withContext Result.failure(Exception("No file manifest in manifest"))
 
-            val chunks = chunkDataList.elements
             val files = fileManifestList.elements
             val chunkDir = manifest.getChunkDir()
 
-            // Download chunks
+            val fileChunkIds = files.map { f -> f.chunkParts.map { it.guidStr } }
+            val chunkQueue = buildFileOrderedChunkQueue(manifest, fileChunkIds)
+            val chunkLastFile = StreamingAssembly.buildChunkLastFileMap(fileChunkIds)
+
             val chunkCacheDir = File(installPath, ".chunks")
             chunkCacheDir.mkdirs()
-
-            var downloadedChunks = 0
-            val totalChunks = chunks.size
-
-            chunks.chunked(MAX_PARALLEL_DOWNLOADS).forEach { chunkBatch ->
-                if (!downloadInfo.isActive()) {
-                    Timber.tag("Epic").w("Download cancelled by user")
-                    return@withContext Result.failure(Exception("Download cancelled"))
-                }
-
-                val results = chunkBatch.map { chunk ->
-                    async {
-                        downloadChunkWithRetry(chunk, chunkCacheDir, chunkDir, cdnUrls, downloadInfo)
-                    }
-                }.awaitAll()
-
-                results.firstOrNull { it.isFailure }?.let { failedResult ->
-                    return@withContext Result.failure(
-                        failedResult.exceptionOrNull() ?: Exception("Failed to download chunk"),
-                    )
-                }
-
-                downloadedChunks += chunkBatch.size
-            }
-
-            // Assemble files
             val installDir = File(installPath)
             installDir.mkdirs()
 
-            files.chunked(4).forEach { fileBatch ->
-                val assembleResults = fileBatch.map { fileManifest ->
-                    async {
-                        assembleFile(fileManifest, chunkCacheDir, installDir)
-                    }
-                }.awaitAll()
+            val dlcDownloadResult = downloadAndAssembleEpicChunks(
+                chunkQueue, files, chunkLastFile, chunkCacheDir, chunkDir, cdnUrls, installDir, downloadInfo,
+            )
+            if (dlcDownloadResult.isFailure) return@withContext dlcDownloadResult
 
-                assembleResults.firstOrNull { it.isFailure }?.let { failedResult ->
-                    return@withContext Result.failure(
-                        failedResult.exceptionOrNull() ?: Exception("Failed to assemble file"),
-                    )
-                }
-            }
-
-            // Cleanup
             chunkCacheDir.deleteRecursively()
 
             // Update database
@@ -956,6 +865,93 @@ class EpicDownloadManager @Inject constructor(
             Timber.tag("Epic").e(e, "Hash verification failed")
             false
         }
+    }
+
+    private fun buildFileOrderedChunkQueue(
+        manifest: EpicManifest,
+        fileChunkIds: List<List<String>>,
+    ): List<app.gamenative.service.epic.manifest.ChunkInfo> {
+        val orderedIds = StreamingAssembly.buildOrderedChunkQueue(fileChunkIds)
+        return orderedIds.map { id ->
+            manifest.chunkDataList?.getChunkByGuid(id)
+                ?: throw IllegalStateException("Chunk $id referenced by file but not found in manifest")
+        }
+    }
+
+    // assembles files as chunks arrive, deletes chunks once their last consumer is assembled
+    private suspend fun downloadAndAssembleEpicChunks(
+        chunkQueue: List<app.gamenative.service.epic.manifest.ChunkInfo>,
+        files: List<app.gamenative.service.epic.manifest.FileManifest>,
+        chunkLastFile: Map<String, Int>,
+        chunkCacheDir: File,
+        chunkDir: String,
+        cdnUrls: List<EpicManager.CdnUrl>,
+        installDir: File,
+        downloadInfo: DownloadInfo,
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        val totalChunks = chunkQueue.size
+        val totalFiles = files.size
+        val downloadedChunkIds = mutableSetOf<String>()
+        var nextFileToAssemble = 0
+
+        downloadInfo.setProgress(0.0f)
+
+        for (chunkBatch in chunkQueue.chunked(MAX_PARALLEL_DOWNLOADS)) {
+            if (!downloadInfo.isActive()) {
+                return@withContext Result.failure(Exception("Download cancelled"))
+            }
+
+            val results = chunkBatch.map { chunk ->
+                async {
+                    downloadChunkWithRetry(chunk, chunkCacheDir, chunkDir, cdnUrls, downloadInfo)
+                }
+            }.awaitAll()
+
+            val failedResult = results.firstOrNull { it.isFailure }
+            if (failedResult != null) {
+                return@withContext Result.failure(
+                    failedResult.exceptionOrNull() ?: Exception("Failed to download chunk"),
+                )
+            }
+
+            chunkBatch.forEach { downloadedChunkIds.add(it.guidStr) }
+            while (nextFileToAssemble < totalFiles) {
+                val file = files[nextFileToAssemble]
+                if (!file.chunkParts.all { it.guidStr in downloadedChunkIds }) break
+
+                val assembleResult = assembleFile(file, chunkCacheDir, installDir)
+                if (assembleResult.isFailure) {
+                    return@withContext Result.failure(
+                        assembleResult.exceptionOrNull() ?: Exception("Failed to assemble file"),
+                    )
+                }
+
+                for (part in file.chunkParts) {
+                    if (chunkLastFile[part.guidStr] == nextFileToAssemble) {
+                        File(chunkCacheDir, part.guidStr).delete()
+                    }
+                }
+
+                nextFileToAssemble++
+            }
+
+            val progress = downloadedChunkIds.size.toFloat() / totalChunks
+            downloadInfo.setProgress(progress)
+            downloadInfo.updateStatusMessage(
+                "Downloading (${downloadedChunkIds.size}/$totalChunks chunks, $nextFileToAssemble/$totalFiles files)",
+            )
+
+            Timber.tag("Epic").d("Progress: ${downloadedChunkIds.size}/$totalChunks chunks, $nextFileToAssemble/$totalFiles files assembled")
+        }
+
+        if (nextFileToAssemble != totalFiles) {
+            return@withContext Result.failure(
+                Exception("Assembly incomplete: only $nextFileToAssemble of $totalFiles files assembled")
+            )
+        }
+
+        Timber.tag("Epic").i("Streaming complete: $totalChunks chunks, $nextFileToAssemble files assembled")
+        Result.success(Unit)
     }
 
     /**

--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -944,6 +944,20 @@ class EpicDownloadManager @Inject constructor(
             Timber.tag("Epic").d("Progress: ${downloadedChunkIds.size}/$totalChunks chunks, $nextFileToAssemble/$totalFiles files assembled")
         }
 
+        // final assembly pass for zero-chunk files that the chunk loop never reaches
+        while (nextFileToAssemble < totalFiles) {
+            val file = files[nextFileToAssemble]
+            if (!file.chunkParts.all { it.guidStr in downloadedChunkIds }) break
+
+            val assembleResult = assembleFile(file, chunkCacheDir, installDir)
+            if (assembleResult.isFailure) {
+                return@withContext Result.failure(
+                    assembleResult.exceptionOrNull() ?: Exception("Failed to assemble file"),
+                )
+            }
+            nextFileToAssemble++
+        }
+
         if (nextFileToAssemble != totalFiles) {
             return@withContext Result.failure(
                 Exception("Assembly incomplete: only $nextFileToAssemble of $totalFiles files assembled")

--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -2,6 +2,7 @@ package app.gamenative.service.gog
 
 import android.content.Context
 import app.gamenative.data.DownloadInfo
+import app.gamenative.service.StreamingAssembly
 import app.gamenative.service.gog.api.DepotFile
 import app.gamenative.service.gog.api.FileChunk
 import app.gamenative.service.gog.api.GOGApiClient
@@ -389,43 +390,35 @@ class GOGDownloadManager @Inject constructor(
                 chunkToProductMap = chunkToProductMap,
             )
 
-            // Step 8: Download chunks
-            Timber.tag("GOG").i("Downoading Chunks for game $gameId")
+            // Step 8+9: Download chunks and assemble files in a unified streaming loop.
+            // Chunks are ordered by file so files complete front-to-back, allowing
+            // early assembly and cache cleanup to reduce peak disk usage.
+            Timber.tag("GOG").i("Downloading and assembling game $gameId")
 
             // Mark download as in-progress so UI and install checks can detect partial installs
             installPath.mkdirs()
             MarkerUtils.addMarker(installPath.absolutePath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
 
-            downloadInfo.updateStatusMessage("Downloading chunks...")
+            downloadInfo.updateStatusMessage("Downloading...")
 
             val chunkCacheDir = File(installPath, ".gog_chunks")
             chunkCacheDir.mkdirs()
+            gameInstallDir.mkdirs()
 
-            val downloadResult = downloadChunks(
+            val downloadAndAssembleResult = downloadAndAssembleChunks(
                 chunkUrlMap = chunkUrlMap,
                 chunkCacheDir = chunkCacheDir,
+                installDir = gameInstallDir,
+                files = gameFiles + supportFilesForGameDirAssemble,
                 downloadInfo = downloadInfo,
                 chunkHashes = chunkHashes,
                 secureLinkContext = secureLinkContext,
                 chunkToProductMap = chunkToProductMap,
             )
 
-            if (downloadResult.isFailure) {
+            if (downloadAndAssembleResult.isFailure) {
                 MarkerUtils.removeMarker(installPath.absolutePath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
-                return@withContext downloadResult
-            }
-
-            // Step 9: Assemble game files
-            downloadInfo.updateStatusMessage("Assembling files...")
-
-            // Use installPath directly since it already includes the game-specific folder
-            gameInstallDir.mkdirs()
-
-            val filesToAssembleInGameDir = gameFiles + supportFilesForGameDirAssemble
-            val assembleResult = assembleFiles(filesToAssembleInGameDir, chunkCacheDir, gameInstallDir, downloadInfo)
-            if (assembleResult.isFailure) {
-                MarkerUtils.removeMarker(installPath.absolutePath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
-                return@withContext assembleResult
+                return@withContext downloadAndAssembleResult
             }
 
             // Download Dependencies (They will either go to root or supportDir depending on )
@@ -434,7 +427,11 @@ class GOGDownloadManager @Inject constructor(
                 supportDir.mkdirs()
 
                 val dependencyResult = downloadDependencies(gameId, dependencies, installPath, supportDir, downloadInfo)
-                if (dependencyResult.isFailure){
+                if (dependencyResult.isFailure) {
+                    if (!downloadInfo.isActive()) {
+                        MarkerUtils.removeMarker(installPath.absolutePath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+                        return@withContext dependencyResult
+                    }
                     Timber.tag("GOG").w("Failed to install Dependencies: ${dependencyResult.exceptionOrNull()?.message}")
                 }
 
@@ -742,48 +739,63 @@ class GOGDownloadManager @Inject constructor(
         }
     }
 
-    /**
-     * Download all chunks from CDN with parallel execution
-     *
-     * @param chunkUrlMap Map of chunk MD5 hash to secure CDN URL
-     * @param chunkCacheDir Directory to cache downloaded chunks
-     * @param downloadInfo Progress tracker
-     * @param chunkHashes List of all chunk hashes needed
-     * @param secureLinkContext Context for refreshing secure links if they expire
-     * @param chunkToProductMap Map of chunk MD5 hash to product ID for debugging
-     */
-    private suspend fun downloadChunks(
+    // assembles files as chunks arrive, deletes chunks once their last consumer is assembled
+    private suspend fun downloadAndAssembleChunks(
         chunkUrlMap: Map<String, String>,
         chunkCacheDir: File,
+        installDir: File,
+        files: List<DepotFile>,
         downloadInfo: DownloadInfo,
         chunkHashes: List<String>,
-        secureLinkContext: SecureLinkContext,
+        secureLinkContext: SecureLinkContext?,
         chunkToProductMap: Map<String, String>,
     ): Result<Unit> = withContext(Dispatchers.IO) {
         try {
+            val fileChunkIds = files.map { f -> f.chunks.map { it.compressedMd5 } }
+            val chunkLastFile = StreamingAssembly.buildChunkLastFileMap(fileChunkIds)
+
             var currentChunkUrlMap = chunkUrlMap
-            val chunks = chunkUrlMap.entries.toList()
-            val totalChunks = chunks.size
-            var downloadedChunks = 0
+            val totalChunks = chunkHashes.size
+            val totalFiles = files.size
+            val downloadedChunkIds = mutableSetOf<String>()
+            var nextFileToAssemble = 0
 
-            Timber.tag("GOG").d("Downloading $totalChunks chunks...")
+            // assemble every file whose chunks have all arrived (or that has zero chunks)
+            suspend fun assembleReady(): Result<Unit> {
+                while (nextFileToAssemble < totalFiles) {
+                    val file = files[nextFileToAssemble]
+                    if (!file.chunks.all { it.compressedMd5 in downloadedChunkIds }) break
+                    if (!downloadInfo.isActive()) return Result.failure(Exception("Download cancelled"))
 
-            // Initialize download progress
+                    val r = assembleFile(file, chunkCacheDir, installDir)
+                    if (r.isFailure) return Result.failure(
+                        r.exceptionOrNull() ?: Exception("Failed to assemble ${file.path}"),
+                    )
+
+                    for (chunk in file.chunks) {
+                        if (chunkLastFile[chunk.compressedMd5] == nextFileToAssemble) {
+                            File(chunkCacheDir, "${chunk.compressedMd5}.chunk").delete()
+                        }
+                    }
+                    nextFileToAssemble++
+                }
+                return Result.success(Unit)
+            }
+
+            Timber.tag("GOG").d("Streaming download+assembly: $totalChunks chunks, $totalFiles files")
+
             downloadInfo.setProgress(0.0f)
             downloadInfo.setActive(true)
-            downloadInfo.emitProgressChange()
 
-            // Download in batches to avoid overwhelming the system
-            chunks.chunked(MAX_PARALLEL_DOWNLOADS).forEach { chunkBatch ->
+            chunkHashes.chunked(MAX_PARALLEL_DOWNLOADS).forEach { chunkBatch ->
                 if (!downloadInfo.isActive()) {
                     Timber.tag("GOG").w("Download cancelled by user")
                     return@withContext Result.failure(Exception("Download cancelled"))
                 }
 
-                // Download batch in parallel with retry logic
-                val results = chunkBatch.map { (chunkMd5, _) ->
+                // Download batch in parallel
+                val results = chunkBatch.map { chunkMd5 ->
                     async {
-                        // Use current URL map in case it was refreshed
                         val url = currentChunkUrlMap[chunkMd5] ?: return@async Result.failure<File>(
                             Exception("No URL found for chunk $chunkMd5"),
                         )
@@ -791,30 +803,26 @@ class GOGDownloadManager @Inject constructor(
                     }
                 }.awaitAll()
 
-                // Check if any download failed due to expired links (401/403/404)
+                // Handle expired secure links (401/403/404)
                 val expiredLinkFailures = results.zip(chunkBatch).filter { (result, _) ->
                     val exception = result.exceptionOrNull()
                     exception is HttpStatusException && exception.statusCode in listOf(401, 403, 404)
                 }
 
-                if (expiredLinkFailures.isNotEmpty()) {
+                if (expiredLinkFailures.isNotEmpty() && secureLinkContext != null) {
                     Timber.tag("GOG").w("Detected ${expiredLinkFailures.size} expired secure link(s), refreshing...")
 
-                    // Log which products the failing chunks belong to
-                    expiredLinkFailures.forEach { (result, chunk) ->
-                        val chunkMd5 = chunk.key
+                    expiredLinkFailures.forEach { (result, chunkMd5) ->
                         val productId = chunkToProductMap[chunkMd5]
                         Timber.tag("GOG").w("Chunk $chunkMd5 belongs to product $productId: ${result.exceptionOrNull()?.message}")
                     }
 
-                    // Refresh secure links
                     val refreshResult = refreshSecureLinks(secureLinkContext, chunkHashes)
                     if (refreshResult.isSuccess) {
                         currentChunkUrlMap = refreshResult.getOrThrow()
-                        Timber.tag("GOG").i("Secure links refreshed successfully, retrying failed chunks")
+                        Timber.tag("GOG").i("Secure links refreshed, retrying batch")
 
-                        // Retry the failed chunks with new URLs
-                        val retryResults = chunkBatch.map { (chunkMd5, _) ->
+                        val retryResults = chunkBatch.map { chunkMd5 ->
                             async {
                                 val url = currentChunkUrlMap[chunkMd5] ?: return@async Result.failure<File>(
                                     Exception("No URL found for chunk $chunkMd5 after refresh"),
@@ -823,20 +831,17 @@ class GOGDownloadManager @Inject constructor(
                             }
                         }.awaitAll()
 
-                        // Check retry results
                         retryResults.firstOrNull { it.isFailure }?.let { failedResult ->
                             return@withContext Result.failure(
                                 failedResult.exceptionOrNull() ?: Exception("Failed to download chunk after link refresh"),
                             )
                         }
                     } else {
-                        Timber.tag("GOG").e("Failed to refresh secure links: ${refreshResult.exceptionOrNull()?.message}")
                         return@withContext Result.failure(
                             refreshResult.exceptionOrNull() ?: Exception("Failed to refresh secure links"),
                         )
                     }
                 } else {
-                    // Check if any download failed for other reasons
                     results.firstOrNull { it.isFailure }?.let { failedResult ->
                         return@withContext Result.failure(
                             failedResult.exceptionOrNull() ?: Exception("Failed to download chunk"),
@@ -844,21 +849,29 @@ class GOGDownloadManager @Inject constructor(
                     }
                 }
 
-                downloadedChunks += chunkBatch.size
+                chunkBatch.forEach { downloadedChunkIds.add(it) }
+                assembleReady().onFailure { return@withContext Result.failure(it) }
 
-                // Update progress with smooth interpolation
-                val progress = downloadedChunks.toFloat() / totalChunks
+                val progress = downloadedChunkIds.size.toFloat() / totalChunks
                 downloadInfo.setProgress(progress)
-                downloadInfo.updateStatusMessage("Downloading chunks ($downloadedChunks/$totalChunks)")
-                downloadInfo.emitProgressChange()
+                downloadInfo.updateStatusMessage(
+                    "Downloading (${downloadedChunkIds.size}/$totalChunks chunks, $nextFileToAssemble/$totalFiles files)",
+                )
 
-                Timber.tag("GOG").d("Progress: ${(progress * 100).toInt()}% ($downloadedChunks/$totalChunks chunks)")
+                Timber.tag("GOG").d("Progress: ${downloadedChunkIds.size}/$totalChunks chunks, $nextFileToAssemble/$totalFiles files assembled")
             }
 
-            Timber.tag("GOG").i("All $totalChunks chunks downloaded successfully")
+            // assemble any remaining files whose chunks are all present (or have zero chunks)
+            assembleReady().onFailure { return@withContext Result.failure(it) }
+
+            if (nextFileToAssemble != totalFiles) {
+                throw Exception("Assembly incomplete: only $nextFileToAssemble of $totalFiles files assembled")
+            }
+
+            Timber.tag("GOG").i("Streaming complete: $totalChunks chunks, $nextFileToAssemble files assembled")
             Result.success(Unit)
         } catch (e: Exception) {
-            Timber.tag("GOG").e(e, "Failed to download chunks")
+            Timber.tag("GOG").e(e, "Failed to download and assemble")
             Result.failure(e)
         }
     }
@@ -965,30 +978,7 @@ class GOGDownloadManager @Inject constructor(
                     continue
                 }
 
-                // Extract chunk hashes
-                val chunkHashes = parser.extractChunkHashes(depotFiles)
-
-                // Build chunk URL map using dependency base URLs
-                val chunkUrlMap = buildChunkUrlMap(chunkHashes, dependencyBaseUrls)
-
-                // Create cache directory for this dependency
-                val depotCacheDir = File(installBaseDir, ".gog_dep_${depot.dependencyId}")
-                depotCacheDir.mkdirs()
-
-                // Download chunks
-                val downloadResult = downloadChunksSimple(chunkUrlMap, depotCacheDir, downloadInfo)
-                if (downloadResult.isFailure) {
-                    Timber.tag("GOG").w("Failed to download chunks for ${depot.readableName}: ${downloadResult.exceptionOrNull()?.message}")
-                    continue
-                }
-
-                // Assemble files - the file paths in the manifest already contain the full directory structure
-                // so we use installBaseDir directly without adding depot.dependencyId
-                val depotInstallDir = installBaseDir
-                depotInstallDir.mkdirs()
-
                 // Strip __redist/ prefix from file paths if they're being installed to supportDir
-                // This prevents paths like supportDir/__redist/DirectX and gives us supportDir/DirectX instead
                 val filesToAssemble = if (installBaseDir == supportDir) {
                     depotFiles.map { file ->
                         if (file.path.startsWith("__redist/")) {
@@ -1001,13 +991,37 @@ class GOGDownloadManager @Inject constructor(
                     depotFiles
                 }
 
-                val assembleResult = assembleFiles(filesToAssemble, depotCacheDir, depotInstallDir, downloadInfo)
-                if (assembleResult.isFailure) {
-                    Timber.tag("GOG").w("Failed to assemble files for ${depot.readableName}: ${assembleResult.exceptionOrNull()?.message}")
+                // Extract chunk hashes and build URLs
+                val depotChunkHashes = parser.extractChunkHashes(filesToAssemble)
+                val chunkUrlMap = buildChunkUrlMap(depotChunkHashes, dependencyBaseUrls)
+
+                // Create cache directory for this dependency
+                val depotCacheDir = File(installBaseDir, ".gog_dep_${depot.dependencyId}")
+                depotCacheDir.mkdirs()
+
+                val depotInstallDir = installBaseDir
+                depotInstallDir.mkdirs()
+
+                // Streaming download + assemble (no secure link refresh for deps)
+                val depotResult = downloadAndAssembleChunks(
+                    chunkUrlMap = chunkUrlMap,
+                    chunkCacheDir = depotCacheDir,
+                    installDir = depotInstallDir,
+                    files = filesToAssemble,
+                    downloadInfo = downloadInfo,
+                    chunkHashes = depotChunkHashes,
+                    secureLinkContext = null,
+                    chunkToProductMap = emptyMap(),
+                )
+                if (depotResult.isFailure) {
+                    // propagate cancellations so finalizeInstallSuccess doesn't run
+                    if (!downloadInfo.isActive()) {
+                        return@withContext depotResult
+                    }
+                    Timber.tag("GOG").w("Failed to download/assemble ${depot.readableName}: ${depotResult.exceptionOrNull()?.message}")
                     continue
                 }
 
-                // Cleanup cache
                 depotCacheDir.deleteRecursively()
 
                 Timber.tag("GOG").i("Successfully downloaded dependency: ${depot.readableName} to ${depotInstallDir.absolutePath}")
@@ -1068,51 +1082,6 @@ class GOGDownloadManager @Inject constructor(
         }
 
         return chunkUrlMap
-    }
-
-    /**
-     * Simplified chunk download without retry and secure link refresh
-     * Used for dependencies which use open links
-     */
-    private suspend fun downloadChunksSimple(
-        chunkUrlMap: Map<String, String>,
-        chunkCacheDir: File,
-        downloadInfo: DownloadInfo,
-    ): Result<Unit> = withContext(Dispatchers.IO) {
-        try {
-            val chunks = chunkUrlMap.entries.toList()
-            val totalChunks = chunks.size
-            var downloadedChunks = 0
-
-            downloadInfo.setProgress(0f)
-            downloadInfo.setActive(true)
-            downloadInfo.emitProgressChange()
-
-            // Download in batches
-            chunks.chunked(MAX_PARALLEL_DOWNLOADS).forEach { chunkBatch ->
-                val results = chunkBatch.map { (chunkMd5, url) ->
-                    async {
-                        downloadChunk(chunkMd5, url, chunkCacheDir, downloadInfo)
-                    }
-                }.awaitAll()
-
-                // Check if any download failed
-                results.firstOrNull { it.isFailure }?.let { failedResult ->
-                    return@withContext Result.failure(
-                        failedResult.exceptionOrNull() ?: Exception("Failed to download chunk"),
-                    )
-                }
-
-                downloadedChunks += chunkBatch.size
-                downloadInfo.setProgress(downloadedChunks.toFloat() / totalChunks)
-                downloadInfo.emitProgressChange()
-            }
-
-            Result.success(Unit)
-        } catch (e: Exception) {
-            Timber.tag("GOG").e(e, "Failed to download dependency chunks")
-            Result.failure(e)
-        }
     }
 
     /**
@@ -1259,46 +1228,6 @@ class GOGDownloadManager @Inject constructor(
             }
         } catch (e: Exception) {
             Timber.tag("GOG").e(e, "Failed to download chunk $chunkMd5")
-            Result.failure(e)
-        }
-    }
-
-    /**
-     * Assemble files from downloaded chunks
-     *
-     * @param files List of files to assemble
-     * @param chunkCacheDir Directory containing downloaded chunks
-     * @param installDir Target installation directory
-     * @param downloadInfo Progress tracker
-     */
-    private suspend fun assembleFiles(
-        files: List<DepotFile>,
-        chunkCacheDir: File,
-        installDir: File,
-        downloadInfo: DownloadInfo,
-    ): Result<Unit> = withContext(Dispatchers.IO) {
-        try {
-            val totalFiles = files.size
-
-            for ((index, file) in files.withIndex()) {
-                if (!downloadInfo.isActive()) {
-                    return@withContext Result.failure(Exception("Download cancelled"))
-                }
-
-                downloadInfo.updateStatusMessage("Assembling ${index + 1}/$totalFiles: ${file.path}")
-
-                val assembleResult = assembleFile(file, chunkCacheDir, installDir)
-                if (assembleResult.isFailure) {
-                    return@withContext Result.failure(
-                        assembleResult.exceptionOrNull() ?: Exception("Failed to assemble ${file.path}"),
-                    )
-                }
-            }
-
-            Timber.tag("GOG").i("Assembled $totalFiles file(s) successfully")
-            Result.success(Unit)
-        } catch (e: Exception) {
-            Timber.tag("GOG").e(e, "Failed to assemble files")
             Result.failure(e)
         }
     }

--- a/app/src/test/java/app/gamenative/service/StreamingAssemblyTest.kt
+++ b/app/src/test/java/app/gamenative/service/StreamingAssemblyTest.kt
@@ -1,0 +1,205 @@
+package app.gamenative.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StreamingAssemblyTest {
+
+    // -- buildOrderedChunkQueue --
+
+    @Test
+    fun `chunks ordered by file appearance, deduplicated`() {
+        val files = listOf(
+            listOf("a", "b"),
+            listOf("c", "d"),
+            listOf("e"),
+        )
+        assertEquals(listOf("a", "b", "c", "d", "e"), StreamingAssembly.buildOrderedChunkQueue(files))
+    }
+
+    @Test
+    fun `shared chunk appears at first file position`() {
+        // chunk "shared" used by file 0 and file 2
+        val files = listOf(
+            listOf("a", "shared"),
+            listOf("b"),
+            listOf("shared", "c"),
+        )
+        val queue = StreamingAssembly.buildOrderedChunkQueue(files)
+        assertEquals(listOf("a", "shared", "b", "c"), queue)
+        // "shared" at index 1 (from file 0), not duplicated at file 2's position
+    }
+
+    @Test
+    fun `empty files produce empty queue`() {
+        val files = listOf(emptyList<String>(), emptyList())
+        assertEquals(emptyList<String>(), StreamingAssembly.buildOrderedChunkQueue(files))
+    }
+
+    @Test
+    fun `single file single chunk`() {
+        val files = listOf(listOf("only"))
+        assertEquals(listOf("only"), StreamingAssembly.buildOrderedChunkQueue(files))
+    }
+
+    // -- buildChunkLastFileMap --
+
+    @Test
+    fun `last file map tracks final consumer`() {
+        val files = listOf(
+            listOf("a", "shared"),
+            listOf("b"),
+            listOf("shared", "c"),
+        )
+        val map = StreamingAssembly.buildChunkLastFileMap(files)
+        assertEquals(0, map["a"])      // only in file 0
+        assertEquals(2, map["shared"]) // last in file 2
+        assertEquals(1, map["b"])      // only in file 1
+        assertEquals(2, map["c"])      // only in file 2
+    }
+
+    @Test
+    fun `chunk in every file maps to last`() {
+        val files = listOf(
+            listOf("everywhere"),
+            listOf("everywhere"),
+            listOf("everywhere"),
+        )
+        assertEquals(2, StreamingAssembly.buildChunkLastFileMap(files)["everywhere"])
+    }
+
+    // -- countReadyFiles --
+
+    @Test
+    fun `no files ready when first file incomplete`() {
+        val files = listOf(listOf("a", "b"), listOf("c"))
+        val downloaded = setOf("a") // missing "b"
+        assertEquals(0, StreamingAssembly.countReadyFiles(files, downloaded, 0))
+    }
+
+    @Test
+    fun `first file ready, second not`() {
+        val files = listOf(listOf("a", "b"), listOf("c"))
+        val downloaded = setOf("a", "b")
+        assertEquals(1, StreamingAssembly.countReadyFiles(files, downloaded, 0))
+    }
+
+    @Test
+    fun `both files ready`() {
+        val files = listOf(listOf("a"), listOf("b"))
+        val downloaded = setOf("a", "b")
+        assertEquals(2, StreamingAssembly.countReadyFiles(files, downloaded, 0))
+    }
+
+    @Test
+    fun `starts counting from nextFileIndex`() {
+        val files = listOf(listOf("a"), listOf("b"), listOf("c"))
+        val downloaded = setOf("a", "b", "c")
+        // already assembled file 0, start from 1
+        assertEquals(2, StreamingAssembly.countReadyFiles(files, downloaded, 1))
+    }
+
+    // -- chunksToDelete --
+
+    @Test
+    fun `deletes exclusive chunks, keeps shared`() {
+        val files = listOf(
+            listOf("exclusive", "shared"),
+            listOf("shared", "other"),
+        )
+        val lastFile = StreamingAssembly.buildChunkLastFileMap(files)
+
+        // after assembling file 0: "exclusive" last consumer is 0, "shared" last is 1
+        val toDelete = StreamingAssembly.chunksToDelete(files, lastFile, 0)
+        assertEquals(listOf("exclusive"), toDelete)
+    }
+
+    @Test
+    fun `shared chunk deleted when last consumer assembled`() {
+        val files = listOf(
+            listOf("exclusive", "shared"),
+            listOf("shared", "other"),
+        )
+        val lastFile = StreamingAssembly.buildChunkLastFileMap(files)
+
+        val toDelete = StreamingAssembly.chunksToDelete(files, lastFile, 1)
+        assertTrue("shared" in toDelete)
+        assertTrue("other" in toDelete)
+    }
+
+    // -- simulated batch loop --
+
+    @Test
+    fun `full batch loop simulation`() {
+        // 3 files, 6 chunks, batch size 2
+        // file 0: chunks [a, b]
+        // file 1: chunks [c, d]
+        // file 2: chunks [d, e]  — "d" shared with file 1
+        val files = listOf(
+            listOf("a", "b"),
+            listOf("c", "d"),
+            listOf("d", "e"),
+        )
+
+        val queue = StreamingAssembly.buildOrderedChunkQueue(files)
+        assertEquals(listOf("a", "b", "c", "d", "e"), queue)
+
+        val lastFile = StreamingAssembly.buildChunkLastFileMap(files)
+        assertEquals(mapOf("a" to 0, "b" to 0, "c" to 1, "d" to 2, "e" to 2), lastFile)
+
+        val batchSize = 2
+        val downloaded = mutableSetOf<String>()
+        var nextFile = 0
+        val assembledOrder = mutableListOf<Int>()
+        val deletedChunks = mutableSetOf<String>()
+
+        for (batch in queue.chunked(batchSize)) {
+            downloaded.addAll(batch)
+
+            val ready = StreamingAssembly.countReadyFiles(files, downloaded, nextFile)
+            repeat(ready) {
+                val toDelete = StreamingAssembly.chunksToDelete(files, lastFile, nextFile)
+                deletedChunks.addAll(toDelete)
+                assembledOrder.add(nextFile)
+                nextFile++
+            }
+        }
+
+        // all files assembled in order
+        assertEquals(listOf(0, 1, 2), assembledOrder)
+        assertEquals(3, nextFile)
+
+        // batch 1 [a,b]: file 0 ready → assembled, a+b deleted (last consumer = 0)
+        // batch 2 [c,d]: file 1 ready → assembled, c deleted (d last consumer = 2)
+        // batch 3 [e]:   file 2 ready → assembled, d+e deleted
+        assertEquals(setOf("a", "b", "c", "d", "e"), deletedChunks)
+    }
+
+    @Test
+    fun `batch loop with late-completing file`() {
+        // file 0 needs chunks spread across many batches
+        // file 1 completes early but can't assemble until file 0 does (front-to-back)
+        // Actually no — countReadyFiles stops at first incomplete file, so file 1
+        // can't assemble until file 0 is done. This tests that invariant.
+        val files = listOf(
+            listOf("slow1", "slow2", "slow3"),
+            listOf("fast"),
+        )
+        val queue = StreamingAssembly.buildOrderedChunkQueue(files)
+        assertEquals(listOf("slow1", "slow2", "slow3", "fast"), queue)
+
+        val lastFile = StreamingAssembly.buildChunkLastFileMap(files)
+        val downloaded = mutableSetOf<String>()
+        var nextFile = 0
+
+        // batch 1: [slow1, slow2]
+        downloaded.addAll(listOf("slow1", "slow2"))
+        assertEquals(0, StreamingAssembly.countReadyFiles(files, downloaded, nextFile))
+
+        // batch 2: [slow3, fast]
+        downloaded.addAll(listOf("slow3", "fast"))
+        // now both are ready
+        assertEquals(2, StreamingAssembly.countReadyFiles(files, downloaded, nextFile))
+    }
+}


### PR DESCRIPTION
## Description
replace two-phase (download all chunks → assemble all files) with a unified loop that assembles files front-to-back as their chunks land and deletes consumed chunks immediately. peak disk usage drops from ~2x install size to ~1x.

- StreamingAssembly: shared pure logic for chunk ordering, last-file tracking, readiness checks, and safe deletion decisions
- EpicDownloadManager: downloadAndAssembleEpicChunks replaces separate download+assembly phases for both base game and DLC
- GOGDownloadManager: downloadAndAssembleChunks with secure link refresh, used by both main game and dependency downloads. removed dead downloadChunksSimple and assembleFiles.
- 14 unit tests covering ordering, deduplication, shared chunks, cleanup safety, and full batch-loop simulations

counterproposal to #1070. closes #1091. tested with GOG Cursed to Golf (698MB compressed, 160 chunks, 50 files) — peak cache ~227MB vs 698MB without streaming.

## Recording
n/a — plumbing change with no visible UI difference

## Test plan
- [x] unit tests for StreamingAssembly (14 tests)
- [x] GOG Gen 2 download (Cursed to Golf) — assembly completes, chunks cleaned up incrementally
- [ ] Epic download
- [ ] cancellation during download

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switched to a streaming download-and-assemble workflow with real-time progress showing both downloaded chunks and assembled files.
  * Automatic cache cleanup removes chunks immediately after their final use.
  * Secure-link refresh is now conditional when not applicable.

* **Bug Fixes**
  * Faster, clearer failure propagation and improved cancellation responsiveness.
  * Improved handling of expired/secure links during streaming.

* **Tests**
  * Added comprehensive tests covering streaming assembly ordering, readiness, and deletion logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->