### PR TITLE
Dont take symlinks into account during size calculation

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream
 import java.io.BufferedOutputStream
 import java.io.File
 import java.io.FileOutputStream
+import java.nio.file.Files
 import java.security.DigestOutputStream
 import java.security.MessageDigest
 import java.util.zip.Inflater
@@ -1457,10 +1458,8 @@ class GOGDownloadManager @Inject constructor(
     }
 
     /**
-     * Calculate the total size of a directory recursively
-     *
-     * @param directory The directory to calculate size for
-     * @return Total size in bytes
+     * Total size under [directory]. Symlinks are skipped so GOG scriptinterpreter
+     * `rootdir` (symlink to install root) does not re-count the whole tree.
      */
     private fun calculateDirectorySize(directory: File): Long {
         var size = 0L
@@ -1471,6 +1470,9 @@ class GOGDownloadManager @Inject constructor(
 
             val files = directory.listFiles() ?: return 0L
             for (file in files) {
+                if (Files.isSymbolicLink(file.toPath())) {
+                    continue
+                }
                 size += if (file.isDirectory) {
                     calculateDirectorySize(file)
                 } else {


### PR DESCRIPTION
## Description
Recursive symlink was causing count to keep increasing.

## Recording

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip symlinks when calculating installed size to prevent recursive re-counting via GOG’s `rootdir` symlink and stop the size from growing indefinitely.

- **Bug Fixes**
  - Updated `calculateDirectorySize` in `GOGDownloadManager` to ignore paths where `Files.isSymbolicLink(...)` is true, avoiding re-counting the install tree.

<sup>Written for commit 982bba2984cf809b195af647986a4fe669898423. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inaccurate directory size calculations when symbolic links are present. The application now properly excludes symlinks during size computation, preventing inflated storage usage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->