### PR TITLE
fix: keep perf hud fps tracking on unrelated window unmaps

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1404,23 +1404,71 @@ fun XServerScreen(
                     getxServer().windowManager.removeOnWindowModificationListener(it)
                 }
                 val wmListener = object : WindowManager.OnWindowModificationListener {
+                        private fun isFrameRatingCandidateProperty(propertyName: String): Boolean {
+                            return propertyName.contains("_UTIL_LAYER") ||
+                                propertyName.contains("_MESA_DRV") ||
+                                (container.containerVariant.equals(Container.GLIBC) && propertyName.contains("_NET_WM_SURFACE"))
+                        }
+
+                        private fun describeFrameRatingWindow(window: Window): String {
+                            return "id=${window.id}, name=${window.name}, class=${window.className}, pid=${window.processId}"
+                        }
+
                         private fun changeFrameRatingVisibility(window: Window, property: Property?) {
-                            if (frameRating == null) return
+                            val rating = frameRating ?: return
                             if (property != null) {
-                                if (frameRatingWindowId == -1 && (
-                                            property.nameAsString().contains("_UTIL_LAYER") ||
-                                            property.nameAsString().contains("_MESA_DRV") ||
-                                            container.containerVariant.equals(Container.GLIBC) && property.nameAsString().contains("_NET_WM_SURFACE"))) {
-                                    frameRatingWindowId = window.id
-                                    (context as? Activity)?.runOnUiThread {
-                                        frameRating?.visibility = View.VISIBLE
+                                val propertyName = property.nameAsString()
+                                if (!isFrameRatingCandidateProperty(propertyName)) return
+
+                                when {
+                                    frameRatingWindowId == -1 -> {
+                                        frameRatingWindowId = window.id
+                                        Timber.i(
+                                            "FrameRating tracking attached via property=%s to %s",
+                                            propertyName,
+                                            describeFrameRatingWindow(window),
+                                        )
+                                        (context as? Activity)?.runOnUiThread {
+                                            frameRating?.visibility = View.VISIBLE
+                                        }
+                                        rating.update()
                                     }
-                                    frameRating?.update()
+                                    frameRatingWindowId == window.id -> {
+                                        Timber.d(
+                                            "FrameRating received candidate property=%s for already tracked window %s",
+                                            propertyName,
+                                            describeFrameRatingWindow(window),
+                                        )
+                                    }
+                                    else -> {
+                                        Timber.d(
+                                            "FrameRating ignoring candidate property=%s for %s because tracking already points to windowId=%d",
+                                            propertyName,
+                                            describeFrameRatingWindow(window),
+                                            frameRatingWindowId,
+                                        )
+                                    }
                                 }
-                            } else if (frameRatingWindowId != -1) {
-                                frameRatingWindowId = -1
-                                (context as? Activity)?.runOnUiThread {
-                                    frameRating?.visibility = View.GONE
+                                return
+                            }
+
+                            when {
+                                frameRatingWindowId == window.id -> {
+                                    Timber.i(
+                                        "FrameRating tracking cleared because tracked window unmapped: %s",
+                                        describeFrameRatingWindow(window),
+                                    )
+                                    frameRatingWindowId = -1
+                                    (context as? Activity)?.runOnUiThread {
+                                        frameRating?.visibility = View.GONE
+                                    }
+                                }
+                                frameRatingWindowId != -1 -> {
+                                    Timber.d(
+                                        "FrameRating ignoring unmap for non-tracked window %s; still tracking windowId=%d",
+                                        describeFrameRatingWindow(window),
+                                        frameRatingWindowId,
+                                    )
                                 }
                             }
                         }
@@ -1437,6 +1485,13 @@ fun XServerScreen(
                         }
 
                         override fun onModifyWindowProperty(window: Window, property: Property) {
+                            if (frameRating != null && isFrameRatingCandidateProperty(property.nameAsString())) {
+                                Timber.d(
+                                    "FrameRating observed candidate property=%s on %s",
+                                    property.nameAsString(),
+                                    describeFrameRatingWindow(window),
+                                )
+                            }
                             changeFrameRatingVisibility(window, property)
                         }
 


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

FPS reading in perf hud was tracking only a single X window as the source for the FPS measurement, but seems if ANY window unmapped, the tracking id for the actual derived window to be tracked got cleared.

So if a game had a splash screen or a separate launcher the properly tracked window would get dropped from tracking when the secondary screen got torn down. That caused FPS readout to stay at 0 for the remainder of the session.

This PR fixes that by only clearing tracking when the unmapped window id = the tracked one. 

This specifically fixed DragonQuest VII (Demo at least) which was at 0 FPS in upstream/master but on this branch is able to grab FPS, very obvious due to the splash screen art which shows fps very very briefly, then black screen into game locks readout at 0 for the rest of the game session.

Now, this probably does not address all the other cases where we could drop or desync proper window to track, particularly it seems in openGL games or on glibc containers, so to that end I also added some healthy logging to further diagnose subsequent cases.


## Recording
<!-- Attach a short recording/GIF showing the change -->




<img width="1345" height="757" alt="image" src="https://github.com/user-attachments/assets/04e4b20c-e9f7-42c7-8ae5-3ab45c72d0f6" />

Before (from https://discord.com/channels/1378308569287622737/1412756778159964201/1489762861663387889)


<img width="1500" height="840" alt="image" src="https://github.com/user-attachments/assets/f01f9ff4-2865-41d9-9d90-72d5059f1221" />
After (this PR)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes perf HUD FPS dropping to 0 after unrelated X windows unmap. Tracking now only resets when the tracked window unmaps, and adds logging to diagnose remaining cases.

- **Bug Fixes**
  - Only clear FPS tracking when the unmapped window is the tracked one; ignore unmaps from other windows.
  - Detect candidate windows via `_UTIL_LAYER`, `_MESA_DRV`, and (in `GLIBC` containers) `_NET_WM_SURFACE`; show HUD and update when first attached.
  - Add `Timber` logs with window id/name/class/pid and property names to trace tracking; helps cases like the DragonQuest VII demo where a splash/launcher previously zeroed FPS.

<sup>Written for commit 42d17b850c0a7af6029ea461020fed9af2c27ef0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frame rating window tracking to correctly identify and attach to target windows only when appropriate.
  * Enhanced visibility updates to properly display frame rating when tracking initiates and hide it when tracking ends.
  * Refined window property change handling for more accurate state transitions and cleaner resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->