### PR TITLE
fix: add app paths to goldberg config to fix games dlc detection

### DIFF
--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -963,8 +963,17 @@ object SteamUtils {
                 }
             }
 
-            // Add cloud save config sections if appInfo exists
+            // Add app paths and cloud save config sections if appInfo exists
             if (appInfo != null) {
+                // Some games required this path to be setup for detecting dlc, e.g. Vampire Survivors
+                val gameDir = File(SteamService.getAppDirPath(steamAppId))
+                val gameName = gameDir.name
+                val actualInstallDir = appInfo.config.installDir.ifEmpty { gameName }
+                appendLine()
+                appendLine("[app::paths]")
+                appendLine("$steamAppId=./steamapps/common/$actualInstallDir")
+
+                // Setup for cloud save
                 appendLine()
                 append(generateCloudSaveConfig(appInfo))
             }


### PR DESCRIPTION
## Description
Add app paths to goldberg config to fix games dlc detection, e.g. Vampire Survivors

## Recording
<img width="1920" height="1080" alt="Screenshot_20260404_104536" src="https://github.com/user-attachments/assets/d275b327-fa74-4c58-93dc-a13dc4d3ece5" />

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an [app::paths] section to the generated Goldberg config to fix DLC detection for games that need explicit paths (e.g., Vampire Survivors). It maps the app ID to `./steamapps/common/<installDir>`, using the app’s `installDir` when set, otherwise the game folder name; cloud-save config remains unchanged.

<sup>Written for commit 20a8b20f7fe71ca03cb06b777046c86c6f1cab66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config generation now adds an explicit "app paths" section for Steam games when app metadata is available, recording the installation directory mapping for each game.
  * This appears before existing cloud-save settings, preserving prior cloud-save behavior while improving how game install locations are referenced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->