### PR TITLE
fix: Migrate GSE Saves to steam userdata, always upload userdata files to steamcloud

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -259,10 +259,15 @@ object SteamAutoCloud {
         val getLocalUserFilesAsPrefixMap: () -> Map<String, List<UserFileInfo>> = {
             val savePatterns = appInfo.ufs.saveFilePatterns.filter { userFile -> userFile.root.isWindows }
 
-            if (savePatterns.isNotEmpty()) {
-                val result = mutableMapOf<String, MutableList<UserFileInfo>>()
+            val result = mutableMapOf<String, MutableList<UserFileInfo>>()
 
+            if (savePatterns.isNotEmpty()) {
                 savePatterns.forEach { userFile ->
+                    if (userFile.root == PathType.SteamUserData) {
+                        // skip handling, use the logic below to scan SteamUserData
+                        return@forEach
+                    }
+
                     val basePath = Paths.get(prefixToPath(userFile.root.toString()), userFile.substitutedPath)
 
                     Timber.i("Looking for saves in $basePath with pattern ${userFile.pattern} (prefix ${userFile.prefix})")
@@ -278,7 +283,15 @@ object SteamAutoCloud {
 
                         val relativePath = basePath.relativize(it).pathString
 
-                        UserFileInfo(userFile.root, userFile.substitutedPath, relativePath, Files.getLastModifiedTime(it).toMillis(), sha, cloudRoot = userFile.uploadRoot, cloudPath = userFile.uploadPath)
+                        UserFileInfo(
+                            root = userFile.root,
+                            path = userFile.substitutedPath,
+                            filename = relativePath,
+                            timestamp = Files.getLastModifiedTime(it).toMillis(),
+                            sha = sha,
+                            cloudRoot = userFile.uploadRoot,
+                            cloudPath = userFile.uploadPath
+                        )
                     }.collect(Collectors.toList())
 
                     Timber.i("Found ${files.size} file(s) in $basePath for pattern ${userFile.pattern}")
@@ -286,34 +299,47 @@ object SteamAutoCloud {
                     val prefixKey = Paths.get(userFile.prefix).pathString
                     result.getOrPut(prefixKey) { mutableListOf() }.addAll(files)
                 }
-
-                result
-            } else {
-                // Fallback: no UFS patterns; scan SteamUserData root recursively (depth 5)
-                val rootType = PathType.SteamUserData
-                val basePath = Paths.get(prefixToPath(rootType.toString()))
-
-                Timber.i("No UFS patterns; scanning $basePath recursively (depth 5) under ${rootType.name}")
-
-                val files = FileUtils.findFilesRecursive(
-                    rootPath = basePath,
-                    pattern = "*",
-                    maxDepth = 5,
-                ).map {
-                    val sha = streamingShaHash(it)
-
-                    val relativePath = basePath.relativize(it).pathString
-
-                    Timber.i("Found ${it.pathString}\n\tin %${rootType.name}%\n\twith sha [${sha.joinToString(", ")}]")
-
-                    // Store relative path in filename; empty path component
-                    UserFileInfo(rootType, "", relativePath, Files.getLastModifiedTime(it).toMillis(), sha)
-                }.collect(Collectors.toList())
-
-                Timber.i("Found ${files.size} file(s) in $basePath for fallback recursive scan")
-
-                mapOf(Paths.get("%${rootType.name}%").pathString to files)
             }
+
+            // Scan SteamUserData root recursively (depth 5)
+            val rootType = PathType.SteamUserData
+            val basePath = Paths.get(prefixToPath(rootType.toString()))
+
+            Timber.i("Scanning $basePath recursively (depth 5) under ${rootType.name}")
+
+            val files = FileUtils.findFilesRecursive(
+                rootPath = basePath,
+                pattern = "*",
+                maxDepth = 5,
+            ).map {
+                val sha = streamingShaHash(it)
+
+                val relativePath = basePath.relativize(it).pathString
+
+                Timber.i("Found ${it.pathString}\n\tin %${rootType.name}%\n\twith sha [${sha.joinToString(", ")}]")
+
+                // Store relative path in filename; empty path component
+                UserFileInfo(
+                    root = rootType,
+                    path = "",
+                    filename = relativePath,
+                    timestamp = Files.getLastModifiedTime(it).toMillis(),
+                    sha = sha,
+                    cloudRoot = rootType,
+                    cloudPath = ""
+                )
+            }.collect(Collectors.toList())
+
+            Timber.i("Found ${files.size} file(s) in $basePath")
+
+            mapOf(Paths.get("%${rootType.name}%").pathString to files)
+
+            if (files.isNotEmpty()) {
+                val prefixKey = "%${rootType.name}%"
+                result.getOrPut(prefixKey) { mutableListOf() }.addAll(files)
+            }
+
+            result
         }
 
         val fileChangeListToUserFiles: (AppFileChangeList) -> List<UserFileInfo> = { appFileListChange ->
@@ -514,9 +540,19 @@ object SteamAutoCloud {
                     val uploadInfo = steamCloud.beginFileUpload(
                         appId = appInfo.id,
                         filename = if (appInfo.ufs.saveFilePatterns.isEmpty()) {
-                            file.path + file.filename
+                            // For SteamUserData files, use just the filename without folder prefix
+                            if (file.root == PathType.SteamUserData) {
+                                file.filename
+                            } else {
+                                file.path + file.filename
+                            }
                         } else {
-                            file.prefixPath
+                            // For SteamUserData files, use just the filename to avoid folder prefix
+                            if (file.root == PathType.SteamUserData) {
+                                file.filename
+                            } else {
+                                file.prefixPath
+                            }
                         },
                         fileSize = fileSize,
                         rawFileSize = fileSize,
@@ -633,9 +669,19 @@ object SteamAutoCloud {
                         appId = appInfo.id,
                         fileSha = file.sha,
                         filename = if (appInfo.ufs.saveFilePatterns.isEmpty()) {
-                            file.path + file.filename
+                            // For SteamUserData files, use just the filename without folder prefix
+                            if (file.root == PathType.SteamUserData) {
+                                file.filename
+                            } else {
+                                file.path + file.filename
+                            }
                         } else {
-                            file.prefixPath
+                            // For SteamUserData files, use just the filename to avoid folder prefix
+                            if (file.root == PathType.SteamUserData) {
+                                file.filename
+                            } else {
+                                file.prefixPath
+                            }
                         },
                     ).await()
 

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2143,6 +2143,9 @@ class SteamService : Service(), IChallengeUrlChanged {
                 return@async PostSyncInfo(SyncResult.InProgress)
             }
 
+            // Migrate GSE Saves to Steam userdata
+            SteamUtils.migrateGSESavesToSteamUserdata(instance?.applicationContext!!, appId)
+
             try {
                 var syncResult = PostSyncInfo(SyncResult.UnknownFail)
 

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2234,6 +2234,9 @@ class SteamService : Service(), IChallengeUrlChanged {
                 return@async PostSyncInfo(SyncResult.InProgress)
             }
 
+            // Migrate GSE Saves to Steam userdata
+            SteamUtils.migrateGSESavesToSteamUserdata(instance?.applicationContext!!, appId)
+
             try {
                 var syncResult = PostSyncInfo(SyncResult.UnknownFail)
 

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -926,6 +926,7 @@ object SteamUtils {
                         file.toPath(),
                         targetFile,
                         StandardCopyOption.REPLACE_EXISTING,
+                        StandardCopyOption.COPY_ATTRIBUTES, // Preserve file attributes like timestamp and permission
                         StandardCopyOption.ATOMIC_MOVE   // will throw if the FS can’t guarantee atomicity
                     )
 

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -984,6 +984,9 @@ object SteamUtils {
                 appendLine("ticket=$ticketBase64")
             }
 
+            // Migrate GSE Saves to Steam userdata
+            migrateGSESavesToSteamUserdata(context, steamAppId)
+
             // Add [user::saves] section
             val steamUserDataPath = "C:\\Program Files (x86)\\Steam\\userdata\\$accountId"
             appendLine()

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -865,7 +865,7 @@ object SteamUtils {
      * This function copies all files from the GSE saves location to the proper Steam userdata
      * location and then removes the original GSE directory to complete the migration.
      */
-    private fun migrateGSESavesToSteamUserdata(context: Context, appId: Int) {
+    fun migrateGSESavesToSteamUserdata(context: Context, appId: Int) {
         val imageFs = ImageFs.find(context)
         val accountId = SteamService.userSteamId?.accountID?.toInt()
             ?: PrefManager.steamUserAccountId.takeIf { it != 0 }
@@ -983,9 +983,6 @@ object SteamUtils {
             if (!ticketBase64.isNullOrEmpty()) {
                 appendLine("ticket=$ticketBase64")
             }
-
-            // Migrate GSE Saves to Steam userdata
-            migrateGSESavesToSteamUserdata(context, steamAppId)
 
             // Add [user::saves] section
             val steamUserDataPath = "C:\\Program Files (x86)\\Steam\\userdata\\$accountId"

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -909,14 +909,22 @@ object SteamUtils {
                 val relativePath = gseDir.toPath().relativize(file.toPath())
                 val targetFile = steamUserdataDir.toPath().resolve(relativePath)
                 try {
-                        Files.createDirectories(targetFile.parent)
-                        Files.copy(file.toPath(), targetFile, StandardCopyOption.REPLACE_EXISTING)
-                        Timber.i("Migrated ${file.name} from GSE saves to Steam userdata")
-                        migratedCount++
-                    } catch (e: IOException) {
-                        migrationFailed = true
-                        Timber.w(e, "Failed to migrate ${file.name}")
-                    }
+                    Files.createDirectories(targetFile.parent)
+
+                    // As Files.move use linux rename syscall (or simply mv command we know, no need to manually remove the target file)
+                    Files.move(
+                        file.toPath(),
+                        targetFile,
+                        StandardCopyOption.REPLACE_EXISTING,
+                        StandardCopyOption.ATOMIC_MOVE   // will throw if the FS can’t guarantee atomicity
+                    )
+
+                    Timber.i("Migrated ${file.name} from GSE saves to Steam userdata")
+                    migratedCount++
+                } catch (e: IOException) {
+                    migrationFailed = true
+                    Timber.w(e, "Failed to migrate ${file.name}")
+                }
             }
 
         if (!migrationFailed) {

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -871,7 +871,7 @@ object SteamUtils {
             ?: PrefManager.steamUserAccountId.takeIf { it != 0 }
 
         if (accountId == null) {
-            Timber.w("Cannot migrate GSE saves: no Steam account ID available")
+            Timber.tag("migrateGSESavesToSteamUserdata").w("Cannot migrate GSE saves: no Steam account ID available")
             return
         }
 
@@ -885,17 +885,27 @@ object SteamUtils {
             "${ImageFs.WINEPREFIX}/drive_c/Program Files (x86)/Steam/userdata/$accountId/$appId"
         )
 
-        if (!gseDir.exists() || !gseDir.isDirectory) {
-            Timber.d("No GSE save directory found for appId=$appId")
+        fun isDirectoryEmpty(file: File): Boolean {
+            return file.isDirectory && file.list()?.isEmpty() ?: true
+        }
+
+        if (
+            !gseDir.exists() ||
+            !gseDir.isDirectory ||
+            isDirectoryEmpty(gseDir) // No files inside gseDir
+        ) {
+            Timber.tag("migrateGSESavesToSteamUserdata").d("No GSE save directory found for appId=$appId")
             return
         }
+
+        Timber.tag("migrateGSESavesToSteamUserdata").i("Starting GSE Saves Migration for appId=$appId")
 
         if (!steamUserdataDir.exists()) {
             try {
                 Files.createDirectories(steamUserdataDir.toPath())
-                Timber.i("Created Steam userdata directory: ${steamUserdataDir.absolutePath}")
+                Timber.tag("migrateGSESavesToSteamUserdata").i("Created Steam userdata directory: ${steamUserdataDir.absolutePath}")
             } catch (e: IOException) {
-                Timber.e(e, "Failed to create Steam userdata directory")
+                Timber.tag("migrateGSESavesToSteamUserdata").e(e, "Failed to create Steam userdata directory")
                 return
             }
         }
@@ -919,11 +929,11 @@ object SteamUtils {
                         StandardCopyOption.ATOMIC_MOVE   // will throw if the FS can’t guarantee atomicity
                     )
 
-                    Timber.i("Migrated ${file.name} from GSE saves to Steam userdata")
+                    Timber.tag("migrateGSESavesToSteamUserdata").i("Migrated ${file.name} from GSE saves to Steam userdata")
                     migratedCount++
                 } catch (e: IOException) {
                     migrationFailed = true
-                    Timber.w(e, "Failed to migrate ${file.name}")
+                    Timber.tag("migrateGSESavesToSteamUserdata").w(e, "Failed to migrate ${file.name}")
                 }
             }
 
@@ -931,7 +941,7 @@ object SteamUtils {
             gseDir.deleteRecursively()
         }
 
-        Timber.i("Migration completed for appId=$appId. Migrated $migratedCount file(s)")
+        Timber.tag("migrateGSESavesToSteamUserdata").i("Migration completed for appId=$appId. Migrated $migratedCount file(s)")
     }
 
     /**

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -861,6 +861,72 @@ object SteamUtils {
     }
 
     /**
+     * Migrates save files from GSE Saves directory to Steam userdata directory.
+     * This function copies all files from the GSE saves location to the proper Steam userdata
+     * location and then removes the original GSE directory to complete the migration.
+     */
+    private fun migrateGSESavesToSteamUserdata(context: Context, appId: Int) {
+        val imageFs = ImageFs.find(context)
+        val accountId = SteamService.userSteamId?.accountID?.toInt()
+            ?: PrefManager.steamUserAccountId.takeIf { it != 0 }
+
+        if (accountId == null) {
+            Timber.w("Cannot migrate GSE saves: no Steam account ID available")
+            return
+        }
+
+        val gseDir = File(
+            imageFs.rootDir,
+            "${ImageFs.WINEPREFIX}/drive_c/users/xuser/AppData/Roaming/GSE Saves/$appId"
+        )
+
+        val steamUserdataDir = File(
+            imageFs.rootDir,
+            "${ImageFs.WINEPREFIX}/drive_c/Program Files (x86)/Steam/userdata/$accountId/$appId"
+        )
+
+        if (!gseDir.exists() || !gseDir.isDirectory) {
+            Timber.d("No GSE save directory found for appId=$appId")
+            return
+        }
+
+        if (!steamUserdataDir.exists()) {
+            try {
+                Files.createDirectories(steamUserdataDir.toPath())
+                Timber.i("Created Steam userdata directory: ${steamUserdataDir.absolutePath}")
+            } catch (e: IOException) {
+                Timber.e(e, "Failed to create Steam userdata directory")
+                return
+            }
+        }
+
+        var migratedCount = 0
+        var migrationFailed = false
+
+        gseDir.walkTopDown()
+            .filter { it.isFile }
+            .forEach { file ->
+                val relativePath = gseDir.toPath().relativize(file.toPath())
+                val targetFile = steamUserdataDir.toPath().resolve(relativePath)
+                try {
+                        Files.createDirectories(targetFile.parent)
+                        Files.copy(file.toPath(), targetFile, StandardCopyOption.REPLACE_EXISTING)
+                        Timber.i("Migrated ${file.name} from GSE saves to Steam userdata")
+                        migratedCount++
+                    } catch (e: IOException) {
+                        migrationFailed = true
+                        Timber.w(e, "Failed to migrate ${file.name}")
+                    }
+            }
+
+        if (!migrationFailed) {
+            gseDir.deleteRecursively()
+        }
+
+        Timber.i("Migration completed for appId=$appId. Migrated $migratedCount file(s)")
+    }
+
+    /**
      * Sibling folder "steam_settings" + empty "offline.txt" file, no-ops if they already exist.
      */
     private fun ensureSteamSettings(context: Context, dllPath: Path, appId: String, ticketBase64: String? = null, isOffline: Boolean = false) {
@@ -908,7 +974,6 @@ object SteamUtils {
 
         // Get appInfo to check if saveFilePatterns exist (used for both user and app configs)
         val appInfo = getAppInfoOf(steamAppId)
-        val hasSaveFilePatterns = appInfo?.ufs?.saveFilePatterns?.isNotEmpty() == true
 
         val iniContent = buildString {
             appendLine("[user::general]")
@@ -919,13 +984,14 @@ object SteamUtils {
                 appendLine("ticket=$ticketBase64")
             }
 
-            // Only add [user::saves] section if no saveFilePatterns are defined
-            if (!hasSaveFilePatterns) {
-                val steamUserDataPath = "C:\\Program Files (x86)\\Steam\\userdata\\$accountId"
-                appendLine()
-                appendLine("[user::saves]")
-                appendLine("local_save_path=$steamUserDataPath")
-            }
+            // Migrate GSE Saves to Steam userdata
+            migrateGSESavesToSteamUserdata(context, steamAppId)
+
+            // Add [user::saves] section
+            val steamUserDataPath = "C:\\Program Files (x86)\\Steam\\userdata\\$accountId"
+            appendLine()
+            appendLine("[user::saves]")
+            appendLine("local_save_path=$steamUserDataPath")
         }
 
         if (Files.notExists(configsIni)) Files.createFile(configsIni)

--- a/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
+++ b/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
@@ -1219,6 +1219,7 @@ class SteamAutoCloudTest {
         ))
 
         val roamingRoot = File(tempDir, "roaming")
+        val userdataRoot = File(tempDir, "userdata")
         // Files live in the addPath subdirectory: <roamingRoot>/MyGame/saves/
         val saveDir = File(roamingRoot, "MyGame/saves")
         saveDir.mkdirs()
@@ -1282,6 +1283,7 @@ class SteamAutoCloudTest {
         val prefixToPath: (String) -> String = { prefix ->
             when (prefix) {
                 "WinAppDataRoaming" -> roamingRoot.absolutePath
+                "SteamUserData" -> userdataRoot.absolutePath
                 else -> tempDir.absolutePath
             }
         }
@@ -1331,6 +1333,7 @@ class SteamAutoCloudTest {
 
         // Create a temp directory to act as the WinAppDataRoaming root
         val roamingRoot = File(tempDir, "roaming")
+        val userdataRoot = File(tempDir, "userdata")
         val saveSubdir = File(roamingRoot, "TheGame")
         saveSubdir.mkdirs()
         val saveFile = File(saveSubdir, "save.sav")
@@ -1391,6 +1394,7 @@ class SteamAutoCloudTest {
         val prefixToPath: (String) -> String = { prefix ->
             when (prefix) {
                 "WinAppDataRoaming" -> roamingRoot.absolutePath
+                "SteamUserData" -> userdataRoot.absolutePath
                 else -> tempDir.absolutePath
             }
         }

--- a/app/src/test/java/app/gamenative/utils/SteamUtilsFileSearchTest.kt
+++ b/app/src/test/java/app/gamenative/utils/SteamUtilsFileSearchTest.kt
@@ -1531,12 +1531,12 @@ class SteamUtilsFileSearchTest {
 
         val userIniContent = userIni.readText()
 
-        // Verify [user::saves] section does NOT exist
-        assertFalse("configs.user.ini should not contain [user::saves] section",
+        // Verify [user::saves] section does exist
+        assertTrue("configs.user.ini should contain [user::saves] section",
             userIniContent.contains("[user::saves]"))
 
-        // Verify local_save_path does NOT exist
-        assertFalse("configs.user.ini should not contain local_save_path",
+        // Verify local_save_path does exist
+        assertTrue("configs.user.ini should contain local_save_path",
             userIniContent.contains("local_save_path="))
     }
 


### PR DESCRIPTION
## Description
Migrate GSE Saves to steam userdata, change logic to always upload userdata files to steamcloud.
It could potentially fix all saves issue related to userdata

In PC Steam, `<STEAM_INSTALL_DIRECTORY>/userdata/<YOUR_STEAM_USER_ID>/<GAME_ID>/remote` will always be created like the following, so it is better for GN to follow the same logic.

<img width="1253" height="973" alt="image" src="https://github.com/user-attachments/assets/c220e6ab-ffb8-4d22-96d9-c2199c40d61e" />

## Recording
Correctly sync SaveData file for Vampire Survivors (note in the screenshot, GN is not loaded the dlc correctly, related to another PR #1098, so only count the Coins number at the top)

GN Game State (1182 Coins)
<img width="1920" height="1080" alt="Screenshot_20260404_212324" src="https://github.com/user-attachments/assets/cebfa61a-759d-428c-bd52-9318906546bc" />

PC Game State (1182 Coins)
<img width="1921" height="1079" alt="螢幕快照 2026-04-04 21-25-15" src="https://github.com/user-attachments/assets/3e955f90-f941-44f3-947f-8c1e6dedc7cc" />

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates GSE saves to Steam `userdata` and uploads `userdata` files to Steam Cloud using filename-only paths to match PC Steam. Migration runs before app launch, before manual/forced cloud sync, and during settings creation; sync stays upload-only (no deletions).

- **New Features**
  - Moves saves to `userdata/<accountId>/<appId>` using atomic moves that preserve timestamps/permissions; removes the old GSE folder after a clean migration.
  - Always writes `[user::saves].local_save_path` to `configs.user.ini` pointing to Steam `userdata`.
  - Scans `%SteamUserData%` recursively (depth 5) and uploads with filename-only; runs alongside other UFS patterns and skips `SteamUserData`-rooted patterns.

- **Refactors**
  - Use `Files.move` with `REPLACE_EXISTING`, `COPY_ATTRIBUTES`, and `ATOMIC_MOVE`; skip migration when the GSE directory is missing or empty; improved logging.

<sup>Written for commit 87c89417ea023d5d313189a148f6c60dad4f4221. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic migration of legacy save files into Steam userdata paths to improve cloud sync.

* **Bug Fixes**
  * More consistent detection and uploading of local save files with corrected filename/path handling.
  * Improved upload batch result reporting to reflect combined upload/delete outcomes.
  * Config generation always includes local save path settings now.

* **Chores**
  * Bumped local JavaSteam dependency snapshots to newer versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->