### PR TITLE
fix: do not crash on game start on Meta Quest

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1125,7 +1125,7 @@ fun XServerScreen(
                     if (!handled) handled = xServerView!!.getxServer().winHandler.onGenericMotionEvent(it.event)
                 }
                 if (PluviaApp.touchpadView?.hasPointerCapture() != true && !PluviaApp.isOverlayPaused) {
-                    if (it.event != null) {
+                    if ((it.event != null) && (it.event.device != null)) {
                         val device = it.event.device
                         val isExternal = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) device.isExternal else true
                         if (device.supportsSource(InputDevice.SOURCE_TOUCHPAD) &&


### PR DESCRIPTION
## Description
GameNative 0.9.0-prerelease doesn't work on Meta Quest. It crashes when starting a container.
This regression wasn't there in version 0.8.1.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup crash on Meta Quest by guarding against a null input device in motion events when starting the X server screen. Restores 0.8.1 behavior so containers start without crashing.

- **Bug Fixes**
  - Add a null check for `it.event.device` in `XServerScreen` before accessing device properties, preventing an NPE on Meta Quest while keeping touchpad detection logic intact.

<sup>Written for commit 11bf5590d26fafb23fda2e6ecb8efb770b94ff14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced input device handling in XServer screen to improve stability during touchpad and pointer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->