### PR TITLE
FIX - BCN emulation was hidden from Proton x86_x64

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/GraphicsTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GraphicsTab.kt
@@ -119,97 +119,95 @@ fun GraphicsTabContent(state: ContainerConfigState) {
                     state.config.value = config.copy(graphicsDriverConfig = cfg.toString())
                 },
             )
-            if (config.wineVersion.contains("arm64ec", true)) {
-                SettingsListDropdown(
-                    colors = settingsTileColors(),
-                    title = { Text(text = stringResource(R.string.present_modes)) },
-                    value = state.presentModeIndex.value.coerceIn(0, state.presentModes.lastIndex.coerceAtLeast(0)),
-                    items = state.presentModes,
-                    onItemSelected = { idx ->
-                        state.presentModeIndex.value = idx
-                        val cfg = KeyValueSet(config.graphicsDriverConfig)
-                        cfg.put("presentMode", state.presentModes[idx])
-                        state.config.value = config.copy(graphicsDriverConfig = cfg.toString())
-                    },
-                )
-                SettingsListDropdown(
-                    colors = settingsTileColors(),
-                    title = { Text(text = stringResource(R.string.resource_type)) },
-                    value = state.resourceTypeIndex.value.coerceIn(0, state.resourceTypes.lastIndex.coerceAtLeast(0)),
-                    items = state.resourceTypes,
-                    onItemSelected = { idx ->
-                        state.resourceTypeIndex.value = idx
-                        val cfg = KeyValueSet(config.graphicsDriverConfig)
-                        cfg.put("resourceType", state.resourceTypes[idx])
-                        state.config.value = config.copy(graphicsDriverConfig = cfg.toString())
-                    },
-                )
-                SettingsListDropdown(
-                    colors = settingsTileColors(),
-                    title = { Text(text = stringResource(R.string.bcn_emulation)) },
-                    value = state.bcnEmulationIndex.value.coerceIn(0, state.bcnEmulationEntries.lastIndex.coerceAtLeast(0)),
-                    items = state.bcnEmulationEntries,
-                    onItemSelected = { idx ->
-                        state.bcnEmulationIndex.value = idx
-                        val cfg = KeyValueSet(config.graphicsDriverConfig)
-                        cfg.put("bcnEmulation", state.bcnEmulationEntries[idx])
-                        state.config.value = config.copy(graphicsDriverConfig = cfg.toString())
-                    },
-                )
-                SettingsListDropdown(
-                    colors = settingsTileColors(),
-                    title = { Text(text = stringResource(R.string.bcn_emulation_type)) },
-                    value = state.bcnEmulationTypeIndex.value.coerceIn(0, state.bcnEmulationTypeEntries.lastIndex.coerceAtLeast(0)),
-                    items = state.bcnEmulationTypeEntries,
-                    onItemSelected = { i ->
-                        state.bcnEmulationTypeIndex.value = i
-                        val cfg = KeyValueSet(config.graphicsDriverConfig)
-                        cfg.put("bcnEmulationType", state.bcnEmulationTypeEntries[i])
-                        state.config.value = config.copy(graphicsDriverConfig = cfg.toString())
-                    },
-                )
-                // Sharpness (vkBasalt)
-                SettingsListDropdown(
-                    colors = settingsTileColors(),
-                    title = { Text(text = stringResource(R.string.sharpness_effect)) },
-                    value = state.sharpnessEffectIndex.value.coerceIn(0, state.sharpnessEffects.lastIndex.coerceAtLeast(0)),
-                    items = state.sharpnessDisplayItems,
-                    onItemSelected = { idx ->
-                        state.sharpnessEffectIndex.value = idx
-                        state.config.value = config.copy(sharpnessEffect = state.sharpnessEffects[idx])
-                    },
-                )
-                val selectedBoost = state.sharpnessEffects
-                    .getOrNull(state.sharpnessEffectIndex.value)
-                    ?.equals("None", ignoreCase = true)
-                    ?.not() ?: false
-                if (selectedBoost) {
-                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                        Text(text = stringResource(R.string.sharpness_level))
-                        Slider(
-                            value = state.sharpnessLevel.value.toFloat(),
-                            onValueChange = { newValue ->
-                                val clamped = newValue.roundToInt().coerceIn(0, 100)
-                                state.sharpnessLevel.value = clamped
-                                state.config.value = config.copy(sharpnessLevel = clamped)
-                            },
-                            valueRange = 0f..100f,
-                        )
-                        Text(text = "${state.sharpnessLevel.value}%")
-                    }
-                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                        Text(text = stringResource(R.string.sharpness_denoise))
-                        Slider(
-                            value = state.sharpnessDenoise.value.toFloat(),
-                            onValueChange = { newValue ->
-                                val clamped = newValue.roundToInt().coerceIn(0, 100)
-                                state.sharpnessDenoise.value = clamped
-                                state.config.value = config.copy(sharpnessDenoise = clamped)
-                            },
-                            valueRange = 0f..100f,
-                        )
-                        Text(text = "${state.sharpnessDenoise.value}%")
-                    }
+            SettingsListDropdown(
+                colors = settingsTileColors(),
+                title = { Text(text = stringResource(R.string.present_modes)) },
+                value = state.presentModeIndex.value.coerceIn(0, state.presentModes.lastIndex.coerceAtLeast(0)),
+                items = state.presentModes,
+                onItemSelected = { idx ->
+                    state.presentModeIndex.value = idx
+                    val cfg = KeyValueSet(config.graphicsDriverConfig)
+                    cfg.put("presentMode", state.presentModes[idx])
+                    state.config.value = config.copy(graphicsDriverConfig = cfg.toString())
+                },
+            )
+            SettingsListDropdown(
+                colors = settingsTileColors(),
+                title = { Text(text = stringResource(R.string.resource_type)) },
+                value = state.resourceTypeIndex.value.coerceIn(0, state.resourceTypes.lastIndex.coerceAtLeast(0)),
+                items = state.resourceTypes,
+                onItemSelected = { idx ->
+                    state.resourceTypeIndex.value = idx
+                    val cfg = KeyValueSet(config.graphicsDriverConfig)
+                    cfg.put("resourceType", state.resourceTypes[idx])
+                    state.config.value = config.copy(graphicsDriverConfig = cfg.toString())
+                },
+            )
+            SettingsListDropdown(
+                colors = settingsTileColors(),
+                title = { Text(text = stringResource(R.string.bcn_emulation)) },
+                value = state.bcnEmulationIndex.value.coerceIn(0, state.bcnEmulationEntries.lastIndex.coerceAtLeast(0)),
+                items = state.bcnEmulationEntries,
+                onItemSelected = { idx ->
+                    state.bcnEmulationIndex.value = idx
+                    val cfg = KeyValueSet(config.graphicsDriverConfig)
+                    cfg.put("bcnEmulation", state.bcnEmulationEntries[idx])
+                    state.config.value = config.copy(graphicsDriverConfig = cfg.toString())
+                },
+            )
+            SettingsListDropdown(
+                colors = settingsTileColors(),
+                title = { Text(text = stringResource(R.string.bcn_emulation_type)) },
+                value = state.bcnEmulationTypeIndex.value.coerceIn(0, state.bcnEmulationTypeEntries.lastIndex.coerceAtLeast(0)),
+                items = state.bcnEmulationTypeEntries,
+                onItemSelected = { i ->
+                    state.bcnEmulationTypeIndex.value = i
+                    val cfg = KeyValueSet(config.graphicsDriverConfig)
+                    cfg.put("bcnEmulationType", state.bcnEmulationTypeEntries[i])
+                    state.config.value = config.copy(graphicsDriverConfig = cfg.toString())
+                },
+            )
+            // Sharpness (vkBasalt)
+            SettingsListDropdown(
+                colors = settingsTileColors(),
+                title = { Text(text = stringResource(R.string.sharpness_effect)) },
+                value = state.sharpnessEffectIndex.value.coerceIn(0, state.sharpnessEffects.lastIndex.coerceAtLeast(0)),
+                items = state.sharpnessDisplayItems,
+                onItemSelected = { idx ->
+                    state.sharpnessEffectIndex.value = idx
+                    state.config.value = config.copy(sharpnessEffect = state.sharpnessEffects[idx])
+                },
+            )
+            val selectedBoost = state.sharpnessEffects
+                .getOrNull(state.sharpnessEffectIndex.value)
+                ?.equals("None", ignoreCase = true)
+                ?.not() ?: false
+            if (selectedBoost) {
+                Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                    Text(text = stringResource(R.string.sharpness_level))
+                    Slider(
+                        value = state.sharpnessLevel.value.toFloat(),
+                        onValueChange = { newValue ->
+                            val clamped = newValue.roundToInt().coerceIn(0, 100)
+                            state.sharpnessLevel.value = clamped
+                            state.config.value = config.copy(sharpnessLevel = clamped)
+                        },
+                        valueRange = 0f..100f,
+                    )
+                    Text(text = "${state.sharpnessLevel.value}%")
+                }
+                Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                    Text(text = stringResource(R.string.sharpness_denoise))
+                    Slider(
+                        value = state.sharpnessDenoise.value.toFloat(),
+                        onValueChange = { newValue ->
+                            val clamped = newValue.roundToInt().coerceIn(0, 100)
+                            state.sharpnessDenoise.value = clamped
+                            state.config.value = config.copy(sharpnessDenoise = clamped)
+                        },
+                        valueRange = 0f..100f,
+                    )
+                    Text(text = "${state.sharpnessDenoise.value}%")
                 }
             }
         } else {


### PR DESCRIPTION
## Description
Runtime does apply BCN emulation to Proton x86_x64 unconditionaly, so there is no current reason to have this settings options invisible from Container Settings.

BCN emulation works at the Vulkan wrapper level (WRAPPER_EMULATE_BCN), which operates independently of whether Wine is arm64ec or x86_64. Even if the game and Proton are x86, the Vulkan Wrapper is a native Android (ARM64) library, so BCN can be used.

Fix was to unhide and then correct indentation. no other functionality changed.

... and present modes, resource type, sharpness boost... were also all hidden to proton x86_x64 unecessarily

## Recording
Previous behaviour:
<img width="270" height="480" alt="Screenshot_20260405-170826 1" src="https://github.com/user-attachments/assets/dad7d201-6028-432b-820d-896d3089c1b3" />


NEW BEHAVIOUR after this PR fix:
<img width="540" height="960" alt="Screenshot_20260405-170840 1" src="https://github.com/user-attachments/assets/8e894d12-c286-4960-ad7d-33d613cee146" />
<img width="540" height="960" alt="Screenshot_20260405-170844 1" src="https://github.com/user-attachments/assets/6924f568-cce2-4ad5-8fa3-3a37185ad294" />


## Checklist
- [Y] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [Y] I have attached a recording of the change.
- [Y] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unhid BCN emulation and related graphics options for Proton x86/x64 containers. These settings run in the Vulkan wrapper on Android (`WRAPPER_EMULATE_BCN`), so they work regardless of Wine architecture.

- **Bug Fixes**
  - Show BCN emulation, present modes, resource type, and sharpness (`vkBasalt`) controls for all Proton builds.
  - Removed the `arm64ec` gating that hid these controls; no runtime behavior changed.
  - Fixed indentation in GraphicsTab.kt.

<sup>Written for commit 6593b221cf360f75bb9465682a085e75d810785c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Graphics settings configuration now consistently provides access to presentation modes, resource types, texture optimization settings, and sharpness controls across all supported system configurations. This enhancement improves user control over graphics rendering and visual quality optimization, ensuring a more intuitive, flexible, and unified configuration experience regardless of underlying system specifications or hardware variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->