### PR TITLE
Revert "fix: fallback fps tracking for non-Vulkan games"

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1477,27 +1477,9 @@ fun XServerScreen(
                                 if (!container.isDisableMouseInput && !container.isTouchscreenMode) renderer?.setCursorVisible(true)
                                 xServerState.value.winStarted = true
                             }
-                            when {
-                                window.id == frameRatingWindowId -> {
-                                    (context as? Activity)?.runOnUiThread {
-                                        frameRating?.update()
-                                    }
-                                }
-                                frameRatingWindowId == -1 -> {
-                                    // Fallback for non-Vulkan games that never set candidate properties.
-                                    val rating = frameRating ?: return
-                                    val targetExe = extractExecutableBasename(container.executablePath)
-                                    if (windowMatchesExecutable(window, targetExe)) {
-                                        frameRatingWindowId = window.id
-                                        Timber.i(
-                                            "FrameRating fallback (non-Vulkan) tracking attached via first content update to %s",
-                                            describeFrameRatingWindow(window),
-                                        )
-                                        (context as? Activity)?.runOnUiThread {
-                                            rating.visibility = View.VISIBLE
-                                        }
-                                        rating.update()
-                                    }
+                            if (window.id == frameRatingWindowId) {
+                                (context as? Activity)?.runOnUiThread {
+                                    frameRating?.update()
                                 }
                             }
                         }


### PR DESCRIPTION
Reverts utkarshdalal/GameNative#1101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the fallback FPS tracking for non-Vulkan games to remove heuristic window matching that could incorrectly attach the HUD. Restores the original behavior: update `frameRating` only when `window.id` matches `frameRatingWindowId`.

<sup>Written for commit 32f505c273c1a63d144e46789677ae5a1de7899d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frame rating detection reliability by refining the window identification logic and removing problematic automatic fallback behavior.

* **Refactor**
  * Simplified frame rating update mechanism for better performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->