### PR TITLE
request best config for specific store

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -617,7 +617,11 @@ abstract class BaseAppScreen {
             val gameName = ContainerUtils.resolveGameName(libraryItem.appId)
             val gpuName = GPUInformation.getRenderer(context)
 
-            val bestConfig = BestConfigService.fetchBestConfig(gameName, gpuName)
+            val bestConfig = BestConfigService.fetchBestConfig(
+                gameName = gameName,
+                gpuName = gpuName,
+                gameStore = libraryItem.gameSource.name,
+            )
             if (bestConfig == null) {
                 SnackbarManager.show(context.getString(R.string.best_config_fetch_failed))
                 return

--- a/app/src/main/java/app/gamenative/utils/BestConfigService.kt
+++ b/app/src/main/java/app/gamenative/utils/BestConfigService.kt
@@ -72,9 +72,10 @@ object BestConfigService {
      */
     suspend fun fetchBestConfig(
         gameName: String,
-        gpuName: String
+        gpuName: String,
+        gameStore: String,
     ): BestConfigResponse? = withContext(Dispatchers.IO) {
-        val cacheKey = "${gameName}_${gpuName}"
+        val cacheKey = "${gameName}_${gpuName}_${gameStore}"
 
         // Check cache first
         cache[cacheKey]?.let {
@@ -86,6 +87,7 @@ object BestConfigService {
             val requestBody = JSONObject().apply {
                 put("gameName", gameName)
                 put("gpuName", gpuName)
+                put("game_store", gameStore)
             }
 
             val attestation = KeyAttestationHelper.getAttestationFields("https://api.gamenative.app")

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -762,7 +762,11 @@ object ContainerUtils {
                     // If not cached, make request on background thread (not UI thread)
                     runBlocking(Dispatchers.IO) {
                         try {
-                            val bestConfig = BestConfigService.fetchBestConfig(gameName, gpuName)
+                            val bestConfig = BestConfigService.fetchBestConfig(
+                                gameName = gameName,
+                                gpuName = gpuName,
+                                gameStore = gameSource.name,
+                            )
                             if (bestConfig != null && bestConfig.matchType != "no_match") {
                                 Timber.i("Applying best config for $gameName (matchType: ${bestConfig.matchType})")
                                 val parsedConfig = BestConfigService.parseConfigToContainerData(


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Best-config fetching is now store-aware to return settings for the correct store and avoid cross-store mismatches. This improves accuracy when the same game exists across multiple stores.

- **New Features**
  - Added `gameStore` to `BestConfigService.fetchBestConfig` and updated call sites in `BaseAppScreen` and `ContainerUtils`.
  - Included `game_store` in the API request body.
  - Updated cache key to include game name, GPU, and store to prevent collisions.

<sup>Written for commit 26532cbe778e23965033c7fafd34b86dd24f46db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Game configuration detection now properly accounts for the game's source or store when retrieving optimization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->