### PR TITLE
fix: Simplifies download status message handling

### DIFF
--- a/app/src/main/java/app/gamenative/data/DownloadInfo.kt
+++ b/app/src/main/java/app/gamenative/data/DownloadInfo.kt
@@ -3,8 +3,6 @@ package app.gamenative.data
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import timber.log.Timber
 import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
@@ -32,7 +30,7 @@ data class DownloadInfo(
     private var emaSpeedBytesPerSec: Double = 0.0
     private var hasEmaSpeed: Boolean = false
     private var isActive: Boolean = true
-    private val statusMessage = MutableStateFlow<String?>(null)
+    private var currentStatusMessage: String? = null
 
     fun cancel() {
         cancel("Cancelled by user")
@@ -135,10 +133,11 @@ data class DownloadInfo(
     }
 
     fun updateStatusMessage(message: String?) {
-        statusMessage.value = message
+        currentStatusMessage = message
+        emitProgressChange()
     }
 
-    fun getStatusMessageFlow(): StateFlow<String?> = statusMessage
+    fun getCurrentStatusMessage(): String? = currentStatusMessage
 
     private fun addSpeedSample(timestampMs: Long) {
         speedSamples.add(SpeedSample(timestampMs, bytesDownloaded))

--- a/app/src/main/java/app/gamenative/ui/model/DownloadsViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/DownloadsViewModel.kt
@@ -62,11 +62,9 @@ class DownloadsViewModel @Inject constructor(
     private data class ObservedDownload(
         val info: DownloadInfo,
         val progressListener: (Float) -> Unit,
-        val statusJob: Job,
     ) {
         fun dispose() {
             info.removeProgressListener(progressListener)
-            statusJob.cancel()
         }
     }
 
@@ -278,7 +276,7 @@ class DownloadsViewModel @Inject constructor(
     ): DownloadItemState {
         val key = downloadKey(gameSource, appId)
         val rawProgress = info.getProgress()
-        val statusMessage = normalizeStatusMessage(info.getStatusMessageFlow().value)
+        val statusMessage = normalizeStatusMessage(info.getCurrentStatusMessage())
         val status = when {
             rawProgress < 0f || statusMessage?.startsWith("Failed", ignoreCase = true) == true -> DownloadItemStatus.FAILED
             info.isActive() -> DownloadItemStatus.DOWNLOADING
@@ -407,16 +405,9 @@ class DownloadsViewModel @Inject constructor(
             }
             binding.info.addProgressListener(progressListener)
 
-            val statusJob = viewModelScope.launch(Dispatchers.Default) {
-                binding.info.getStatusMessageFlow().collect {
-                    updateObservedDownloadItem(binding)
-                }
-            }
-
             observedDownloads[key] = ObservedDownload(
                 info = binding.info,
                 progressListener = progressListener,
-                statusJob = statusJob,
             )
         }
     }

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -91,6 +92,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewModelScope
 import app.gamenative.NetworkMonitor
 import app.gamenative.PrefManager
 import app.gamenative.R
@@ -113,6 +115,7 @@ import app.gamenative.ui.screen.library.components.GameOptionsPanel
 import app.gamenative.ui.theme.PluviaTheme
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.coil.CoilImage
+import kotlinx.coroutines.Dispatchers
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -521,12 +524,44 @@ internal fun AppScreenContent(
     // Calculate parallax offset based on scroll
     val parallaxOffset = scrollState.value * 0.5f
 
+    var downloadTimeLeftText by remember { mutableStateOf<String?>(null)}
+
+    val progressListener: (Float) -> Unit = {
+        val downloadStatusMessage = downloadInfo?.getCurrentStatusMessage()
+
+        downloadTimeLeftText = run {
+            val etaMs = downloadInfo?.getEstimatedTimeRemaining()
+            if (etaMs != null && etaMs > 0L) {
+                val totalSeconds = etaMs / 1000
+                val minutesLeft = totalSeconds / 60
+                val secondsPart = totalSeconds % 60
+                "${minutesLeft}m ${secondsPart}s left"
+            } else if (isDownloading && downloadProgress >= 1f) {
+                "Unpacking..."
+            } else if (downloadProgress in 0f..1f && downloadProgress < 1f) {
+                downloadStatusMessage?.takeUnless { it.isBlank() } ?: ""
+            } else {
+                ""
+            }
+        }
+    }
+
     LaunchedEffect(displayInfo.appId) {
         scrollState.animateScrollTo(0)
     }
 
     LaunchedEffect(Unit) {
         playButtonFocusRequester.requestFocus()
+    }
+
+    LaunchedEffect(downloadInfo) {
+        downloadInfo?.addProgressListener(progressListener)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            downloadInfo?.removeProgressListener(progressListener)
+        }
     }
 
     // Button state calculations (needed by key event handler)
@@ -552,28 +587,7 @@ internal fun AppScreenContent(
         }
     }
 
-    // Download progress texts hoisted here so they can be shown inside the button
-    val downloadStatusMessageFlow = remember(downloadInfo) { downloadInfo?.getStatusMessageFlow() }
-    val downloadStatusMessage by (
-        downloadStatusMessageFlow?.collectAsState(initial = downloadStatusMessageFlow.value)
-            ?: remember { mutableStateOf<String?>(null) }
-        )
     val downloadingLabel = stringResource(R.string.downloading)
-    val downloadTimeLeftText = remember(displayInfo.appId, downloadProgress, downloadInfo, isDownloading, downloadStatusMessage) {
-        val etaMs = downloadInfo?.getEstimatedTimeRemaining()
-        if (etaMs != null && etaMs > 0L) {
-            val totalSeconds = etaMs / 1000
-            val minutesLeft = totalSeconds / 60
-            val secondsPart = totalSeconds % 60
-            "${minutesLeft}m ${secondsPart}s left"
-        } else if (isDownloading && downloadProgress >= 1f) {
-            "Unpacking..."
-        } else if (downloadProgress in 0f..1f && downloadProgress < 1f) {
-            downloadStatusMessage?.takeUnless { it.isBlank() } ?: ""
-        } else {
-            ""
-        }
-    }
     val downloadSizeText = remember(displayInfo.gameId, downloadProgress, downloadInfo) {
         val (bytesDone, bytesTotal) = downloadInfo?.getBytesProgress() ?: (0L to 0L)
         if (bytesTotal > 0L) {
@@ -848,9 +862,9 @@ internal fun AppScreenContent(
                                         overflow = TextOverflow.Ellipsis,
                                     )
                                 }
-                                if (downloadTimeLeftText.isNotEmpty()) {
+                                if (downloadTimeLeftText != null) {
                                     Text(
-                                        text = downloadTimeLeftText,
+                                        text = downloadTimeLeftText!!,
                                         style = MaterialTheme.typography.labelSmall,
                                         color = Color.White.copy(alpha = 0.65f),
                                         maxLines = 1,
@@ -894,9 +908,9 @@ internal fun AppScreenContent(
                                     maxLines = 1,
                                 )
                             }
-                            if (downloadTimeLeftText.isNotEmpty()) {
+                            if (downloadTimeLeftText != null) {
                                 Text(
-                                    text = downloadTimeLeftText,
+                                    text = downloadTimeLeftText!!,
                                     style = MaterialTheme.typography.labelSmall,
                                     color = Color.White.copy(alpha = 0.65f),
                                     maxLines = 1,


### PR DESCRIPTION
Removes the `StateFlow` for download status messages within `DownloadInfo`, simplifying its internal state management.

Updates `DownloadsViewModel` to directly access the current status message, removing the need for dedicated `Flow` collection and associated coroutine job management for status.

Refactors `LibraryAppScreen` to update download time-related texts and status messages via the existing progress listener. This consolidates status message propagation with progress updates, ensuring timely UI reflection and reducing complexity in reactive data handling for download information.

## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies download status handling by replacing the `StateFlow` in `DownloadInfo` with a simple field and emitting progress on status changes. Status/ETA now update via the existing progress listener for snappier library UI and fewer coroutines.

- **Refactors**
  - `DownloadInfo`: swap `MutableStateFlow` for `currentStatusMessage`; call `emitProgressChange()` on updates; add `getCurrentStatusMessage()`.
  - `DownloadsViewModel`: stop collecting a status `Flow`; read `getCurrentStatusMessage()`; remove the status job and simplify disposal.
  - `LibraryAppScreen`: compute ETA/status in a single progress listener; add/remove it with `LaunchedEffect`/`DisposableEffect`; render text only when non-null.

<sup>Written for commit 0f60a3c023abac853e6eff70a932eb79c33e7f44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified download status handling: status messages now come from a single current value and progress listeners instead of continuous background streams.
  * UI updates for downloads are now driven by progress events and refreshes, improving responsiveness.
  * ETA/“time left” display refined (shows “Unpacking…” when appropriate) and null-safe rendering for status/ETA text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->