### PR TITLE
refactor: GLRenderer compatible with XrRenderer

### DIFF
--- a/app/src/main/java/com/winlator/renderer/EffectComposer.java
+++ b/app/src/main/java/com/winlator/renderer/EffectComposer.java
@@ -62,7 +62,7 @@ public class EffectComposer {
         int width = renderer.getSurfaceWidth();
         int height = renderer.getSurfaceHeight();
         if (effects.isEmpty() || width <= 0 || height <= 0) {
-            renderer.drawScene();
+            renderer.drawFrame();
             return;
         }
 
@@ -70,7 +70,7 @@ public class EffectComposer {
         writeBuffer.allocateFramebuffer(width, height);
 
         GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, readBuffer.getFramebuffer());
-        renderer.drawScene();
+        renderer.drawFrame();
 
         ArrayList<Effect> snapshot = new ArrayList<>(effects);
         RenderTarget source = readBuffer;

--- a/app/src/main/java/com/winlator/renderer/GLRenderer.java
+++ b/app/src/main/java/com/winlator/renderer/GLRenderer.java
@@ -5,10 +5,11 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.opengl.GLES20;
 import android.opengl.GLSurfaceView;
+import android.os.SystemClock;
+import android.util.Pair;
 
-// import com.winlator.R;
-// import com.winlator.XrActivity;
 import app.gamenative.R;
+
 import com.winlator.math.Mathf;
 import com.winlator.math.XForm;
 import com.winlator.renderer.material.CursorMaterial;
@@ -32,28 +33,33 @@ import javax.microedition.khronos.opengles.GL10;
 
 public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindowModificationListener, Pointer.OnPointerMotionListener {
     public final XServerView xServerView;
-    private final XServer xServer;
-    private final VertexAttribute quadVertices = new VertexAttribute("position", 2);
+    protected final XServer xServer;
+    protected final VertexAttribute quadVertices = new VertexAttribute("position", 2);
     private final float[] tmpXForm1 = XForm.getInstance();
-    private final float[] tmpXForm2 = XForm.getInstance();
+    protected final float[] tmpXForm2 = XForm.getInstance();
     private final CursorMaterial cursorMaterial = new CursorMaterial();
     private final WindowMaterial windowMaterial = new WindowMaterial();
     public final ViewTransformation viewTransformation = new ViewTransformation();
     private final Drawable rootCursorDrawable;
-    private final ArrayList<RenderableWindow> renderableWindows = new ArrayList<>();
+    protected final ArrayList<RenderableWindow> renderableWindows = new ArrayList<>();
     private String forceFullscreenWMClass = null;
-    private boolean fullscreen = false;
+    protected boolean fullscreen = false;
     private boolean toggleFullscreen = false;
     private boolean viewportNeedsUpdate = true;
     private boolean cursorVisible = true;
+    private boolean rootWindowDownsized = false;
     private boolean screenOffsetYRelativeToCursor = false;
     private String[] unviewableWMClasses = null;
-    private float magnifierZoom = 1.0f;
-    private boolean magnifierEnabled = true;
+    protected float magnifierZoom = 1.0f;
+    protected boolean magnifierEnabled = true;
     private int surfaceWidth;
     private int surfaceHeight;
     private boolean sceneInitialized = false;
     private final EffectComposer effectComposer;
+
+    private float lastFPS = 0;
+    private long lastTime = 0;
+    private int frameCount = 0;
 
     public GLRenderer(XServerView xServerView, XServer xServer) {
         this.xServerView = xServerView;
@@ -102,15 +108,6 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
 
     @Override
     public void onSurfaceChanged(GL10 gl, int width, int height) {
-        // if (XrActivity.isSupported()) {
-        //     XrActivity activity = XrActivity.getInstance();
-        //     activity.init();
-        //     width = activity.getWidth();
-        //     height = activity.getHeight();
-        //     GLES20.glViewport(0, 0, width, height);
-        //     magnifierEnabled = false;
-        // }
-
         surfaceWidth = width;
         surfaceHeight = height;
         viewTransformation.update(width, height, xServer.screenInfo.width, xServer.screenInfo.height);
@@ -119,24 +116,61 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
 
     @Override
     public void onDrawFrame(GL10 gl) {
+        preFrame();
+        if (effectComposer.hasEffects()) {
+            effectComposer.render();
+        }
+        else {
+            drawFrame();
+        }
+        postFrame();
+    }
+
+    protected void preFrame() {
         if (toggleFullscreen) {
             fullscreen = !fullscreen;
             toggleFullscreen = false;
             viewportNeedsUpdate = true;
         }
-
-        if (effectComposer.hasEffects()) {
-            effectComposer.render();
-        }
-        else {
-            drawScene();
-        }
     }
 
-    void drawScene() {
-        boolean xrFrame = false;
-        // if (XrActivity.isSupported()) xrFrame = XrActivity.getInstance().beginFrame(XrActivity.getImmersive(), XrActivity.getSBS());
+    protected void postFrame() {}
 
+    protected boolean preDrawable(ShaderMaterial material, Drawable drawable) { return true; }
+
+    protected Pair<Float, Float> preTransform() {
+        float pointerX = 0;
+        float pointerY = 0;
+
+        if (magnifierZoom != 1.0f) {
+            pointerX = Mathf.clamp(xServer.pointer.getX() * magnifierZoom - xServer.screenInfo.width * 0.5f, 0, xServer.screenInfo.width * Math.abs(1.0f - magnifierZoom));
+        }
+
+        if (screenOffsetYRelativeToCursor || magnifierZoom != 1.0f) {
+            float scaleY = magnifierZoom != 1.0f ? Math.abs(1.0f - magnifierZoom) : 0.5f;
+            float offsetY = xServer.screenInfo.height * (screenOffsetYRelativeToCursor ? 0.25f : 0.5f);
+            pointerY = Mathf.clamp(xServer.pointer.getY() * magnifierZoom - offsetY, 0, xServer.screenInfo.height * scaleY);
+        }
+
+        return new Pair<>(pointerX, pointerY);
+    }
+
+    protected void preWindows() {}
+
+    protected void postWindows() {}
+
+    protected float getLastFPS() {
+        if (lastTime == 0) lastTime = SystemClock.elapsedRealtime();
+        long time = SystemClock.elapsedRealtime();
+        if (time >= lastTime + 500) {
+            lastFPS = ((float)(frameCount * 1000) / (time - lastTime));
+            lastTime = time;
+            frameCount = 0;
+        }
+        return lastFPS;
+    }
+
+    public void drawFrame() {
         if (viewportNeedsUpdate && magnifierEnabled) {
             if (fullscreen) {
                 GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight);
@@ -148,21 +182,10 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
         GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
 
         if (magnifierEnabled) {
-            float pointerX = 0;
-            float pointerY = 0;
             float magnifierZoom = !screenOffsetYRelativeToCursor ? this.magnifierZoom : 1.0f;
 
-            if (magnifierZoom != 1.0f) {
-                pointerX = Mathf.clamp(xServer.pointer.getX() * magnifierZoom - xServer.screenInfo.width * 0.5f, 0, xServer.screenInfo.width * Math.abs(1.0f - magnifierZoom));
-            }
-
-            if (screenOffsetYRelativeToCursor || magnifierZoom != 1.0f) {
-                float scaleY = magnifierZoom != 1.0f ? Math.abs(1.0f - magnifierZoom) : 0.5f;
-                float offsetY = xServer.screenInfo.height * (screenOffsetYRelativeToCursor ? 0.25f : 0.5f);
-                pointerY = Mathf.clamp(xServer.pointer.getY() * magnifierZoom - offsetY, 0, xServer.screenInfo.height * scaleY);
-            }
-
-            XForm.makeTransform(tmpXForm2, -pointerX, -pointerY, magnifierZoom, magnifierZoom, 0);
+            Pair<Float, Float> offset = preTransform();
+            XForm.makeTransform(tmpXForm2, -offset.first, -offset.second, magnifierZoom, magnifierZoom, 0);
         }
         else {
             if (!fullscreen) {
@@ -180,16 +203,11 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
             else XForm.identity(tmpXForm2);
         }
 
-        renderWindows();
-        if (cursorVisible) renderCursor();
+        renderWindows(windowMaterial, false);
+
+        if (cursorVisible && !rootWindowDownsized) renderCursor();
 
         if (!magnifierEnabled && !fullscreen) GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
-
-        if (xrFrame) {
-            // XrActivity.getInstance().endFrame();
-            // XrActivity.updateControllers();
-            xServerView.requestRender();
-        }
     }
 
     @Override
@@ -213,6 +231,7 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
     @Override
     public void onUpdateWindowContent(Window window) {
         xServerView.requestRender();
+        frameCount++;
     }
 
     @Override
@@ -235,42 +254,65 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
     }
 
     private void renderDrawable(Drawable drawable, int x, int y, ShaderMaterial material) {
-        renderDrawable(drawable, x, y, material, false);
+        renderDrawable(drawable, x, y, material, false, 1, 1);
     }
 
     private void renderDrawable(Drawable drawable, int x, int y, ShaderMaterial material, boolean forceFullscreen) {
-        if (drawable == null) return;
-        synchronized (drawable.renderLock) {
-            Texture texture = drawable.getTexture();
-            texture.updateFromDrawable(drawable);
+        renderDrawable(drawable, x, y, material, forceFullscreen, 1, 1);
+    }
 
+    protected void renderDrawable(Drawable drawable, int x, int y, ShaderMaterial material, boolean forceFullscreen, float sx, float sy) {
+        synchronized (drawable.renderLock) {
             if (forceFullscreen) {
                 short newHeight = (short)Math.min(xServer.screenInfo.height, ((float)xServer.screenInfo.width / drawable.width) * drawable.height);
                 short newWidth = (short)(((float)newHeight / drawable.height) * drawable.width);
                 XForm.set(tmpXForm1, (xServer.screenInfo.width - newWidth) * 0.5f, (xServer.screenInfo.height - newHeight) * 0.5f, newWidth, newHeight);
             }
-            else XForm.set(tmpXForm1, x, y, drawable.width, drawable.height);
-
+            else XForm.set(tmpXForm1, x, y, drawable.width * sx, drawable.height * sy);
             XForm.multiply(tmpXForm1, tmpXForm1, tmpXForm2);
+            if (!preDrawable(material, drawable)) return;
 
-            GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
-            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texture.getTextureId());
-            GLES20.glUniform1i(material.getUniformLocation("texture"), 0);
-            GLES20.glUniform1fv(material.getUniformLocation("xform"), tmpXForm1.length, tmpXForm1, 0);
-            GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, quadVertices.count());
-            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
+            Texture texture = drawable.getTexture();
+            texture.updateFromDrawable(drawable);
+            renderTexture(texture, material);
         }
     }
 
-    private void renderWindows() {
-        windowMaterial.use();
-        GLES20.glUniform2f(windowMaterial.getUniformLocation("viewSize"), xServer.screenInfo.width, xServer.screenInfo.height);
-        quadVertices.bind(windowMaterial.programId);
+    protected void renderTexture(Texture texture, ShaderMaterial material) {
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texture.getTextureId());
+        GLES20.glUniform1i(material.getUniformLocation("texture"), 0);
+        GLES20.glUniform1fv(material.getUniformLocation("xform"), tmpXForm1.length, tmpXForm1, 0);
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, quadVertices.count());
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
+    }
 
+    protected void renderWindows(ShaderMaterial material, boolean forceFullscreen) {
+        material.use();
+        GLES20.glUniform2f(material.getUniformLocation("viewSize"), xServer.screenInfo.width, xServer.screenInfo.height);
+        quadVertices.bind(material.programId);
+
+        boolean singleWindow = forceFullscreen;
         try (XLock lock = xServer.lock(XServer.Lockable.DRAWABLE_MANAGER)) {
-            for (RenderableWindow window : renderableWindows) {
-                renderDrawable(window.content, window.rootX, window.rootY, windowMaterial, window.forceFullscreen);
+            rootWindowDownsized = false;
+            if (fullscreen && !renderableWindows.isEmpty()) {
+                RenderableWindow root = renderableWindows.get(0);
+                if ((root.content.width < xServer.screenInfo.width) || (root.content.height < xServer.screenInfo.height)) {
+                    rootWindowDownsized = true;
+                    singleWindow = true;
+                }
             }
+
+            preWindows();
+            if (singleWindow && !renderableWindows.isEmpty()) {
+                RenderableWindow window = renderableWindows.get(renderableWindows.size() - 1);
+                renderDrawable(window.content, window.rootX, window.rootY, material, true);
+            } else {
+                for (RenderableWindow window : renderableWindows) {
+                    renderDrawable(window.content, window.rootX, window.rootY, material, window.forceFullscreen);
+                }
+            }
+            postWindows();
         }
 
         quadVertices.disable();

--- a/app/src/main/java/com/winlator/renderer/GLRenderer.java
+++ b/app/src/main/java/com/winlator/renderer/GLRenderer.java
@@ -262,6 +262,7 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
     }
 
     protected void renderDrawable(Drawable drawable, int x, int y, ShaderMaterial material, boolean forceFullscreen, float sx, float sy) {
+        if (drawable == null) return;
         synchronized (drawable.renderLock) {
             if (forceFullscreen) {
                 short newHeight = (short)Math.min(xServer.screenInfo.height, ((float)xServer.screenInfo.width / drawable.width) * drawable.height);

--- a/app/src/main/java/com/winlator/renderer/RenderableWindow.java
+++ b/app/src/main/java/com/winlator/renderer/RenderableWindow.java
@@ -2,7 +2,7 @@ package com.winlator.renderer;
 
 import com.winlator.xserver.Drawable;
 
-class RenderableWindow {
+public class RenderableWindow {
     final Drawable content;
     short rootX;
     short rootY;
@@ -17,5 +17,21 @@ class RenderableWindow {
         this.rootX = (short)rootX;
         this.rootY = (short)rootY;
         this.forceFullscreen = forceFullscreen;
+    }
+
+    public short getRootX() {
+        return rootX;
+    }
+
+    public short getRootY() {
+        return rootY;
+    }
+
+    public short getWidth() {
+        return content.width;
+    }
+
+    public short getHeight() {
+        return content.height;
     }
 }

--- a/app/src/main/java/com/winlator/renderer/Texture.java
+++ b/app/src/main/java/com/winlator/renderer/Texture.java
@@ -3,7 +3,6 @@ package com.winlator.renderer;
 import android.opengl.GLES11Ext;
 import android.opengl.GLES20;
 
-// import com.winlator.XrActivity;
 import com.winlator.xserver.Drawable;
 
 import java.nio.ByteBuffer;
@@ -49,19 +48,22 @@ public class Texture {
         this.needsUpdate = needsUpdate;
     }
 
-    public void updateFromDrawable(Drawable drawable) {
-        ByteBuffer data = drawable.getData();
+    public void updateFromBuffer(ByteBuffer data, short width, short height) {
         if (data == null) return;
 
         if (!isAllocated()) {
-            allocateTexture(drawable.width, drawable.height, data);
+            allocateTexture(width, height, data);
         }
         else if (needsUpdate) {
             GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId);
-            GLES20.glTexSubImage2D(GLES20.GL_TEXTURE_2D, 0, 0, 0, drawable.width, drawable.height, format, GLES20.GL_UNSIGNED_BYTE, data);
+            GLES20.glTexSubImage2D(GLES20.GL_TEXTURE_2D, 0, 0, 0, width, height, format, GLES20.GL_UNSIGNED_BYTE, data);
             GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
             needsUpdate = false;
         }
+    }
+
+    public void updateFromDrawable(Drawable drawable) {
+        updateFromBuffer(drawable.getData(), drawable.width, drawable.height);
     }
 
     public boolean isAllocated() {

--- a/app/src/main/java/com/winlator/renderer/material/BGRMaterial.java
+++ b/app/src/main/java/com/winlator/renderer/material/BGRMaterial.java
@@ -1,0 +1,37 @@
+package com.winlator.renderer.material;
+
+public class BGRMaterial extends ShaderMaterial {
+    public BGRMaterial() {
+        setUniformNames("xform", "viewSize", "texture");
+    }
+
+    @Override
+    protected String getVertexShader() {
+        return
+            "uniform float xform[6];\n" +
+            "uniform vec2 viewSize;\n" +
+            "attribute vec2 position;\n" +
+            "varying vec2 vUV;\n" +
+
+            "void main() {\n" +
+                "vUV = position;\n" +
+                "vec2 transformedPos = applyXForm(position, xform);\n" +
+                "gl_Position = vec4(2.0 * transformedPos.x / viewSize.x - 1.0, 1.0 - 2.0 * transformedPos.y / viewSize.y, 0.0, 1.0);\n" +
+            "}"
+        ;
+    }
+
+    @Override
+    protected String getFragmentShader() {
+        return
+            "precision mediump float;\n" +
+
+            "uniform sampler2D texture;\n" +
+            "varying vec2 vUV;\n" +
+
+            "void main() {\n" +
+                "gl_FragColor = texture2D(texture, vUV).bgra;\n" +
+            "}"
+        ;
+    }
+}

--- a/app/src/main/java/com/winlator/xserver/Drawable.java
+++ b/app/src/main/java/com/winlator/xserver/Drawable.java
@@ -207,6 +207,9 @@ public class Drawable extends XResource {
     }
 
     public void drawBitmap(Bitmap bitmap) {
+        if (this.data == null) {
+            return;
+        }
         fromBitmap(bitmap, data);
         texture.setNeedsUpdate(true);
         if (onDrawListener != null) onDrawListener.run();

--- a/app/src/main/java/com/winlator/xserver/Drawable.java
+++ b/app/src/main/java/com/winlator/xserver/Drawable.java
@@ -82,7 +82,7 @@ public class Drawable extends XResource {
         this.data = data;
     }
 
-    private short getStride() {
+    public short getStride() {
         return texture instanceof GPUImage ? ((GPUImage)texture).getStride() : width;
     }
 
@@ -204,6 +204,12 @@ public class Drawable extends XResource {
 
         this.data.rewind();
         forceUpdate();
+    }
+
+    public void drawBitmap(Bitmap bitmap) {
+        fromBitmap(bitmap, data);
+        texture.setNeedsUpdate(true);
+        if (onDrawListener != null) onDrawListener.run();
     }
 
     public void drawAlphaMaskedBitmap(byte foreRed, byte foreGreen, byte foreBlue, byte backRed, byte backGreen, byte backBlue, Drawable srcDrawable, Drawable maskDrawable) {

--- a/app/src/main/java/com/winlator/xserver/Pointer.java
+++ b/app/src/main/java/com/winlator/xserver/Pointer.java
@@ -102,7 +102,7 @@ public class Pointer {
         }
     }
 
-    private void triggerOnPointerMove(short x, short y) {
+    public void triggerOnPointerMove(short x, short y) {
         for (int i = onPointerMotionListeners.size()-1; i >= 0; i--) {
             onPointerMotionListeners.get(i).onPointerMove(x, y);
         }


### PR DESCRIPTION
## Description
This is a dependency to support OpenXR integration (3D stereoscopy, VR controllers support and much better performance on headsets like Meta Quest or Pico 4 Ultra). No functionality was changed for existing flow. The renderer was refactored to be able to access its parts from outside.

## Recording
https://github.com/user-attachments/assets/e7bdae62-b7e1-4039-9be7-22f00fa5fa02
Performance test by @GmoLargey of the XR integration prototype.


## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the GL renderer to be XR-ready and subclassable, introducing a modular `drawFrame` pipeline with overridable hooks. 2D rendering behavior remains unchanged.

- **Refactors**
  - Pipeline: replaced `drawScene` with `drawFrame`; added hooks (`preFrame`, `postFrame`, `preTransform`, `preWindows`, `postWindows`, `preDrawable`); exposed key fields as protected; extracted `renderTexture`; `renderWindows` takes a material and fullscreen flag; `renderDrawable` supports scaling; added `BGRMaterial` for BGRA sampling.
  - Window behavior: supports single-window fullscreen when the root window is smaller; cursor is skipped in that mode; `EffectComposer` now calls `drawFrame`.
  - API: added `Texture.updateFromBuffer`; made `RenderableWindow` public with getters; made `Drawable.getStride` public and added `Drawable.drawBitmap`; made `Pointer.triggerOnPointerMove` public; added lightweight FPS tracking via `getLastFPS`.

<sup>Written for commit 116ac49940e91d65d77ed2039ae1aadf7495e9f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BGR color rendering support.
  * Exposed manual frame-rendering entrypoint and public window position/size accessors.
  * Direct bitmap upload to drawable textures.
  * Lightweight FPS reporting.

* **Improvements**
  * More extensible rendering pipeline with pre/post hooks and transform scaling for non‑fullscreen content.
  * Smarter fullscreen/root-window handling; improved magnifier and pointer offset behavior.
  * More flexible and efficient texture update API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->