### PR TITLE
fix: reduce GC pressure in CaseInsensitiveFileSystem

### DIFF
--- a/app/src/main/java/app/gamenative/utils/CaseInsensitiveFileSystem.kt
+++ b/app/src/main/java/app/gamenative/utils/CaseInsensitiveFileSystem.kt
@@ -11,40 +11,47 @@ import java.util.concurrent.ConcurrentHashMap
  * when Steam depot manifests use different casing than what's already installed
  * (e.g. DLC referencing `_Work` when the base game created `_work`).
  *
- * Resolved segments are cached for the lifetime of this instance (one download
- * session) so repeated lookups for the same parent+segment are O(1).
+ * Two-level cache: full-path results are cached so repeat operations on the same
+ * path (common during chunk writes) skip per-segment resolution entirely.
+ * Per-segment results are cached in a nested map so different paths sharing a
+ * common prefix reuse earlier resolution work without allocating keys.
  */
 class CaseInsensitiveFileSystem(
     delegate: FileSystem = SYSTEM,
 ) : ForwardingFileSystem(delegate) {
 
-    // (parent, lowercased segment) → resolved child path.
-    // keyed by lowercase so all casing variants ("Saves", "saves", "SAVES") hit
-    // the same entry. computeIfAbsent is atomic on ConcurrentHashMap, so
-    // concurrent threads won't race to create duplicate directories.
-    private val cache = ConcurrentHashMap<Pair<Path, String>, Path>()
+    // full path → resolved path. most calls hit this and return immediately.
+    private val pathCache = ConcurrentHashMap<Path, Path>()
+
+    // parent → (lowercase segment → resolved child path).
+    // nested map avoids key concatenation/Pair allocation on every lookup.
+    private val segmentCache = ConcurrentHashMap<Path, ConcurrentHashMap<String, Path>>()
+
+    // segment string → its lowercase form. game paths reuse a small vocabulary
+    // of directory names, so this prevents repeated lowercase() allocation.
+    private val lowercasePool = ConcurrentHashMap<String, String>()
 
     override fun onPathParameter(path: Path, functionName: String, parameterName: String): Path {
+        pathCache[path]?.let { return it }
+
         val root = path.root ?: return path
         var resolved = root
         for (segment in path.segments) {
-            val key = resolved to segment.lowercase()
-            resolved = cache.computeIfAbsent(key) {
-                // fast path: exact casing exists
-                val exact = resolved / segment
+            val lower = lowercasePool.computeIfAbsent(segment) { it.lowercase() }
+            val parent = resolved
+            val children = segmentCache.computeIfAbsent(parent) { ConcurrentHashMap() }
+            resolved = children.computeIfAbsent(lower) {
+                val exact = parent / segment
                 if (delegate.metadataOrNull(exact) != null) {
                     exact
                 } else {
-                    // slow path: list parent and match case-insensitively.
-                    // if multiple entries match (e.g. leftover _Work + _work from a
-                    // prior bug), the first one returned by the filesystem wins —
-                    // non-deterministic but unavoidable without deeper heuristics.
-                    delegate.listOrNull(resolved)
+                    delegate.listOrNull(parent)
                         ?.firstOrNull { it.name.equals(segment, ignoreCase = true) }
                         ?: exact
                 }
             }
         }
+        pathCache[path] = resolved
         return resolved
     }
 }


### PR DESCRIPTION
Closes #1119

## Description
<!-- What changed and why? -->
`CaseInsensitiveFileSystem.onPathParameter()` allocated a `Pair` key and a fresh `lowercase()` string on every call. During large downloads with thousands of depot files this generated enough short-lived garbage to trigger `WaitForGcToComplete blocked Alloc` GC stalls.

Replace with a three-level caching strategy:
- **Full-path cache** — repeat operations on the same path (chunk writes) skip per-segment resolution entirely
- **Nested segment cache** (`parent → lowercase segment → child`) — avoids `Pair` allocation while still reusing prefix resolution across different paths
- **Lowercase string pool** — game paths reuse a small vocabulary of directory names; pool prevents repeated `lowercase()` allocation

## Recording
n/a — backend change, no visible UI change

## Test plan
- Download a large game (many depot files) and monitor `adb logcat` for `WaitForGcToComplete` / `GC freed` events
- Verify `dumpsys meminfo` shows Dalvik heap staying well under capacity during download
- Confirm files are written with correct casing (case-insensitive resolution still works)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have NOT attached a recording of the change (but it's backend).
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce GC pressure in the case-insensitive filesystem to prevent WaitForGcToComplete stalls during large downloads. Improves stability during large depot writes.

- **Refactors**
  - Added a full-path cache to skip per-segment resolution on repeat calls.
  - Replaced `(parent, lowercase segment)` Pair keys with nested caches: parent → lowercase segment → child.
  - Introduced a lowercase string pool to avoid repeated `lowercase()` allocations while preserving case-insensitive resolution.

<sup>Written for commit 5e144a0541cf22ec4667cb2f5413a5dbea532722. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced performance of file system operations through internal optimization of path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->