### PR TITLE
fix: Added additional directory for xna msi

### DIFF
--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/XnaFrameworkStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/XnaFrameworkStep.kt
@@ -26,9 +26,12 @@ object XnaFrameworkStep : PreInstallStep {
     ): String? {
         val searchDirs = listOf(
             File(gameDirPath, "_CommonRedist/xnafx"),
+            File(gameDirPath, "_CommonRedist/XNA_40"),
             File(gameDirPath, "redist"),
             File(gameDirPath, "Redist"),
-        ).filter { it.exists() && it.isDirectory }
+        )
+            .filter { it.exists() && it.isDirectory }
+            .distinctBy { it.absolutePath.lowercase() } // Avoid duplicate directories
 
         if (searchDirs.isEmpty()) {
             Timber.tag("XnaFrameworkStep").i("No XNA Framework search directories found for game at $gameDirPath")


### PR DESCRIPTION
## Description
Auto installs a new xna msi.

## Recording
just check here: https://discord.com/channels/1378308569287622737/1489996209257971894

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for auto-installing the XNA Framework when the MSI is under `_CommonRedist/XNA_40`. Also de-duplicates search directories (case-insensitive) to avoid redundant scans, e.g., `redist` vs `Redist`.

<sup>Written for commit 7b8c91c84d137bd48dbcc5151d5fc6c5ce21b8ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of XNA Framework installers by adding an additional candidate location to the search and avoiding repeated directory scans caused by path casing differences, increasing the chance installers are found.
  * No changes to public APIs or exported interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->