### PR TITLE
fix: prevent carousel touch loss during pagination

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
@@ -86,6 +86,7 @@ private const val CAROUSEL_CARD_SIZE_MULTIPLIER = 1.22f
 private const val CAROUSEL_CARD_VERTICAL_OVERFLOW = 32f
 private const val CAROUSEL_BADGE_RESERVED_HEIGHT = 0f
 private const val CAROUSEL_MOUSE_WHEEL_SCROLL_MULTIPLIER = 72f
+private const val CAROUSEL_MOUSE_DRAG_SLOP_PX = 8f
 
 
 private fun Modifier.carouselMouseInput(listState: LazyListState): Modifier =
@@ -94,6 +95,7 @@ private fun Modifier.carouselMouseInput(listState: LazyListState): Modifier =
             awaitPointerEventScope {
                 var isDragging = false
                 var lastDragX = 0f
+                var pressedStartX: Float? = null
                 while (true) {
                     val event = awaitPointerEvent()
                     val mouseChange = event.changes.firstOrNull { it.type == PointerType.Mouse }
@@ -115,24 +117,33 @@ private fun Modifier.carouselMouseInput(listState: LazyListState): Modifier =
 
                         PointerEventType.Press -> {
                             if (mouseChange?.pressed == true) {
-                                lastDragX = mouseChange.position.x
-                                isDragging = true
+                                pressedStartX = mouseChange.position.x
+                                isDragging = false
                             }
                         }
 
                         PointerEventType.Move -> {
-                            if (isDragging && mouseChange != null) {
+                            if (mouseChange != null) {
                                 val currentX = mouseChange.position.x
-                                val delta = currentX - lastDragX
-                                lastDragX = currentX
-                                if (delta != 0f) {
-                                    listState.dispatchRawDelta(-delta)
+                                if (isDragging) {
+                                    val delta = currentX - lastDragX
+                                    lastDragX = currentX
+                                    if (delta != 0f) {
+                                        listState.dispatchRawDelta(-delta)
+                                    }
+                                } else {
+                                    val startX = pressedStartX
+                                    if (startX != null && abs(currentX - startX) > CAROUSEL_MOUSE_DRAG_SLOP_PX) {
+                                        isDragging = true
+                                        lastDragX = currentX
+                                    }
                                 }
                             }
                         }
 
                         PointerEventType.Release, PointerEventType.Exit -> {
                             isDragging = false
+                            pressedStartX = null
                         }
 
                         else -> Unit

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
@@ -2,9 +2,6 @@ package app.gamenative.ui.screen.library.components
 
 import android.view.KeyEvent
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.draggable
-import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
@@ -50,6 +47,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
@@ -94,8 +92,11 @@ private fun Modifier.carouselMouseInput(listState: LazyListState): Modifier =
     pointerInput(listState) {
         coroutineScope {
             awaitPointerEventScope {
+                var isDragging = false
+                var lastDragX = 0f
                 while (true) {
                     val event = awaitPointerEvent()
+                    val isMouseEvent = event.changes.any { it.type == PointerType.Mouse }
                     when (event.type) {
                         PointerEventType.Scroll -> {
                             val scrollDelta = event.changes.firstOrNull()?.scrollDelta
@@ -110,6 +111,28 @@ private fun Modifier.carouselMouseInput(listState: LazyListState): Modifier =
                                     }
                                 }
                             }
+                        }
+
+                        PointerEventType.Press -> {
+                            if (isMouseEvent) {
+                                lastDragX = event.changes.firstOrNull()?.position?.x ?: 0f
+                                isDragging = true
+                            }
+                        }
+
+                        PointerEventType.Move -> {
+                            if (isDragging && isMouseEvent) {
+                                val currentX = event.changes.firstOrNull()?.position?.x ?: lastDragX
+                                val delta = currentX - lastDragX
+                                lastDragX = currentX
+                                if (delta != 0f) {
+                                    launch { listState.dispatchRawDelta(-delta) }
+                                }
+                            }
+                        }
+
+                        PointerEventType.Release -> {
+                            isDragging = false
                         }
 
                         else -> Unit
@@ -330,19 +353,11 @@ internal fun LibraryCarouselPane(
                 if (state.appInfoList.isNotEmpty()) {
                     val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
 
-                    val mouseDragState = rememberDraggableState { delta ->
-                        listState.dispatchRawDelta(-delta)
-                    }
-
                     LazyRow(
                         state = listState,
                         modifier = Modifier
                             .fillMaxSize()
-                            .carouselMouseInput(listState)
-                            .draggable(
-                                state = mouseDragState,
-                                orientation = Orientation.Horizontal,
-                            ),
+                            .carouselMouseInput(listState),
                         flingBehavior = flingBehavior,
                         horizontalArrangement = Arrangement.spacedBy(carouselItemSpacing),
                         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
@@ -96,10 +96,10 @@ private fun Modifier.carouselMouseInput(listState: LazyListState): Modifier =
                 var lastDragX = 0f
                 while (true) {
                     val event = awaitPointerEvent()
-                    val isMouseEvent = event.changes.any { it.type == PointerType.Mouse }
+                    val mouseChange = event.changes.firstOrNull { it.type == PointerType.Mouse }
                     when (event.type) {
                         PointerEventType.Scroll -> {
-                            val scrollDelta = event.changes.firstOrNull()?.scrollDelta
+                            val scrollDelta = mouseChange?.scrollDelta
                             if (scrollDelta != null) {
                                 val dominantDelta =
                                     if (abs(scrollDelta.x) > abs(scrollDelta.y)) scrollDelta.x else scrollDelta.y
@@ -114,24 +114,24 @@ private fun Modifier.carouselMouseInput(listState: LazyListState): Modifier =
                         }
 
                         PointerEventType.Press -> {
-                            if (isMouseEvent) {
-                                lastDragX = event.changes.firstOrNull()?.position?.x ?: 0f
+                            if (mouseChange?.pressed == true) {
+                                lastDragX = mouseChange.position.x
                                 isDragging = true
                             }
                         }
 
                         PointerEventType.Move -> {
-                            if (isDragging && isMouseEvent) {
-                                val currentX = event.changes.firstOrNull()?.position?.x ?: lastDragX
+                            if (isDragging && mouseChange != null) {
+                                val currentX = mouseChange.position.x
                                 val delta = currentX - lastDragX
                                 lastDragX = currentX
                                 if (delta != 0f) {
-                                    launch { listState.dispatchRawDelta(-delta) }
+                                    listState.dispatchRawDelta(-delta)
                                 }
                             }
                         }
 
-                        PointerEventType.Release -> {
+                        PointerEventType.Release, PointerEventType.Exit -> {
                             isDragging = false
                         }
 


### PR DESCRIPTION
## Description

 when you scroll to the end and pagination fires (new items appended, triggering recomposition), the `draggable` modifier's drag session gets reset, dropping the in-flight touch gesture. 

Fix: Touch events now flow exclusively through `LazyRow`'s own native scrolling, which is stable across pagination recomps.

Discord report: https://discord.com/channels/1378308569287622737/1490021951224287443

## Recording
<!-- Attach a short recording/GIF showing the change -->


https://github.com/user-attachments/assets/05159d61-73f5-4a8a-be56-a581707e9ec0



## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved carousel mouse dragging: dragging now starts only after a small movement threshold, produces smoother horizontal scrolling, and correctly stops on release or exit; scroll-wheel scrolling behavior remains intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->