### PR TITLE
fix: Download support files for gen 2

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -261,6 +261,21 @@ class GOGDownloadManager @Inject constructor(
             }
             Timber.tag("GOG").d("Skipping ${beforeCount - gameFiles.size} existing file(s), downloading ${gameFiles.size}")
 
+            val beforeSupportCount = supportFiles.size
+            supportFiles = supportFiles.filter { file ->
+                val installRelativePath = getSupportInstallPath(file.path)
+                val outputFile = File(gameInstallDir, installRelativePath)
+                val expectedSize = file.chunks.sumOf { it.size }
+                !fileExistsWithCorrectSize(outputFile, expectedSize, file.md5)
+            }
+            val supportFilesForGameDirAssemble = supportFiles.map { file ->
+                val installRelativePath = getSupportInstallPath(file.path)
+                if (installRelativePath != file.path) file.copy(path = installRelativePath) else file
+            }
+            Timber.tag("GOG").d(
+                "Skipping ${beforeSupportCount - supportFiles.size} existing support file(s), downloading ${supportFiles.size}",
+            )
+
             // Calculate sizes separately for transparency
             val (baseGameFiles, _) = parser.separateSupportFiles(baseFiles)
             val baseGameSize = parser.calculateTotalSize(baseGameFiles)
@@ -285,15 +300,16 @@ class GOGDownloadManager @Inject constructor(
             )
 
             // Step 6: Calculate sizes and extract chunk hashes
-            val totalSize = parser.calculateTotalSize(gameFiles)
-            val chunkHashes = parser.extractChunkHashes(gameFiles)
+            val allDownloadFiles = gameFiles + supportFiles
+            val totalSize = parser.calculateTotalSize(allDownloadFiles)
+            val chunkHashes = parser.extractChunkHashes(allDownloadFiles)
 
             Timber.tag("GOG").d(
                 """
                 |Download stats:
                 |  Total compressed size: ${totalSize / 1_000_000.0} MB (${if (withDlcs) "including DLC" else "base game only"})
                 |  Unique chunks: ${chunkHashes.size}
-                |  Files: ${gameFiles.size}
+                |  Files: ${allDownloadFiles.size}
                 """.trimMargin(),
             )
 
@@ -308,7 +324,7 @@ class GOGDownloadManager @Inject constructor(
 
             Timber.tag("GOG").d("Mapping chunks to products. gameId parameter: $gameId, realGameId: $realGameId, manifest baseProductId: ${gameManifest.baseProductId}")
 
-            val filesToDownloadPaths = gameFiles.map { it.path }.toSet()
+            val filesToDownloadPaths = allDownloadFiles.map { it.path }.toSet()
             // Map each chunk to its product ID using depot info
             allFilesWithDepots.forEach { (file, depotProductId) ->
                 if (file.path !in filesToDownloadPaths) return@forEach
@@ -405,7 +421,8 @@ class GOGDownloadManager @Inject constructor(
             // Use installPath directly since it already includes the game-specific folder
             gameInstallDir.mkdirs()
 
-            val assembleResult = assembleFiles(gameFiles, chunkCacheDir, gameInstallDir, downloadInfo)
+            val filesToAssembleInGameDir = gameFiles + supportFilesForGameDirAssemble
+            val assembleResult = assembleFiles(filesToAssembleInGameDir, chunkCacheDir, gameInstallDir, downloadInfo)
             if (assembleResult.isFailure) {
                 MarkerUtils.removeMarker(installPath.absolutePath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
                 return@withContext assembleResult
@@ -1427,6 +1444,10 @@ class GOGDownloadManager @Inject constructor(
         val digest = MessageDigest.getInstance("MD5")
         digest.update(data)
         return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun getSupportInstallPath(path: String): String {
+        return if (path.startsWith("app/")) path.removePrefix("app/") else path
     }
 
     /**

--- a/app/src/test/java/app/gamenative/service/gog/GOGDownloadManagerTest.kt
+++ b/app/src/test/java/app/gamenative/service/gog/GOGDownloadManagerTest.kt
@@ -1,0 +1,274 @@
+package app.gamenative.service.gog
+
+import android.content.Context
+import app.gamenative.data.DownloadInfo
+import app.gamenative.data.GOGGame
+import app.gamenative.service.gog.api.BuildsResponse
+import app.gamenative.service.gog.api.Depot
+import app.gamenative.service.gog.api.DepotFile
+import app.gamenative.service.gog.api.DepotManifest
+import app.gamenative.service.gog.api.GOGApiClient
+import app.gamenative.service.gog.api.GOGBuild
+import app.gamenative.service.gog.api.GOGManifestMeta
+import app.gamenative.service.gog.api.GOGManifestParser
+import app.gamenative.service.gog.api.Product
+import app.gamenative.service.gog.api.SecureLinksResponse
+import app.gamenative.service.gog.api.V1DepotFile
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE, application = android.app.Application::class)
+class GOGDownloadManagerTest {
+    private lateinit var apiClient: GOGApiClient
+    private lateinit var parser: GOGManifestParser
+    private lateinit var gogManager: GOGManager
+    private lateinit var context: Context
+    private lateinit var manager: GOGDownloadManager
+
+    @Before
+    fun setUp() {
+        apiClient = mock()
+        parser = mock()
+        gogManager = mock()
+        context = mock()
+        manager = GOGDownloadManager(apiClient, parser, gogManager, context)
+    }
+
+    // ===== Gen 2 =====
+
+    @Test
+    fun gen2_download_includes_game_and_support_files() = runTest {
+        val gameId = "12345"
+        val installPath = Files.createTempDirectory("gog-gen2-install").toFile()
+        val downloadInfo = DownloadInfo(
+            jobCount = 1,
+            gameId = gameId.toInt(),
+            downloadingAppIds = CopyOnWriteArrayList(),
+        )
+
+        val selectedBuild = GOGBuild(
+            buildId = "build-1",
+            productId = gameId,
+            platform = "windows",
+            generation = 2,
+            versionName = "1.0.0",
+            branch = "master",
+            link = "https://manifest.test",
+            legacyBuildId = null,
+        )
+
+        val depot = Depot(
+            productId = gameId,
+            languages = listOf("en-US"),
+            manifest = "depot-manifest",
+            compressedSize = 0L,
+            size = 0L,
+            osBitness = emptyList(),
+        )
+
+        val gameFile = depotFile(path = "bin/game.exe", support = false)
+        val supportFile = depotFile(path = "app/support/vcredist.exe", support = true)
+
+        val manifest = GOGManifestMeta(
+            baseProductId = gameId,
+            installDirectory = "Game",
+            depots = listOf(depot),
+            dependencies = emptyList(),
+            products = listOf(Product(productId = gameId, name = "Game")),
+            productTimestamp = null,
+            scriptInterpreter = false,
+        )
+
+        whenever(gogManager.getGameFromDbById(gameId)).thenReturn(
+            GOGGame(id = gameId, title = "Test Game"),
+            GOGGame(id = gameId, title = "Test Game"),
+        )
+        whenever(gogManager.getAllGameIds()).thenReturn(setOf(gameId))
+        whenever(apiClient.getBuildsForGame(gameId, "windows", 2)).thenReturn(
+            Result.success(BuildsResponse(totalCount = 1, count = 1, items = listOf(selectedBuild))),
+        )
+        whenever(parser.selectBuild(any(), eq(2), eq("windows"))).thenReturn(selectedBuild)
+        whenever(apiClient.fetchManifest(selectedBuild.link)).thenReturn(Result.success(manifest))
+        whenever(parser.filterDepotsByLanguage(manifest, "english")).thenReturn(listOf(depot) to "en-US")
+        whenever(parser.filterDepotsByOwnership(listOf(depot), setOf(gameId))).thenReturn(listOf(depot))
+        whenever(apiClient.fetchDepotManifest(depot.manifest)).thenReturn(
+            Result.success(DepotManifest(files = listOf(gameFile, supportFile), directories = emptyList(), links = emptyList())),
+        )
+        whenever(parser.separateBaseDLC(listOf(gameFile, supportFile), gameId)).thenReturn(
+            listOf(gameFile, supportFile) to emptyList(),
+        )
+        whenever(parser.separateSupportFiles(listOf(gameFile, supportFile))).thenReturn(
+            listOf(gameFile) to listOf(supportFile),
+        )
+        whenever(parser.calculateTotalSize(any())).thenReturn(0L)
+        whenever(parser.extractChunkHashes(any())).thenReturn(emptyList())
+        whenever(parser.buildChunkUrlMapWithProducts(any(), any(), any())).thenReturn(emptyMap())
+
+        val result = manager.downloadGame(
+            gameId = gameId,
+            installPath = installPath,
+            downloadInfo = downloadInfo,
+            language = "english",
+            withDlcs = false,
+            supportDir = null,
+        )
+
+        assertTrue(result.isSuccess)
+
+        val extractedHashesCaptor = argumentCaptor<List<DepotFile>>()
+        verify(parser).extractChunkHashes(extractedHashesCaptor.capture())
+        val hashedPaths = extractedHashesCaptor.firstValue.map { it.path }
+        assertTrue(hashedPaths.contains("bin/game.exe"))
+        assertTrue(hashedPaths.contains("app/support/vcredist.exe"))
+
+        val totalSizeCaptor = argumentCaptor<List<DepotFile>>()
+        verify(parser, atLeastOnce()).calculateTotalSize(totalSizeCaptor.capture())
+        val capturedSizeInputs = totalSizeCaptor.allValues.map { files -> files.map { it.path } }
+        assertTrue(capturedSizeInputs.any { it.contains("bin/game.exe") && it.contains("app/support/vcredist.exe") })
+
+        assertTrue(File(installPath, "bin/game.exe").exists())
+        assertTrue(File(installPath, "support/vcredist.exe").exists())
+
+        installPath.deleteRecursively()
+    }
+
+    // ===== Gen 1 =====
+
+    @Test
+    fun gen1_download_includes_game_and_support_files() = runTest {
+        val gameId = "12345"
+        val installPath = Files.createTempDirectory("gog-gen1-install").toFile()
+        val supportDir = Files.createTempDirectory("gog-gen1-support").toFile()
+        val downloadInfo = DownloadInfo(
+            jobCount = 1,
+            gameId = gameId.toInt(),
+            downloadingAppIds = CopyOnWriteArrayList(),
+        )
+
+        val gen1Build = GOGBuild(
+            buildId = "legacy-build",
+            productId = gameId,
+            platform = "windows",
+            generation = 1,
+            versionName = "1.0.0",
+            branch = "master",
+            link = "https://manifest.test",
+            legacyBuildId = null,
+        )
+
+        val depot = Depot(
+            productId = gameId,
+            languages = listOf("en-US"),
+            manifest = "legacy-manifest",
+            compressedSize = 0L,
+            size = 0L,
+            osBitness = emptyList(),
+        )
+
+        val manifest = GOGManifestMeta(
+            baseProductId = gameId,
+            installDirectory = "Game",
+            depots = listOf(depot),
+            dependencies = emptyList(),
+            products = listOf(Product(productId = gameId, name = "Game")),
+            productTimestamp = "111111",
+            scriptInterpreter = false,
+        )
+
+        val gameV1File = V1DepotFile(
+            path = "bin/game.exe",
+            size = 0L,
+            hash = "",
+            url = null,
+            offset = null,
+            isSupport = false,
+        )
+        val supportV1File = V1DepotFile(
+            path = "__redist/vcredist.exe",
+            size = 0L,
+            hash = "",
+            url = null,
+            offset = null,
+            isSupport = true,
+        )
+
+        whenever(gogManager.getGameFromDbById(gameId)).thenReturn(
+            GOGGame(id = gameId, title = "Test Game"),
+            GOGGame(id = gameId, title = "Test Game"),
+        )
+        whenever(gogManager.getAllGameIds()).thenReturn(setOf(gameId))
+        whenever(apiClient.getBuildsForGame(gameId, "windows", 2)).thenReturn(
+            Result.success(BuildsResponse(totalCount = 0, count = 0, items = emptyList())),
+        )
+        whenever(apiClient.getBuildsForGame(gameId, "windows", 1)).thenReturn(
+            Result.success(BuildsResponse(totalCount = 1, count = 1, items = listOf(gen1Build))),
+        )
+        whenever(parser.selectBuild(any(), eq(2), eq("windows"))).thenReturn(null)
+        whenever(parser.selectBuild(any(), eq(1), eq("windows"))).thenReturn(gen1Build)
+        whenever(apiClient.fetchManifest(gen1Build.link)).thenReturn(Result.success(manifest))
+        whenever(parser.filterDepotsByLanguage(manifest, "english")).thenReturn(listOf(depot) to "en-US")
+        whenever(parser.filterDepotsByOwnership(listOf(depot), setOf(gameId))).thenReturn(listOf(depot))
+        whenever(
+            apiClient.getSecureLink(
+                productId = gameId,
+                path = "/windows/111111/",
+                generation = 1,
+            ),
+        ).thenReturn(Result.success(SecureLinksResponse(urls = listOf("https://cdn.example.com"))))
+        whenever(
+            apiClient.fetchDepotManifestV1(
+                productId = gameId,
+                platform = "windows",
+                timestamp = "111111",
+                manifestHash = "legacy-manifest",
+            ),
+        ).thenReturn(Result.success("{}"))
+        whenever(parser.parseV1DepotManifest("{}")).thenReturn(listOf(gameV1File, supportV1File))
+
+        val result = manager.downloadGame(
+            gameId = gameId,
+            installPath = installPath,
+            downloadInfo = downloadInfo,
+            language = "english",
+            withDlcs = false,
+            supportDir = supportDir,
+        )
+
+        assertTrue(result.isSuccess)
+        assertTrue(File(installPath, "bin/game.exe").exists())
+        assertTrue(File(supportDir, "__redist/vcredist.exe").exists())
+
+        installPath.deleteRecursively()
+        supportDir.deleteRecursively()
+    }
+
+    private fun depotFile(path: String, support: Boolean): DepotFile {
+        val flags = if (support) listOf("support") else emptyList()
+        return DepotFile(
+            path = path,
+            chunks = emptyList(),
+            md5 = null,
+            sha256 = null,
+            flags = flags,
+            productId = null,
+        )
+    }
+}


### PR DESCRIPTION
## Description
Download support files instead of only counting them.

## Recording
In the tread.
https://discord.com/channels/1378308569287622737/1488619279363477514

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable downloading and assembly of GOG support files for Gen 2 installs instead of only counting them. Support files now install into the game folder with correct paths and are included in download stats.

- **Bug Fixes**
  - Include support files in total size, unique chunk hashes, file count, and file-to-product mapping.
  - Skip existing support files by verifying size and optional MD5.
  - Normalize support install paths by stripping the `app/` prefix before assembly and assemble them into the game folder for Gen 2.

<sup>Written for commit 76b3a0aa52d6e513131026660642c2a529636f4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download manager to correctly include and assemble support/redistributable files with proper path normalization, skipping already-complete files and accurately accounting total sizes and progress.

* **Tests**
  * Added end-to-end tests verifying downloads include both primary game files and support files across product generations and installation layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->