### PR TITLE
fix: clear stale container state on task swipe and app restart

### DIFF
--- a/app/src/main/java/app/gamenative/MainActivity.kt
+++ b/app/src/main/java/app/gamenative/MainActivity.kt
@@ -144,6 +144,12 @@ class MainActivity : ComponentActivity() {
         )
         super.onCreate(savedInstanceState)
 
+        // stale keepAlive from a prior crash/swipe — no container is actually running
+        if (SteamService.keepAlive && PluviaApp.xEnvironment == null) {
+            Timber.w("onCreate: clearing stale keepAlive — no container running")
+            PluviaApp.shutdownEnvironment()
+        }
+
         // Apply immersive mode based on user preference
         applyImmersiveMode()
 
@@ -265,9 +271,20 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
+        // emit before super so Compose DisposableEffects (which unregister
+        // listeners during super.onDestroy's lifecycle transition) still fire
+        if (!isChangingConfigurations) {
+            PluviaApp.events.emit(AndroidEvent.ActivityDestroyed)
 
-        PluviaApp.events.emit(AndroidEvent.ActivityDestroyed)
+            // if exit() didn't run (listener already unregistered, race, etc.)
+            // force-clear so the app isn't stuck on next launch
+            if (SteamService.keepAlive) {
+                Timber.w("onDestroy: keepAlive still set after ActivityDestroyed — forcing cleanup")
+                PluviaApp.shutdownEnvironment()
+            }
+        }
+
+        super.onDestroy()
 
         PluviaApp.events.off<AndroidEvent.SetSystemUIVisibility, Unit>(onSetSystemUi)
         PluviaApp.events.off<AndroidEvent.StartOrientator, Unit>(onStartOrientator)

--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -10,6 +10,7 @@ import app.gamenative.db.dao.GOGGameDao
 import app.gamenative.events.AndroidEvent
 import app.gamenative.events.EventDispatcher
 import app.gamenative.service.DownloadService
+import app.gamenative.service.SteamService
 import app.gamenative.utils.ContainerMigrator
 import app.gamenative.utils.IntentLaunchManager
 import app.gamenative.utils.PlayIntegrity
@@ -28,13 +29,13 @@ import com.winlator.widget.InputControlsView
 import com.winlator.widget.TouchpadView
 import com.winlator.widget.XServerView
 import com.winlator.xenvironment.XEnvironment
+import timber.log.Timber
 import dagger.hilt.android.HiltAndroidApp
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 typealias NavChangedListener = NavController.OnDestinationChangedListener
 
@@ -198,6 +199,33 @@ class PluviaApp : SplitCompatApplication() {
         fun setActiveSuspendPolicy(policy: String) {
             activeSuspendPolicy = Container.normalizeSuspendPolicy(policy)
             hasInitializedSuspendPolicyState = true
+        }
+
+        /**
+         * full environment teardown — shared by XServerScreen.exit() and
+         * MainActivity.onDestroy fallback so both paths clean up identically
+         */
+        fun shutdownEnvironment() {
+            val env = xEnvironment
+            Timber.i("shutdownEnvironment: env=%s", env != null)
+
+            // per-step catch so one failing teardown doesn't prevent the rest from running
+            runCatching { achievementWatcher?.stop() }
+                .onFailure { Timber.e(it, "shutdownEnvironment: achievementWatcher.stop") }
+            runCatching { SteamService.clearCachedAchievements() }
+                .onFailure { Timber.e(it, "shutdownEnvironment: clearCachedAchievements") }
+            runCatching { touchpadView?.releasePointerCapture() }
+                .onFailure { Timber.e(it, "shutdownEnvironment: releasePointerCapture") }
+            runCatching { env?.stopEnvironmentComponents() }
+                .onFailure { Timber.e(it, "shutdownEnvironment: stopEnvironmentComponents") }
+
+            xEnvironment = null
+            inputControlsView = null
+            inputControlsManager = null
+            touchpadView = null
+            achievementWatcher = null
+            SteamService.keepAlive = false
+            clearActiveSuspendState()
         }
 
         fun clearActiveSuspendState() {

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -3224,6 +3224,16 @@ class SteamService : Service(), IChallengeUrlChanged {
         scope.launch { stop() }
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        if (!hasActiveOperations()) {
+            Timber.i("Task removed and no active work — stopping service")
+            stopSelf()
+        } else {
+            Timber.i("Task removed but active work exists — keeping service alive")
+        }
+    }
+
     override fun onBind(intent: Intent?): IBinder? = null
 
     private fun connectToSteam() {

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -642,5 +642,15 @@ class EpicService : Service() {
         instance = null
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        if (!hasActiveOperations()) {
+            Timber.tag("Epic").i("Task removed and no active work — stopping service")
+            stopSelf()
+        } else {
+            Timber.tag("Epic").i("Task removed but active work exists — keeping service alive")
+        }
+    }
+
     override fun onBind(intent: Intent?): IBinder? = null
 }

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -167,7 +167,7 @@ class GOGService : Service() {
         // ==========================================================================
 
         fun hasActiveOperations(): Boolean {
-            return syncInProgress || backgroundSyncJob?.isActive == true
+            return syncInProgress || backgroundSyncJob?.isActive == true || hasActiveDownload()
         }
 
         private fun setSyncInProgress(inProgress: Boolean) {
@@ -693,6 +693,16 @@ class GOGService : Service() {
         stopForeground(STOP_FOREGROUND_REMOVE)
         notificationHelper.cancel()
         instance = null
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        if (!hasActiveOperations()) {
+            Timber.tag("GOG").i("Task removed and no active work — stopping service")
+            stopSelf()
+        } else {
+            Timber.tag("GOG").i("Task removed but active work exists — keeping service alive")
+        }
     }
 
     override fun onBind(intent: Intent?): IBinder? = null

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -633,7 +633,6 @@ fun XServerScreen(
                             withContext(Dispatchers.Main) {
                                 exit(
                                     winHandler,
-                                    PluviaApp.xEnvironment,
                                     frameRating,
                                     currentAppInfo,
                                     container,
@@ -949,7 +948,7 @@ fun XServerScreen(
                 imeInputReceiver?.hideKeyboard()
                 // Resume processes before exiting so they can receive SIGTERM cleanly.
                 forceResumeIfSuspended()
-                exit(xServerView!!.getxServer().winHandler, PluviaApp.xEnvironment, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+                exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
                 true
             }
 
@@ -1051,7 +1050,7 @@ fun XServerScreen(
     DisposableEffect(lifecycleOwner, container) {
         val onActivityDestroyed: (AndroidEvent.ActivityDestroyed) -> Unit = {
             Timber.i("onActivityDestroyed")
-            exit(xServerView!!.getxServer().winHandler, PluviaApp.xEnvironment, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+            exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
         }
         val onKeyEvent: (AndroidEvent.KeyEvent) -> Boolean = {
             val isKeyboard = Keyboard.isKeyboardDevice(it.event.device)
@@ -1151,11 +1150,11 @@ fun XServerScreen(
         }
         val onGuestProgramTerminated: (AndroidEvent.GuestProgramTerminated) -> Unit = {
             Timber.i("onGuestProgramTerminated")
-            exit(xServerView!!.getxServer().winHandler, PluviaApp.xEnvironment, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+            exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
         }
         val onForceCloseApp: (SteamEvent.ForceCloseApp) -> Unit = {
             Timber.i("onForceCloseApp")
-            exit(xServerView!!.getxServer().winHandler, PluviaApp.xEnvironment, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+            exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
         }
         val debugCallback = Callback<String> { outputLine ->
             Timber.i(outputLine ?: "")
@@ -3359,7 +3358,6 @@ private fun getSteamlessTarget(
 
 private fun exit(
     winHandler: WinHandler?,
-    environment: XEnvironment?,
     frameRating: FrameRating?,
     appInfo: SteamApp?,
     container: Container,
@@ -3392,15 +3390,13 @@ private fun exit(
         container.saveData()
     }
 
-    PluviaApp.achievementWatcher?.stop()
-    PluviaApp.achievementWatcher = null
-    SteamService.clearCachedAchievements()
-
-    PluviaApp.touchpadView?.releasePointerCapture()
-    winHandler?.stop()
-    environment?.stopEnvironmentComponents()
-    SteamService.keepAlive = false
-    PluviaApp.clearActiveSuspendState()
+    // only needed in exit() — OS reclaims on process death, so onDestroy fallback skips this
+    try {
+        winHandler?.stop()
+    } catch (e: Exception) {
+        Timber.e(e, "winHandler.stop() failed during exit")
+    }
+    PluviaApp.shutdownEnvironment()
 
     // empty Wine/XDG trash in background after container stops
     CoroutineScope(Dispatchers.IO).launch {
@@ -3420,16 +3416,6 @@ private fun exit(
             Timber.e(e, "Error emptying Wine/XDG trash")
         }
     }
-    // AppUtils.restartApplication(this)
-    // PluviaApp.xServerState = null
-    // PluviaApp.xServer = null
-    // PluviaApp.xServerView = null
-    PluviaApp.xEnvironment = null
-    PluviaApp.inputControlsView = null
-    PluviaApp.inputControlsManager = null
-    PluviaApp.touchpadView = null
-    // PluviaApp.touchMouse = null
-    // PluviaApp.keyboard = null
     frameRating?.writeSessionSummary()
 
     if (MainActivity.wasLaunchedViaExternalIntent) {


### PR DESCRIPTION
## Description

Fixes app getting stuck on the container screen after task-swiping during a game.

`onDestroy` was calling `super.onDestroy()` before emitting `ActivityDestroyed`, so Compose `DisposableEffect` listeners (including `exit()`) were already unregistered and never fired. Even when re-ordered, a race between listener teardown and event emission can still leave stale state.

- Reorder `onDestroy` so `ActivityDestroyed` fires before lifecycle teardown, giving `exit()` a chance to run
- Add fallback cleanup in `onDestroy` when `exit()` doesn't fire (listener race / task swipe)
- Clear stale `keepAlive` flag in `onCreate` when no container is actually running (crash recovery)

Closes #1135

## Recording

n/a — no visible UI changes

## Test plan
- [ ] Launch a game, swipe app from recents, reopen — should not be stuck on container screen
- [ ] Launch a game, exit normally — should still work as before
- [ ] Force-kill app during game, reopen — should recover cleanly

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have NOT attached a recording of the change (it's backend).
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented lingering background keep-alive at startup and ensured activity destruction reliably triggers coordinated cleanup so resources are released promptly.
  * Background services will now stop when the app task is removed if no active work remains, reducing orphaned background activity.

* **Refactor**
  * Consolidated environment shutdown into a single, resilient teardown used by screen exits and activity-destroy flows for more predictable cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->