### PR TITLE
Don't show logged out steam splash when offline and steam games are i…

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -847,9 +847,10 @@ private fun LibraryScreenContent(
         if (selectedAppId == null) {
             // Use Box to allow content to scroll behind the tab bar
             Box(modifier = Modifier.fillMaxSize()) {
+                val hasSteamCredentials = PrefManager.refreshToken.isNotEmpty() && PrefManager.username.isNotEmpty()
                 // When on Steam/GOG/Epic/Amazon tab and not logged in, or LOCAL tab with no custom games, show splash
                 val showEmptyStateSplash = when (state.currentTab) {
-                    LibraryTab.STEAM -> !SteamService.isLoggedIn
+                    LibraryTab.STEAM -> !hasSteamCredentials && !state.isLoading
                     LibraryTab.GOG -> !GOGService.hasStoredCredentials(context)
                     LibraryTab.EPIC -> !EpicService.hasStoredCredentials(context)
                     LibraryTab.AMAZON -> !AmazonService.hasStoredCredentials(context)


### PR DESCRIPTION
…nstalled

## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing the “Logged out of Steam” splash when the user is offline but has stored Steam credentials, so the Steam library remains visible. Also avoids splash flicker while data is loading.

- **Bug Fixes**
  - Use stored Steam credentials to decide splash visibility on the Steam tab.
  - Hide the splash during loading to prevent flicker.

<sup>Written for commit 5c002ece1ac17e59cf4d7260027e6deb7bebccd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Steam library empty-state display to correctly reflect login status based on stored credentials, preventing the splash screen from appearing while data is loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->