### PR TITLE
Hide local saves only setting

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
@@ -320,13 +320,13 @@ fun GeneralTabContent(
             state = config.forceDlc,
             onCheckedChange = { state.config.value = config.copy(forceDlc = it) },
         )
-        SettingsSwitch(
-            colors = settingsTileColorsAlt(),
-            title = { Text(text = stringResource(R.string.local_saves_only)) },
-            subtitle = { Text(text = stringResource(R.string.local_saves_only_description)) },
-            state = config.localSavesOnly,
-            onCheckedChange = { state.config.value = config.copy(localSavesOnly = it) },
-        )
+//        SettingsSwitch(
+//            colors = settingsTileColorsAlt(),
+//            title = { Text(text = stringResource(R.string.local_saves_only)) },
+//            subtitle = { Text(text = stringResource(R.string.local_saves_only_description)) },
+//            state = config.localSavesOnly,
+//            onCheckedChange = { state.config.value = config.copy(localSavesOnly = it) },
+//        )
         SettingsSwitch(
             colors = settingsTileColorsAlt(),
             title = { Text(text = stringResource(R.string.use_legacy_drm)) },


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hid the “Local saves only” toggle in the General settings panel to remove it from the UI. The underlying config remains, so existing users keep their setting; only the switch is hidden.

<sup>Written for commit 8fceae5c9bef3bc9f8d8b80f1ad7fc885e9c7020. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed the "local saves only" setting toggle from the General settings tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->