### PR TITLE
tests: Added test to keep canonical root at the correct location

### DIFF
--- a/app/src/test/java/com/winlator/core/WineUtilsTest.kt
+++ b/app/src/test/java/com/winlator/core/WineUtilsTest.kt
@@ -1,0 +1,65 @@
+package com.winlator.core
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.winlator.container.Container
+import com.winlator.xenvironment.ImageFs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+@RunWith(RobolectricTestRunner::class)
+class WineUtilsTest {
+    private lateinit var context: Context
+    private lateinit var container: Container
+    private lateinit var rootDir: File
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        container = mockk(relaxed = true)
+        rootDir = createTempDirectory(prefix = "wine-utils-test").toFile()
+        File(rootDir, ".wine/dosdevices").mkdirs()
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+        rootDir.deleteRecursively()
+    }
+
+    @Test
+    fun createDosdevicesSymlinks_usesCanonicalImageFsRootForZDrive() {
+        val imageFs = mockk<ImageFs>()
+        val nonCanonicalRoot = File(rootDir, "imagefs/../imagefs-real")
+        val canonicalRoot = nonCanonicalRoot.absoluteFile.canonicalPath
+        val expectedDosdevicesPath = File(rootDir, ".wine/dosdevices").path
+
+        every { container.rootDir } returns rootDir
+        every { container.drives } returns "D:/downloads;E:/storage"
+        every { container.drivesIterator() } returns emptyList<Array<String>>()
+
+        mockkStatic(ImageFs::class)
+        every { ImageFs.find(context) } returns imageFs
+        every { imageFs.rootDir } returns nonCanonicalRoot
+
+        mockkStatic(FileUtils::class)
+        every { FileUtils.symlink(any<String>(), any<String>()) } just runs
+
+        WineUtils.createDosdevicesSymlinks(context, container)
+
+        verify { FileUtils.symlink("../drive_c", "$expectedDosdevicesPath/c:") }
+        verify { FileUtils.symlink(canonicalRoot, "$expectedDosdevicesPath/z:") }
+    }
+}


### PR DESCRIPTION
## Description
It's very important this drive dir does not shift. I've implemented a fix earlier. And adding a test now to keep it this way.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Robolectric test for `WineUtils.createDosdevicesSymlinks` to ensure the Z: drive uses the canonical `ImageFs` root so the drive dir doesn’t shift. Also verifies the C: drive symlink points to `../drive_c` under `.wine/dosdevices`.

<sup>Written for commit b0adee871656a210cb5829d71075b6eaab8cc3b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test that verifies DOS-device symlink creation uses the expected targets and correctly handles non-canonical filesystem roots.
  * Ensures symlink creation is exercised safely using mocks (no real symlinks are created) and that temporary filesystem state is cleaned up after each run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->