### PR TITLE
Re-enable local saves only with cloud sync safety nets

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -482,6 +482,18 @@ object PrefManager {
             setPref(LOCAL_SAVES_ONLY, value)
         }
 
+    // app IDs whose cloud cache was cleared because local-saves-only was toggled off
+    // (not an upgrade) — checked in SteamAutoCloud to avoid showing upgrade conflict text
+    private val PENDING_CLOUD_RESYNC = stringPreferencesKey("pending_cloud_resync")
+    var pendingCloudResync: Set<Int>
+        get() {
+            val raw = getPref(PENDING_CLOUD_RESYNC, "")
+            return if (raw.isEmpty()) emptySet() else raw.split(',').mapNotNull { it.toIntOrNull() }.toSet()
+        }
+        set(value) {
+            setPref(PENDING_CLOUD_RESYNC, value.joinToString(","))
+        }
+
     private val STEAM_OFFLINE_MODE = booleanPreferencesKey("steam_offline_mode")
     var steamOfflineMode: Boolean
         get() = getPref(STEAM_OFFLINE_MODE, false)

--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -847,13 +847,10 @@ object SteamAutoCloud {
                         // check if local state is byte-identical to remote — this is
                         // the "cache-wiped by destructive migration, nothing actually
                         // changed" case and should be silent. key by absolute filesystem
-                        // path: cloud stores files as (pathPrefixIndex, basename) while
-                        // local scan stores filename as subdir-relative path with a
-                        // single pattern prefix, so basename-only keys won't match for
-                        // nested files.
-                        // windows paths are case-insensitive; steam cloud and wine may
-                        // disagree on case. lowercase the keys so content-identical
-                        // files compare equal regardless.
+                        // path (cloud stores (pathPrefixIndex, basename), local scan
+                        // stores subpath-relative filename; basename-only won't match
+                        // for nested files). lowercase since windows paths are
+                        // case-insensitive and wine/cloud may disagree on case.
                         val localByPath = allLocalUserFiles.associate {
                             it.getAbsPath(prefixToPath).toString().lowercase() to it.sha
                         }
@@ -878,9 +875,12 @@ object SteamAutoCloud {
                             rehydratedSilently = true
                         } else {
                             hasLocalChanges = true
-                            conflictUfsVersion = CURRENT_UFS_PARSE_VERSION
                             remoteTimestamp = appFileListChange.files.map { it.timestamp.time }.maxOrNull() ?: 0L
                             localTimestamp = allLocalUserFiles.map { it.timestamp }.maxOrNull() ?: 0L
+                            // show upgrade-specific text unless this was a local-saves toggle-off
+                            if (appInfo.id !in PrefManager.pendingCloudResync) {
+                                conflictUfsVersion = CURRENT_UFS_PARSE_VERSION
+                            }
                         }
                     }
 

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -61,7 +61,11 @@ import app.gamenative.utils.generateSteamApp
 import app.gamenative.workshop.WorkshopManager
 import com.winlator.container.Container
 import com.winlator.xenvironment.ImageFs
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
 import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 import `in`.dragonbra.javasteam.depotdownloader.DepotDownloader
 import `in`.dragonbra.javasteam.depotdownloader.IDownloadListener
 import `in`.dragonbra.javasteam.depotdownloader.data.AppItem
@@ -2807,6 +2811,25 @@ class SteamService : Service(), IChallengeUrlChanged {
             EResult.ParentalControlRestricted,
             EResult.CachedCredentialInvalid -> true
             else -> false
+        }
+
+        @EntryPoint
+        @InstallIn(SingletonComponent::class)
+        interface CloudSyncCacheEntryPoint {
+            fun fileChangeListsDao(): FileChangeListsDao
+        }
+
+        // runBlocking is intentional: must complete before pendingCloudResync write that follows
+        fun clearCloudSyncCache(context: Context, appId: Int) {
+            val dao = instance?.fileChangeListsDao
+                ?: EntryPointAccessors.fromApplication(
+                    context.applicationContext,
+                    CloudSyncCacheEntryPoint::class.java,
+                ).fileChangeListsDao()
+            runBlocking {
+                dao.deleteByAppId(appId)
+            }
+            Timber.i("Cleared cloud sync cache for appId=$appId")
         }
 
         fun clearDatabase(clearCloudSyncState: Boolean = false) {

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -2042,6 +2042,9 @@ fun preLaunchApp(
 
         when (postSyncInfo.syncResult) {
             SyncResult.Conflict -> {
+                // clear pending resync flag if present — it already prevented
+                // SteamAutoCloud from setting conflictUfsVersion
+                PrefManager.pendingCloudResync = PrefManager.pendingCloudResync - gameId
                 val localDate = Date(postSyncInfo.localTimestamp).toString()
                 val remoteDate = Date(postSyncInfo.remoteTimestamp).toString()
                 val (conflictTitle, conflictMessage) = postSyncInfo.conflictUfsVersion

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
@@ -330,13 +330,13 @@ fun GeneralTabContent(
             state = config.forceDlc,
             onCheckedChange = { state.config.value = config.copy(forceDlc = it) },
         )
-//        SettingsSwitch(
-//            colors = settingsTileColorsAlt(),
-//            title = { Text(text = stringResource(R.string.local_saves_only)) },
-//            subtitle = { Text(text = stringResource(R.string.local_saves_only_description)) },
-//            state = config.localSavesOnly,
-//            onCheckedChange = { state.config.value = config.copy(localSavesOnly = it) },
-//        )
+        SettingsSwitch(
+            colors = settingsTileColorsAlt(),
+            title = { Text(text = stringResource(R.string.local_saves_only)) },
+            subtitle = { Text(text = stringResource(R.string.local_saves_only_description)) },
+            state = config.localSavesOnly,
+            onCheckedChange = { state.config.value = config.copy(localSavesOnly = it) },
+        )
         SettingsSwitch(
             colors = settingsTileColorsAlt(),
             title = { Text(text = stringResource(R.string.use_legacy_drm)) },

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -34,13 +34,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.content.ContextCompat
-import app.gamenative.PrefManager
 import app.gamenative.PluviaApp
-
+import app.gamenative.PrefManager
 import app.gamenative.R
 import app.gamenative.data.LibraryItem
 import app.gamenative.enums.Marker
 import app.gamenative.enums.PathType
+import app.gamenative.enums.SaveLocation
 import app.gamenative.enums.SyncResult
 import app.gamenative.events.AndroidEvent
 import app.gamenative.service.DownloadService
@@ -53,6 +53,7 @@ import app.gamenative.ui.data.AppMenuOption
 import app.gamenative.ui.data.GameDisplayInfo
 import app.gamenative.ui.enums.AppOptionMenuType
 import app.gamenative.ui.enums.DialogType
+import java.util.Date
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.MarkerUtils
 import app.gamenative.utils.SteamUtils
@@ -217,6 +218,78 @@ class SteamAppScreen : BaseAppScreen() {
 
         fun getPendingUpdateVerifyOperation(gameId: Int): AppOptionMenuType? {
             return pendingUpdateVerifyOperations[gameId]
+        }
+
+        fun performForceCloudSync(
+            context: Context,
+            appId: String,
+            gameId: Int,
+            preferredSave: SaveLocation = SaveLocation.None,
+            container: Container? = null,
+        ) {
+            CoroutineScope(Dispatchers.IO).launch {
+                val steamId = SteamService.userSteamId
+                if (steamId == null) {
+                    SnackbarManager.show(context.getString(R.string.steam_not_logged_in))
+                    return@launch
+                }
+
+                val resolvedContainer = container ?: ContainerUtils.getOrCreateContainer(context, appId)
+                val containerManager = ContainerManager(context)
+                containerManager.activateContainer(resolvedContainer)
+
+                SnackbarManager.show(context.getString(R.string.library_cloud_sync_starting))
+
+                val prefixToPath: (String) -> String = { prefix ->
+                    PathType.from(prefix).toAbsPath(resolvedContainer, gameId, steamId.accountID)
+                }
+                val syncResult = SteamService.forceSyncUserFiles(
+                    appId = gameId,
+                    prefixToPath = prefixToPath,
+                    preferredSave = preferredSave,
+                ).await()
+
+                when (syncResult.syncResult) {
+                    SyncResult.Success -> {
+                        SnackbarManager.show(context.getString(R.string.library_cloud_sync_success))
+                    }
+
+                    SyncResult.UpToDate -> {
+                        SnackbarManager.show(context.getString(R.string.library_cloud_sync_up_to_date))
+                    }
+
+                    SyncResult.InProgress -> {
+                        SnackbarManager.show(context.getString(R.string.library_cloud_sync_in_progress))
+                    }
+
+                    SyncResult.Conflict -> {
+                        val localDate = Date(syncResult.localTimestamp).toString()
+                        val remoteDate = Date(syncResult.remoteTimestamp).toString()
+                        withContext(Dispatchers.Main) {
+                            showInstallDialog(
+                                gameId,
+                                MessageDialogState(
+                                    visible = true,
+                                    type = DialogType.SYNC_CONFLICT,
+                                    title = context.getString(R.string.main_save_conflict_title),
+                                    message = context.getString(R.string.main_save_conflict_message, localDate, remoteDate),
+                                    confirmBtnText = context.getString(R.string.main_keep_remote),
+                                    dismissBtnText = context.getString(R.string.main_keep_local),
+                                ),
+                            )
+                        }
+                    }
+
+                    else -> {
+                        SnackbarManager.show(
+                            context.getString(
+                                R.string.library_cloud_sync_error,
+                                syncResult.syncResult,
+                            ),
+                        )
+                    }
+                }
+            }
         }
     }
 
@@ -747,15 +820,20 @@ class SteamAppScreen : BaseAppScreen() {
             AppMenuOption(
                 AppOptionMenuType.VerifyFiles,
                 onClick = {
-                    // Show confirmation dialog before verifying
                     setPendingUpdateVerifyOperation(gameId, AppOptionMenuType.VerifyFiles)
+                    val container = ContainerUtils.getOrCreateContainer(context, appId)
+                    val verifyMessage = if (container.isLocalSavesOnly) {
+                        context.getString(R.string.steam_verify_files_message_local_saves)
+                    } else {
+                        context.getString(R.string.steam_verify_files_message)
+                    }
                     showInstallDialog(
                         gameId,
                         MessageDialogState(
                             visible = true,
                             type = DialogType.UPDATE_VERIFY_CONFIRM,
                             title = context.getString(R.string.steam_verify_files_title),
-                            message = context.getString(R.string.steam_verify_files_message),
+                            message = verifyMessage,
                             confirmBtnText = context.getString(R.string.steam_continue),
                             dismissBtnText = context.getString(R.string.cancel),
                         ),
@@ -795,43 +873,21 @@ class SteamAppScreen : BaseAppScreen() {
                             properties = mapOf("game_name" to appInfo.name),
                         )
                     }
-                    CoroutineScope(Dispatchers.IO).launch {
-                        SnackbarManager.show(context.getString(R.string.library_cloud_sync_starting))
-
-                        val steamId = SteamService.userSteamId
-                        if (steamId == null) {
-                            SnackbarManager.show(context.getString(R.string.steam_not_logged_in))
-                            return@launch
-                        }
-
-                        val container = ContainerUtils.getOrCreateContainer(context, appId)
-
-                        val prefixToPath: (String) -> String = { prefix ->
-                            PathType.from(prefix).toAbsPath(container, gameId, steamId.accountID)
-                        }
-                        val syncResult = SteamService.forceSyncUserFiles(
-                            appId = gameId,
-                            prefixToPath = prefixToPath,
-                        ).await()
-
-                        when (syncResult.syncResult) {
-                            SyncResult.Success -> {
-                                SnackbarManager.show(context.getString(R.string.library_cloud_sync_success))
-                            }
-
-                            SyncResult.UpToDate -> {
-                                SnackbarManager.show(context.getString(R.string.library_cloud_sync_up_to_date))
-                            }
-
-                            else -> {
-                                SnackbarManager.show(
-                                    context.getString(
-                                        R.string.library_cloud_sync_error,
-                                        syncResult.syncResult,
-                                    ),
-                                )
-                            }
-                        }
+                    val container = ContainerUtils.getOrCreateContainer(context, appId)
+                    if (container.isLocalSavesOnly) {
+                        showInstallDialog(
+                            gameId,
+                            MessageDialogState(
+                                visible = true,
+                                type = DialogType.SYNC_CONFLICT,
+                                title = context.getString(R.string.cloud_sync_local_saves_only_title),
+                                message = context.getString(R.string.cloud_sync_local_saves_only_message),
+                                confirmBtnText = context.getString(R.string.main_keep_remote),
+                                dismissBtnText = context.getString(R.string.main_keep_local),
+                            ),
+                        )
+                    } else {
+                        performForceCloudSync(context, appId, gameId, container = container)
                     }
                 },
             ),
@@ -1101,18 +1157,21 @@ class SteamAppScreen : BaseAppScreen() {
 
                                 if (operation == AppOptionMenuType.VerifyFiles) {
                                     MarkerUtils.clearInstalledPrerequisiteMarkers(getAppDirPath(gameId))
-                                    val steamId = SteamService.userSteamId
-                                    if (steamId != null) {
-                                        val prefixToPath: (String) -> String = { prefix ->
-                                            PathType.from(prefix).toAbsPath(container, gameId, steamId.accountID)
+                                    // skip cloud sync if local saves only — verify is about game files, not saves
+                                    if (!container.isLocalSavesOnly) {
+                                        val steamId = SteamService.userSteamId
+                                        if (steamId != null) {
+                                            val prefixToPath: (String) -> String = { prefix ->
+                                                PathType.from(prefix).toAbsPath(container, gameId, steamId.accountID)
+                                            }
+                                            SteamService.forceSyncUserFiles(
+                                                appId = gameId,
+                                                prefixToPath = prefixToPath,
+                                                overrideLocalChangeNumber = -1,
+                                            ).await()
+                                        } else {
+                                            SnackbarManager.show(context.getString(R.string.steam_not_logged_in))
                                         }
-                                        SteamService.forceSyncUserFiles(
-                                            appId = gameId,
-                                            prefixToPath = prefixToPath,
-                                            overrideLocalChangeNumber = -1,
-                                        ).await()
-                                    } else {
-                                        SnackbarManager.show(context.getString(R.string.steam_not_logged_in))
                                     }
                                 }
 
@@ -1163,14 +1222,32 @@ class SteamAppScreen : BaseAppScreen() {
                     }
                 }
 
+                DialogType.SYNC_CONFLICT -> {
+                    {
+                        hideInstallDialog(gameId)
+                        PrefManager.pendingCloudResync = PrefManager.pendingCloudResync - gameId
+                        performForceCloudSync(context, libraryItem.appId, gameId, SaveLocation.Remote)
+                    }
+                }
+
                 else -> null
+            }
+            val effectiveDismissClick: (() -> Unit)? = when (installDialogState.type) {
+                DialogType.SYNC_CONFLICT -> {
+                    {
+                        hideInstallDialog(gameId)
+                        PrefManager.pendingCloudResync = PrefManager.pendingCloudResync - gameId
+                        performForceCloudSync(context, libraryItem.appId, gameId, SaveLocation.Local)
+                    }
+                }
+                else -> onDismissClick
             }
 
             MessageDialog(
                 visible = installDialogState.visible,
                 onDismissRequest = onDismissRequest,
                 onConfirmClick = onConfirmClick,
-                onDismissClick = onDismissClick,
+                onDismissClick = effectiveDismissClick,
                 confirmBtnText = installDialogState.confirmBtnText,
                 dismissBtnText = installDialogState.dismissBtnText,
                 title = installDialogState.title,

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -474,6 +474,15 @@ object ContainerUtils {
         container.setExternalDisplayMode(containerData.externalDisplayMode)
         container.setExternalDisplaySwap(containerData.externalDisplaySwap)
         container.setForceDlc(containerData.forceDlc)
+        // clear stale cloud cache so next sync detects divergence and shows conflict dialog
+        if (saveToDisk && container.isLocalSavesOnly && !containerData.localSavesOnly) {
+            val gameId = extractGameIdFromContainerId(container.id)
+            SteamService.clearCloudSyncCache(context, gameId)
+            PrefManager.pendingCloudResync = PrefManager.pendingCloudResync + gameId
+        } else if (saveToDisk && !container.isLocalSavesOnly && containerData.localSavesOnly) {
+            val gameId = extractGameIdFromContainerId(container.id)
+            PrefManager.pendingCloudResync = PrefManager.pendingCloudResync - gameId
+        }
         container.setLocalSavesOnly(containerData.localSavesOnly)
         container.setSteamOfflineMode(containerData.steamOfflineMode)
         container.setUseLegacyDRM(containerData.useLegacyDRM)

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -486,6 +486,8 @@
     <!-- Container Configuration: Steam Integration -->
     <string name="force_dlc">Gennemtving DLC</string>
     <string name="force_dlc_description">Kun aktiver hvis DLC\'er ikke opdages, eller gemfiler med DLC ikke virker</string>
+    <string name="local_saves_only">Kun lokale gemte data</string>
+    <string name="local_saves_only_description">Deaktiver cloud-synkronisering af gemte data for dette spil og behold kun gemte data på enheden</string>
     <string name="launch_steam_client_beta">Start Steam-klient (Beta)</string>
     <string name="steam_offline_mode">Steam Offline-tilstand</string>
     <string name="steam_offline_mode_description">Start Steam-spil i offline-tilstand</string>
@@ -835,6 +837,7 @@
     <string name="library_cloud_sync_up_to_date">Gemfiler er allerede opdaterede</string>
     <string name="library_cloud_sync_failed">Sky-synkronisering fejlede</string>
     <string name="library_cloud_sync_error">Fejl ved synkronisering af cloud-gemmer: %1$s</string>
+    <string name="library_cloud_sync_in_progress">Synkronisering af cloud-gemmer er allerede i gang</string>
 
     <!-- TODO: Manual review - LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Internet påkrævet for installation</string>
@@ -1118,6 +1121,7 @@
     <string name="steam_reset_container_message">Dette vil nulstille din container til standardkonfigurationen.</string>
     <string name="steam_verify_files_title">Verificér filer</string>
     <string name="steam_verify_files_message">Sørg venligst for, at dine gemfiler er uploadet til skyen eller sikkerhedskopieret før verificering, da de ellers kan blive overskrevet.</string>
+    <string name="steam_verify_files_message_local_saves">Cloud-synkronisering springes over under verificering, fordi kun lokale gemte data er aktiveret.</string>
     <string name="steam_update_title">Opdatering</string>
     <string name="steam_update_message">Sørg venligst for, at dine gemfiler er uploadet til skyen eller sikkerhedskopieret før opdatering, da de ellers kan blive overskrevet.</string>
     <string name="steam_storage_permission_required">Lagertilladelse påkrævet</string>
@@ -1310,4 +1314,6 @@
     <string name="lsfg_install_message">Dette downloader Lossless Scaling fra Steam for at aktivere billedgenerering.</string>
     <string name="lsfg_installing">Downloader Lossless Scaling…</string>
     <string name="lsfg_performance_mode_desc">Reducerer kvalitet for højere gennemstrømning</string>
+    <string name="cloud_sync_local_saves_only_title">Kun lokale gemte data</string>
+    <string name="cloud_sync_local_saves_only_message">"Kun lokale gemte data" er aktiveret for dette spil. Cloud-gemte data kan afvige fra lokale gemte data. Hvilke vil du beholde?</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -27,6 +27,7 @@
     <string name="steam_verify_files_title">Dateien überprüfen</string>
     <string name="steam_verify_files_message">Stelle bitte sicher, dass deine Spielstände vorher in die Cloud hochgeladen oder gesichert wurden, da sie sonst überschrieben werden können.</string>
     <string name="steam_cloud_sync_downloading_save_files">Speicherstände werden heruntergeladen %1$d/%2$d</string>
+    <string name="steam_verify_files_message_local_saves">Cloud-Synchronisierung wird bei der Überprüfung übersprungen, da nur lokale Speicherstände aktiviert sind.</string>
     <string name="steam_update_title">Aktualisieren</string>
     <string name="steam_update_message">Stelle sicher, dass deine Speicherstände vor dem Aktualisieren in der Cloud gesichert oder gebackupt sind, um ein Überschreiben zu verhindern.</string>
     <string name="steam_not_logged_in">Du musst bei Steam angemeldet sein, um diese Funktion zu nutzen</string>
@@ -624,6 +625,8 @@
     <string name="unpack_files_description">Nur verwenden, wenn \'Application Load Error 3:0000065432\' auftritt.</string>
     <string name="force_dlc">DLC erzwingen</string>
     <string name="force_dlc_description">Nur aktivieren, falls DLCs nicht erkannt werden oder Spielstände mit DLC nicht funktionieren</string>
+    <string name="local_saves_only">Nur lokale Speicherstände</string>
+    <string name="local_saves_only_description">Cloud-Synchronisierung der Speicherstände für dieses Spiel deaktivieren und nur auf dem Gerät speichern</string>
     <string name="launch_steam_client_beta">Steam-Client starten (Beta)</string>
     <string name="steam_offline_mode">Steam Offline-Modus</string>
     <string name="steam_offline_mode_description">Steam-Spiele im Offlinemodus starten</string>
@@ -966,6 +969,7 @@
     <string name="library_cloud_sync_up_to_date">Spielstände sind aktuell</string>
     <string name="library_cloud_sync_failed">Cloud-Synchronisierung fehlgeschlagen</string>
     <string name="library_cloud_sync_error">Cloud-Synchronisierungsfehler: %1$s</string>
+    <string name="library_cloud_sync_in_progress">Cloud-Synchronisierung läuft bereits</string>
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Internetverbindung erforderlich</string>
     <string name="library_wifi_only_enabled">Installieren nur über WLAN/LAN aktiviert</string>
@@ -1380,4 +1384,6 @@
     <string name="lsfg_install_message">Dies lädt Lossless Scaling von Steam herunter, um Bildgenerierung zu aktivieren.</string>
     <string name="lsfg_installing">Lossless Scaling wird heruntergeladen…</string>
     <string name="lsfg_performance_mode_desc">Reduziert Qualität für höheren Durchsatz</string>
+    <string name="cloud_sync_local_saves_only_title">Nur lokale Speicherstände</string>
+    <string name="cloud_sync_local_saves_only_message">"Nur lokale Speicherstände" ist für dieses Spiel aktiviert. Cloud-Speicherstände können von lokalen Speicherständen abweichen. Welche möchtest du behalten?</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -28,6 +28,7 @@
     <string name="steam_verify_files_title">Verificar archivos</string>
     <string name="steam_verify_files_message">Asegúrate de que tus archivos de guardado están en la nube o respaldados antes de verificar, ya que podrían sobrescribirse.</string>
     <string name="steam_cloud_sync_downloading_save_files">Descargando archivos de guardado %1$d/%2$d</string>
+    <string name="steam_verify_files_message_local_saves">La sincronización en la nube se omitirá durante la verificación porque \"Solo guardados locales\" está activado.</string>
     <string name="steam_update_title">Actualizar</string>
     <string name="steam_update_message">Asegúrate de que tus archivos de guardado están en la nube o respaldados antes de actualizar, ya que podrían sobrescribirse.</string>
     <string name="steam_not_logged_in">Debes iniciar sesión en Steam para usar esta función.</string>
@@ -696,6 +697,8 @@
     <string name="unpack_files_description">Úsalo solo si obtienes el error \'Application Load Error 3:0000065432\'.</string>
     <string name="force_dlc">Forzar DLC</string>
     <string name="force_dlc_description">Actívalo solo si los DLC no se detectan o los archivos de guardados con DLC no funcionan.</string>
+    <string name="local_saves_only">Solo guardados locales</string>
+    <string name="local_saves_only_description">Desactiva la sincronización de guardados en la nube para este juego y mantén los guardados solo en el dispositivo</string>
     <string name="launch_steam_client_beta">Iniciar cliente de Steam (Beta)</string>
     <string name="launch_steam_client_description">Reduce el rendimiento y ralentiza el inicio.\nPermite el juego en línea y soluciona problemas de DRM y de mando.\nNo todos los juegos funcionan.</string>
     <string name="steam_offline_mode">Modo sin conexión de Steam</string>
@@ -1023,6 +1026,7 @@
     <string name="library_cloud_sync_up_to_date">Los archivos de guardado ya están actualizados.</string>
     <string name="library_cloud_sync_failed">Fallo en la sincronización con la nube.</string>
     <string name="library_cloud_sync_error">Error de sincronización en la nube: %1$s.</string>
+    <string name="library_cloud_sync_in_progress">La sincronización en la nube ya está en curso</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Necesitas conexión a internet para instalar.</string>
@@ -1446,4 +1450,6 @@
     <string name="lsfg_install_message">Esto descargará Lossless Scaling de Steam para habilitar la generación de fotogramas.</string>
     <string name="lsfg_installing">Descargando Lossless Scaling…</string>
     <string name="lsfg_performance_mode_desc">Reduce calidad para mayor rendimiento</string>
+    <string name="cloud_sync_local_saves_only_title">Solo guardados locales</string>
+    <string name="cloud_sync_local_saves_only_message">"Solo guardados locales" está activado para este juego. Los guardados en la nube pueden diferir de los guardados locales. ¿Cuáles deseas conservar?</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -28,6 +28,7 @@
     <string name="steam_verify_files_title">Vérifier les fichiers</string>
     <string name="steam_verify_files_message">Veuillez vous assurer que vos sauvegardes sont téléchargées dans le cloud ou sauvegardées avant de vérifier, car elles peuvent être écrasées.</string>
     <string name="steam_cloud_sync_downloading_save_files">Téléchargement des fichiers de sauvegarde %1$d/%2$d</string>
+    <string name="steam_verify_files_message_local_saves">La synchronisation cloud sera ignorée pendant la vérification car seules les sauvegardes locales sont activées.</string>
     <string name="steam_update_title">Mettre à jour</string>
     <string name="steam_update_message">Veuillez vous assurer que vos sauvegardes sont téléchargées dans le cloud ou sauvegardées avant de mettre à jour, car elles peuvent être écrasées.</string>
     <string name="steam_not_logged_in">Vous devez être connecté à Steam pour utiliser cette fonctionnalité</string>
@@ -647,6 +648,8 @@
     <string name="unpack_files_description">Utiliser uniquement si vous obtenez \'Application Load Error 3:0000065432\'.</string>
     <string name="force_dlc">Forcer les DLC</string>
     <string name="force_dlc_description">N\'activer que si les DLC ne sont pas détectés ou si les sauvegardes avec DLC ne fonctionnent pas</string>
+    <string name="local_saves_only">Sauvegardes locales uniquement</string>
+    <string name="local_saves_only_description">Désactiver la synchronisation cloud des sauvegardes pour ce jeu et conserver les sauvegardes uniquement sur l\'appareil</string>
     <string name="launch_steam_client_beta">Lancer le client Steam (Bêta)</string>
     <string name="steam_offline_mode">Mode Hors Ligne Steam</string>
     <string name="steam_offline_mode_description">Lancer les jeux Steam en mode hors ligne</string>
@@ -1009,6 +1012,7 @@
     <string name="library_cloud_sync_up_to_date">Les fichiers de sauvegarde sont déjà à jour</string>
     <string name="library_cloud_sync_failed">Échec de la synchronisation cloud</string>
     <string name="library_cloud_sync_error">Erreur de synchronisation des sauvegardes cloud: %1$s</string>
+    <string name="library_cloud_sync_in_progress">La synchronisation cloud est déjà en cours</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Connexion internet nécessaire pour installer</string>
@@ -1440,4 +1444,6 @@
     <string name="lsfg_install_message">Cela téléchargera Lossless Scaling depuis Steam pour activer la génération d\'images.</string>
     <string name="lsfg_installing">Téléchargement de Lossless Scaling…</string>
     <string name="lsfg_performance_mode_desc">Réduit la qualité pour un débit plus élevé</string>
+    <string name="cloud_sync_local_saves_only_title">Sauvegardes locales uniquement</string>
+    <string name="cloud_sync_local_saves_only_message">"Sauvegardes locales uniquement" est activé pour ce jeu. Les sauvegardes cloud peuvent différer des sauvegardes locales. Lesquelles souhaitez-vous conserver ?</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -28,6 +28,7 @@
     <string name="steam_verify_files_title">Verifica File</string>
     <string name="steam_verify_files_message">Assicurati che i tuoi salvataggi siano caricati sul cloud o sottoposti a backup prima della verifica, altrimenti potrebbero essere sovrascritti.</string>
     <string name="steam_cloud_sync_downloading_save_files">Download dei file di salvataggio %1$d/%2$d</string>
+    <string name="steam_verify_files_message_local_saves">La sincronizzazione cloud verrà saltata durante la verifica perché sono attivi solo i salvataggi locali.</string>
     <string name="steam_update_title">Aggiorna</string>
     <string name="steam_update_message">Assicurati che i tuoi salvataggi siano caricati sul cloud o sottoposti a backup prima dell\'aggiornamento, altrimenti potrebbero essere sovrascritti.</string>
     <string name="steam_not_logged_in">Devi aver effettuato l\'accesso a Steam per utilizzare questa funzione</string>
@@ -651,6 +652,8 @@
     <string name="unpack_files_description">Usa solo se ottieni \'Application Load Error 3:0000065432\'.</string>
     <string name="force_dlc">Forza DLC</string>
     <string name="force_dlc_description">Abilita solo se i DLC non vengono rilevati o i salvataggi con DLC non funzionano</string>
+    <string name="local_saves_only">Solo salvataggi locali</string>
+    <string name="local_saves_only_description">Disattiva la sincronizzazione cloud dei salvataggi per questo gioco e conserva i salvataggi solo sul dispositivo</string>
     <string name="launch_steam_client_beta">Avvia Client Steam (Beta)</string>
     <string name="steam_offline_mode">Modalità Offline Steam</string>
     <string name="steam_offline_mode_description">Avvia i giochi Steam in modalità offline</string>
@@ -1005,6 +1008,7 @@
     <string name="library_cloud_sync_up_to_date">I file di salvataggio sono già aggiornati</string>
     <string name="library_cloud_sync_failed">Sincronizzazione cloud fallita</string>
     <string name="library_cloud_sync_error">Errore sincronizzazione salvataggi cloud: %1$s</string>
+    <string name="library_cloud_sync_in_progress">Sincronizzazione cloud già in corso</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Serve internet per installare</string>
@@ -1436,4 +1440,6 @@
     <string name="lsfg_install_message">Scaricherà Lossless Scaling da Steam per abilitare la generazione di fotogrammi.</string>
     <string name="lsfg_installing">Download di Lossless Scaling in corso…</string>
     <string name="lsfg_performance_mode_desc">Riduce la qualità per una maggiore velocità</string>
+    <string name="cloud_sync_local_saves_only_title">Solo salvataggi locali</string>
+    <string name="cloud_sync_local_saves_only_message">\"Solo salvataggi locali\" è attivata per questo gioco. I salvataggi cloud potrebbero differire da quelli locali. Quali desideri conservare?</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -28,6 +28,7 @@
     <string name="steam_verify_files_title">파일 검증</string>
     <string name="steam_verify_files_message">검증하기 전에 저장 파일이 클라우드에 업로드되었거나 백업되었는지 확인하세요. 그렇지 않으면 덮어쓰기될 수 있습니다.</string>
     <string name="steam_cloud_sync_downloading_save_files">저장 파일 다운로드 중 %1$d/%2$d</string>
+    <string name="steam_verify_files_message_local_saves">로컬 저장 데이터만 사용이 활성화되어 있어 검증 중 클라우드 동기화를 건너뜁니다.</string>
     <string name="steam_update_title">업데이트</string>
     <string name="steam_update_message">업데이트하기 전에 저장 파일이 클라우드에 업로드되었거나 백업되었는지 확인하세요. 그렇지 않으면 덮어쓰기될 수 있습니다.</string>
     <string name="steam_not_logged_in">이 기능을 사용하려면 Steam에 로그인해야 합니다</string>
@@ -661,6 +662,8 @@
     <string name="unpack_files_description">\'Application Load Error 3:0000065432\'가 발생하는 경우에만 사용하세요.</string>
     <string name="force_dlc">DLC 강제</string>
     <string name="force_dlc_description">DLC가 감지되지 않거나 DLC가 있는 저장 파일이 작동하지 않는 경우에만 활성화</string>
+    <string name="local_saves_only">로컬 저장 데이터만 사용</string>
+    <string name="local_saves_only_description">이 게임의 클라우드 저장 동기화를 비활성화하고 기기에만 저장</string>
     <string name="launch_steam_client_beta">Steam 클라이언트 실행(베타)</string>
     <string name="steam_offline_mode">Steam 오프라인 모드</string>
     <string name="steam_offline_mode_description">Steam 게임을 오프라인 모드로 실행</string>
@@ -1023,6 +1026,7 @@
     <string name="library_cloud_sync_up_to_date">저장 파일이 이미 최신 상태입니다</string>
     <string name="library_cloud_sync_failed">클라우드 동기화 실패</string>
     <string name="library_cloud_sync_error">클라우드 저장 파일 동기화 오류: %1$s</string>
+    <string name="library_cloud_sync_in_progress">클라우드 동기화가 이미 진행 중입니다</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">설치하려면 인터넷이 필요합니다</string>
@@ -1444,4 +1448,6 @@
     <string name="lsfg_install_message">프레임 생성을 활성화하기 위해 Steam에서 Lossless Scaling을 다운로드합니다.</string>
     <string name="lsfg_installing">Lossless Scaling 다운로드 중…</string>
     <string name="lsfg_performance_mode_desc">처리량 향상을 위해 품질 감소</string>
+    <string name="cloud_sync_local_saves_only_title">로컬 저장 데이터만 사용</string>
+    <string name="cloud_sync_local_saves_only_message">이 게임에 "로컬 저장 데이터만 사용"이 활성화되어 있습니다. 클라우드 저장 데이터가 로컬 저장 데이터와 다를 수 있습니다. 어떤 데이터를 유지하시겠습니까?</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -28,6 +28,7 @@
     <string name="steam_verify_files_title">Zweryfikuj pliki</string>
     <string name="steam_verify_files_message">Upewnij się, że Twoje zapisy są przesłane do chmury lub utworzono ich kopię zapasową przed weryfikacją, w przeciwnym razie mogą zostać nadpisane.</string>
     <string name="steam_cloud_sync_downloading_save_files">Pobieranie plików zapisów %1$d/%2$d</string>
+    <string name="steam_verify_files_message_local_saves">Synchronizacja z chmurą zostanie pominięta podczas weryfikacji, ponieważ włączone są tylko lokalne zapisy.</string>
     <string name="steam_update_title">Aktualizuj</string>
     <string name="steam_update_message">Upewnij się, że Twoje zapisy są przesłane do chmury lub utworzono ich kopię zapasową przed aktualizacją, w przeciwnym razie mogą zostać nadpisane.</string>
     <string name="steam_not_logged_in">Musisz być zalogowany do Steam, aby użyć tej funkcji</string>
@@ -660,6 +661,8 @@
     <string name="unpack_files_description">Używaj tylko w przypadku błędu \'Application Load Error\'. Może zmniejszyć FPS.</string>
     <string name="force_dlc">Wymuś DLC</string>
     <string name="force_dlc_description">Włącz tylko jeśli DLC nie są wykrywane lub zapisy z DLC nie działają</string>
+    <string name="local_saves_only">Tylko lokalne zapisy</string>
+    <string name="local_saves_only_description">Wyłącz synchronizację zapisów z chmurą dla tej gry i przechowuj zapisy tylko na urządzeniu</string>
     <string name="launch_steam_client_beta">Uruchom Klienta Steam (Beta)</string>
     <string name="steam_offline_mode">Tryb Offline Steam</string>
     <string name="steam_offline_mode_description">Uruchamiaj gry Steam w trybie offline</string>
@@ -1022,6 +1025,7 @@
     <string name="library_cloud_sync_up_to_date">Pliki zapisu są już aktualne</string>
     <string name="library_cloud_sync_failed">Synchronizacja z chmurą nie powiodła się</string>
     <string name="library_cloud_sync_error">Błąd synchronizacji zapisów w chmurze: %1$s</string>
+    <string name="library_cloud_sync_in_progress">Synchronizacja z chmurą już trwa</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Wymagany internet do instalacji</string>
@@ -1443,4 +1447,6 @@
     <string name="lsfg_install_message">Spowoduje to pobranie Lossless Scaling ze Steam, aby umożliwić generowanie klatek.</string>
     <string name="lsfg_installing">Pobieranie Lossless Scaling…</string>
     <string name="lsfg_performance_mode_desc">Zmniejsza jakość dla wyższej przepustowości</string>
+    <string name="cloud_sync_local_saves_only_title">Tylko lokalne zapisy</string>
+    <string name="cloud_sync_local_saves_only_message">"Tylko lokalne zapisy" jest włączone dla tej gry. Zapisy w chmurze mogą różnić się od lokalnych zapisów. Które chcesz zachować?</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -486,6 +486,8 @@
     <!-- Container Configuration: Steam Integration -->
     <string name="force_dlc">Forçar DLC</string>
     <string name="force_dlc_description">Ative somente se os DLCs não forem detectados ou os saves com DLC não estiverem funcionando</string>
+    <string name="local_saves_only">Apenas saves locais</string>
+    <string name="local_saves_only_description">Desativar sincronização de saves na nuvem para este jogo e manter saves apenas no dispositivo</string>
     <string name="launch_steam_client_beta">Iniciar o cliente Steam (Beta)</string>
     <string name="steam_offline_mode">Modo Offline do Steam</string>
     <string name="steam_offline_mode_description">Iniciar jogos Steam no modo offline</string>
@@ -835,6 +837,7 @@
     <string name="library_cloud_sync_up_to_date">Os arquivos de save já estão atualizados</string>
     <string name="library_cloud_sync_failed">Sincronização na nuvem falhou</string>
     <string name="library_cloud_sync_error">Erro na sincronização de salvamentos na nuvem: %1$s</string>
+    <string name="library_cloud_sync_in_progress">A sincronização na nuvem já está em andamento</string>
 
     <!-- TODO: Revisão manual - LibraryAppScreen: Rótulos de UI -->
     <string name="library_need_internet">Internet necessária para instalar</string>
@@ -1118,6 +1121,7 @@
     <string name="steam_reset_container_message">Isso redefinirá seu contêiner para a configuração padrão.</string>
     <string name="steam_verify_files_title">Verificar arquivos</string>
     <string name="steam_verify_files_message">Certifique-se de que seus saves foram enviados para a nuvem ou foram feitos backups antes de verificar, caso contrário, eles podem ser sobrescritos.</string>
+    <string name="steam_verify_files_message_local_saves">A sincronização na nuvem será ignorada durante a verificação porque apenas os saves locais estão ativados.</string>
     <string name="steam_update_title">Atualização</string>
     <string name="steam_update_message">Certifique-se de que seus saves foram enviados para a nuvem ou foram feitos backups antes de atualizar, caso contrário, eles podem ser sobrescritos.</string>
     <string name="steam_storage_permission_required">Permissão de armazenamento necessária</string>
@@ -1310,4 +1314,6 @@
     <string name="lsfg_install_message">Isso baixará o Lossless Scaling do Steam para ativar a geração de quadros.</string>
     <string name="lsfg_installing">Baixando Lossless Scaling…</string>
     <string name="lsfg_performance_mode_desc">Reduz qualidade para maior taxa de processamento</string>
+    <string name="cloud_sync_local_saves_only_title">Apenas saves locais</string>
+    <string name="cloud_sync_local_saves_only_message">"Apenas saves locais" está ativado para este jogo. Os saves na nuvem podem ser diferentes dos saves locais. Quais você deseja manter?</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -28,6 +28,7 @@
     <string name="steam_verify_files_title">Verificare fișiere</string>
     <string name="steam_verify_files_message">Asigură-te că salvările sunt încărcate în cloud sau copiate în altă parte înainte de verificare, deoarece pot fi suprascrise.</string>
     <string name="steam_cloud_sync_downloading_save_files">Se descarcă fișierele de salvare %1$d/%2$d</string>
+    <string name="steam_verify_files_message_local_saves">Sincronizarea cloud va fi omisă în timpul verificării deoarece opțiunea „Doar salvări locale” este activată.</string>
     <string name="steam_update_title">Actualizare</string>
     <string name="steam_update_message">Asigură-te că salvările sunt încărcate în cloud sau copiate în altă parte înainte de actualizare, deoarece pot fi suprascrise.</string>
     <string name="steam_not_logged_in">Trebuie să fii autentificat în Steam pentru a folosi această funcție</string>
@@ -652,6 +653,8 @@
 	<string name="unpack_files_description">Folosește doar dacă primești \'Application Load Error 3:0000065432\'.</string>
 	<string name="force_dlc">Forțează DLC</string>
 	<string name="force_dlc_description">Activează doar dacă DLC‑urile nu sunt detectate sau salvările cu DLC nu funcționează</string>
+	<string name="local_saves_only">Doar salvări locale</string>
+	<string name="local_saves_only_description">Dezactivează sincronizarea salvărilor în cloud pentru acest joc și păstrează salvările doar pe dispozitiv</string>
 	<string name="launch_steam_client_beta">Pornește Steam Client (Beta)</string>
 	<string name="steam_offline_mode">Mod Offline Steam</string>
 	<string name="steam_offline_mode_description">Pornește jocurile Steam în mod offline</string>
@@ -1013,6 +1016,7 @@
 	<string name="library_cloud_sync_up_to_date">Fișierele de salvare sunt deja la zi</string>
 	<string name="library_cloud_sync_failed">Sincronizare cloud eșuată</string>
 	<string name="library_cloud_sync_error">Eroare la sincronizarea salvărilor din cloud: %1$s</string>
+	<string name="library_cloud_sync_in_progress">Sincronizarea cloud este deja în curs</string>
 
 	<!-- LibraryAppScreen: UI Labels -->
 	<string name="library_need_internet">Este necesar internet pentru instalare</string>
@@ -1445,4 +1449,6 @@
     <string name="lsfg_install_message">Aceasta va descărca Lossless Scaling din Steam pentru a activa generarea de cadre.</string>
     <string name="lsfg_installing">Se descarcă Lossless Scaling…</string>
     <string name="lsfg_performance_mode_desc">Reduce calitatea pentru un debit mai mare</string>
+    <string name="cloud_sync_local_saves_only_title">Doar salvări locale</string>
+    <string name="cloud_sync_local_saves_only_message">Opțiunea „Doar salvări locale” este activată pentru acest joc. Salvările din cloud pot fi diferite de cele locale. Pe care vrei să le păstrezi?</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -422,6 +422,8 @@
     <string name="fexcore_version">Версия FEXCore</string>
     <string name="force_dlc">Принудительно включить DLC</string>
     <string name="force_dlc_description">Включайте только если DLC не обнаружены или сохранения с DLC не работают</string>
+    <string name="local_saves_only">Только локальные сохранения</string>
+    <string name="local_saves_only_description">Отключить облачную синхронизацию сохранений для этой игры и хранить сохранения только на устройстве</string>
     <string name="frame_synchronization">Синхронизация кадров</string>
     <string name="game_executable_not_found">Исполняемый файл не смог быть автоматически выбран. Пожалуйста, установите путь исполняемого файла в настройках контейнера.</string>
     <string name="game_executable_not_found_title">Невозможно запустить</string>
@@ -571,6 +573,7 @@ Ubuntu RootFs - releases.ubuntu.com/focal</string>
     <string name="library_cloud_sync_up_to_date">Файлы сохранения уже актуальны</string>
     <string name="library_cloud_sync_failed">Ошибка синхронизации облака</string>
     <string name="library_cloud_sync_error">Ошибка синхронизации облачного сохранения: %1$s</string>
+    <string name="library_cloud_sync_in_progress">Синхронизация облачных сохранений уже выполняется</string>
     <string name="library_compatibility_unknown">Неизвестно</string>
     <string name="library_compatible">Совместимо</string>
     <string name="library_config_title">Конфигурация %s</string>
@@ -1131,6 +1134,7 @@ https://gamenative.app
     <string name="steam_update_message">Пожалуйста, убедитесь, что ваши сохранения загружены в облако или скопированы, поскольку они могут быть перезаписаны.</string>
     <string name="steam_update_title">Обновление</string>
     <string name="steam_verify_files_message">Пожалуйста, убедитесь, что ваши сохранения загружены в облако или скопированы, поскольку они могут быть перезаписаны.</string>
+    <string name="steam_verify_files_message_local_saves">Облачная синхронизация будет пропущена при проверке, так как включены только локальные сохранения.</string>
     <string name="steam_verify_files_title">Проверить файлы</string>
     <string name="storage_info">Информация о хранилище</string>
     <string name="summary_collapsed_preference_list">%1$s, %2$s</string>
@@ -1373,4 +1377,6 @@ https://gamenative.app
     <string name="lsfg_install_message">Это загрузит Lossless Scaling из Steam для включения генерации кадров.</string>
     <string name="lsfg_installing">Загрузка Lossless Scaling…</string>
     <string name="lsfg_performance_mode_desc">Снижает качество для повышения пропускной способности</string>
+    <string name="cloud_sync_local_saves_only_title">Только локальные сохранения</string>
+    <string name="cloud_sync_local_saves_only_message">"Только локальные сохранения" включено для этой игры. Облачные сохранения могут отличаться от локальных. Какие вы хотите оставить?</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -28,6 +28,7 @@
     <string name="steam_verify_files_title">Перевірити файли</string>
     <string name="steam_verify_files_message">Будь ласка, переконайтеся, що ваші збереження завантажено у хмару або створено їхню резервну копію перед перевіркою, оскільки інакше вони можуть бути перезаписані.</string>
     <string name="steam_cloud_sync_downloading_save_files">Завантаження файлів збережень %1$d/%2$d</string>
+    <string name="steam_verify_files_message_local_saves">Хмарна синхронізація буде пропущена під час перевірки, оскільки увімкнено лише локальні збереження.</string>
     <string name="steam_update_title">Оновити</string>
     <string name="steam_update_message">Будь ласка, переконайтеся, що ваші збереження завантажено у хмару або створено їхню резервну копію перед оновленням, оскільки інакше вони можуть бути перезаписані.</string>
     <string name="steam_not_logged_in">Ви повинні увійти в Steam, щоб використовувати цю функцію</string>
@@ -646,6 +647,8 @@
     <string name="unpack_files_description">Використовувати лише якщо з\'являється \'Application Load Error 3:0000065432\'.</string>
     <string name="force_dlc">Примусити DLC</string>
     <string name="force_dlc_description">Увімкнути лише тоді, якщо не виявлено DLC або не працюють збереження з DLC</string>
+    <string name="local_saves_only">Лише локальні збереження</string>
+    <string name="local_saves_only_description">Вимкнути хмарну синхронізацію збережень для цієї гри та зберігати лише на пристрої</string>
     <string name="launch_steam_client_beta">Запустити клієнт Steam (Бета)</string>
     <string name="steam_offline_mode">Режим Офлайн Steam</string>
     <string name="steam_offline_mode_description">Запускати ігри Steam в офлайн режимі</string>
@@ -1008,6 +1011,7 @@
     <string name="library_cloud_sync_up_to_date">Файли збереження вже актуальні</string>
     <string name="library_cloud_sync_failed">Помилка синхронізації з хмарою</string>
     <string name="library_cloud_sync_error">Помилка синхронізації з хмарою: %1$s</string>
+    <string name="library_cloud_sync_in_progress">Синхронізація з хмарою вже виконується</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">Потрібне інтернет-з\'єднання для інсталяції</string>
@@ -1439,4 +1443,6 @@
     <string name="lsfg_install_message">Це завантажить Lossless Scaling зі Steam для увімкнення генерації кадрів.</string>
     <string name="lsfg_installing">Завантаження Lossless Scaling…</string>
     <string name="lsfg_performance_mode_desc">Знижує якість для вищої пропускної здатності</string>
+    <string name="cloud_sync_local_saves_only_title">Лише локальні збереження</string>
+    <string name="cloud_sync_local_saves_only_message">"Лише локальні збереження" увімкнено для цієї гри. Хмарні збереження можуть відрізнятися від локальних. Які ви хочете залишити?</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -28,6 +28,7 @@
     <string name="steam_verify_files_title">验证文件</string>
     <string name="steam_verify_files_message">验证前请确保存档已上传至云端或已备份，否则存档可能会被覆盖</string>
     <string name="steam_cloud_sync_downloading_save_files">正在下载存档文件 %1$d/%2$d</string>
+    <string name="steam_verify_files_message_local_saves">由于已启用仅本地存档，验证期间将跳过云同步。</string>
     <string name="steam_update_title">更新</string>
     <string name="steam_update_message">更新前请确保存档已上传至云端或已备份，否则存档可能会被覆盖</string>
     <string name="steam_storage_permission_required">需要存储权限</string>
@@ -642,6 +643,8 @@
     <string name="unpack_files_description">仅在出现\'应用程序加载错误\'时使用。可能会降低帧率。</string>
     <string name="force_dlc">强制开启DLC</string>
     <string name="force_dlc_description">仅在未检测到 DLC 或包含 DLC 的存档无法运作时启用</string>
+    <string name="local_saves_only">仅本地存档</string>
+    <string name="local_saves_only_description">禁用此游戏的云存档同步，仅在设备上保存</string>
     <string name="launch_steam_client_beta">启动 Steam 客户端（Beta）</string>
     <string name="steam_offline_mode">Steam 离线模式</string>
     <string name="steam_offline_mode_description">以离线模式启动 Steam 游戏</string>
@@ -1004,6 +1007,7 @@
     <string name="library_cloud_sync_up_to_date">云存档同步已是最新状态</string>
     <string name="library_cloud_sync_failed">云存档同步失败</string>
     <string name="library_cloud_sync_error">云存档同步错误：%1$s</string>
+    <string name="library_cloud_sync_in_progress">云存档同步正在进行中</string>
 
     <!-- 库应用界面：UI标签 -->
     <string name="library_need_internet">需联网安装</string>
@@ -1446,10 +1450,6 @@
     <string name="library_compatibility_unknown">未知</string>
     <string name="library_not_compatible">不兼容</string>
 
-    <!-- Steam 集成：存档设置 -->
-    <string name="local_saves_only">仅本地存档</string>
-    <string name="local_saves_only_description">禁用此游戏的云存档同步，仅将存档保存在本地设备上</string>
-
     <!-- 主界面：下载条目 -->
     <string name="main_downloading_entry">正在下载 %s</string>
 
@@ -1513,4 +1513,6 @@
     <string name="lsfg_install_message">将从 Steam 下载 Lossless Scaling 以启用帧生成。</string>
     <string name="lsfg_installing">正在下载 Lossless Scaling…</string>
     <string name="lsfg_performance_mode_desc">降低画质以提升吞吐量</string>
+    <string name="cloud_sync_local_saves_only_title">仅本地存档</string>
+    <string name="cloud_sync_local_saves_only_message">此游戏已启用\u201C仅本地存档\u201D。云端存档可能与本地存档不同。您想保留哪个？</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -28,6 +28,7 @@
     <string name="steam_verify_files_title">驗證檔案</string>
     <string name="steam_verify_files_message">請確保您的存檔已上傳至雲端或已備份, 然後再進行驗證, 否則存檔可能會被覆蓋</string>
     <string name="steam_cloud_sync_downloading_save_files">正在下載存檔檔案 %1$d/%2$d</string>
+    <string name="steam_verify_files_message_local_saves">由於已啟用僅本地存檔，驗證期間將跳過雲端同步。</string>
     <string name="steam_update_title">更新</string>
     <string name="steam_update_message">請確保您的存檔已上傳至雲端或已備份, 然後再進行驗證, 否則存檔可能會被覆蓋</string>
     <string name="steam_storage_permission_required">需要存儲權限</string>
@@ -644,6 +645,8 @@
     <string name="unpack_files_description">僅在出現\'應用程式載入錯誤\'時使用。可能會降低幀率。</string>
     <string name="force_dlc">強制開啟DLC</string>
     <string name="force_dlc_description">僅在未偵測到 DLC 或包含 DLC 的存檔無法運作時啟用</string>
+    <string name="local_saves_only">僅本地存檔</string>
+    <string name="local_saves_only_description">停用此遊戲的雲端存檔同步，僅在裝置上保存</string>
     <string name="launch_steam_client_beta">啟動 Steam 用戶端 (Beta)</string>
     <string name="steam_offline_mode">Steam 離線模式</string>
     <string name="steam_offline_mode_description">以離線模式啟動 Steam 遊戲</string>
@@ -1007,6 +1010,7 @@
     <string name="library_cloud_sync_up_to_date">儲存檔案已更新至最新版本</string>
     <string name="library_cloud_sync_failed">雲端同步失敗</string>
     <string name="library_cloud_sync_error">雲端存檔同步錯誤：%1$s</string>
+    <string name="library_cloud_sync_in_progress">雲端存檔同步正在進行中</string>
 
     <!-- LibraryAppScreen: UI Labels -->
     <string name="library_need_internet">需連網安裝</string>
@@ -1445,9 +1449,6 @@
     <string name="library_compatibility_unknown">未知</string>
     <string name="library_not_compatible">不相容</string>
 
-    <string name="local_saves_only">僅限本地存檔</string>
-    <string name="local_saves_only_description">停用此遊戲的雲端存檔同步，僅將存檔儲存在本地裝置上</string>
-
     <string name="main_downloading_entry">正在下載 %s</string>
 
     <string name="option_open_store_page">開啟商店頁面</string>
@@ -1505,4 +1506,6 @@
     <string name="lsfg_install_message">將從 Steam 下載 Lossless Scaling 以啟用幀生成。</string>
     <string name="lsfg_installing">正在下載 Lossless Scaling…</string>
     <string name="lsfg_performance_mode_desc">降低畫質以提升吞吐量</string>
+    <string name="cloud_sync_local_saves_only_title">僅本地存檔</string>
+    <string name="cloud_sync_local_saves_only_message">此遊戲已啟用「僅本地存檔」。雲端存檔可能與本地存檔不同。您想保留哪一個？</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="steam_verify_files_title">Verify Files</string>
     <string name="steam_verify_files_message">Please ensure your saves are uploaded to the cloud or backed up before verifying, as they may be overwritten otherwise.</string>
     <string name="steam_cloud_sync_downloading_save_files">Downloading save files %1$d/%2$d</string>
+    <string name="steam_verify_files_message_local_saves">Cloud sync will be skipped during verification because local saves only is enabled.</string>
     <string name="steam_update_title">Update</string>
     <string name="steam_update_message">Please ensure your saves are uploaded to the cloud or backed up before updating, as they may be overwritten otherwise.</string>
     <string name="steam_not_logged_in">You must be logged into Steam to use this feature</string>
@@ -1045,6 +1046,7 @@
     <string name="library_cloud_sync_success">Cloud sync completed successfully</string>
     <string name="library_cloud_sync_up_to_date">Save files are already up to date</string>
     <string name="library_cloud_sync_failed">Cloud sync failed</string>
+    <string name="library_cloud_sync_in_progress">Cloud sync is already in progress</string>
     <string name="library_cloud_sync_error">Cloud sync error: %1$s</string>
 
     <!-- LibraryAppScreen: UI Labels -->
@@ -1104,6 +1106,8 @@
     <string name="main_keep_remote">Keep remote</string>
     <string name="main_save_conflict_upgrade_v1_title">Choose Save Version</string>
     <string name="main_save_conflict_upgrade_v1_message">We fixed cloud save path handling for this game and found different local and cloud saves. Pick one version to keep.\n\nLocal:\n\t%1$s\nCloud:\n\t%2$s</string>
+    <string name="cloud_sync_local_saves_only_title">Local Saves Only</string>
+    <string name="cloud_sync_local_saves_only_message">"Local saves only" is enabled for this game. Cloud saves may differ from local saves. Which would you like to keep?</string>
 
     <!-- PluviaMain: Sync Errors -->
     <string name="main_sync_in_progress_retry">Sync operation is taking too long. Please try launching the game again in a moment.</string>

--- a/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
+++ b/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
@@ -3,6 +3,7 @@ package app.gamenative.service
 import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import app.gamenative.PrefManager
 import app.gamenative.data.ConfigInfo
 import app.gamenative.data.FileChangeLists
 import app.gamenative.data.PostSyncInfo
@@ -26,6 +27,7 @@ import `in`.dragonbra.javasteam.steam.handlers.steamcloud.SteamCloud
 import `in`.dragonbra.javasteam.steam.handlers.steamcloud.FileDownloadInfo
 import `in`.dragonbra.javasteam.steam.steamclient.configuration.SteamConfiguration
 import app.gamenative.enums.SyncResult
+import app.gamenative.utils.CURRENT_UFS_PARSE_VERSION
 import `in`.dragonbra.javasteam.util.crypto.CryptoHelper
 import kotlinx.coroutines.runBlocking
 import okhttp3.Call
@@ -80,6 +82,10 @@ class SteamAutoCloudTest {
         every { Net.httpForParallelDownloads(any()) } returns mockParallelHttpClient
 
         context = ApplicationProvider.getApplicationContext()
+
+        // PrefManager uses a real Robolectric-backed DataStore so pendingCloudResync persists
+        PrefManager.init(context)
+
         tempDir = File.createTempFile("steam_autocloud_test_", null)
         tempDir.delete()
         tempDir.mkdirs()
@@ -246,6 +252,7 @@ class SteamAutoCloudTest {
     @After
     fun tearDown() {
         unmockkObject(Net)
+        PrefManager.pendingCloudResync = emptySet()
 
         // Clean up ImageFs directory first (files created in wineprefix)
         // This is critical because ImageFs uses context.getFilesDir() which is inside Robolectric's temp directory
@@ -2396,46 +2403,17 @@ class SteamAutoCloudTest {
         )
     }
 
-    // ── Scenario 16: DB cache wiped by destructive migration, local == remote ──
-    // Repro of the "every steam game reports conflict post-update" bug. When
-    // fallbackToDestructiveMigration wipes file_change_lists but local save files
-    // are byte-identical to the cloud manifest, we must rehydrate the cache
-    // silently and NOT show a conflict dialog.
+    // ── Scenario 14: pendingCloudResync flag suppresses upgrade conflict text ──
     @Test
-    fun dbCleared_localMatchesRemote_rehydratesSilently_noConflict() = runBlocking {
+    fun cacheCleared_pendingResync_conflictWithoutUpgradeText() = runBlocking {
         db.appChangeNumbersDao().deleteByAppId(steamAppId)
         db.appFileChangeListsDao().deleteByAppId(steamAppId)
-
-        // the 5 files created in setUp() — cloud manifest must match exactly.
-        // local scan basePath = %WinMyDocuments%/My Games/TestGame/Steam/{id},
-        // files live under SaveGames/ → filename (relativized) includes that prefix.
-        val localFiles = mapOf(
-            "SaveGames/AutoSaveData.sav" to "autosave content".toByteArray(),
-            "SaveGames/SaveData_0.sav" to "savedata0 content".toByteArray(),
-            "SaveGames/ContinueSaveData.sav" to "continue content".toByteArray(),
-            "SaveGames/SaveData_1.sav" to "savedata1 content".toByteArray(),
-            "SaveGames/SystemData_0.sav" to "systemdata content".toByteArray(),
-        )
-
         assertTrue("Precondition: local save files exist", saveFilesDir.listFiles()!!.isNotEmpty())
 
-        val cloudFiles = localFiles.map { (name, content) ->
-            val m = mock<AppFileInfo>()
-            whenever(m.filename).thenReturn(name)
-            whenever(m.shaFile).thenReturn(sha1(content))
-            whenever(m.pathPrefixIndex).thenReturn(0)
-            whenever(m.timestamp).thenReturn(Date())
-            whenever(m.rawFileSize).thenReturn(content.size)
-            m
-        }
+        PrefManager.pendingCloudResync = setOf(steamAppId)
 
-        val cloudFileChangeList = makeCloudFileChangeList(
-            cloudChangeNumber = 5,
-            files = cloudFiles,
-            pathPrefixes = listOf("%WinMyDocuments%/My Games/TestGame/Steam/76561198025127569"),
-        )
         every { mockSteamCloud.getAppFileListChange(any(), any(), any()) } returns
-            CompletableFuture.completedFuture(cloudFileChangeList)
+            CompletableFuture.completedFuture(makeCloudFileChangeList(cloudChangeNumber = 5))
 
         val testApp = db.steamAppDao().findApp(steamAppId)!!
         val result = SteamAutoCloud.syncUserFiles(
@@ -2448,31 +2426,41 @@ class SteamAutoCloudTest {
         ).await()
 
         assertNotNull(result)
-        assertEquals(
-            "local matches remote exactly — should be UpToDate, not Conflict",
-            SyncResult.UpToDate,
-            result!!.syncResult,
-        )
+        assertEquals("Should still be Conflict", SyncResult.Conflict, result!!.syncResult)
         assertNull(
-            "no conflict dialog — conflictUfsVersion must be null",
+            "conflictUfsVersion should be null — generic text, not upgrade",
             result.conflictUfsVersion,
         )
-        assertEquals("no downloads", 0, result.filesDownloaded)
-        assertEquals("no uploads", 0, result.filesUploaded)
+    }
 
-        // cache must be rehydrated so next launch doesn't trip the same path
-        val rehydrated = db.appFileChangeListsDao().getByAppId(steamAppId)
-        assertNotNull("cache should be rehydrated", rehydrated)
+    // ── Scenario 15: Without pendingCloudResync, conflict sets conflictUfsVersion ──
+    @Test
+    fun cacheCleared_noPendingResync_conflictWithUpgradeText() = runBlocking {
+        db.appChangeNumbersDao().deleteByAppId(steamAppId)
+        db.appFileChangeListsDao().deleteByAppId(steamAppId)
+        assertTrue("Precondition: local save files exist", saveFilesDir.listFiles()!!.isNotEmpty())
+
+        PrefManager.pendingCloudResync = emptySet()
+
+        every { mockSteamCloud.getAppFileListChange(any(), any(), any()) } returns
+            CompletableFuture.completedFuture(makeCloudFileChangeList(cloudChangeNumber = 5))
+
+        val testApp = db.steamAppDao().findApp(steamAppId)!!
+        val result = SteamAutoCloud.syncUserFiles(
+            appInfo = testApp,
+            clientId = clientId,
+            steamInstance = mockSteamService,
+            steamCloud = mockSteamCloud,
+            preferredSave = SaveLocation.None,
+            prefixToPath = makePrefixToPath(),
+        ).await()
+
+        assertNotNull(result)
+        assertEquals("Should be Conflict", SyncResult.Conflict, result!!.syncResult)
         assertEquals(
-            "rehydrated cache should contain all 5 local files",
-            5,
-            rehydrated!!.userFileInfo.size,
-        )
-        val rehydratedCn = db.appChangeNumbersDao().getByAppId(steamAppId)
-        assertEquals(
-            "rehydrated change number should match cloud",
-            5L,
-            rehydratedCn!!.changeNumber,
+            "conflictUfsVersion should be set for upgrade text",
+            CURRENT_UFS_PARSE_VERSION,
+            result.conflictUfsVersion,
         )
     }
 }


### PR DESCRIPTION
## Description

Re-enable "local saves only" with proper cloud sync safety nets.

Depends on #1169 (the sync cache fix).

- Unhide "local saves only" toggle in GeneralTab
- Show conflict dialog (Keep Remote / Keep Local) when force-syncing with local-saves-only enabled
- Clear cloud sync cache on toggle-off so next sync detects divergence
- `pendingCloudResync` flag distinguishes "cache cleared by toggle" from "cache cleared by app update" — the former gets generic conflict text, the latter gets upgrade-specific text
- Skip cloud sync during verify-files when local-saves-only is active
- Localized new strings across all supported languages

Closes #1145

## Recording

<img width="1920" height="1080" alt="Screenshot_20260408-100943" src="https://github.com/user-attachments/assets/ab6ad1f5-398b-4d59-b242-a24ac419c5e9" />

## Test plan

- [ ] Enable "local saves only" for a game, click Force Cloud Sync — conflict dialog appears
- [ ] Choose "Keep Remote" — cloud saves download
- [ ] Choose "Keep Local" — local saves upload
- [ ] Disable "local saves only" — next force sync detects divergence correctly
- [ ] Verify Files with local-saves-only on — no cloud sync triggered
- [ ] Unit tests pass: `./gradlew testDebugUnitTest --tests "*.SteamAutoCloudTest"`

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-enabled per-game "Local saves only" toggle and added a conflict dialog to choose Keep Local or Keep Remote.
  * Centralized forced cloud-sync flow with clearer success/error feedback and explicit conflict prompts.

* **Behavior Changes**
  * Toggling local-only clears related cloud-sync cache and updates a persisted pending-resync set to schedule or skip resyncs.
  * Conflict handling updates pending-resync state and retries syncs based on user choice.

* **Localization**
  * Added translations for the new flow across many languages.

* **Tests**
  * Expanded sync-decision tests covering pending-resync and conflict messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->