### PR TITLE
fix: don't let expired free weekend licenses shadow owned games

### DIFF
--- a/app/src/main/java/app/gamenative/db/dao/DbConstants.kt
+++ b/app/src/main/java/app/gamenative/db/dao/DbConstants.kt
@@ -1,0 +1,3 @@
+package app.gamenative.db.dao
+
+const val SQLITE_MAX_VARS = 999

--- a/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
@@ -145,6 +145,20 @@ interface SteamAppDao {
     @Query("SELECT * FROM steam_app WHERE id = :appId")
     suspend fun findApp(appId: Int): SteamApp?
 
+    @Query("SELECT * FROM steam_app WHERE id IN (:appIds)")
+    suspend fun _findApps(appIds: List<Int>): List<SteamApp>
+
+    @Transaction
+    suspend fun findApps(appIds: List<Int>): List<SteamApp> {
+        if (appIds.isEmpty()) return emptyList()
+        val results = mutableListOf<SteamApp>()
+        for (chunkStart in appIds.indices step SQLITE_MAX_VARS) {
+            val chunkEnd = minOf(chunkStart + SQLITE_MAX_VARS, appIds.size)
+            results += _findApps(appIds.subList(chunkStart, chunkEnd))
+        }
+        return results
+    }
+
     @Query("SELECT * FROM steam_app AS app WHERE dlc_for_app_id = :appId AND depots <> '{}' AND " +
             " EXISTS (" +
             "   SELECT * FROM steam_license AS license " +

--- a/app/src/main/java/app/gamenative/db/dao/SteamLicenseDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/SteamLicenseDao.kt
@@ -9,8 +9,6 @@ import androidx.room.Update
 import app.gamenative.data.SteamLicense
 import kotlin.math.min
 
-val SQLITE_MAX_VARS = 999
-
 @Dao
 interface SteamLicenseDao {
 

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -68,7 +68,9 @@ import `in`.dragonbra.javasteam.depotdownloader.data.AppItem
 import `in`.dragonbra.javasteam.depotdownloader.data.DownloadItem
 import `in`.dragonbra.javasteam.enums.EDepotFileFlag
 import `in`.dragonbra.javasteam.enums.ELicenseFlags
+import `in`.dragonbra.javasteam.enums.ELicenseType
 import `in`.dragonbra.javasteam.enums.EOSType
+import `in`.dragonbra.javasteam.enums.EPaymentMethod
 import `in`.dragonbra.javasteam.enums.EPersonaState
 import `in`.dragonbra.javasteam.enums.EResult
 import `in`.dragonbra.javasteam.networking.steam3.ProtocolTypes
@@ -360,6 +362,70 @@ class SteamService : Service(), IChallengeUrlChanged {
             if (removed != null) {
                 notifyDownloadStopped(appId)
             }
+        }
+
+        internal fun selectPreferredPackageId(
+            existingPackageId: Int,
+            incomingPackageId: Int,
+            licensesByPackageId: Map<Int, SteamLicense>,
+        ): Int {
+            if (existingPackageId == INVALID_PKG_ID) return incomingPackageId
+            if (incomingPackageId == INVALID_PKG_ID) return existingPackageId
+
+            val existingPriority = packageSelectionPriority(existingPackageId, licensesByPackageId[existingPackageId])
+            val incomingPriority = packageSelectionPriority(incomingPackageId, licensesByPackageId[incomingPackageId])
+
+            return if (incomingPriority > existingPriority) incomingPackageId else existingPackageId
+        }
+
+        private data class PackageSelectionPriority(
+            val hasMetadata: Boolean,
+            val isNonExpired: Boolean,
+            val isDurable: Boolean,
+            val timeCreatedMs: Long,
+            val packageId: Int,
+        ) : Comparable<PackageSelectionPriority> {
+            override fun compareTo(other: PackageSelectionPriority): Int =
+                compareValuesBy(
+                    this,
+                    other,
+                    PackageSelectionPriority::hasMetadata,
+                    PackageSelectionPriority::isNonExpired,
+                    PackageSelectionPriority::isDurable,
+                    PackageSelectionPriority::timeCreatedMs,
+                    PackageSelectionPriority::packageId,
+                )
+        }
+
+        private fun packageSelectionPriority(
+            packageId: Int,
+            license: SteamLicense?,
+        ): PackageSelectionPriority = PackageSelectionPriority(
+            hasMetadata = license != null,
+            isNonExpired = license?.licenseFlags?.contains(ELicenseFlags.Expired) != true,
+            isDurable = license?.let(::isDurableLicense) == true,
+            timeCreatedMs = license?.timeCreated?.time ?: Long.MIN_VALUE,
+            packageId = packageId,
+        )
+
+        private fun isDurableLicense(license: SteamLicense): Boolean {
+            val limitedUseLicense = when (license.licenseType) {
+                ELicenseType.SinglePurchaseLimitedUse,
+                ELicenseType.RecurringChargeLimitedUse,
+                ELicenseType.RecurringChargeLimitedUseWithOverages,
+                ELicenseType.LimitedUseDelayedActivation -> true
+                else -> false
+            }
+
+            val temporaryPaymentMethod = when (license.paymentMethod) {
+                EPaymentMethod.GuestPass,
+                EPaymentMethod.Promotional,
+                EPaymentMethod.AutoGrant,
+                EPaymentMethod.Complimentary -> true
+                else -> false
+            }
+
+            return !limitedUseLicense && !temporaryPaymentMethod
         }
 
         /** Returns true if there is an incomplete download on disk (no complete marker). */
@@ -4054,67 +4120,61 @@ class SteamService : Service(), IChallengeUrlChanged {
                             // implementation overwrote SteamApp.packageId with whichever pkg was iterated
                             // last — non-deterministic and prone to landing on a non-user-owned package,
                             // which then makes the user's own game appear as family-shared in the library.
-                            // To fix that we (a) process user-owned packages last so they win the
-                            // last-write-wins assignment within this batch and (b) refuse to downgrade an
-                            // existing user-owned packageId across batches.
-                            val accountId = userSteamId?.accountID?.toInt()
-                            val packageLicenses: Map<Int, SteamLicense> = if (accountId != null) {
-                                val packageIds = picsCallback.packages.values.map { it.id }
-                                licenseDao.findLicenses(packageIds).associateBy { it.packageId }
-                            } else {
-                                emptyMap()
-                            }
-                            val userOwnedPackageIds: Set<Int> = if (accountId != null) {
-                                packageLicenses.values
-                                    .filter { it.ownerAccountId.contains(accountId) }
-                                    .mapTo(HashSet()) { it.packageId }
-                            } else {
-                                emptySet()
+                            data class PackageAppsAndDepots(
+                                val packageId: Int,
+                                val appIds: List<Int>,
+                                val depotIds: List<Int>,
+                            )
+
+                            val packageData = picsCallback.packages.values.map { pkg ->
+                                PackageAppsAndDepots(
+                                    packageId = pkg.id,
+                                    appIds = pkg.keyValues["appids"].children.map { it.asInteger() },
+                                    depotIds = pkg.keyValues["depotids"].children.map { it.asInteger() },
+                                )
                             }
 
-                            // Prefer non-expired user-owned packages so a live sub wins over an expired remnant.
-                            fun pkgRank(pkgId: Int): Int {
-                                if (pkgId !in userOwnedPackageIds) return 0
-                                val expired = packageLicenses[pkgId]?.licenseFlags?.contains(ELicenseFlags.Expired) == true
-                                return if (expired) 1 else 2
-                            }
+                            val appIdsInBatch = packageData
+                                .flatMap { it.appIds }
+                                .distinct()
+                            val appsById = appDao.findApps(appIdsInBatch)
+                                .associateBy { it.id }
+                                .toMutableMap()
+                            val existingPackageIds = appsById.values
+                                .map { it.packageId }
+                                .filter { it != INVALID_PKG_ID }
+                            val packageIdsNeedingMetadata = (packageData.map { it.packageId } + existingPackageIds).distinct()
+                            val licensesByPackageId = licenseDao.findLicenses(packageIdsNeedingMetadata).associateBy { it.packageId }
 
-                            val orderedPackages = picsCallback.packages.values.sortedBy { pkgRank(it.id) }
-
-                            orderedPackages.forEach { pkg ->
-                                val appIds = pkg.keyValues["appids"].children.map { it.asInteger() }
-                                licenseDao.updateApps(pkg.id, appIds)
-
-                                val depotIds = pkg.keyValues["depotids"].children.map { it.asInteger() }
-                                licenseDao.updateDepots(pkg.id, depotIds)
+                            packageData.forEach { pkg ->
+                                licenseDao.updateApps(pkg.packageId, pkg.appIds)
+                                licenseDao.updateDepots(pkg.packageId, pkg.depotIds)
 
                                 // Insert a stub row (or update) of SteamApps to the database.
-                                appIds.forEach { appid ->
-                                    val existing = appDao.findApp(appid)
-                                    if (existing == null) {
-                                        appDao.insert(SteamApp(id = appid, packageId = pkg.id))
-                                        return@forEach
-                                    }
-                                    if (existing.packageId == pkg.id) {
-                                        return@forEach
-                                    }
-                                    if (accountId != null && existing.packageId != INVALID_PKG_ID) {
-                                        val existingLicense = packageLicenses[existing.packageId]
-                                            ?: licenseDao.findLicense(existing.packageId)
-                                        val existingRank = when {
-                                            existingLicense == null -> 0
-                                            !existingLicense.ownerAccountId.contains(accountId) -> 0
-                                            ELicenseFlags.Expired in existingLicense.licenseFlags -> 1
-                                            else -> 2
+                                // Steam can report multiple packages for the same app. Choose a
+                                // stable winner so temporary licenses do not overwrite durable
+                                // purchases based on callback iteration order.
+                                pkg.appIds.forEach { appid ->
+                                    val steamApp = appsById[appid]
+                                    if (steamApp != null) {
+                                        val selectedPackageId = selectPreferredPackageId(
+                                            existingPackageId = steamApp.packageId,
+                                            incomingPackageId = pkg.packageId,
+                                            licensesByPackageId = licensesByPackageId,
+                                        )
+                                        if (selectedPackageId != steamApp.packageId) {
+                                            val updatedSteamApp = steamApp.copy(packageId = selectedPackageId)
+                                            appDao.update(updatedSteamApp)
+                                            appsById[appid] = updatedSteamApp
                                         }
-                                        if (existingRank > pkgRank(pkg.id)) {
-                                            return@forEach
-                                        }
+                                    } else {
+                                        val stubSteamApp = SteamApp(id = appid, packageId = pkg.packageId)
+                                        appDao.insert(stubSteamApp)
+                                        appsById[appid] = stubSteamApp
                                     }
-                                    appDao.update(existing.copy(packageId = pkg.id))
                                 }
 
-                                queue.addAll(appIds)
+                                queue.addAll(pkg.appIds)
                             }
                         }
 

--- a/app/src/test/java/app/gamenative/service/SteamPackageSelectionTest.kt
+++ b/app/src/test/java/app/gamenative/service/SteamPackageSelectionTest.kt
@@ -113,6 +113,51 @@ class SteamPackageSelectionTest {
     }
 
     @Test
+    fun `autogrant only license is selected for free to play games`() {
+        val autoGrant = makeLicense(
+            packageId = 0,
+            createdAtMs = 1_000L,
+            paymentMethod = EPaymentMethod.AutoGrant,
+            licenseType = ELicenseType.SinglePurchase,
+        )
+
+        val selected = SteamService.selectPreferredPackageId(
+            existingPackageId = SteamService.INVALID_PKG_ID,
+            incomingPackageId = autoGrant.packageId,
+            licensesByPackageId = mapOf(autoGrant.packageId to autoGrant),
+        )
+
+        assertEquals(autoGrant.packageId, selected)
+    }
+
+    @Test
+    fun `durable purchase beats autogrant when both are present`() {
+        val autoGrant = makeLicense(
+            packageId = 0,
+            createdAtMs = 2_000L,
+            paymentMethod = EPaymentMethod.AutoGrant,
+            licenseType = ELicenseType.SinglePurchase,
+        )
+        val purchased = makeLicense(
+            packageId = 100,
+            createdAtMs = 1_000L,
+            paymentMethod = EPaymentMethod.CreditCard,
+            licenseType = ELicenseType.SinglePurchase,
+        )
+
+        val selected = SteamService.selectPreferredPackageId(
+            existingPackageId = autoGrant.packageId,
+            incomingPackageId = purchased.packageId,
+            licensesByPackageId = mapOf(
+                autoGrant.packageId to autoGrant,
+                purchased.packageId to purchased,
+            ),
+        )
+
+        assertEquals(purchased.packageId, selected)
+    }
+
+    @Test
     fun `package id breaks complete ties deterministically`() {
         val first = makeLicense(
             packageId = 100,

--- a/app/src/test/java/app/gamenative/service/SteamPackageSelectionTest.kt
+++ b/app/src/test/java/app/gamenative/service/SteamPackageSelectionTest.kt
@@ -1,0 +1,137 @@
+package app.gamenative.service
+
+import app.gamenative.data.SteamLicense
+import `in`.dragonbra.javasteam.enums.ELicenseFlags
+import `in`.dragonbra.javasteam.enums.ELicenseType
+import `in`.dragonbra.javasteam.enums.EPaymentMethod
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Date
+import java.util.EnumSet
+
+class SteamPackageSelectionTest {
+
+    private fun makeLicense(
+        packageId: Int,
+        createdAtMs: Long,
+        flags: EnumSet<ELicenseFlags> = EnumSet.of(ELicenseFlags.None),
+        paymentMethod: EPaymentMethod = EPaymentMethod.CreditCard,
+        licenseType: ELicenseType = ELicenseType.SinglePurchase,
+    ) = SteamLicense(
+        packageId = packageId,
+        lastChangeNumber = 0,
+        timeCreated = Date(createdAtMs),
+        timeNextProcess = Date(createdAtMs),
+        minuteLimit = 0,
+        minutesUsed = 0,
+        paymentMethod = paymentMethod,
+        licenseFlags = flags,
+        purchaseCode = "",
+        licenseType = licenseType,
+        territoryCode = 0,
+        accessToken = 0L,
+        ownerAccountId = listOf(1),
+        masterPackageID = 0,
+    )
+
+    @Test
+    fun `durable purchase beats active guest pass`() {
+        val guestPass = makeLicense(
+            packageId = 100,
+            createdAtMs = 2_000L,
+            paymentMethod = EPaymentMethod.GuestPass,
+            licenseType = ELicenseType.SinglePurchaseLimitedUse,
+        )
+        val purchased = makeLicense(
+            packageId = 200,
+            createdAtMs = 1_000L,
+            paymentMethod = EPaymentMethod.CreditCard,
+            licenseType = ELicenseType.SinglePurchase,
+        )
+
+        val selected = SteamService.selectPreferredPackageId(
+            existingPackageId = purchased.packageId,
+            incomingPackageId = guestPass.packageId,
+            licensesByPackageId = mapOf(
+                guestPass.packageId to guestPass,
+                purchased.packageId to purchased,
+            ),
+        )
+
+        assertEquals(purchased.packageId, selected)
+    }
+
+    @Test
+    fun `active temporary package beats expired purchase`() {
+        val expiredPurchase = makeLicense(
+            packageId = 100,
+            createdAtMs = 1_000L,
+            flags = EnumSet.of(ELicenseFlags.Expired),
+            paymentMethod = EPaymentMethod.CreditCard,
+            licenseType = ELicenseType.SinglePurchase,
+        )
+        val activeTemporary = makeLicense(
+            packageId = 200,
+            createdAtMs = 2_000L,
+            paymentMethod = EPaymentMethod.GuestPass,
+            licenseType = ELicenseType.SinglePurchaseLimitedUse,
+        )
+
+        val selected = SteamService.selectPreferredPackageId(
+            existingPackageId = expiredPurchase.packageId,
+            incomingPackageId = activeTemporary.packageId,
+            licensesByPackageId = mapOf(
+                expiredPurchase.packageId to expiredPurchase,
+                activeTemporary.packageId to activeTemporary,
+            ),
+        )
+
+        assertEquals(activeTemporary.packageId, selected)
+    }
+
+    @Test
+    fun `newer durable purchase wins when both packages are durable`() {
+        val olderPurchase = makeLicense(
+            packageId = 100,
+            createdAtMs = 1_000L,
+        )
+        val newerPurchase = makeLicense(
+            packageId = 200,
+            createdAtMs = 2_000L,
+        )
+
+        val selected = SteamService.selectPreferredPackageId(
+            existingPackageId = olderPurchase.packageId,
+            incomingPackageId = newerPurchase.packageId,
+            licensesByPackageId = mapOf(
+                olderPurchase.packageId to olderPurchase,
+                newerPurchase.packageId to newerPurchase,
+            ),
+        )
+
+        assertEquals(newerPurchase.packageId, selected)
+    }
+
+    @Test
+    fun `package id breaks complete ties deterministically`() {
+        val first = makeLicense(
+            packageId = 100,
+            createdAtMs = 1_000L,
+        )
+        val second = makeLicense(
+            packageId = 200,
+            createdAtMs = 1_000L,
+        )
+
+        val selected = SteamService.selectPreferredPackageId(
+            existingPackageId = first.packageId,
+            incomingPackageId = second.packageId,
+            licensesByPackageId = mapOf(
+                first.packageId to first,
+                second.packageId to second,
+            ),
+        )
+
+        assertEquals(second.packageId, selected)
+    }
+}


### PR DESCRIPTION
## Summary

I played Dying Light during a Steam free weekend, then later bought it. After purchasing, the game wasn't showing up in GameNative's library at all.

This is related to but distinct from the expired-license filtering work in #945, #982, and #985. Those PRs addressed expired free weekend games *appearing* in the library. This fixes the inverse: a game you genuinely own *disappearing* because the expired free weekend license shadows the real purchase.

**Root cause:** During PICS package processing, each package unconditionally overwrote the `packageId` on its associated `SteamApp` rows. If the expired free weekend package happened to be processed after the real purchase package, it clobbered `packageId` with the expired license's ID — making the game invisible to the owned apps query (which, post-#985, correctly filters out expired packages).

## What this adds over #1353

#1353 landed a fix that sorts packages so user-owned ones are processed last (last-write-wins) and refuses to downgrade an existing user-owned `packageId` across batches. That covers the most common case but leaves three gaps:

1. **Same-batch AutoGrant vs real purchase.** Both land in the "user-owned" bucket after the sort, so their relative order is still non-deterministic. Free-to-play games (`AutoGrant` package 0) can still win over a paid purchase within the same PICS callback.

2. **Expired licenses treated as valid.** `ELicenseFlags.Expired` is not checked during package selection. An expired prior purchase is considered "user-owned" and can block an active package from being assigned.

3. **Guest passes / promotional grants indistinguishable from purchases.** `GuestPass`, `Promotional`, and `Complimentary` payment methods appear identical to a real purchase in the `ownerAccountId` check, so they can shadow a later durable purchase.

**This PR's fix:** replace last-write-wins ordering with a deterministic `PackageSelectionPriority` comparator that ranks every package on four criteria in order:

| Priority | Criterion | Rationale |
|---|---|---|
| 1 | `hasMetadata` | prefer any package we have license data for |
| 2 | `isNonExpired` | active license beats expired |
| 3 | `isDurable` | real purchase beats AutoGrant / GuestPass / Promotional / Complimentary |
| 4 | `timeCreatedMs` | newer license wins among equals |
| tiebreak | `packageId` | fully deterministic |

`selectPreferredPackageId()` replaces every per-app `packageId` write and operates over a single bulk license lookup (pre-loaded per batch), so the N+1 per-app DB queries from #1353 are also eliminated.

## Changes

- `SteamService`: `selectPreferredPackageId` + `PackageSelectionPriority` + `isDurableLicense` in companion object; PICS package loop refactored to bulk-load apps and licenses before iterating
- `SteamAppDao`: new `findApps(List<Int>)` with `SQLITE_MAX_VARS` chunking for safe bulk lookup
- `DbConstants`: shared `SQLITE_MAX_VARS` constant extracted from `SteamLicenseDao`
- `SteamPackageSelectionTest`: unit tests covering expired, guest pass, AutoGrant, and durable-purchase priority cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Steam package metadata selection to intelligently choose the most relevant package when multiple packages reference the same app, considering license cache status, expiration, durability, and creation date.
  * Added bulk-fetch optimization for app data retrieval.

* **Refactor**
  * Centralized database constants for better maintainability.
  * Enhanced data synchronization pipeline with improved transaction handling.

* **Tests**
  * Added comprehensive test suite for package selection logic covering multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->