### PR TITLE
fix: Missing X11 keysym entries for Num and Caps Lock keys

### DIFF
--- a/app/src/main/java/com/winlator/xserver/Keyboard.java
+++ b/app/src/main/java/com/winlator/xserver/Keyboard.java
@@ -335,6 +335,8 @@ public class Keyboard {
         keyboard.setKeysyms(XKeycode.KEY_F10.getId(), 65479, 0);
         keyboard.setKeysyms(XKeycode.KEY_F11.getId(), 65480, 0);
         keyboard.setKeysyms(XKeycode.KEY_F12.getId(), 65481, 0);
+        keyboard.setKeysyms(XKeycode.KEY_NUM_LOCK.getId(), 65407, 0);
+        keyboard.setKeysyms(XKeycode.KEY_CAPS_LOCK.getId(), 65509, 0);
         return keyboard;
     }
 


### PR DESCRIPTION
## Description
<!-- What changed and why? -->
~~Windows expects some of the keys to send keyboard symbols for the keys that should have it and no symbol for non-standard keys.
With Android to X11 conversion, it is also required to properly remap Android keys to X11 keys.~~

~~What was changed, is that non-printable keys were predefined and are ultimately used, to determine whether an equivalent symbol should be sent to xServer or not.
This way, some of the games using DirectX's DirectInput, properly recognizes non-standard keys like TAB, Space etc.~~

~~In addition, missing key symbols were added for Num Lock and Caps Lock.~~

edit:

Rebased again upon newer changes; in the current state indeed only missing entries are required. No changes in keysym handling.

## Recording
<!-- Attach a short recording/GIF showing the change -->
Hard to showcase, keys now work in games like TES IV: Oblivion, Hidden & Dangerous 2 etc.
The Elder Scrolls IV: Oblivion
https://drive.proton.me/urls/XJ91Y5FBTW#lR1DKvrjJ4H7

https://github.com/user-attachments/assets/dfa22122-eaf3-46f4-b9fe-10ac726b4fff

Half-Life 2
https://drive.proton.me/urls/TKJPSHPCSM#OmfoqTYmeBu-

https://github.com/user-attachments/assets/e47dd551-b5fd-43cd-8c18-d85ffd7aedd5

Hidden & Dangerous 2:
https://drive.proton.me/urls/JB5GA4G27W#8AjvijWz7IVS

https://github.com/user-attachments/assets/f0983930-620b-4514-807e-9aafe4a57065

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [ ] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Android→X11 keyboard mapping by sending keysym 0 for non-printable keys and adding missing Num Lock/Caps Lock keysyms. DirectInput apps now recognize control and navigation keys correctly.

- **Bug Fixes**
  - Mark modifier, control, navigation, and function keys as non-printable; pass keysym 0 to X11.
  - Compute keysym once per event; send Unicode only for printable keys.
  - Map Num Lock (65407) and Caps Lock (65509) keysyms.

<sup>Written for commit 0ad553cfb9859a891d11c7446c3e0113c97dfe1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for NUM_LOCK and CAPS_LOCK behavior.

* **Bug Fixes**
  * Improved keyboard input handling for modifier, navigation and function keys.
  * Ensured consistent character injection for printable keys and suppression for non-printable keys across virtual and physical key events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->