### PR TITLE
Empty Wine/XDG trash on container shutdown

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3401,6 +3401,25 @@ private fun exit(
     environment?.stopEnvironmentComponents()
     SteamService.keepAlive = false
     PluviaApp.clearActiveSuspendState()
+
+    // empty Wine/XDG trash in background after container stops
+    CoroutineScope(Dispatchers.IO).launch {
+        try {
+            val trashDir = File(container.rootDir, ".local/share/Trash")
+            val children = trashDir.listFiles()
+            if (children == null) {
+                Timber.w("Trash dir missing or unreadable: ${trashDir.path}")
+            } else if (children.isEmpty()) {
+                Timber.d("Trash empty")
+            } else {
+                Timber.d("Emptying trash (${children.size} items)")
+                val deleted = children.count { child -> FileUtils.delete(child) }
+                Timber.d("Trash cleanup done: $deleted/${children.size} items deleted")
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error emptying Wine/XDG trash")
+        }
+    }
     // AppUtils.restartApplication(this)
     // PluviaApp.xServerState = null
     // PluviaApp.xServer = null


### PR DESCRIPTION
## Description
<!-- What changed and why? -->
Wine's XDG trash (`~/.local/share/Trash`) accumulates deleted files but is never cleaned up, wasting storage in each container's home directory. The trash isn't created by Wine itself, but software running in the container (such as Chromium-based games like Sol Cesto) can create it.

- Empty `.local/share/Trash` in background coroutine when container shuts down
- Uses existing `FileUtils.delete()` for recursive cleanup

Closes #1150

## Recording
<!-- Attach a short recording/GIF showing the change -->
n/a — backend cleanup, no UI change

## Test plan
- [ ] Delete a file from within a running Wine container
- [ ] Exit the container and check logcat for "Emptying trash" / "Trash cleanup done"
- [ ] Verify `.local/share/Trash` is empty after shutdown

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have NOT attached a recording of the change (n/a).
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved app shutdown with a non-blocking background cleanup that inspects and removes leftover local trash items, logs progress (deleted/total), and records errors on failures without delaying exit—resulting in cleaner shutdowns and better diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->