### PR TITLE
fix: use horizontal tab row for downloads and storage in portrait

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/downloads/DownloadsScreen.kt
@@ -179,13 +179,27 @@ fun HomeDownloadsScreen(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
         )
 
+        val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
+
+        if (isPortrait && selectedLibraryItem == null) {
+            // Portrait: horizontal tab row above the content
+            DownloadsTabRow(
+                sections = sections,
+                selectedSection = selectedSection,
+                onSectionSelected = { selectedSectionIndex = it.ordinal },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            )
+        }
+
         Row(
             modifier = Modifier
                 .weight(1f)
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+                .padding(horizontal = 16.dp, vertical = if (isPortrait) 0.dp else 8.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            if (selectedLibraryItem == null) {
+            if (!isPortrait && selectedLibraryItem == null) {
                 DownloadsSidebar(
                     sections = sections,
                     selectedSection = selectedSection,
@@ -344,6 +358,70 @@ private fun DownloadsSidebar(
                 return@LaunchedEffect
             } catch (_: Exception) {
                 delay(80)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DownloadsTabRow(
+    sections: List<DownloadsSection>,
+    selectedSection: DownloadsSection,
+    onSectionSelected: (DownloadsSection) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        sections.forEach { section ->
+            val isSelected = selectedSection == section
+            val accentColor = PluviaTheme.colors.accentPurple
+
+            Surface(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(16.dp))
+                    .selectable(
+                        selected = isSelected,
+                        onClick = { onSectionSelected(section) },
+                    ),
+                shape = RoundedCornerShape(16.dp),
+                color = if (isSelected) {
+                    accentColor.copy(alpha = 0.16f)
+                } else {
+                    PluviaTheme.colors.surfacePanel.copy(alpha = 0.88f)
+                },
+                border = BorderStroke(
+                    width = if (isSelected) 1.5.dp else 1.dp,
+                    color = if (isSelected) {
+                        accentColor.copy(alpha = 0.45f)
+                    } else {
+                        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.15f)
+                    },
+                ),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = section.icon,
+                        contentDescription = stringResource(section.titleResId),
+                        tint = if (isSelected) accentColor else MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Text(
+                        text = stringResource(section.titleResId),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = if (isSelected) accentColor else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
per https://discord.com/channels/1378308569287622737/1491494500676276337

adding a vertical layout to better use space on the screen when vertical
## Recording
<!-- Attach a short recording/GIF showing the change -->
Before:
![Screenshot_20260408_194431_GameNative](https://github.com/user-attachments/assets/18c8b280-6628-4715-8aaa-b923a3dd413a)



After:
<img width="544" height="960" alt="Screenshot_20260408-192218_GameNative" src="https://github.com/user-attachments/assets/aee4d5a0-50bc-44e4-a5d4-89016959f70b" />


## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a horizontal tab row on the Downloads screen in portrait to better use vertical space and make switching between Downloads and Storage easier. The vertical sidebar remains in landscape; tabs show above content only when no library item is selected.

<sup>Written for commit e88e29852b1e047a7ee7a919146248557e42cc59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized downloads screen layout for portrait mode with horizontal tab navigation, replacing the sidebar for improved mobile usability.

* **Style**
  * Refined vertical spacing for better visual balance in portrait orientation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->