### PR TITLE
fix: recognize unhandled UFS path types and fix save pattern parsing edge cases

### DIFF
--- a/app/src/main/java/app/gamenative/enums/PathType.kt
+++ b/app/src/main/java/app/gamenative/enums/PathType.kt
@@ -96,6 +96,7 @@ enum class PathType {
             WinAppDataLocalLow,
             WinAppDataRoaming,
             WinSavedGames,
+            Root,
             -> true
             else -> false
         }
@@ -294,6 +295,9 @@ enum class PathType {
                 "%${MacAppSupport.name.lowercase()}%",
                 MacAppSupport.name.lowercase(),
                 -> MacAppSupport
+                "windowshome",
+                "%windowshome%",
+                Root.name.lowercase(),
                 "%ROOT_MOD%",
                 "ROOT_MOD",
                 -> Root

--- a/app/src/main/java/app/gamenative/enums/PathType.kt
+++ b/app/src/main/java/app/gamenative/enums/PathType.kt
@@ -14,6 +14,7 @@ enum class PathType {
     WinAppDataLocalLow,
     WinAppDataRoaming,
     WinSavedGames,
+    WinProgramData,
     LinuxHome,
     LinuxXdgDataHome,
     LinuxXdgConfigHome,
@@ -72,6 +73,11 @@ enum class PathType {
                 ImageFs.USER,
                 "Saved Games/",
             ).toString()
+            WinProgramData -> Paths.get(
+                ImageFs.find(context).rootDir.absolutePath,
+                ImageFs.WINEPREFIX,
+                "/drive_c/ProgramData/",
+            ).toString()
             Root -> Paths.get(
                 ImageFs.find(context).rootDir.absolutePath,
                 ImageFs.WINEPREFIX,
@@ -96,6 +102,7 @@ enum class PathType {
             WinAppDataLocalLow,
             WinAppDataRoaming,
             WinSavedGames,
+            WinProgramData,
             Root,
             -> true
             else -> false
@@ -264,6 +271,7 @@ enum class PathType {
                 -> GameInstall
                 "%${SteamUserData.name.lowercase()}%",
                 SteamUserData.name.lowercase(),
+                "steamuserbasestorage",
                 -> SteamUserData
                 "%${WinMyDocuments.name.lowercase()}%",
                 WinMyDocuments.name.lowercase(),
@@ -282,6 +290,9 @@ enum class PathType {
                 "%${WinSavedGames.name.lowercase()}%",
                 WinSavedGames.name.lowercase(),
                 -> WinSavedGames
+                "%${WinProgramData.name.lowercase()}%",
+                WinProgramData.name.lowercase(),
+                -> WinProgramData
                 "%${LinuxHome.name.lowercase()}%",
                 LinuxHome.name.lowercase(),
                 -> LinuxHome

--- a/app/src/main/java/app/gamenative/enums/PathType.kt
+++ b/app/src/main/java/app/gamenative/enums/PathType.kt
@@ -267,6 +267,8 @@ enum class PathType {
                 -> SteamUserData
                 "%${WinMyDocuments.name.lowercase()}%",
                 WinMyDocuments.name.lowercase(),
+                "steamclouddocuments",
+                "%steamclouddocuments%",
                 -> WinMyDocuments
                 "%${WinAppDataLocal.name.lowercase()}%",
                 WinAppDataLocal.name.lowercase(),

--- a/app/src/main/java/app/gamenative/enums/PathType.kt
+++ b/app/src/main/java/app/gamenative/enums/PathType.kt
@@ -272,6 +272,7 @@ enum class PathType {
                 "%${SteamUserData.name.lowercase()}%",
                 SteamUserData.name.lowercase(),
                 "steamuserbasestorage",
+                "%steamuserbasestorage%",
                 -> SteamUserData
                 "%${WinMyDocuments.name.lowercase()}%",
                 WinMyDocuments.name.lowercase(),

--- a/app/src/main/java/app/gamenative/enums/PathType.kt
+++ b/app/src/main/java/app/gamenative/enums/PathType.kt
@@ -308,11 +308,12 @@ enum class PathType {
                 "%${MacAppSupport.name.lowercase()}%",
                 MacAppSupport.name.lowercase(),
                 -> MacAppSupport
+                "%${Root.name.lowercase()}%",
+                Root.name.lowercase(),
                 "windowshome",
                 "%windowshome%",
-                Root.name.lowercase(),
-                "%ROOT_MOD%",
-                "ROOT_MOD",
+                "%root_mod%",
+                "root_mod",
                 -> Root
                 else -> {
                     if (keyValue != null) {

--- a/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
@@ -184,7 +184,10 @@ fun KeyValue.generateSteamApp(): SteamApp {
                     if (platforms.isNotEmpty() && "windows" !in platforms) return@mapNotNull null
 
                     val originalRoot = PathType.from(saveFile["root"].value)
-                    val originalPath = saveFile["path"].value.orEmpty()
+                    // Treat "." as empty: it means "root of this path type" with no subdirectory.
+                    // Keeping the literal dot causes addpath joins to produce "MyGame/." and
+                    // uploadPath = "." which breaks cloud key lookups in SteamAutoCloud.
+                    val originalPath = saveFile["path"].value.orEmpty().let { if (it == ".") "" else it }
                     val rootRemap = rootOverrides.find { it.fromRoot == originalRoot }
 
                     SaveFilePattern(

--- a/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
@@ -25,7 +25,7 @@ import `in`.dragonbra.javasteam.types.KeyValue
 import java.util.Date
 import timber.log.Timber
 
-const val CURRENT_UFS_PARSE_VERSION = 1
+const val CURRENT_UFS_PARSE_VERSION = 2
 
 /**
  * Extension functions relating to [KeyValue] as the receiver type.

--- a/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
@@ -164,7 +164,10 @@ fun KeyValue.generateSteamApp(): SteamApp {
 
             val rootOverrides = this["ufs"]["rootoverrides"].children.mapNotNull { rootOverride ->
                 val os = rootOverride["os"].value.orEmpty()
-                if (!os.equals("Windows", ignoreCase = true)) return@mapNotNull null
+                val oslist = rootOverride["oslist"].value.orEmpty()
+                val isWindowsOverride = os.equals("Windows", ignoreCase = true) ||
+                    oslist.split(",").any { it.trim().equals("windows", ignoreCase = true) }
+                if (!isWindowsOverride) return@mapNotNull null
                 val pathTransforms = rootOverride["pathtransforms"].children.map { transform ->
                     transform["find"].value.orEmpty() to transform["replace"].value.orEmpty()
                 }

--- a/app/src/test/java/app/gamenative/utils/KeyValueUtilsTest.kt
+++ b/app/src/test/java/app/gamenative/utils/KeyValueUtilsTest.kt
@@ -684,6 +684,107 @@ class KeyValueUtilsTest {
         assertEquals(PathType.WinMyDocuments, patterns[0].uploadRoot)
     }
 
+    /**
+     * Spiritfarer (App ID 972660) has `path: .` with a Windows rootoverride that adds
+     * `addpath: Thunder Lotus Games/Spiritfarer`. The dot means "no subdirectory" and must not
+     * be appended to the addpath (producing "Thunder Lotus Games/Spiritfarer/."), nor stored as
+     * uploadPath (producing cloud key "%GameInstall%.") — both break download path resolution.
+     */
+    @Test
+    fun spiritfarerDotPathWithAddpathIsNormalizedToEmpty() {
+        val kvString = """
+            "appinfo"
+            {
+                "appid"     "972660"
+                "ufs"
+                {
+                    "quota"         "100000000"
+                    "maxnumfiles"   "20"
+                    "savefiles"
+                    {
+                        "0"
+                        {
+                            "root"      "gameinstall"
+                            "path"      "."
+                            "pattern"   "*.sav"
+                        }
+                    }
+                    "rootoverrides"
+                    {
+                        "0"
+                        {
+                            "root"          "gameinstall"
+                            "os"            "Windows"
+                            "oscompare"     "="
+                            "useinstead"    "WinAppDataLocalLow"
+                            "addpath"       "Thunder Lotus Games/Spiritfarer"
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+        val kv = KeyValue.loadFromString(kvString)!!
+        val steamApp = kv.generateSteamApp()
+
+        val patterns = steamApp.ufs.saveFilePatterns
+        assertEquals(1, patterns.size)
+        assertEquals(PathType.WinAppDataLocalLow, patterns[0].root)
+        assertEquals("Thunder Lotus Games/Spiritfarer", patterns[0].path)
+        assertEquals("*.sav", patterns[0].pattern)
+        assertEquals(PathType.GameInstall, patterns[0].uploadRoot)
+        assertEquals("", patterns[0].uploadPath)
+    }
+
+    /**
+     * CrossCode (App ID 368340) has `path: .` with a Windows rootoverride that adds
+     * `addpath: CrossCode`. Same class of bug as Spiritfarer — dot must not be appended to
+     * the addpath or stored as uploadPath.
+     */
+    @Test
+    fun crossCodeDotPathWithAddpathIsNormalizedToEmpty() {
+        val kvString = """
+            "appinfo"
+            {
+                "appid"     "368340"
+                "ufs"
+                {
+                    "quota"         "100000000"
+                    "maxnumfiles"   "5"
+                    "savefiles"
+                    {
+                        "0"
+                        {
+                            "root"      "WinAppDataLocal"
+                            "path"      "."
+                            "pattern"   "cc.sav*"
+                        }
+                    }
+                    "rootoverrides"
+                    {
+                        "0"
+                        {
+                            "root"          "WinAppDataLocal"
+                            "os"            "Windows"
+                            "oscompare"     "="
+                            "useinstead"    "WinAppDataLocal"
+                            "addpath"       "CrossCode"
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+        val kv = KeyValue.loadFromString(kvString)!!
+        val steamApp = kv.generateSteamApp()
+
+        val patterns = steamApp.ufs.saveFilePatterns
+        assertEquals(1, patterns.size)
+        assertEquals(PathType.WinAppDataLocal, patterns[0].root)
+        assertEquals("CrossCode", patterns[0].path)
+        assertEquals("cc.sav*", patterns[0].pattern)
+        assertEquals(PathType.WinAppDataLocal, patterns[0].uploadRoot)
+        assertEquals("", patterns[0].uploadPath)
+    }
+
     @Test
     fun generateSteamAppStampsCurrentUfsParseVersion() {
         val kvString = """

--- a/app/src/test/java/app/gamenative/utils/KeyValueUtilsTest.kt
+++ b/app/src/test/java/app/gamenative/utils/KeyValueUtilsTest.kt
@@ -605,6 +605,46 @@ class KeyValueUtilsTest {
         assertEquals("", patterns[0].uploadPath)
     }
 
+    /**
+     * Stellar Blade (App ID 3489700) has a save pattern with `root: WindowsHome`, which is the
+     * Windows user home directory (C:\users\xuser\ in Wine). It must be recognized as PathType.Root
+     * and pass the isWindows filter so the pattern is not silently dropped.
+     */
+    @Test
+    fun stellarBladeWindowsHomeRootIsRecognizedAndPassesIsWindowsFilter() {
+        val kvString = """
+            "appinfo"
+            {
+                "appid"     "3489700"
+                "ufs"
+                {
+                    "quota"         "600000000"
+                    "maxnumfiles"   "20"
+                    "savefiles"
+                    {
+                        "0"
+                        {
+                            "root"      "WindowsHome"
+                            "path"      "Documents/StellarBlade/{64BitSteamID}"
+                            "pattern"   "*.sav"
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+        val kv = KeyValue.loadFromString(kvString)!!
+        val steamApp = kv.generateSteamApp()
+
+        val patterns = steamApp.ufs.saveFilePatterns
+        assertEquals(1, patterns.size)
+        assertEquals(PathType.Root, patterns[0].root)
+        assertEquals(true, patterns[0].root.isWindows)
+        assertEquals("Documents/StellarBlade/{64BitSteamID}", patterns[0].path)
+        assertEquals("*.sav", patterns[0].pattern)
+        assertEquals(0, patterns[0].recursive)
+        assertEquals(PathType.Root, patterns[0].uploadRoot)
+    }
+
     @Test
     fun generateSteamAppStampsCurrentUfsParseVersion() {
         val kvString = """

--- a/app/src/test/java/app/gamenative/utils/KeyValueUtilsTest.kt
+++ b/app/src/test/java/app/gamenative/utils/KeyValueUtilsTest.kt
@@ -799,4 +799,170 @@ class KeyValueUtilsTest {
 
         assertEquals(CURRENT_UFS_PARSE_VERSION, steamApp.ufsParseVersion)
     }
+
+    @Test
+    fun winProgramDataRootIsRecognized() {
+        val kvString = """
+            "appinfo"
+            {
+                "appid"     "99999"
+                "ufs"
+                {
+                    "quota"         "10000000"
+                    "maxnumfiles"   "10"
+                    "savefiles"
+                    {
+                        "0"
+                        {
+                            "root"      "winprogramdata"
+                            "path"      "MyPublisher/MyGame"
+                            "pattern"   "*.sav"
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val kv = KeyValue.loadFromString(kvString)!!
+        val steamApp = kv.generateSteamApp()
+
+        val patterns = steamApp.ufs.saveFilePatterns
+        assertEquals(1, patterns.size)
+        assertEquals(PathType.WinProgramData, patterns[0].root)
+        assertEquals(true, patterns[0].root.isWindows)
+        assertEquals("MyPublisher/MyGame", patterns[0].path)
+        assertEquals("*.sav", patterns[0].pattern)
+        assertEquals(PathType.WinProgramData, patterns[0].uploadRoot)
+    }
+
+    @Test
+    fun steamUserBaseStorageRootIsRecognizedAsSteamUserData() {
+        val kvString = """
+            "appinfo"
+            {
+                "appid"     "88888"
+                "ufs"
+                {
+                    "quota"         "10000000"
+                    "maxnumfiles"   "10"
+                    "savefiles"
+                    {
+                        "0"
+                        {
+                            "root"      "SteamUserBaseStorage"
+                            "path"      "saves"
+                            "pattern"   "*.dat"
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val kv = KeyValue.loadFromString(kvString)!!
+        val steamApp = kv.generateSteamApp()
+
+        val patterns = steamApp.ufs.saveFilePatterns
+        assertEquals(1, patterns.size)
+        assertEquals(PathType.SteamUserData, patterns[0].root)
+        assertEquals(true, patterns[0].root.isWindows)
+        assertEquals("saves", patterns[0].path)
+        assertEquals("*.dat", patterns[0].pattern)
+        assertEquals(PathType.SteamUserData, patterns[0].uploadRoot)
+    }
+
+    /**
+     * A rootoverride using `oslist: "windows,linux"` instead of `os: "Windows"` must still
+     * be applied. Previously this was silently skipped because only the `os` field was checked.
+     */
+    @Test
+    fun rootOverrideWithOslistWindowsIsApplied() {
+        val kvString = """
+            "appinfo"
+            {
+                "appid"     "77777"
+                "ufs"
+                {
+                    "quota"         "10000000"
+                    "maxnumfiles"   "10"
+                    "savefiles"
+                    {
+                        "0"
+                        {
+                            "root"      "gameinstall"
+                            "path"      "saves"
+                            "pattern"   "*.sav"
+                        }
+                    }
+                    "rootoverrides"
+                    {
+                        "0"
+                        {
+                            "root"          "gameinstall"
+                            "oslist"        "windows,linux"
+                            "oscompare"     "="
+                            "useinstead"    "WinAppDataRoaming"
+                            "addpath"       "MyGame"
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val kv = KeyValue.loadFromString(kvString)!!
+        val steamApp = kv.generateSteamApp()
+
+        val patterns = steamApp.ufs.saveFilePatterns
+        assertEquals(1, patterns.size)
+        assertEquals(PathType.WinAppDataRoaming, patterns[0].root)
+        assertEquals("MyGame/saves", patterns[0].path)
+        assertEquals("*.sav", patterns[0].pattern)
+        assertEquals(PathType.GameInstall, patterns[0].uploadRoot)
+        assertEquals("saves", patterns[0].uploadPath)
+    }
+
+    @Test
+    fun rootOverrideWithOslistOnlyLinuxIsNotApplied() {
+        val kvString = """
+            "appinfo"
+            {
+                "appid"     "66666"
+                "ufs"
+                {
+                    "quota"         "10000000"
+                    "maxnumfiles"   "10"
+                    "savefiles"
+                    {
+                        "0"
+                        {
+                            "root"      "WinMyDocuments"
+                            "path"      "saves"
+                            "pattern"   "*.sav"
+                        }
+                    }
+                    "rootoverrides"
+                    {
+                        "0"
+                        {
+                            "root"          "WinMyDocuments"
+                            "oslist"        "linux"
+                            "oscompare"     "="
+                            "useinstead"    "LinuxHome"
+                            "addpath"       ".local/share/mygame"
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val kv = KeyValue.loadFromString(kvString)!!
+        val steamApp = kv.generateSteamApp()
+
+        val patterns = steamApp.ufs.saveFilePatterns
+        assertEquals(1, patterns.size)
+        assertEquals(PathType.WinMyDocuments, patterns[0].root)
+        assertEquals("saves", patterns[0].path)
+        assertEquals("*.sav", patterns[0].pattern)
+        assertEquals(PathType.WinMyDocuments, patterns[0].uploadRoot)
+    }
+
 }

--- a/app/src/test/java/app/gamenative/utils/KeyValueUtilsTest.kt
+++ b/app/src/test/java/app/gamenative/utils/KeyValueUtilsTest.kt
@@ -645,6 +645,45 @@ class KeyValueUtilsTest {
         assertEquals(PathType.Root, patterns[0].uploadRoot)
     }
 
+    /**
+     * Sonic Mania (App ID 584400) has a save pattern with `root: SteamCloudDocuments`, which is
+     * Steam's name for the user's Documents folder (WinMyDocuments in Wine). It must be recognized
+     * and pass the isWindows filter so the pattern is not silently dropped.
+     */
+    @Test
+    fun sonicManiaSteamCloudDocumentsRootIsRecognizedAsWinMyDocuments() {
+        val kvString = """
+            "appinfo"
+            {
+                "appid"     "584400"
+                "ufs"
+                {
+                    "quota"         "67108864"
+                    "maxnumfiles"   "64"
+                    "savefiles"
+                    {
+                        "0"
+                        {
+                            "root"      "SteamCloudDocuments"
+                            "path"      "SavesDir"
+                            "pattern"   "*.sav"
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+        val kv = KeyValue.loadFromString(kvString)!!
+        val steamApp = kv.generateSteamApp()
+
+        val patterns = steamApp.ufs.saveFilePatterns
+        assertEquals(1, patterns.size)
+        assertEquals(PathType.WinMyDocuments, patterns[0].root)
+        assertEquals(true, patterns[0].root.isWindows)
+        assertEquals("SavesDir", patterns[0].path)
+        assertEquals("*.sav", patterns[0].pattern)
+        assertEquals(PathType.WinMyDocuments, patterns[0].uploadRoot)
+    }
+
     @Test
     fun generateSteamAppStampsCurrentUfsParseVersion() {
         val kvString = """


### PR DESCRIPTION
## Description

Fixes several cases where Steam Cloud save sync silently failed because `PathType.from()` didn't recognise certain UFS root tokens, causing save patterns to be dropped. Also fixes a path normalisation edge case and a missing `oslist` check in rootoverride parsing.

**`WindowsHome` → `Root`** (e.g. Stellar Blade, app 3489700): `root: WindowsHome` fell through to `PathType.None`, so the save pattern was silently dropped. `WindowsHome` is the Windows user home directory (`C:\users\xuser\`), which is what `PathType.Root` maps to. Also adds `Root` to `isWindows` so it passes the save pattern filter.

**`SteamCloudDocuments` → `WinMyDocuments`** (e.g. Sonic Mania, app 584400): `root: SteamCloudDocuments` was unrecognised and fell through to `None`. This is Steam's name for the user's Documents folder, which maps to `WinMyDocuments` in Wine.

**`WinProgramData`** (new path type): Added mapping to `drive_c/ProgramData/`. Previously any game using this root had its saves silently dropped.

**`SteamUserBaseStorage` → `SteamUserData`**: Added alias so this token resolves correctly.

**`oslist` in rootoverrides**: Some manifests specify the OS via `oslist` (comma-separated) rather than the `os` field. The Windows rootoverride filter now checks both, so remaps aren't skipped for affected games.

**`.` path normalisation** (e.g. Spiritfarer, CrossCode): Steam manifests sometimes use `path: .` to mean "root of this path type with no subdirectory" (common in Unity games). When combined with a rootoverride `addpath`, the dot was appended literally — producing paths like `Thunder Lotus Games/Spiritfarer/.` and `uploadPath = "."` — causing cloud key lookups to never match. Fixed by normalising `"."` to `""` at parse time.

**Note:** I don't own any of the games listed above and have not personally tested these fixes. The affected games were identified by inspecting Steam PICS data for those app IDs.

`CURRENT_UFS_PARSE_VERSION` bumped to `2` so existing cached `SteamApp` rows are re-parsed on next launch.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands UFS root recognition and fixes path parsing so Steam Cloud save patterns aren’t dropped. Affected games now scan and sync correctly; cached app data will re-parse on next launch.

- **Bug Fixes**
  - Recognize additional UFS roots and aliases: `WindowsHome`→`Root` (and treat `Root` as Windows), `SteamCloudDocuments`→`WinMyDocuments`, new `WinProgramData`, and `SteamUserBaseStorage`→`SteamUserData` (accept plain and `%...%` forms); also accept lowercase and `%...%` aliases for `Root`/`ROOT_MOD`.
  - Normalize `path: "."` to empty for correct cloud key lookups, and apply Windows `rootoverrides` when listed in `oslist`.

- **Migration**
  - Bump `CURRENT_UFS_PARSE_VERSION` to `2` to force re-parse of cached UFS data.

<sup>Written for commit db6aaa8f34808342645ace65d0215c0feb40dc7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added support for a Windows ProgramData-style path and several new aliases for Windows-related roots; expanded recognition of Windows home/document roots.
  - Override matching now treats comma-separated os lists that include Windows as applicable.

* **Bug Fixes**
  - Save-file path normalization: a literal "." is now treated as an empty subdirectory to avoid invalid path segments.

* **Tests**
  - Expanded coverage for save-file patterns, root mappings, and override application scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->