### PR TITLE
gamefix: Added multifix support + added slay the spire 2 fix

### DIFF
--- a/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
@@ -38,6 +38,7 @@ object GameFixesRegistry {
         STEAM_Fix_413150,
         STEAM_Fix_752580,
         STEAM_Fix_1637320,
+        STEAM_Fix_2868840,
         STEAM_Fix_3373660,
         EPIC_Fix_b1b4e0b67a044575820cb5e63028dcae,
         EPIC_Fix_dabb52e328834da7bbe99691e374cb84,

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_2868840.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_2868840.kt
@@ -1,0 +1,21 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Slay the Spire 2 (Steam)
+ */
+val STEAM_Fix_2868840: KeyedGameFix = KeyedCompositeGameFix(
+    gameSource = GameSource.STEAM,
+    gameId = "2868840",
+    fixes = listOf(
+        LaunchArgFix("--rendering-driver vulkan"),
+        WineEnvVarFix(
+            mapOf(
+                "WINEDLLOVERRIDES" to "icu=d",
+                "DOTNET_EnableWriteXorExecute" to "0",
+                "DOTNET_GCHeapHardLimit" to "0x400000000",
+            ),
+        ),
+    ),
+)

--- a/app/src/main/java/app/gamenative/gamefixes/types/KeyedCompositeGameFix.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/types/KeyedCompositeGameFix.kt
@@ -1,0 +1,36 @@
+package app.gamenative.gamefixes
+
+import android.content.Context
+import app.gamenative.data.GameSource
+import com.winlator.container.Container
+
+/**
+ * Applies multiple fixes for the same game key.
+ * Every fix in [fixes] runs in order.
+ */
+class CompositeGameFix(
+    private val fixes: List<GameFix>,
+) : GameFix {
+    override fun apply(
+        context: Context,
+        gameId: String,
+        installPath: String,
+        installPathWindows: String,
+        container: Container,
+    ): Boolean {
+        var allSucceeded = true
+        for (fix in fixes) {
+            val succeeded = fix.apply(context, gameId, installPath, installPathWindows, container)
+            if (!succeeded) {
+                allSucceeded = false
+            }
+        }
+        return allSucceeded
+    }
+}
+
+class KeyedCompositeGameFix(
+    override val gameSource: GameSource,
+    override val gameId: String,
+    fixes: List<GameFix>,
+) : KeyedGameFix, GameFix by CompositeGameFix(fixes)

--- a/app/src/test/java/app/gamenative/gamefixes/types/KeyedCompositeGameFixTest.kt
+++ b/app/src/test/java/app/gamenative/gamefixes/types/KeyedCompositeGameFixTest.kt
@@ -1,0 +1,118 @@
+package app.gamenative.gamefixes
+
+import androidx.test.core.app.ApplicationProvider
+import app.gamenative.data.GameSource
+import com.winlator.container.Container
+import java.io.File
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class KeyedCompositeGameFixTest {
+    private lateinit var baseDir: File
+
+    @Before
+    fun setUp() {
+        baseDir = Files.createTempDirectory("keyed-composite-fix-tests").toFile()
+        baseDir.deleteOnExit()
+    }
+
+    @Test
+    fun keyedComposite_apply_runsAllFixesInOrder_whenAllFixesSucceed() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val applied = mutableListOf<String>()
+        val container = createContainer("c1")
+
+        val fix = KeyedCompositeGameFix(
+            gameSource = GameSource.STEAM,
+            gameId = "2868840",
+            fixes = listOf(
+                RecordingFix("first", true, applied),
+                RecordingFix("second", true, applied),
+                RecordingFix("third", true, applied),
+            ),
+        )
+
+        val result = fix.apply(
+            context = context,
+            gameId = "2868840",
+            installPath = "",
+            installPathWindows = "",
+            container = container,
+        )
+
+        assertTrue(result)
+        assertEquals(listOf("first", "second", "third"), applied)
+    }
+
+    @Test
+    fun keyedComposite_apply_returnsFalseButStillRunsRemainingFixes_whenAnyFixFails() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val applied = mutableListOf<String>()
+        val container = createContainer("c2")
+
+        val fix = KeyedCompositeGameFix(
+            gameSource = GameSource.STEAM,
+            gameId = "2868840",
+            fixes = listOf(
+                RecordingFix("first", true, applied),
+                RecordingFix("second", false, applied),
+                RecordingFix("third", true, applied),
+            ),
+        )
+
+        val result = fix.apply(
+            context = context,
+            gameId = "2868840",
+            installPath = "",
+            installPathWindows = "",
+            container = container,
+        )
+
+        assertFalse(result)
+        assertEquals(listOf("first", "second", "third"), applied)
+    }
+
+    @Test
+    fun keyedComposite_keyedProperties_matchConstructorValues() {
+        val fix = KeyedCompositeGameFix(
+            gameSource = GameSource.GOG,
+            gameId = "1635627436",
+            fixes = emptyList(),
+        )
+
+        assertEquals(GameSource.GOG, fix.gameSource)
+        assertEquals("1635627436", fix.gameId)
+    }
+
+    private fun createContainer(id: String): Container {
+        val rootDir = File(baseDir, id).apply { mkdirs() }
+        return Container(id).apply {
+            this.rootDir = rootDir
+            this.envVars = "WINEESYNC=1"
+        }
+    }
+
+    private class RecordingFix(
+        private val label: String,
+        private val result: Boolean,
+        private val applied: MutableList<String>,
+    ) : GameFix {
+        override fun apply(
+            context: android.content.Context,
+            gameId: String,
+            installPath: String,
+            installPathWindows: String,
+            container: Container,
+        ): Boolean {
+            applied += label
+            return result
+        }
+    }
+}


### PR DESCRIPTION
## Description
Added the launch arg fix as gamefix. So it works as a sensible default even when known config is not applied.

## Recording
No recording. But verified in the discord and reddit multiple times.
https://discord.com/channels/1378308569287622737/1490412953260920905

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added multi-fix support (`CompositeGameFix`/`KeyedCompositeGameFix`) that runs fixes in order and only returns success if all pass. Added Slay the Spire 2 fix (`STEAM_Fix_2868840`) to force Vulkan and set Wine env vars for ICU and .NET, added to `GameFixesRegistry`.

<sup>Written for commit 71ed268e829032a16ef83fe90c971d9109404251. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1160?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a game fix for Steam game 2868840 that enables the Vulkan renderer and sets Wine environment variables.
  * Introduced composite game fixes to apply multiple fixes sequentially with aggregate success reporting.

* **Bug Fixes**
  * Adjusted Steam fix ordering to ensure the intended fix is associated for duplicate Steam entries.

* **Tests**
  * Added tests verifying composite fix execution order, success/failure behavior, and keyed properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->