### PR TITLE
gamefix: Kingdom hearts 3 (epic) gamefix

### DIFF
--- a/app/src/main/java/app/gamenative/gamefixes/EPIC_e345fdb9186645a48d30c3f85a8951dc.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/EPIC_e345fdb9186645a48d30c3f85a8951dc.kt
@@ -1,0 +1,14 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Kingdom Hearts III (Epic)
+ */
+val EPIC_Fix_e345fdb9186645a48d30c3f85a8951dc: KeyedGameFix = KeyedWineEnvVarFix(
+    gameSource = GameSource.EPIC,
+    gameId = "e345fdb9186645a48d30c3f85a8951dc",
+    envVarsToSet = mapOf(
+        "WINEDLLOVERRIDES" to "mf=n;mfmediaengine=n",
+    ),
+)

--- a/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
@@ -40,6 +40,7 @@ object GameFixesRegistry {
         STEAM_Fix_3373660,
         EPIC_Fix_b1b4e0b67a044575820cb5e63028dcae,
         EPIC_Fix_dabb52e328834da7bbe99691e374cb84,
+        EPIC_Fix_e345fdb9186645a48d30c3f85a8951dc,
         EPIC_Fix_59a0c86d02da42e8ba6444cb171e61bf,
     ).associateBy { it.gameSource to it.gameId }
 


### PR DESCRIPTION
## Description
Fixes kingdom hearts for epic.

## Recording
Nope. But numerous accounts of the fix working here:
https://discord.com/channels/1378308569287622737/1490230113042960444

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kingdom Hearts III (Epic) launch by auto-applying a Wine DLL override and registering the game fix for Epic installations.

- **Bug Fixes**
  - Kingdom Hearts III (Epic `e345fdb9186645a48d30c3f85a8951dc`): apply `WINEDLLOVERRIDES=mf=n;mfmediaengine=n` via `KeyedWineEnvVarFix`; added to `GameFixesRegistry`.

<sup>Written for commit 14a58012bad4cd63d3ea0880998ff573d81d2719. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a compatibility fix for Kingdom Hearts III (Epic Games Store) to improve launch stability and media playback, reducing in-game video and audio issues.
  * The fix is applied automatically to matching Epic installations—no user configuration required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->