### PR TITLE
fix: perf hud fps fix for other wrappers

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1404,94 +1404,70 @@ fun XServerScreen(
                     getxServer().windowManager.removeOnWindowModificationListener(it)
                 }
                 val wmListener = object : WindowManager.OnWindowModificationListener {
-                        private fun isFrameRatingCandidateProperty(propertyName: String): Boolean {
-                            return propertyName.contains("_UTIL_LAYER") ||
-                                propertyName.contains("_MESA_DRV") ||
-                                (container.containerVariant.equals(Container.GLIBC) && propertyName.contains("_NET_WM_SURFACE"))
-                        }
-
                         private fun describeFrameRatingWindow(window: Window): String {
                             return "id=${window.id}, name=${window.name}, class=${window.className}, pid=${window.processId}"
                         }
 
-                        private fun changeFrameRatingVisibility(window: Window, property: Property?) {
-                            val rating = frameRating ?: return
-                            if (property != null) {
-                                val propertyName = property.nameAsString()
-                                if (!isFrameRatingCandidateProperty(propertyName)) return
+                        private fun findTopmostApplicationWindow(window: Window): Window? {
+                            val children = window.children
+                            for (i in children.indices.reversed()) {
+                                val child = children[i]
+                                if (!child.attributes.isMapped()) continue
+                                val topmostInChild = findTopmostApplicationWindow(child)
+                                if (topmostInChild != null) return topmostInChild
+                                if (child.isApplicationWindow() && child.isRenderable()) {
+                                    return child
+                                }
+                            }
+                            return null
+                        }
 
-                                when {
-                                    frameRatingWindowId == -1 -> {
-                                        frameRatingWindowId = window.id
-                                        Timber.i(
-                                            "FrameRating tracking attached via property=%s to %s",
-                                            propertyName,
-                                            describeFrameRatingWindow(window),
-                                        )
-                                        (context as? Activity)?.runOnUiThread {
-                                            frameRating?.reset()
-                                            frameRating?.visibility = View.VISIBLE
-                                        }
-                                    }
-                                    frameRatingWindowId == window.id -> {
-                                        Timber.d(
-                                            "FrameRating received candidate property=%s for already tracked window %s",
-                                            propertyName,
-                                            describeFrameRatingWindow(window),
-                                        )
-                                    }
-                                    else -> {
-                                        Timber.d(
-                                            "FrameRating ignoring candidate property=%s for %s because tracking already points to windowId=%d",
-                                            propertyName,
-                                            describeFrameRatingWindow(window),
-                                            frameRatingWindowId,
-                                        )
-                                    }
+                        private fun refreshFrameRatingTracking(reason: String) {
+                            val rating = frameRating ?: return
+                            val topmost = findTopmostApplicationWindow(getxServer().windowManager.rootWindow)
+                            val nextId = topmost?.id ?: -1
+                            if (frameRatingWindowId == nextId) return
+
+                            if (topmost == null) {
+                                if (frameRatingWindowId != -1) {
+                                    Timber.i(
+                                        "FrameRating tracking cleared (%s); no topmost application window remains",
+                                        reason,
+                                    )
+                                }
+                                frameRatingWindowId = -1
+                                (context as? Activity)?.runOnUiThread {
+                                    rating.visibility = View.GONE
                                 }
                                 return
                             }
 
-                            when {
-                                frameRatingWindowId == window.id -> {
-                                    Timber.i(
-                                        "FrameRating tracking cleared because tracked window unmapped: %s",
-                                        describeFrameRatingWindow(window),
-                                    )
-                                    frameRatingWindowId = -1
-                                    (context as? Activity)?.runOnUiThread {
-                                        frameRating?.visibility = View.GONE
-                                    }
-                                }
-                                frameRatingWindowId != -1 -> {
-                                    Timber.d(
-                                        "FrameRating ignoring unmap for non-tracked window %s; still tracking windowId=%d",
-                                        describeFrameRatingWindow(window),
-                                        frameRatingWindowId,
-                                    )
-                                }
+                            frameRatingWindowId = nextId
+                            Timber.i(
+                                "FrameRating tracking attached (%s) to topmost app window %s",
+                                reason,
+                                describeFrameRatingWindow(topmost),
+                            )
+                            (context as? Activity)?.runOnUiThread {
+                                rating.reset()
+                                rating.visibility = View.VISIBLE
                             }
                         }
+
                         override fun onUpdateWindowContent(window: Window) {
                             if (!xServerState.value.winStarted && window.isApplicationWindow()) {
                                 if (!container.isDisableMouseInput && !container.isTouchscreenMode) renderer?.setCursorVisible(true)
                                 xServerState.value.winStarted = true
                             }
-                            if (window.id == frameRatingWindowId) {
-                                // FPS is now counted from GLRenderer.onDrawFrame() while the tracked window is visible.
-                                // Keep this callback only as a no-op marker that the tracked window is still active.
+                            if (frameRatingWindowId == -1 && window.isApplicationWindow()) {
+                                refreshFrameRatingTracking("content-update")
                             }
                         }
 
                         override fun onModifyWindowProperty(window: Window, property: Property) {
-                            if (frameRating != null && isFrameRatingCandidateProperty(property.nameAsString())) {
-                                Timber.d(
-                                    "FrameRating observed candidate property=%s on %s",
-                                    property.nameAsString(),
-                                    describeFrameRatingWindow(window),
-                                )
+                            if (window.id == frameRatingWindowId || window.isApplicationWindow()) {
+                                refreshFrameRatingTracking("property:${property.nameAsString()}")
                             }
-                            changeFrameRatingVisibility(window, property)
                         }
 
                         override fun onMapWindow(window: Window) {
@@ -1503,6 +1479,7 @@ fun XServerScreen(
                                         "\n\thasParent: ${window.parent != null}" +
                                         "\n\tchildrenSize: ${window.children.size}",
                             )
+                            refreshFrameRatingTracking("map-window")
                             win32AppWorkarounds?.applyWindowWorkarounds(window)
                             onWindowMapped?.invoke(context, window)
                         }
@@ -1516,9 +1493,19 @@ fun XServerScreen(
                                         "\n\thasParent: ${window.parent != null}" +
                                         "\n\tchildrenSize: ${window.children.size}",
                             )
-                            changeFrameRatingVisibility(window, null)
+                            refreshFrameRatingTracking("unmap-window")
                             startExitWatchForUnmappedGameWindow(window)
                             onWindowUnmapped?.invoke(window)
+                        }
+
+                        override fun onChangeWindowZOrder(window: Window) {
+                            refreshFrameRatingTracking("z-order")
+                        }
+
+                        override fun onUpdateWindowGeometry(window: Window, resized: Boolean) {
+                            if (window.id == frameRatingWindowId || window.isApplicationWindow()) {
+                                refreshFrameRatingTracking(if (resized) "geometry-resize" else "geometry-move")
+                            }
                         }
                     }
                 getxServer().windowManager.addOnWindowModificationListener(wmListener)

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1429,9 +1429,9 @@ fun XServerScreen(
                                             describeFrameRatingWindow(window),
                                         )
                                         (context as? Activity)?.runOnUiThread {
+                                            frameRating?.reset()
                                             frameRating?.visibility = View.VISIBLE
                                         }
-                                        rating.update()
                                     }
                                     frameRatingWindowId == window.id -> {
                                         Timber.d(
@@ -1478,9 +1478,8 @@ fun XServerScreen(
                                 xServerState.value.winStarted = true
                             }
                             if (window.id == frameRatingWindowId) {
-                                (context as? Activity)?.runOnUiThread {
-                                    frameRating?.update()
-                                }
+                                // FPS is now counted from GLRenderer.onDrawFrame() while the tracked window is visible.
+                                // Keep this callback only as a no-op marker that the tracked window is still active.
                             }
                         }
 
@@ -1879,6 +1878,7 @@ fun XServerScreen(
             }
             frameRating = FrameRating(context)
             frameRating?.setVisibility(View.GONE)
+            xServerView.renderer.setFrameRating(frameRating)
 
             if (isPerformanceHudEnabled) {
                 frameLayout.post {

--- a/app/src/main/java/com/winlator/renderer/GLRenderer.java
+++ b/app/src/main/java/com/winlator/renderer/GLRenderer.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.opengl.GLES20;
 import android.opengl.GLSurfaceView;
+import android.view.View;
 
 // import com.winlator.R;
 // import com.winlator.XrActivity;
@@ -14,6 +15,7 @@ import com.winlator.math.XForm;
 import com.winlator.renderer.material.CursorMaterial;
 import com.winlator.renderer.material.ShaderMaterial;
 import com.winlator.renderer.material.WindowMaterial;
+import com.winlator.widget.FrameRating;
 import com.winlator.widget.XServerView;
 import com.winlator.xserver.Bitmask;
 import com.winlator.xserver.Cursor;
@@ -54,6 +56,7 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
     private int surfaceHeight;
     private boolean sceneInitialized = false;
     private final EffectComposer effectComposer;
+    private FrameRating frameRating;
 
     public GLRenderer(XServerView xServerView, XServer xServer) {
         this.xServerView = xServerView;
@@ -130,6 +133,10 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
         }
         else {
             drawScene();
+        }
+
+        if (frameRating != null && frameRating.getVisibility() == View.VISIBLE) {
+            frameRating.update();
         }
     }
 
@@ -450,5 +457,9 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
 
     public EffectComposer getEffectComposer() {
         return effectComposer;
+    }
+
+    public void setFrameRating(FrameRating frameRating) {
+        this.frameRating = frameRating;
     }
 }

--- a/app/src/main/java/com/winlator/widget/FrameRating.java
+++ b/app/src/main/java/com/winlator/widget/FrameRating.java
@@ -87,6 +87,19 @@ public class FrameRating extends FrameLayout implements Runnable {
         frameCount++;
     }
 
+    public void reset() {
+        lastTime = 0;
+        frameCount = 0;
+        lastFPS = 0;
+        readingCount = 0;
+        sessionStartTime = 0;
+        maxFPS = 0;
+        minFPS = Integer.MAX_VALUE;
+        lastReadingTime = 0;
+        fpsSum = 0;
+        post(() -> textView.setText(String.format(Locale.ENGLISH, "%.1f", 0f)));
+    }
+
     /** Returns the most recent measured FPS value for the active session. */
     public float getCurrentFPS() {
         return lastFPS;


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

rework the fps hud to read surface updates from top active window instead of relying on _MESA_DRV or _UTIL_LAYER x property emissions. should be more evergreen approach across wrappers and game api's. 

fixes bug reports:

https://discord.com/channels/1378308569287622737/1483543374853312696

https://discord.com/channels/1378308569287622737/1492991364277993715

https://discord.com/channels/1378308569287622737/1489978573841240135


## Recording
<!-- Attach a short recording/GIF showing the change -->

![wrapper-fps-fix-under10mb](https://github.com/user-attachments/assets/3ceceff6-7885-418f-ae06-cdce28f029ac)


## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the performance HUD to calculate FPS from actual render frames and follow the topmost app window instead of X property hints. Fixes missing or inaccurate FPS across wrappers and game APIs.

- **Bug Fixes**
  - FPS updates on every frame via `GLRenderer` (`onDrawFrame` calls `FrameRating.update()`).
  - HUD tracks the topmost app window and hides/resets on changes (map/unmap, z-order, geometry); no longer depends on `_UTIL_LAYER`/`_MESA_DRV` signals.

- **Refactors**
  - Replaced property-based detection with a window-tree scan to find the topmost renderable app window.
  - Added `FrameRating.reset()` and passed `FrameRating` to the renderer from `XServerScreen`.

<sup>Written for commit 0f261008b270cd42205ec103dbece0986e1d9581. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

