### PR TITLE
fix: include shared redistributables when resolving steam depots

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -546,6 +546,12 @@ class SteamService : Service(), IChallengeUrlChanged {
             }
         }
 
+        fun getSharedPkg(): SteamLicense? {
+            return runBlocking(Dispatchers.IO) {
+                instance?.licenseDao?.findLicense(0)
+            }
+        }
+
         /**
          * Depot IDs the user's license actually grants for [appId].
          * Returns null when unknown (license not cached yet) so callers
@@ -553,7 +559,9 @@ class SteamService : Service(), IChallengeUrlChanged {
          */
         fun getLicensedDepotIds(appId: Int): Set<Int>? {
             val ids = getPkgInfoOf(appId)?.depotIds ?: return null
-            return ids.takeIf { it.isNotEmpty() }?.toSet()
+            val directDepotIds = ids.takeIf { it.isNotEmpty() }?.toSet() ?: emptySet()
+            val sharedDepotIds = getSharedPkg()?.depotIds?.takeIf { it.isNotEmpty() }?.toSet() ?: emptySet()
+            return directDepotIds + sharedDepotIds
         }
 
         /**
@@ -807,7 +815,7 @@ class SteamService : Service(), IChallengeUrlChanged {
         fun getMainAppDepots(appId: Int, containerLanguage: String): Map<Int, DepotInfo> {
             val appInfo = getAppInfoOf(appId) ?: return emptyMap()
             val ownedDlc = runBlocking { getOwnedAppDlc(appId) }
- val hasSteamUnlockedBranch = runBlocking { getSteamUnlockedBranches(appId).isNotEmpty() }
+            val hasSteamUnlockedBranch = runBlocking { getSteamUnlockedBranches(appId).isNotEmpty() }
             val licensedDepots = getLicensedDepotIds(appId)
             return resolveDownloadableDepots(appInfo.depots, containerLanguage, ownedDlc, licensedDepots, hasSteamUnlockedBranch)
         }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -561,7 +561,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             val ids = getPkgInfoOf(appId)?.depotIds ?: return null
             val directDepotIds = ids.takeIf { it.isNotEmpty() }?.toSet() ?: emptySet()
             val sharedDepotIds = getSharedPkg()?.depotIds?.takeIf { it.isNotEmpty() }?.toSet() ?: emptySet()
-            return directDepotIds + sharedDepotIds
+            return (directDepotIds + sharedDepotIds).takeIf { it.isNotEmpty() }
         }
 
         /**


### PR DESCRIPTION
## Description
Merges depot IDs from the shared license (ID 0) with app-specific depots to ensure common redistributables and dependencies are correctly identified and downloaded along with game-specific files.

Redistributables are missing in the downloaded files, making _CommonRedist is always empty

## Recording
None

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merges depot IDs from the shared Steam license (ID 0) with app-specific depots so shared redistributables like `_CommonRedist` are detected and downloaded with the game.

- **Bug Fixes**
  - Added `getSharedPkg` and merged shared depot IDs in `getLicensedDepotIds`.
  - Minor formatting fix in `getMainAppDepots`.

<sup>Written for commit cb663a9397df313091790e9acd9529778c5d278c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Steam license support to include shared licenses, allowing games to access depot content available via shared Steam accounts.
  * Improved license entitlement resolution so depot access now combines direct and shared license entitlements, reducing missed content when shared licenses apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->