### PR TITLE
fix(): fix gha fexcore fix

### DIFF
--- a/.github/workflows/update-fexcore.yml
+++ b/.github/workflows/update-fexcore.yml
@@ -33,25 +33,25 @@ jobs:
 
           # Pick the file with the highest YYMM version.
           # Only considers files whose names start with 4 digits (e.g. 2604.wcp, 2508.1.wcp).
-          LATEST=$(python3 - <<'EOF'
-          import sys, json, re
+          LATEST=$(echo "$RESPONSE" | python3 - <<'EOF'
+import sys, json, re
 
-          data = json.loads(sys.stdin.read())
-          files = [f["name"] for f in data if f["type"] == "file" and f["name"].endswith(".wcp")]
+data = json.loads(sys.stdin.read())
+files = [f["name"] for f in data if f["type"] == "file" and f["name"].endswith(".wcp")]
 
-          best = None
-          best_ver = (-1, -1)
-          for name in files:
-              m = re.match(r'^(\d{4})(?:\.(\d+))?\.wcp$', name)
-              if m:
-                  ver = (int(m.group(1)), int(m.group(2) or 0))
-                  if ver > best_ver:
-                      best_ver = ver
-                      best = name
+best = None
+best_ver = (-1, -1)
+for name in files:
+    m = re.match(r'^(\d{4})(?:\.(\d+))?\.wcp$', name)
+    if m:
+        ver = (int(m.group(1)), int(m.group(2) or 0))
+        if ver > best_ver:
+            best_ver = ver
+            best = name
 
-          print(best or "")
-          EOF
-          <<< "$RESPONSE")
+print(best or "")
+EOF
+)
 
           if [[ -z "$LATEST" ]]; then
             echo "Could not determine latest .wcp file." >&2

--- a/.github/workflows/update-fexcore.yml
+++ b/.github/workflows/update-fexcore.yml
@@ -1,0 +1,149 @@
+name: Update FEXCore
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-fexcore:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install zstd
+        run: sudo apt-get install -y zstd
+
+      - name: Find latest FEXCore .wcp
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fetch the file listing from the upstream repo via the GitHub API.
+          # Authenticate to avoid anonymous rate-limit (60 req/hr).
+          RESPONSE=$(curl -sf \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/StevenMXZ/Winlator-Contents/contents/FEXCore")
+
+          # Pick the file with the highest YYMM version.
+          # Only considers files whose names start with 4 digits (e.g. 2604.wcp, 2508.1.wcp).
+          LATEST=$(python3 - <<'EOF'
+          import sys, json, re
+
+          data = json.loads(sys.stdin.read())
+          files = [f["name"] for f in data if f["type"] == "file" and f["name"].endswith(".wcp")]
+
+          best = None
+          best_ver = (-1, -1)
+          for name in files:
+              m = re.match(r'^(\d{4})(?:\.(\d+))?\.wcp$', name)
+              if m:
+                  ver = (int(m.group(1)), int(m.group(2) or 0))
+                  if ver > best_ver:
+                      best_ver = ver
+                      best = name
+
+          print(best or "")
+          EOF
+          <<< "$RESPONSE")
+
+          if [[ -z "$LATEST" ]]; then
+            echo "Could not determine latest .wcp file." >&2
+            exit 1
+          fi
+
+          # Extract the YYMM version (first four digits) for the output filename.
+          VERSION=$(echo "$LATEST" | grep -oP '^\d{4}')
+          TZST_PATH="app/src/main/assets/fexcore/fexcore-${VERSION}.tzst"
+
+          echo "LATEST_FILE=$LATEST"  >> "$GITHUB_OUTPUT"
+          echo "VERSION=$VERSION"     >> "$GITHUB_OUTPUT"
+          echo "TZST_PATH=$TZST_PATH" >> "$GITHUB_OUTPUT"
+
+          if [[ -f "$TZST_PATH" ]]; then
+            echo "ALREADY_EXISTS=true" >> "$GITHUB_OUTPUT"
+            echo "fexcore-${VERSION}.tzst already present — nothing to do."
+          else
+            echo "ALREADY_EXISTS=false" >> "$GITHUB_OUTPUT"
+            echo "New release found: $LATEST → $TZST_PATH"
+          fi
+
+      - name: Download ${{ steps.check.outputs.LATEST_FILE }}
+        if: steps.check.outputs.ALREADY_EXISTS == 'false'
+        run: |
+          curl -fL -o latest.wcp \
+            "https://raw.githubusercontent.com/StevenMXZ/Winlator-Contents/main/FEXCore/${{ steps.check.outputs.LATEST_FILE }}"
+
+      - name: Convert .wcp → .tzst
+        if: steps.check.outputs.ALREADY_EXISTS == 'false'
+        run: |
+          chmod +x tools/convert-wcp-to-tzst.sh
+          ./tools/convert-wcp-to-tzst.sh latest.wcp "${{ steps.check.outputs.TZST_PATH }}"
+
+      - name: Update arrays.xml
+        if: steps.check.outputs.ALREADY_EXISTS == 'false'
+        run: |
+          VERSION="${{ steps.check.outputs.VERSION }}"
+          ARRAYS_XML="app/src/main/res/values/arrays.xml"
+
+          # Check if this version is already listed in arrays.xml.
+          if grep -qF "<item>${VERSION}</item>" "$ARRAYS_XML"; then
+            echo "Version $VERSION already present in arrays.xml — skipping XML update."
+          else
+            # Insert the new version as the last <item> of fexcore_version_entries.
+            # We find the closing </string-array> that follows the fexcore_version_entries
+            # block and insert directly before it.
+            python3 - "$ARRAYS_XML" "$VERSION" <<'PYEOF'
+          import sys, re
+
+          path, version = sys.argv[1], sys.argv[2]
+          with open(path, "r", encoding="utf-8") as f:
+              content = f.read()
+
+          # Find the fexcore_version_entries block and append the new item before its closing tag.
+          pattern = r'(name="fexcore_version_entries".*?)(</string-array>)'
+          replacement = r'\g<1>        <item>' + version + r'</item>\n    \g<2>'
+          new_content, count = re.subn(pattern, replacement, content, count=1, flags=re.DOTALL)
+
+          if count == 0:
+              print("ERROR: fexcore_version_entries array not found in arrays.xml", file=sys.stderr)
+              sys.exit(1)
+
+          with open(path, "w", encoding="utf-8") as f:
+              f.write(new_content)
+
+          print(f"Appended <item>{version}</item> to fexcore_version_entries.")
+          PYEOF
+          fi
+
+      - name: Create PR branch, commit, and open PR
+        if: steps.check.outputs.ALREADY_EXISTS == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.check.outputs.VERSION }}"
+          BRANCH="fexcore/update-${VERSION}"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git add "${{ steps.check.outputs.TZST_PATH }}"
+          git add app/src/main/res/values/arrays.xml
+          git commit -m "chore: add FEXCore ${VERSION}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: add FEXCore ${VERSION}" \
+            --body "Automated update from [StevenMXZ/Winlator-Contents](https://github.com/StevenMXZ/Winlator-Contents/tree/main/FEXCore).
+
+          - Converted \`${{ steps.check.outputs.LATEST_FILE }}\` → \`${{ steps.check.outputs.TZST_PATH }}\`
+          - Added \`${VERSION}\` to \`fexcore_version_entries\` in \`arrays.xml\`" \
+            --head "$BRANCH" \
+            --base "$(git remote show origin | awk '/HEAD branch/ {print $NF}')"

--- a/tools/convert-wcp-to-tzst.sh
+++ b/tools/convert-wcp-to-tzst.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# convert-wcp-to-tzst.sh
+# Converts a FEX .wcp release (XZ-compressed tar) into a fexcore .tzst file
+# compatible with the GameNative app assets format.
+#
+# Usage: ./tools/convert-wcp-to-tzst.sh <input.wcp> <output.tzst>
+# Example: ./tools/convert-wcp-to-tzst.sh FEX-2603.wcp app/src/main/assets/fexcore/fexcore-2603.tzst
+
+set -euo pipefail
+
+INPUT="${1:-}"
+OUTPUT="${2:-}"
+
+if [[ -z "$INPUT" || -z "$OUTPUT" ]]; then
+    echo "Usage: $0 <input.wcp> <output.tzst>"
+    exit 1
+fi
+
+if [[ ! -f "$INPUT" ]]; then
+    echo "Error: input file '$INPUT' not found"
+    exit 1
+fi
+
+# Ensure output directory exists
+mkdir -p "$(dirname "$OUTPUT")"
+
+echo "Converting '$INPUT' -> '$OUTPUT' ..."
+
+# Decompress XZ, extract only the two DLLs from system32/, strip the
+# system32/ path component, then repack as a zstd-compressed tar.
+#
+# The reference format (fexcore-2601.tzst) contains:
+#   ./libwow64fex.dll
+#   ./libarm64ecfex.dll
+# The .wcp source contains them under system32/, so we use --strip-components=1.
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "  Extracting DLLs from archive..."
+xz -dc "$INPUT" \
+    | tar -x \
+          --strip-components=1 \
+          -C "$TMPDIR" \
+          system32/libwow64fex.dll \
+          system32/libarm64ecfex.dll
+
+echo "  Repacking as zstd tar..."
+# Use compression level 19 for smallest output (matches prior releases in size range).
+tar -c -C "$TMPDIR" . \
+    | zstd -19 -o "$OUTPUT" --force
+
+echo "Done: $(du -sh "$OUTPUT" | cut -f1)  $OUTPUT"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automates FEXCore updates with a scheduled GitHub Action that fetches the latest `.wcp`, converts it to `.tzst`, updates `arrays.xml`, and opens a PR only when a new version exists.

- **New Features**
  - Adds a daily (06:00 UTC) and manual workflow to update FEXCore.
  - Detects the latest `.wcp` from `StevenMXZ/Winlator-Contents` and skips if already present.
  - Converts `.wcp` → `.tzst` via `tools/convert-wcp-to-tzst.sh` and appends the version to `fexcore_version_entries`.
  - Pushes a branch and creates a PR with the new asset and XML update.

<sup>Written for commit 1d7fd8d118d322fa1cbb01cf951e7e029881910a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated FEXCore updates: System now checks for new versions daily and automatically creates pull requests to integrate them.
  * Added file conversion tooling to support FEX format processing and asset compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->