### PR TITLE
Added gyro aiming support (gamepad & mouse)

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -677,6 +677,38 @@ object PrefManager {
             setPref(PORTRAIT_MODE, value)
         }
 
+    private val CONTROLS_GYRO_MODE = stringPreferencesKey("controls_gyro_mode")
+    var controlsGyroMode: String
+        get() = getPref(CONTROLS_GYRO_MODE, "disabled")
+        set(value) {
+            setPref(CONTROLS_GYRO_MODE, value)
+        }
+
+    fun setGyroMode(value: String) {
+        controlsGyroMode = value
+    }
+
+    private val CONTROLS_GYRO_LAST_TARGET = intPreferencesKey("controls_gyro_last_target")
+    var controlsGyroLastTarget: Int
+        get() = getPref(CONTROLS_GYRO_LAST_TARGET, 1).coerceIn(1, 3)
+        set(value) {
+            setPref(CONTROLS_GYRO_LAST_TARGET, value.coerceIn(1, 3))
+        }
+
+    private val CONTROLS_GYRO_INVERT_X = booleanPreferencesKey("controls_gyro_invert_x")
+    var controlsGyroInvertX: Boolean
+        get() = getPref(CONTROLS_GYRO_INVERT_X, false)
+        set(value) {
+            setPref(CONTROLS_GYRO_INVERT_X, value)
+        }
+
+    private val CONTROLS_GYRO_INVERT_Y = booleanPreferencesKey("controls_gyro_invert_y")
+    var controlsGyroInvertY: Boolean
+        get() = getPref(CONTROLS_GYRO_INVERT_Y, false)
+        set(value) {
+            setPref(CONTROLS_GYRO_INVERT_Y, value)
+        }
+
     private val BOX_86_VERSION = stringPreferencesKey("box86_version")
     var box86Version: String
         get() = getPref(BOX_86_VERSION, DefaultVersion.BOX86)

--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -253,6 +254,16 @@ fun QuickMenu(
     hasPhysicalController: Boolean = false,
     isTouchscreenModeActive: Boolean = false,
     onTouchGestureSettingsClick: () -> Unit = {},
+    gyroEnabled: Boolean = false,
+    onGyroEnabledChanged: (Boolean) -> Unit = {},
+    gyroMapping: Int = 1,
+    onGyroMappingChanged: (Int) -> Unit = {},
+    gyroSensitivity: Float = 0.35f,
+    onGyroSensitivityChanged: (Float) -> Unit = {},
+    gyroInvertX: Boolean = false,
+    gyroInvertY: Boolean = false,
+    onGyroInvertXChanged: (Boolean) -> Unit = {},
+    onGyroInvertYChanged: (Boolean) -> Unit = {},
     activeToggleIds: Set<Int> = emptySet(),
     // LSFG hot-reload state (tab only visible when isLsfgAvailable)
     isLsfgAvailable: Boolean = false,
@@ -626,7 +637,7 @@ fun QuickMenu(
                                         )
                                     }
 
-                                    else -> {
+                                    QuickMenuTab.CONTROLLER -> {
                                         Column(
                                             modifier = Modifier
                                                 .fillMaxSize()
@@ -650,6 +661,18 @@ fun QuickMenu(
                                                         onTouchGestureSettingsClick else null,
                                                 )
                                             }
+                                            ControllerGyroSection(
+                                                gyroEnabled = gyroEnabled,
+                                                onGyroEnabledChanged = onGyroEnabledChanged,
+                                                gyroMapping = gyroMapping,
+                                                onGyroMappingChanged = onGyroMappingChanged,
+                                                gyroSensitivity = gyroSensitivity,
+                                                onGyroSensitivityChanged = onGyroSensitivityChanged,
+                                                gyroInvertX = gyroInvertX,
+                                                onGyroInvertXChanged = onGyroInvertXChanged,
+                                                gyroInvertY = gyroInvertY,
+                                                onGyroInvertYChanged = onGyroInvertYChanged,
+                                            )
                                         }
                                     }
                                 }
@@ -731,6 +754,91 @@ private fun ToolsQuickMenuTab(
             }
         }
     }
+}
+
+@Composable
+private fun ControllerGyroSection(
+    gyroEnabled: Boolean,
+    onGyroEnabledChanged: (Boolean) -> Unit,
+    gyroMapping: Int,
+    onGyroMappingChanged: (Int) -> Unit,
+    gyroSensitivity: Float,
+    onGyroSensitivityChanged: (Float) -> Unit,
+    gyroInvertX: Boolean,
+    onGyroInvertXChanged: (Boolean) -> Unit,
+    gyroInvertY: Boolean,
+    onGyroInvertYChanged: (Boolean) -> Unit,
+) {
+    val accentColor = PluviaTheme.colors.accentPurple
+    Spacer(modifier = Modifier.height(8.dp))
+    QuickMenuToggleRow(
+        title = stringResource(R.string.quick_menu_tab_gyro),
+        subtitle = stringResource(R.string.controller_gyro_mode_subtitle),
+        enabled = gyroEnabled,
+        onToggle = { onGyroEnabledChanged(!gyroEnabled) },
+        accentColor = accentColor,
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    Column(
+        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.controller_gyro_mapping),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Medium,
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            QuickMenuChoiceChip(
+                text = stringResource(R.string.left_stick),
+                selected = gyroMapping == 1,
+                accentColor = accentColor,
+                onClick = { onGyroMappingChanged(1) },
+            )
+            QuickMenuChoiceChip(
+                text = stringResource(R.string.right_stick),
+                selected = gyroMapping == 2,
+                accentColor = accentColor,
+                onClick = { onGyroMappingChanged(2) },
+            )
+            QuickMenuChoiceChip(
+                text = stringResource(R.string.mouse),
+                selected = gyroMapping == 3,
+                accentColor = accentColor,
+                onClick = { onGyroMappingChanged(3) },
+            )
+        }
+    }
+    Spacer(modifier = Modifier.height(8.dp))
+    QuickMenuAdjustmentRow(
+        title = stringResource(R.string.controller_gyro_sensitivity),
+        valueText = stringResource(
+            R.string.controller_gyro_sensitivity_value,
+            (gyroSensitivity * 100f).roundToInt(),
+        ),
+        progress = normalizedProgress(gyroSensitivity, 0.1f, 2.0f),
+        onDecrease = { onGyroSensitivityChanged((gyroSensitivity - 0.05f).coerceIn(0.1f, 2.0f)) },
+        onIncrease = { onGyroSensitivityChanged((gyroSensitivity + 0.05f).coerceIn(0.1f, 2.0f)) },
+        accentColor = accentColor,
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    QuickMenuToggleRow(
+        title = stringResource(R.string.controller_gyro_invert_x),
+        enabled = gyroInvertX,
+        onToggle = { onGyroInvertXChanged(!gyroInvertX) },
+        accentColor = accentColor,
+    )
+    QuickMenuToggleRow(
+        title = stringResource(R.string.controller_gyro_invert_y),
+        enabled = gyroInvertY,
+        onToggle = { onGyroInvertYChanged(!gyroInvertY) },
+        accentColor = accentColor,
+    )
+    Spacer(modifier = Modifier.height(12.dp))
 }
 
 @Composable

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -210,6 +211,12 @@ private const val DEFAULT_FPS_LIMITER_MAX_HZ = 60
 private const val DEFAULT_FPS_LIMITER_TARGET_HZ = 60
 private const val FPS_LIMITER_ENABLED_EXTRA = "fpsLimiterEnabled"
 private const val FPS_LIMITER_TARGET_EXTRA = "fpsLimiterTarget"
+private const val PREF_CONTROLS_GYRO_MODE = "controls_gyro_mode"
+private const val PREF_CONTROLS_GYRO_SENSITIVITY = "controls_gyro_sensitivity"
+private const val GYRO_MODE_DISABLED = 0
+private const val GYRO_MODE_LEFT_STICK = 1
+private const val GYRO_MODE_RIGHT_STICK = 2
+private const val GYRO_MODE_MOUSE = 3
 
 private fun initialFpsLimiterEnabled(container: Container): Boolean =
     parseBooleanExtra(container.getExtra(FPS_LIMITER_ENABLED_EXTRA)) ?: true
@@ -237,6 +244,24 @@ private fun detectMaxRefreshRateHz(context: Context, attachedView: View?): Int {
         ?.roundToInt()
         ?.coerceAtLeast(5)
         ?: DEFAULT_FPS_LIMITER_MAX_HZ
+}
+
+private fun parseGyroMode(value: String?): Int {
+    return when (value?.lowercase(Locale.getDefault())) {
+        "left_stick" -> GYRO_MODE_LEFT_STICK
+        "right_stick" -> GYRO_MODE_RIGHT_STICK
+        "mouse" -> GYRO_MODE_MOUSE
+        else -> GYRO_MODE_DISABLED
+    }
+}
+
+private fun gyroModeToPrefValue(mode: Int): String {
+    return when (mode) {
+        GYRO_MODE_LEFT_STICK -> "left_stick"
+        GYRO_MODE_RIGHT_STICK -> "right_stick"
+        GYRO_MODE_MOUSE -> "mouse"
+        else -> "disabled"
+    }
 }
 
 private data class XServerViewReleaseBinding(
@@ -436,6 +461,18 @@ fun XServerScreen(
     var hasPhysicalMouse by remember { mutableStateOf(false) }
     var hasInternalTouchpad by remember { mutableStateOf(false) }
     var hasUpdatedScreenGamepad by remember { mutableStateOf(false) }
+    var controlsGyroMode by remember {
+        mutableStateOf(parseGyroMode(PrefManager.getString(PREF_CONTROLS_GYRO_MODE, "disabled")))
+    }
+    var controlsGyroLastTarget by remember {
+        val mode = parseGyroMode(PrefManager.getString(PREF_CONTROLS_GYRO_MODE, "disabled"))
+        mutableIntStateOf(if (mode != GYRO_MODE_DISABLED) mode else PrefManager.controlsGyroLastTarget.coerceIn(1, 3))
+    }
+    var controlsGyroSensitivity by remember {
+        mutableStateOf(PrefManager.getFloat(PREF_CONTROLS_GYRO_SENSITIVITY, 0.35f).coerceIn(0.1f, 2.0f))
+    }
+    var controlsGyroInvertX by remember { mutableStateOf(PrefManager.controlsGyroInvertX) }
+    var controlsGyroInvertY by remember { mutableStateOf(PrefManager.controlsGyroInvertY) }
     var isPerformanceHudEnabled by remember { mutableStateOf(PrefManager.showFps) }
     val shouldTrackDisplayedFrames = remember { AtomicBoolean(false) }
     var detectedMaxRefreshRateHz by remember { mutableIntStateOf(detectMaxRefreshRateHz(context, null)) }
@@ -1343,8 +1380,13 @@ fun XServerScreen(
             } else {
                 var handled = false
                 if (isGamepad && it.event != null) {
+                    // Physical handler and InputControlsView share the same joystick pipeline; do not
+                    // call both or axes/triggers are applied twice. Match onKeyEvent: physical first,
+                    // overlay only if nothing consumed (e.g. no PhysicalControllerHandler yet).
                     handled = physicalControllerHandler?.onGenericMotionEvent(it.event!!) == true
-                    if (!handled) handled = PluviaApp.inputControlsView?.onGenericMotionEvent(it.event) == true
+                    if (!handled) {
+                        handled = PluviaApp.inputControlsView?.onGenericMotionEvent(it.event) == true
+                    }
                     // Final fallback to WinHandler passthrough
                     if (!handled) handled = xServerView!!.getxServer().winHandler.onGenericMotionEvent(it.event)
                 }
@@ -2026,6 +2068,10 @@ fun XServerScreen(
 
                 // Set container-level shooter mode
                 setContainerShooterMode(container.isShooterMode)
+                setGyroMode(controlsGyroMode)
+                setGyroSensitivity(controlsGyroSensitivity)
+                setGyroInvertX(controlsGyroInvertX)
+                setGyroInvertY(controlsGyroInvertY)
             }
             PluviaApp.inputControlsView = icView
 
@@ -2381,6 +2427,53 @@ fun XServerScreen(
             hasPhysicalController = hasPhysicalController,
             isTouchscreenModeActive = isTouchscreenModeActive,
             onTouchGestureSettingsClick = { showTouchGestureDialog = true },
+            gyroEnabled = controlsGyroMode != GYRO_MODE_DISABLED,
+            onGyroEnabledChanged = { enabled ->
+                if (enabled) {
+                    val target = controlsGyroLastTarget.coerceIn(GYRO_MODE_LEFT_STICK, GYRO_MODE_MOUSE)
+                    controlsGyroLastTarget = target
+                    controlsGyroMode = target
+                    PrefManager.controlsGyroLastTarget = target
+                    PrefManager.setGyroMode(gyroModeToPrefValue(target))
+                    PluviaApp.inputControlsView?.setGyroMode(target)
+                } else {
+                    val target = controlsGyroLastTarget.coerceIn(GYRO_MODE_LEFT_STICK, GYRO_MODE_MOUSE)
+                    controlsGyroLastTarget = target
+                    PrefManager.controlsGyroLastTarget = target
+                    controlsGyroMode = GYRO_MODE_DISABLED
+                    PrefManager.setGyroMode("disabled")
+                    PluviaApp.inputControlsView?.setGyroMode(GYRO_MODE_DISABLED)
+                }
+            },
+            gyroMapping = controlsGyroLastTarget.coerceIn(GYRO_MODE_LEFT_STICK, GYRO_MODE_MOUSE),
+            onGyroMappingChanged = { target ->
+                val t = target.coerceIn(GYRO_MODE_LEFT_STICK, GYRO_MODE_MOUSE)
+                controlsGyroLastTarget = t
+                PrefManager.controlsGyroLastTarget = t
+                if (controlsGyroMode != GYRO_MODE_DISABLED) {
+                    controlsGyroMode = t
+                    PrefManager.setGyroMode(gyroModeToPrefValue(t))
+                    PluviaApp.inputControlsView?.setGyroMode(t)
+                }
+            },
+            gyroSensitivity = controlsGyroSensitivity,
+            onGyroSensitivityChanged = { sensitivity ->
+                controlsGyroSensitivity = sensitivity
+                PrefManager.setFloat(PREF_CONTROLS_GYRO_SENSITIVITY, sensitivity)
+                PluviaApp.inputControlsView?.setGyroSensitivity(sensitivity)
+            },
+            gyroInvertX = controlsGyroInvertX,
+            gyroInvertY = controlsGyroInvertY,
+            onGyroInvertXChanged = { invert ->
+                controlsGyroInvertX = invert
+                PrefManager.controlsGyroInvertX = invert
+                PluviaApp.inputControlsView?.setGyroInvertX(invert)
+            },
+            onGyroInvertYChanged = { invert ->
+                controlsGyroInvertY = invert
+                PrefManager.controlsGyroInvertY = invert
+                PluviaApp.inputControlsView?.setGyroInvertY(invert)
+            },
             activeToggleIds = buildSet {
                 if (areControlsVisible) add(QuickMenuAction.INPUT_CONTROLS)
                 if (isTouchscreenModeActive) add(QuickMenuAction.TOUCHSCREEN_MODE)
@@ -2765,7 +2858,6 @@ private fun showInputControls(profile: ControlsProfile, winHandler: WinHandler, 
 private fun hideInputControls() {
     PluviaApp.inputControlsView?.setShowTouchscreenControls(false)
     PluviaApp.inputControlsView?.setVisibility(View.GONE)
-    PluviaApp.inputControlsView?.setProfile(null)
 
     PluviaApp.touchpadView?.setSensitivity(1.0f)
     PluviaApp.touchpadView?.setPointerButtonLeftEnabled(true)

--- a/app/src/main/java/com/winlator/widget/GyroController.java
+++ b/app/src/main/java/com/winlator/widget/GyroController.java
@@ -1,0 +1,182 @@
+package com.winlator.widget;
+
+import android.content.Context;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+import android.view.Surface;
+import android.view.WindowManager;
+
+import androidx.annotation.NonNull;
+
+import com.winlator.math.Mathf;
+
+class GyroController implements SensorEventListener {
+    interface Listener {
+        void onGyroOutput(float x, float y, boolean rightStick, boolean isMouse);
+    }
+
+    private final SensorManager sensorManager;
+    private final Sensor gyroscopeSensor;
+    private final Listener listener;
+    private final WindowManager windowManager;
+
+    private int mode = InputControlsView.GYRO_MODE_DISABLED;
+    private float sensitivity = 0.35f;
+    private boolean invertX = false;
+    private boolean invertY = false;
+    private boolean editMode = false;
+    private boolean hasProfile = false;
+    private boolean isRegistered = false;
+    private boolean isAttached = false;
+
+    GyroController(@NonNull Context context, @NonNull Listener listener) {
+        this.listener = listener;
+        sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
+        gyroscopeSensor = sensorManager != null ? sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE) : null;
+        windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+    }
+
+    int getMode() {
+        return mode;
+    }
+
+    void setMode(int mode) {
+        int normalizedMode = (mode == InputControlsView.GYRO_MODE_LEFT_STICK
+                || mode == InputControlsView.GYRO_MODE_RIGHT_STICK
+                || mode == InputControlsView.GYRO_MODE_MOUSE)
+                ? mode : InputControlsView.GYRO_MODE_DISABLED;
+        if (this.mode == normalizedMode) {
+            updateRegistration();
+            return;
+        }
+        clearCurrentStick();
+        this.mode = normalizedMode;
+        updateRegistration();
+    }
+
+    void setEditMode(boolean editMode) {
+        if (!this.editMode && editMode) {
+            clearCurrentStick();
+        }
+        this.editMode = editMode;
+        updateRegistration();
+    }
+
+    void setSensitivity(float sensitivity) {
+        this.sensitivity = Mathf.clamp(sensitivity, 0.1f, 2.0f);
+    }
+
+    void setInvertX(boolean invertX) {
+        this.invertX = invertX;
+    }
+
+    void setInvertY(boolean invertY) {
+        this.invertY = invertY;
+    }
+
+    void setHasProfile(boolean hasProfile) {
+        if (this.hasProfile && !hasProfile &&
+                (mode == InputControlsView.GYRO_MODE_LEFT_STICK || mode == InputControlsView.GYRO_MODE_RIGHT_STICK)) {
+            clearCurrentStick();
+        }
+        this.hasProfile = hasProfile;
+        updateRegistration();
+    }
+
+    void onAttachedToWindow() {
+        isAttached = true;
+        updateRegistration();
+    }
+
+    void onDetachedFromWindow() {
+        isAttached = false;
+        unregister();
+        clearCurrentStick();
+    }
+
+    @Override
+    public void onSensorChanged(SensorEvent event) {
+        if (event == null || event.sensor == null || event.sensor.getType() != Sensor.TYPE_GYROSCOPE) return;
+        if (mode == InputControlsView.GYRO_MODE_DISABLED || editMode || !hasProfile) return;
+
+        float rawX = -event.values[1];
+        float rawY = -event.values[0];
+        int rotation = windowManager != null && windowManager.getDefaultDisplay() != null
+                ? windowManager.getDefaultDisplay().getRotation()
+                : Surface.ROTATION_0;
+        float[] mapped = mapToStick(rawX, rawY, rotation);
+        float x = mapped[0];
+        float y = mapped[1];
+
+        boolean isMouse = mode == InputControlsView.GYRO_MODE_MOUSE;
+        listener.onGyroOutput(x, y, mode == InputControlsView.GYRO_MODE_RIGHT_STICK, isMouse);
+    }
+
+    float[] mapToStick(float rawX, float rawY, int rotation) {
+        float mappedX;
+        float mappedY;
+        switch (rotation) {
+            case Surface.ROTATION_90:
+                mappedX = rawY;
+                mappedY = -rawX;
+                break;
+            case Surface.ROTATION_180:
+                mappedX = -rawX;
+                mappedY = -rawY;
+                break;
+            case Surface.ROTATION_270:
+                mappedX = -rawY;
+                mappedY = rawX;
+                break;
+            case Surface.ROTATION_0:
+            default:
+                mappedX = rawX;
+                mappedY = rawY;
+                break;
+        }
+
+        if (invertX) mappedX = -mappedX;
+        if (invertY) mappedY = -mappedY;
+
+        float x = Mathf.clamp(mappedX * sensitivity, -1f, 1f);
+        float y = Mathf.clamp(mappedY * sensitivity, -1f, 1f);
+        if (Math.abs(x) < 0.03f) x = 0f;
+        if (Math.abs(y) < 0.03f) y = 0f;
+        return new float[]{x, y};
+    }
+
+    @Override
+    public void onAccuracyChanged(Sensor sensor, int accuracy) {
+        // no-op
+    }
+
+    private void clearCurrentStick() {
+        if (mode == InputControlsView.GYRO_MODE_LEFT_STICK) {
+            listener.onGyroOutput(0f, 0f, false, false);
+        } else if (mode == InputControlsView.GYRO_MODE_RIGHT_STICK) {
+            listener.onGyroOutput(0f, 0f, true, false);
+        }
+    }
+
+    private void updateRegistration() {
+        if (!isAttached || sensorManager == null || gyroscopeSensor == null) {
+            unregister();
+            return;
+        }
+        if (mode == InputControlsView.GYRO_MODE_DISABLED || editMode || !hasProfile) {
+            unregister();
+            return;
+        }
+        if (isRegistered) return;
+        sensorManager.registerListener(this, gyroscopeSensor, SensorManager.SENSOR_DELAY_GAME);
+        isRegistered = true;
+    }
+
+    private void unregister() {
+        if (sensorManager == null || !isRegistered) return;
+        sensorManager.unregisterListener(this, gyroscopeSensor);
+        isRegistered = false;
+    }
+}

--- a/app/src/main/java/com/winlator/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/widget/InputControlsView.java
@@ -46,6 +46,10 @@ import java.util.TimerTask;
 
 public class InputControlsView extends View {
     public static final float DEFAULT_OVERLAY_OPACITY = 0.4f;
+    public static final int GYRO_MODE_DISABLED = 0;
+    public static final int GYRO_MODE_LEFT_STICK = 1;
+    public static final int GYRO_MODE_RIGHT_STICK = 2;
+    public static final int GYRO_MODE_MOUSE = 3;
     private boolean editMode = false;
     private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Path path = new Path();
@@ -87,6 +91,15 @@ public class InputControlsView extends View {
     // Container-level shooter mode (auto-replaces STICK elements)
     private boolean containerShooterMode = false;
     private boolean containerShooterModeRuntime = false; // runtime toggle state
+    private final GyroController gyroController;
+    private float baseThumbLX = 0f;
+    private float baseThumbLY = 0f;
+    private float baseThumbRX = 0f;
+    private float baseThumbRY = 0f;
+    private float gyroThumbLX = 0f;
+    private float gyroThumbLY = 0f;
+    private float gyroThumbRX = 0f;
+    private float gyroThumbRY = 0f;
 
     // Callback invoked when the SHOW_KEYBOARD binding is triggered
     private Runnable showKeyboardCallback;
@@ -96,6 +109,13 @@ public class InputControlsView extends View {
     @SuppressLint("ResourceType")
     public InputControlsView(Context context) {
         super(context);
+        gyroController = new GyroController(context, (x, y, rightStick, isMouse) -> {
+            if (isMouse) {
+                updateGyroMouse(x, y);
+            } else {
+                updateGyroStick(rightStick, x, y);
+            }
+        });
         setClickable(true);
         setFocusable(true);
         setFocusableInTouchMode(true);
@@ -110,6 +130,7 @@ public class InputControlsView extends View {
 
     public void setEditMode(boolean editMode) {
         this.editMode = editMode;
+        gyroController.setEditMode(editMode);
         invalidate(); // Trigger redraw to show/hide grid background immediately
     }
 
@@ -276,7 +297,11 @@ public class InputControlsView extends View {
             this.profile = profile;
             deselectAllElements();
         }
-        else this.profile = null;
+        else {
+            this.profile = null;
+            resetThumbContributions();
+        }
+        gyroController.setHasProfile(this.profile != null);
     }
 
     public boolean isShowTouchscreenControls() {
@@ -285,6 +310,26 @@ public class InputControlsView extends View {
 
     public void setShowTouchscreenControls(boolean showTouchscreenControls) {
         this.showTouchscreenControls = showTouchscreenControls;
+    }
+
+    public int getGyroMode() {
+        return gyroController.getMode();
+    }
+
+    public void setGyroMode(int mode) {
+        gyroController.setMode(mode);
+    }
+
+    public void setGyroSensitivity(float sensitivity) {
+        gyroController.setSensitivity(sensitivity);
+    }
+
+    public void setGyroInvertX(boolean invertX) {
+        gyroController.setInvertX(invertX);
+    }
+
+    public void setGyroInvertY(boolean invertY) {
+        gyroController.setInvertY(invertY);
     }
 
     public int getPrimaryColor() {
@@ -339,9 +384,16 @@ public class InputControlsView extends View {
 
     @Override
     protected void onDetachedFromWindow() {
+        gyroController.onDetachedFromWindow();
         if (mouseMoveTimer != null)
             mouseMoveTimer.cancel();
         super.onDetachedFromWindow();
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        gyroController.onAttachedToWindow();
     }
 
     public int getMaxHeight() {
@@ -955,6 +1007,7 @@ public class InputControlsView extends View {
 
     public void handleInputEvent(Binding binding, boolean isActionDown, float offset) {
         if (binding.isGamepad()) {
+            if (profile == null) return;
             WinHandler winHandler = xServer != null ? xServer.getWinHandler() : null;
             GamepadState state = profile.getGamepadState();
 
@@ -970,16 +1023,20 @@ public class InputControlsView extends View {
                     state.setPressed(buttonIdx, isActionDown);
             }
             else if (binding == Binding.GAMEPAD_LEFT_THUMB_UP || binding == Binding.GAMEPAD_LEFT_THUMB_DOWN) {
-                state.thumbLY = isActionDown ? offset : 0;
+                baseThumbLY = isActionDown ? offset : 0;
+                state.thumbLY = Mathf.clamp(baseThumbLY + gyroThumbLY, -1f, 1f);
             }
             else if (binding == Binding.GAMEPAD_LEFT_THUMB_LEFT || binding == Binding.GAMEPAD_LEFT_THUMB_RIGHT) {
-                state.thumbLX = isActionDown ? offset : 0;
+                baseThumbLX = isActionDown ? offset : 0;
+                state.thumbLX = Mathf.clamp(baseThumbLX + gyroThumbLX, -1f, 1f);
             }
             else if (binding == Binding.GAMEPAD_RIGHT_THUMB_UP || binding == Binding.GAMEPAD_RIGHT_THUMB_DOWN) {
-                state.thumbRY = isActionDown ? offset : 0;
+                baseThumbRY = isActionDown ? offset : 0;
+                state.thumbRY = Mathf.clamp(baseThumbRY + gyroThumbRY, -1f, 1f);
             }
             else if (binding == Binding.GAMEPAD_RIGHT_THUMB_LEFT || binding == Binding.GAMEPAD_RIGHT_THUMB_RIGHT) {
-                state.thumbRX = isActionDown ? offset : 0;
+                baseThumbRX = isActionDown ? offset : 0;
+                state.thumbRX = Mathf.clamp(baseThumbRX + gyroThumbRX, -1f, 1f);
             }
             else if (binding == Binding.GAMEPAD_DPAD_UP || binding == Binding.GAMEPAD_DPAD_RIGHT ||
                      binding == Binding.GAMEPAD_DPAD_DOWN || binding == Binding.GAMEPAD_DPAD_LEFT) {
@@ -1029,6 +1086,55 @@ public class InputControlsView extends View {
                 }
             }
         }
+    }
+
+    private void updateGyroMouse(float x, float y) {
+        if (profile == null || xServer == null) return;
+        if (Math.abs(x) < 0.001f && Math.abs(y) < 0.001f) return;
+        float cursorSpeed = profile.getCursorSpeed();
+        int moveX = Mathf.roundPoint(x * 24f * cursorSpeed);
+        int moveY = Mathf.roundPoint(y * 24f * cursorSpeed);
+        if (moveX == 0 && moveY == 0) return;
+        if (xServer.isRelativeMouseMovement()) {
+            xServer.getWinHandler().mouseEvent(MouseEventFlags.MOVE, moveX, moveY, 0);
+        } else {
+            xServer.injectPointerMoveDelta(moveX, moveY);
+        }
+    }
+
+    private void updateGyroStick(boolean rightStick, float x, float y) {
+        if (profile == null) return;
+        GamepadState state = profile.getGamepadState();
+        if (rightStick) {
+            gyroThumbRX = x;
+            gyroThumbRY = y;
+            state.thumbRX = Mathf.clamp(baseThumbRX + gyroThumbRX, -1f, 1f);
+            state.thumbRY = Mathf.clamp(baseThumbRY + gyroThumbRY, -1f, 1f);
+        } else {
+            gyroThumbLX = x;
+            gyroThumbLY = y;
+            state.thumbLX = Mathf.clamp(baseThumbLX + gyroThumbLX, -1f, 1f);
+            state.thumbLY = Mathf.clamp(baseThumbLY + gyroThumbLY, -1f, 1f);
+        }
+
+        WinHandler winHandler = xServer != null ? xServer.getWinHandler() : null;
+        if (winHandler != null) {
+            ExternalController controller = winHandler.getCurrentController();
+            if (controller != null) controller.state.copy(state);
+            winHandler.sendGamepadState();
+            winHandler.sendVirtualGamepadState(state);
+        }
+    }
+
+    private void resetThumbContributions() {
+        baseThumbLX = 0f;
+        baseThumbLY = 0f;
+        baseThumbRX = 0f;
+        baseThumbRY = 0f;
+        gyroThumbLX = 0f;
+        gyroThumbLY = 0f;
+        gyroThumbRX = 0f;
+        gyroThumbRY = 0f;
     }
 
     public Bitmap getIcon(byte id) {

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -226,6 +226,13 @@
     <string name="screen_effects_close">Luk</string>
     <string name="quick_menu_tab_general">Generelt</string>
     <string name="quick_menu_tab_controller">Controller</string>
+    <string name="quick_menu_tab_gyro">Gyro</string>
+    <string name="controller_gyro_mode_subtitle">Tildel enhedens gyro til en gamepad-joystick eller mus</string>
+    <string name="controller_gyro_mapping">Tildel til</string>
+    <string name="controller_gyro_sensitivity">Følsomhed</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">Inverter vandret</string>
+    <string name="controller_gyro_invert_y">Inverter lodret</string>
     <string name="performance_hud">Ydelses-HUD</string>
     <string name="performance_hud_description">Vis eller skjul overlayet i spillet.</string>
     <string name="performance_hud_fps_limiter">FPS-begrænser</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -288,6 +288,13 @@
     <string name="screen_effects_close">Schließen</string>
     <string name="quick_menu_tab_general">Allgemein</string>
     <string name="quick_menu_tab_controller">Controller</string>
+    <string name="quick_menu_tab_gyro">Gyro</string>
+    <string name="controller_gyro_mode_subtitle">Geräte-Gyroskop einem Gamepad-Stick oder der Maus zuordnen</string>
+    <string name="controller_gyro_mapping">Zuordnen zu</string>
+    <string name="controller_gyro_sensitivity">Empfindlichkeit</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">Horizontalachse umkehren</string>
+    <string name="controller_gyro_invert_y">Vertikalachse umkehren</string>
     <string name="performance_hud">Leistungs-HUD</string>
     <string name="performance_hud_description">Leistungsoverlay im Spiel ein- oder ausblenden.</string>
     <string name="performance_hud_fps_limiter">FPS-Begrenzer</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -310,6 +310,13 @@
     <string name="screen_effects_close">Cerrar</string>
     <string name="quick_menu_tab_general">General</string>
     <string name="quick_menu_tab_controller">Controles</string>
+    <string name="quick_menu_tab_gyro">Giroscopio</string>
+    <string name="controller_gyro_mode_subtitle">Asigna el giroscopio del dispositivo a un joystick de mando o al ratón</string>
+    <string name="controller_gyro_mapping">Asignar a</string>
+    <string name="controller_gyro_sensitivity">Sensibilidad</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">Invertir horizontal</string>
+    <string name="controller_gyro_invert_y">Invertir vertical</string>
     <string name="performance_hud">HUD de rendimiento</string>
     <string name="performance_hud_description">Mostrar u ocultar la superposición en el juego.</string>
     <string name="performance_hud_fps_limiter">Limitador de FPS</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -295,6 +295,13 @@
     <string name="screen_effects_close">Fermer</string>
     <string name="quick_menu_tab_general">Général</string>
     <string name="quick_menu_tab_controller">Contrôles</string>
+    <string name="quick_menu_tab_gyro">Gyroscope</string>
+    <string name="controller_gyro_mode_subtitle">Associer le gyroscope de l\'appareil à un joystick de manette ou à la souris</string>
+    <string name="controller_gyro_mapping">Affecter à</string>
+    <string name="controller_gyro_sensitivity">Sensibilité</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">Inverser l\'axe horizontal</string>
+    <string name="controller_gyro_invert_y">Inverser l\'axe vertical</string>
     <string name="performance_hud">HUD de performance</string>
     <string name="performance_hud_description">Afficher ou masquer la surcouche en jeu.</string>
     <string name="performance_hud_fps_limiter">Limiteur de FPS</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -299,6 +299,13 @@
     <string name="screen_effects_close">Chiudi</string>
     <string name="quick_menu_tab_general">Generale</string>
     <string name="quick_menu_tab_controller">Controller</string>
+    <string name="quick_menu_tab_gyro">Giroscopio</string>
+    <string name="controller_gyro_mode_subtitle">Mappa il giroscopio del dispositivo su uno stick del controller o sul mouse</string>
+    <string name="controller_gyro_mapping">Mappa su</string>
+    <string name="controller_gyro_sensitivity">Sensibilità</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">Inverti orizzontale</string>
+    <string name="controller_gyro_invert_y">Inverti verticale</string>
     <string name="performance_hud">HUD prestazioni</string>
     <string name="performance_hud_description">Mostra o nascondi l’overlay di gioco.</string>
     <string name="performance_hud_fps_limiter">Limitatore FPS</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -308,6 +308,13 @@
     <string name="screen_effects_close">닫기</string>
     <string name="quick_menu_tab_general">일반</string>
     <string name="quick_menu_tab_controller">컨트롤러</string>
+    <string name="quick_menu_tab_gyro">자이로</string>
+    <string name="controller_gyro_mode_subtitle">기기 자이로를 게임패드 스틱이나 마우스에 매핑합니다</string>
+    <string name="controller_gyro_mapping">매핑 대상</string>
+    <string name="controller_gyro_sensitivity">감도</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">가로 반전</string>
+    <string name="controller_gyro_invert_y">세로 반전</string>
     <string name="performance_hud">성능 HUD</string>
     <string name="performance_hud_description">게임 내 오버레이를 표시하거나 숨깁니다.</string>
     <string name="performance_hud_fps_limiter">FPS 제한기</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -307,6 +307,13 @@
     <string name="screen_effects_close">Zamknij</string>
     <string name="quick_menu_tab_general">Ogólne</string>
     <string name="quick_menu_tab_controller">Kontroler</string>
+    <string name="quick_menu_tab_gyro">Żyroskop</string>
+    <string name="controller_gyro_mode_subtitle">Mapuj żyroskop urządzenia na joystick pada lub mysz</string>
+    <string name="controller_gyro_mapping">Mapuj na</string>
+    <string name="controller_gyro_sensitivity">Czułość</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">Odwróć poziomo</string>
+    <string name="controller_gyro_invert_y">Odwróć pionowo</string>
     <string name="performance_hud">HUD wydajności</string>
     <string name="performance_hud_description">Pokaż lub ukryj nakładkę w grze.</string>
     <string name="performance_hud_fps_limiter">Ogranicznik FPS</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -226,6 +226,13 @@
     <string name="screen_effects_close">Fechar</string>
     <string name="quick_menu_tab_general">Geral</string>
     <string name="quick_menu_tab_controller">Controle</string>
+    <string name="quick_menu_tab_gyro">Giroscópio</string>
+    <string name="controller_gyro_mode_subtitle">Mapeie o giroscópio do dispositivo para um analógico do controle ou mouse</string>
+    <string name="controller_gyro_mapping">Mapear para</string>
+    <string name="controller_gyro_sensitivity">Sensibilidade</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">Inverter horizontal</string>
+    <string name="controller_gyro_invert_y">Inverter vertical</string>
     <string name="performance_hud">HUD de desempenho</string>
     <string name="performance_hud_description">Mostrar ou ocultar a sobreposição no jogo.</string>
     <string name="performance_hud_fps_limiter">Limitador de FPS</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -297,6 +297,13 @@
     <string name="screen_effects_close">Închide</string>
     <string name="quick_menu_tab_general">General</string>
     <string name="quick_menu_tab_controller">Controller</string>
+    <string name="quick_menu_tab_gyro">Giroscop</string>
+    <string name="controller_gyro_mode_subtitle">Mapează giroscopul dispozitivului la un joystick de gamepad sau la mouse</string>
+    <string name="controller_gyro_mapping">Mapează la</string>
+    <string name="controller_gyro_sensitivity">Sensibilitate</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">Inversează orizontal</string>
+    <string name="controller_gyro_invert_y">Inversează vertical</string>
     <string name="performance_hud">HUD de performanță</string>
     <string name="performance_hud_description">Afișează sau ascunde suprapunerea din joc.</string>
     <string name="performance_hud_fps_limiter">Limitator FPS</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -871,6 +871,13 @@ https://gamenative.app
     <string name="screen_effects_close">Закрыть</string>
     <string name="quick_menu_tab_general">Общие</string>
     <string name="quick_menu_tab_controller">Контроллер</string>
+    <string name="quick_menu_tab_gyro">Гироскоп</string>
+    <string name="controller_gyro_mode_subtitle">Назначить гироскоп устройства на стик геймпада или мышь</string>
+    <string name="controller_gyro_mapping">Назначить на</string>
+    <string name="controller_gyro_sensitivity">Чувствительность</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">Инвертировать по горизонтали</string>
+    <string name="controller_gyro_invert_y">Инвертировать по вертикали</string>
     <string name="performance_hud">HUD производительности</string>
     <string name="performance_hud_description">Показывать или скрывать игровое наложение.</string>
     <string name="performance_hud_fps_limiter">Ограничитель FPS</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -294,6 +294,13 @@
     <string name="screen_effects_close">Закрити</string>
     <string name="quick_menu_tab_general">Загальні</string>
     <string name="quick_menu_tab_controller">Контролер</string>
+    <string name="quick_menu_tab_gyro">Гіроскоп</string>
+    <string name="controller_gyro_mode_subtitle">Призначити гіроскоп пристрою на стік геймпада або мишу</string>
+    <string name="controller_gyro_mapping">Призначити на</string>
+    <string name="controller_gyro_sensitivity">Чутливість</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">Інвертувати по горизонталі</string>
+    <string name="controller_gyro_invert_y">Інвертувати по вертикалі</string>
     <string name="performance_hud">HUD продуктивності</string>
     <string name="performance_hud_description">Показувати або приховувати ігрове накладання.</string>
     <string name="performance_hud_fps_limiter">Обмежувач FPS</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -293,6 +293,13 @@
     <string name="screen_effects_close">关闭</string>
     <string name="quick_menu_tab_general">常规</string>
     <string name="quick_menu_tab_controller">控制器</string>
+    <string name="quick_menu_tab_gyro">陀螺仪</string>
+    <string name="controller_gyro_mode_subtitle">将设备陀螺仪映射到手柄摇杆或鼠标</string>
+    <string name="controller_gyro_mapping">映射到</string>
+    <string name="controller_gyro_sensitivity">灵敏度</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">水平反转</string>
+    <string name="controller_gyro_invert_y">垂直反转</string>
     <string name="performance_hud">性能 HUD</string>
     <string name="performance_hud_description">显示或隐藏游戏内叠加层。</string>
     <string name="performance_hud_fps_limiter">FPS 限制器</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -293,6 +293,13 @@
     <string name="screen_effects_close">關閉</string>
     <string name="quick_menu_tab_general">一般</string>
     <string name="quick_menu_tab_controller">控制器</string>
+    <string name="quick_menu_tab_gyro">陀螺儀</string>
+    <string name="controller_gyro_mode_subtitle">將裝置陀螺儀映射到手把搖桿或滑鼠</string>
+    <string name="controller_gyro_mapping">映射到</string>
+    <string name="controller_gyro_sensitivity">靈敏度</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">水平反轉</string>
+    <string name="controller_gyro_invert_y">垂直反轉</string>
     <string name="performance_hud">效能 HUD</string>
     <string name="performance_hud_description">顯示或隱藏遊戲內疊加層。</string>
     <string name="performance_hud_fps_limiter">FPS 限制器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -283,6 +283,13 @@
     <string name="quick_menu_tab_controller">Controller</string>
     <string name="tools_wine_processes_running_hint">%1$d running, tap/click a process to close</string>
     <string name="tools_wine_processes_empty">No running EXEs detected.</string>
+    <string name="quick_menu_tab_gyro">Gyro</string>
+    <string name="controller_gyro_mode_subtitle">Map device gyro to a gamepad joystick or mouse</string>
+    <string name="controller_gyro_mapping">Map to</string>
+    <string name="controller_gyro_sensitivity">Sensitivity</string>
+    <string name="controller_gyro_sensitivity_value">%1$d%%</string>
+    <string name="controller_gyro_invert_x">Invert Horizontal</string>
+    <string name="controller_gyro_invert_y">Invert Vertical</string>
     <string name="performance_hud">Performance HUD</string>
     <string name="performance_hud_description">Show or hide the in-game overlay.</string>
     <string name="performance_hud_fps_limiter">FPS limiter</string>

--- a/app/src/test/java/com/winlator/widget/GyroControllerTest.kt
+++ b/app/src/test/java/com/winlator/widget/GyroControllerTest.kt
@@ -1,0 +1,243 @@
+package com.winlator.widget
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.view.Surface
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+
+class GyroControllerTest {
+    private data class GyroEvent(val x: Float, val y: Float, val rightStick: Boolean, val isMouse: Boolean)
+
+    private class RecordingListener : GyroController.Listener {
+        val events = mutableListOf<GyroEvent>()
+
+        override fun onGyroOutput(x: Float, y: Float, rightStick: Boolean, isMouse: Boolean) {
+            events += GyroEvent(x, y, rightStick, isMouse)
+        }
+    }
+
+    private fun createController(listener: RecordingListener): GyroController {
+        val context = Mockito.mock(Context::class.java)
+        return GyroController(context, listener)
+    }
+
+    private fun createControllerWithGyroSensor(listener: RecordingListener): Pair<GyroController, SensorManager> {
+        val sensorManager = Mockito.mock(SensorManager::class.java)
+        val sensor = Mockito.mock(Sensor::class.java)
+        Mockito.`when`(sensor.type).thenReturn(Sensor.TYPE_GYROSCOPE)
+        Mockito.`when`(sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)).thenReturn(sensor)
+        val context = Mockito.mock(Context::class.java)
+        Mockito.`when`(context.getSystemService(Context.SENSOR_SERVICE)).thenReturn(sensorManager)
+        Mockito.`when`(context.getSystemService(Context.WINDOW_SERVICE)).thenReturn(null)
+        return Pair(GyroController(context, listener), sensorManager)
+    }
+
+    @Test
+    fun mapToStick_appliesRotation() {
+        val listener = RecordingListener()
+        val controller = createController(listener)
+        controller.setSensitivity(1f)
+
+        val mapped = controller.mapToStick(0.4f, 0.2f, Surface.ROTATION_90)
+
+        assertEquals(0.2f, mapped[0], 0.0001f)
+        assertEquals(-0.4f, mapped[1], 0.0001f)
+    }
+
+    @Test
+    fun mapToStick_appliesInvertToggles() {
+        val listener = RecordingListener()
+        val controller = createController(listener)
+        controller.setSensitivity(1f)
+        controller.setInvertX(true)
+        controller.setInvertY(true)
+
+        val mapped = controller.mapToStick(0.3f, -0.6f, Surface.ROTATION_0)
+
+        assertEquals(-0.3f, mapped[0], 0.0001f)
+        assertEquals(0.6f, mapped[1], 0.0001f)
+    }
+
+    @Test
+    fun mapToStick_clampsAndDeadzonesWithSensitivity() {
+        val listener = RecordingListener()
+        val controller = createController(listener)
+
+        controller.setSensitivity(2f)
+        val high = controller.mapToStick(0.8f, -0.8f, Surface.ROTATION_0)
+        assertEquals(1f, high[0], 0.0001f)
+        assertEquals(-1f, high[1], 0.0001f)
+
+        controller.setSensitivity(0f) // clamp to minimum 0.1
+        val low = controller.mapToStick(0.5f, 0.2f, Surface.ROTATION_0)
+        assertEquals(0.05f, low[0], 0.0001f)
+        assertEquals(0f, low[1], 0.0001f) // deadzone (< 0.03 after scaling)
+    }
+
+    @Test
+    fun setMode_clearsPreviousStickContribution() {
+        val listener = RecordingListener()
+        val controller = createController(listener)
+
+        controller.setMode(InputControlsView.GYRO_MODE_LEFT_STICK)
+        assertTrue(listener.events.isEmpty())
+
+        controller.setMode(InputControlsView.GYRO_MODE_RIGHT_STICK)
+        assertEquals(1, listener.events.size)
+        assertEquals(0f, listener.events[0].x, 0.0001f)
+        assertEquals(0f, listener.events[0].y, 0.0001f)
+        assertFalse(listener.events[0].rightStick)
+        assertFalse(listener.events[0].isMouse)
+
+        controller.setMode(InputControlsView.GYRO_MODE_DISABLED)
+        assertEquals(2, listener.events.size)
+        assertTrue(listener.events[1].rightStick)
+        assertFalse(listener.events[1].isMouse)
+    }
+
+    @Test
+    fun setEditMode_enteringEditMode_clearsLeftStick() {
+        val listener = RecordingListener()
+        val controller = createController(listener)
+        controller.setMode(InputControlsView.GYRO_MODE_LEFT_STICK)
+        assertTrue(listener.events.isEmpty())
+
+        controller.setEditMode(true)
+
+        assertEquals(1, listener.events.size)
+        assertEquals(0f, listener.events[0].x, 0.0001f)
+        assertEquals(0f, listener.events[0].y, 0.0001f)
+        assertFalse(listener.events[0].rightStick)
+        assertFalse(listener.events[0].isMouse)
+    }
+
+    @Test
+    fun setEditMode_enteringEditMode_clearsRightStick() {
+        val listener = RecordingListener()
+        val controller = createController(listener)
+        controller.setMode(InputControlsView.GYRO_MODE_RIGHT_STICK)
+        assertTrue(listener.events.isEmpty())
+
+        controller.setEditMode(true)
+
+        assertEquals(1, listener.events.size)
+        assertEquals(0f, listener.events[0].x, 0.0001f)
+        assertEquals(0f, listener.events[0].y, 0.0001f)
+        assertTrue(listener.events[0].rightStick)
+        assertFalse(listener.events[0].isMouse)
+    }
+
+    @Test
+    fun setEditMode_enteringEditMode_withGyroDisabled_doesNotNotifyListener() {
+        val listener = RecordingListener()
+        val controller = createController(listener)
+        controller.setMode(InputControlsView.GYRO_MODE_DISABLED)
+
+        controller.setEditMode(true)
+
+        assertTrue(listener.events.isEmpty())
+    }
+
+    @Test
+    fun setEditMode_exitingEditMode_doesNotClearStickAgain() {
+        val listener = RecordingListener()
+        val controller = createController(listener)
+        controller.setMode(InputControlsView.GYRO_MODE_LEFT_STICK)
+        controller.setEditMode(true)
+        assertEquals(1, listener.events.size)
+
+        controller.setEditMode(false)
+
+        assertEquals(1, listener.events.size)
+    }
+
+    /**
+     * When profile goes away while gyro targets a stick, unregister alone would leave the
+     * last merged stick value latched in InputControlsView until something else overwrites it.
+     */
+    @Test
+    fun setHasProfile_losingProfile_clearsLeftStick() {
+        val listener = RecordingListener()
+        val controller = createController(listener)
+        controller.setMode(InputControlsView.GYRO_MODE_LEFT_STICK)
+        controller.setHasProfile(true)
+        listener.events.clear()
+
+        controller.setHasProfile(false)
+
+        assertEquals(1, listener.events.size)
+        assertEquals(0f, listener.events[0].x, 0.0001f)
+        assertEquals(0f, listener.events[0].y, 0.0001f)
+        assertFalse(listener.events[0].rightStick)
+        assertFalse(listener.events[0].isMouse)
+    }
+
+    @Test
+    fun setMode_mouseMode_doesNotEmitStickClearWhenSwitchingAway() {
+        val listener = RecordingListener()
+        val controller = createController(listener)
+        controller.setMode(InputControlsView.GYRO_MODE_MOUSE)
+        assertTrue(listener.events.isEmpty())
+
+        controller.setMode(InputControlsView.GYRO_MODE_LEFT_STICK)
+        assertTrue(listener.events.isEmpty())
+    }
+
+    @Test
+    fun updateRegistration_registersGyroListenerOnlyAfterViewAttached() {
+        val listener = RecordingListener()
+        val (controller, sensorManager) = createControllerWithGyroSensor(listener)
+        val sensor = sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)!!
+
+        controller.setMode(InputControlsView.GYRO_MODE_LEFT_STICK)
+        controller.setHasProfile(true)
+
+        verify(sensorManager, never()).registerListener(
+            any(SensorEventListener::class.java),
+            eq(sensor),
+            eq(SensorManager.SENSOR_DELAY_GAME),
+        )
+
+        controller.onAttachedToWindow()
+
+        verify(sensorManager).registerListener(
+            eq(controller),
+            eq(sensor),
+            eq(SensorManager.SENSOR_DELAY_GAME),
+        )
+    }
+
+    @Test
+    fun onDetachedFromWindow_unregistersGyroListener() {
+        val listener = RecordingListener()
+        val (controller, sensorManager) = createControllerWithGyroSensor(listener)
+        val sensor = sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)!!
+
+        controller.setMode(InputControlsView.GYRO_MODE_LEFT_STICK)
+        controller.setHasProfile(true)
+        controller.onAttachedToWindow()
+
+        verify(sensorManager).registerListener(
+            eq(controller),
+            eq(sensor),
+            eq(SensorManager.SENSOR_DELAY_GAME),
+        )
+
+        controller.onDetachedFromWindow()
+
+        verify(sensorManager).unregisterListener(
+            eq(controller),
+            eq(sensor),
+        )
+    }
+}


### PR DESCRIPTION
## Description
A better gyro implementation not relying on code from original winlator implementations. This better fits in gamenative as it works for both gamepad joysticks & mouse.

## Recording
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c60e5fc0-ee1c-4cf5-81d5-d13b57598cb2" />


>
Another vids  can be found in discord (they were too big for the github upload):
https://discord.com/channels/1378308569287622737/1452868088277241979

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gyro controller support: enable/disable, mapping targets (1–3 / left/right/mouse), sensitivity slider, X/Y invert toggles, persisted settings, and a Gyro tab in the Quick Menu.

* **Bug Fixes**
  * Improved gamepad motion handling and input-control lifecycle to preserve profiles when hiding controls.

* **Tests**
  * Added unit tests for gyro mapping, rotation/inversion, sensitivity, clamping, deadzone, and lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->