### PR TITLE
Simplify settings screen copywriting

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupDebug.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupDebug.kt
@@ -191,7 +191,7 @@ fun SettingsGroupDebug() {
             subtitle = {
                 Text(
                     text = if (selectedWineChannels.isNotEmpty() && selectedWineChannels.any { it.isNotBlank() })
-                        selectedWineChannels.filter { it.isNotBlank() }.joinToString(",")
+                        selectedWineChannels.filter { it.isNotBlank() }.joinToString(", ")
                     else
                         stringResource(R.string.settings_debug_no_channels_selected)
                 )

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupEmulation.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupEmulation.kt
@@ -105,31 +105,26 @@ fun SettingsGroupEmulation() {
         SettingsMenuLink(
             colors = settingsTileColors(),
             title = { Text(text = stringResource(R.string.settings_emulation_box64_presets_title)) },
-            subtitle = { Text(stringResource(R.string.settings_emulation_box64_presets_subtitle)) },
             onClick = { showBox64PresetsDialog = true },
         )
         SettingsMenuLink(
             colors = settingsTileColors(),
             title = { Text(text = stringResource(R.string.fexcore_presets)) },
-            subtitle = { Text(text = stringResource(R.string.fexcore_presets_description)) },
             onClick = { showFexcorePresetsDialog = true },
         )
         SettingsMenuLink(
             colors = settingsTileColors(),
             title = { Text(text = stringResource(R.string.settings_emulation_driver_manager_title)) },
-            subtitle = { Text(text = stringResource(R.string.settings_emulation_driver_manager_subtitle)) },
             onClick = { showDriverManager = true },
         )
         SettingsMenuLink(
             colors = settingsTileColors(),
             title = { Text(text = stringResource(R.string.settings_emulation_contents_manager_title)) },
-            subtitle = { Text(text = stringResource(R.string.settings_emulation_contents_manager_subtitle)) },
             onClick = { showContentsManager = true },
         )
         SettingsMenuLink(
             colors = settingsTileColors(),
             title = { Text(text = stringResource(R.string.settings_emulation_wine_proton_manager_title)) },
-            subtitle = { Text(text = stringResource(R.string.settings_emulation_wine_proton_manager_subtitle)) },
             onClick = { showWineProtonManager = true },
         )
     }

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInfo.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInfo.kt
@@ -49,7 +49,6 @@ fun SettingsGroupInfo() {
             colors = settingsTileColorsAlt(),
             state = askForTip,
             title = { Text(stringResource(R.string.settings_info_ask_tip_title)) },
-            subtitle = { Text(text = stringResource(R.string.settings_info_ask_tip_subtitle)) },
             onCheckedChange = {
                 askForTip = it
                 PrefManager.tipped = !askForTip
@@ -59,21 +58,18 @@ fun SettingsGroupInfo() {
         SettingsMenuLink(
             colors = settingsTileColors(),
             title = { Text(text = stringResource(R.string.settings_info_source_title)) },
-            subtitle = { Text(text = stringResource(R.string.settings_info_source_subtitle)) },
             onClick = { uriHandler.openUri(Constants.Misc.GITHUB_LINK) },
         )
 
         SettingsMenuLink(
             colors = settingsTileColors(),
             title = { Text(text = stringResource(R.string.settings_info_libraries_title)) },
-            subtitle = { Text(text = stringResource(R.string.settings_info_libraries_subtitle)) },
             onClick = { showLibrariesDialog = true },
         )
 
         SettingsMenuLink(
             colors = settingsTileColors(),
             title = { Text(text = stringResource(R.string.settings_info_privacy_title)) },
-            subtitle = { Text(text = stringResource(R.string.settings_info_privacy_subtitle)) },
             onClick = {
                 uriHandler.openUri(Constants.Misc.PRIVACY_LINK)
             },

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
@@ -229,7 +229,6 @@ fun SettingsGroupInterface(
         SettingsSwitch(
             colors = settingsTileColorsAlt(),
             title = { Text(text = stringResource(R.string.settings_interface_external_links_title)) },
-            subtitle = { Text(text = stringResource(R.string.settings_interface_external_links_subtitle)) },
             state = openWebLinks,
             onCheckedChange = {
                 openWebLinks = it
@@ -383,6 +382,16 @@ fun SettingsGroupInterface(
             }
         }
 
+        // Steam download server selection
+        SettingsMenuLink(
+            colors = settingsTileColorsAlt(),
+            title = { Text(text = stringResource(R.string.settings_interface_download_server_title)) },
+            subtitle = {
+                Text(text = steamRegionsList.getOrNull(selectedRegionIndex)?.second ?: stringResource(R.string.settings_region_default))
+            },
+            onClick = { openRegionDialog = true },
+        )
+
         val ctx = LocalContext.current
         val sm = ctx.getSystemService(StorageManager::class.java)
 
@@ -439,15 +448,6 @@ fun SettingsGroupInterface(
                 colors = settingsTileColorsAlt(),
             )
         }
-        // Steam download server selection
-        SettingsMenuLink(
-            colors = settingsTileColorsAlt(),
-            title = { Text(text = stringResource(R.string.settings_interface_download_server_title)) },
-            subtitle = {
-                Text(text = steamRegionsList.getOrNull(selectedRegionIndex)?.second ?: stringResource(R.string.settings_region_default))
-            },
-            onClick = { openRegionDialog = true },
-        )
     }
 
     // Steam Download Server choice dialog
@@ -653,4 +653,3 @@ private fun Preview_SettingsScreen() {
         )
     }
 }
-

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsScreen.kt
@@ -190,11 +190,6 @@ private fun SettingsHeader(
                 ),
                 color = MaterialTheme.colorScheme.onSurface,
             )
-            Text(
-                text = stringResource(R.string.settings_subtitle),
-                style = MaterialTheme.typography.bodySmall,
-                color = PluviaTheme.colors.textMuted,
-            )
         }
 
         Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Gamepad
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Palette
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -189,31 +188,6 @@ private fun SettingsHeader(
                     letterSpacing = 0.5.sp,
                 ),
                 color = MaterialTheme.colorScheme.onSurface,
-            )
-        }
-
-        Spacer(modifier = Modifier.weight(1f))
-
-        // Settings icon decoration
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(CircleShape)
-                .background(
-                    Brush.radialGradient(
-                        colors = listOf(
-                            PluviaTheme.colors.accentCyan.copy(alpha = 0.2f),
-                            Color.Transparent,
-                        ),
-                    ),
-                ),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                imageVector = Icons.Default.Settings,
-                contentDescription = null,
-                tint = PluviaTheme.colors.accentCyan.copy(alpha = 0.6f),
-                modifier = Modifier.size(24.dp),
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -818,7 +818,7 @@
     <string name="settings_emulation_default_config_subtitle">Initial container settings for newly installed games</string>
     <string name="settings_emulation_default_config_dialog_title">Default Container Config</string>
     <string name="settings_emulation_auto_apply_known_config_title">Auto-apply known config</string>
-    <string name="settings_emulation_auto_apply_known_config_subtitle">Automatically apply recommended settings for Steam games on first launch</string>
+    <string name="settings_emulation_auto_apply_known_config_subtitle">Automatically apply recommended game settings on first launch</string>
     <string name="settings_emulation_box64_presets_title">Box64 Presets</string>
     <string name="settings_emulation_driver_manager_title">Driver Manager</string>
     <string name="settings_emulation_contents_manager_title">Contents Manager</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -785,7 +785,7 @@
     <string name="get_support_on_discord">Get support on Discord</string>
 
     <!-- Driver Manager -->
-    <string name="driver_manager">Manage Drivers</string>
+    <string name="driver_manager">Driver Manager</string>
     <string name="select_a_driver">Select a driver</string>
     <string name="import_zip_from_device">Import ZIP from device</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -855,13 +855,9 @@
     <string name="settings_info_send_tip_title">Send tip</string>
     <string name="settings_info_send_tip_subtitle">Contribute to ongoing development</string>
     <string name="settings_info_ask_tip_title">Ask for tip on startup</string>
-    <string name="settings_info_ask_tip_subtitle">Stops the tip message from appearing</string>
     <string name="settings_info_source_title">Source code</string>
-    <string name="settings_info_source_subtitle">View the source code of this project</string>
     <string name="settings_info_libraries_title">Libraries Used</string>
-    <string name="settings_info_libraries_subtitle">See what technologies make GameNative possible</string>
     <string name="settings_info_privacy_title">Privacy Policy</string>
-    <string name="settings_info_privacy_subtitle">Opens a link to GameNative\'s privacy policy</string>
 
     <!-- Settings: Interface Group -->
     <string name="settings_interface_title">Interface</string>
@@ -1242,7 +1238,6 @@
 
     <!-- Settings Screen -->
     <string name="settings_title">Settings</string>
-    <string name="settings_subtitle">Customize your experience</string>
 
     <!-- Contents Install Finish -->
     <string name="contents_install_success">Content installed successfully</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -443,7 +443,7 @@
     <string name="toast_failed_log_save">Failed to save logcat to destination</string>
 
     <!-- Settings -->
-    <string name="settings_save_logcat_subtitle">Saves a snapshot of the logcat only for this app\'s PID</string>
+    <string name="settings_save_logcat_subtitle">Saves a logcat snapshot only for this app\'s PID</string>
     <string name="settings_save_logcat_title">Save logcat</string>
 
     <string name="box86_64_env_var_help__dynarec_safeflags"><![CDATA[
@@ -696,7 +696,6 @@
     <string name="box64_preset">Box64 Preset</string>
     <string name="box64_presets">Box64 Presets</string>
     <string name="fexcore_presets">FEXCore Presets</string>
-    <string name="fexcore_presets_description">View, modify, and create FEXCore presets</string>
     <string name="preset_name">Preset name</string>
 
     <!-- Container Configuration: Input -->
@@ -780,13 +779,13 @@
 
     <!-- Dialogs -->
     <string name="allowed_orientations">Allowed Orientations</string>
-    <string name="select_wine_debug_channels">Select Wine Debug Channels</string>
+    <string name="select_wine_debug_channels">Wine Debug Channels</string>
     <string name="cpu_label">CPU%d</string>
     <string name="describe_what_happened">Describe what happened</string>
     <string name="get_support_on_discord">Get support on Discord</string>
 
     <!-- Driver Manager -->
-    <string name="driver_manager">Driver Manager</string>
+    <string name="driver_manager">Manage Drivers</string>
     <string name="select_a_driver">Select a driver</string>
     <string name="import_zip_from_device">Import ZIP from device</string>
 
@@ -814,20 +813,16 @@
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulation</string>
     <string name="settings_emulation_orientations_title">Allowed Orientations</string>
-    <string name="settings_emulation_orientations_subtitle">Choose which orientations can be rotated to when in-game</string>
+    <string name="settings_emulation_orientations_subtitle">Choose which orientations can be used in-game</string>
     <string name="settings_emulation_default_config_title">Modify Default Config</string>
-    <string name="settings_emulation_default_config_subtitle">The initial container settings for each game (does not affect already installed games)</string>
+    <string name="settings_emulation_default_config_subtitle">Initial container settings for newly installed games</string>
     <string name="settings_emulation_default_config_dialog_title">Default Container Config</string>
     <string name="settings_emulation_auto_apply_known_config_title">Auto-apply known config</string>
     <string name="settings_emulation_auto_apply_known_config_subtitle">Automatically apply recommended settings for Steam games on first launch</string>
     <string name="settings_emulation_box64_presets_title">Box64 Presets</string>
-    <string name="settings_emulation_box64_presets_subtitle">View, modify, and create Box64 presets</string>
     <string name="settings_emulation_driver_manager_title">Driver Manager</string>
-    <string name="settings_emulation_driver_manager_subtitle">Install or remove custom graphics driver packages</string>
     <string name="settings_emulation_contents_manager_title">Contents Manager</string>
-    <string name="settings_emulation_contents_manager_subtitle">Install additional components (.wcp)</string>
-    <string name="settings_emulation_wine_proton_manager_title">Wine/Proton Manager</string>
-    <string name="settings_emulation_wine_proton_manager_subtitle">Import custom Wine/Proton versions (Bionic only)</string>
+    <string name="settings_emulation_wine_proton_manager_title">Custom Wine/Proton versions</string>
 
     <!-- Settings: Debug Group -->
     <string name="settings_debug_title">Debug</string>
@@ -861,13 +856,12 @@
 
     <!-- Settings: Interface Group -->
     <string name="settings_interface_title">Interface</string>
-    <string name="settings_interface_external_links_title">Open web links externally</string>
-    <string name="settings_interface_external_links_subtitle">Links open with your main web browser</string>
+    <string name="settings_interface_external_links_title">Open links in external browser</string>
     <string name="settings_interface_hide_statusbar_title">Hide status bar when not in game</string>
-    <string name="settings_interface_hide_statusbar_subtitle">Hide Android status bar in game list, settings, etc. App will restart when changed.</string>
+    <string name="settings_interface_hide_statusbar_subtitle">Hide Android status bar in game list, settings, etc. Restart required.</string>
     <string name="settings_interface_swap_face_buttons_title">Swap face buttons</string>
     <string name="settings_interface_swap_face_buttons_subtitle">Swap A↔B and X↔Y button icons</string>
-    <string name="settings_interface_icon_style">Icon style</string>
+    <string name="settings_interface_icon_style">App icon style</string>
     <string name="settings_interface_wifi_only_title">Download only over Wi-Fi/LAN</string>
     <string name="settings_interface_wifi_only_subtitle">Prevent downloads on cellular data</string>
     <string name="settings_interface_external_storage_title">Write to external storage</string>


### PR DESCRIPTION
## Description

This is a very "conservative" PR with focus on minor copywriting aspects to clean up clutter in the settings screen, and making it easier to scroll, glance and navigate.

A couple of subtitles in the settings screen have been removed to decrease clutter in the settings screen. This should spotting their titles easier, and proper nouns like Box64 and FEXCore stand out better.

No information has really been lost, especially where a dialog still contains further details (like Driver Manager). People tend to scan titles and ignore additional descriptions anyway.

A couple of the text descriptions have been shortened. The decorative settings icon at the top has also been removed, because it looks a bit like a button but isn't one, and isn't really needed either.

I moved the external storage option below "Steam Download Server". The former is often disabled, and can expose additional options, so it's more natural to have it as the last menu item of the group.

### Other notes

- I was getting some warnings about unused variables, properties, imports etc. but did not start cleaning them up as part of this PR as they seem unrelated to any of the changes here
- I would wrap download options into its own group, but did not want to do it in this PR as it needs more changes than the very simple ones I wanted to focus on in this PR
- I did remove the culled strings from `values/strings.xml`, but I did NOT touch translations
- What are the spelling rules for menu items and buttons? It seems like there is a mix of _Title Case_ and _Sentence case_ used, but it's not clear to me if the current labels are correctly or incorrectely spelled. In this PR, I did not make changes related to this but it does seem slightly inconsistent now.

## Recording

https://github.com/user-attachments/assets/e4f51eac-f3e9-4097-ba4a-94af628e7ef0


## Checklist

- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the settings screen language and layout to reduce clutter and improve scanability. Removes redundant subtitles, cleans the header, tightens labels, and makes the download server setting service-agnostic while keeping it above External storage.

- **Refactors**
  - Removed non-essential subtitles in Emulation, Interface, and Info; dialogs still provide details.
  - Shortened labels and descriptions in `strings.xml` (e.g., “Custom Wine/Proton versions”, “Open links in external browser”); removed unused strings.
  - Removed the decorative header icon and secondary subtitle.
  - Renamed the download server setting to be service-agnostic and kept it above External storage.
  - Wine debug channels: shortened dialog title and display selected channels as "a, b, c".

<sup>Written for commit affad692a9226668e5df60df00a21102f646f96f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Streamlined Settings header for a cleaner appearance.
  * Repositioned Steam download server selection within Settings.
  * Removed many secondary/subtitle descriptions across Emulation, Info, and Interface groups to declutter options.
  * Minor subtitle formatting change for Wine debug channel display (uses comma + space).

* **Documentation / Text**
  * Updated or removed multiple Settings-related strings for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->