### PR TITLE
Add Xclipse defaults and Box64 fallback

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
@@ -205,7 +205,6 @@ fun GeneralTabContent(
                         currentConfig.put("version", DefaultVersion.DXVK)
                         currentConfig.put("async", DefaultVersion.ASYNC)
                         currentConfig.put("asyncCache", DefaultVersion.ASYNC_CACHE)
-                        state.config.value = config.copy(dxwrapperConfig = currentConfig.toString())
 
                         state.config.value = config.copy(
                             containerVariant = newVariant,
@@ -213,6 +212,7 @@ fun GeneralTabContent(
                             graphicsDriver = defaultBionicDriver,
                             graphicsDriverVersion = "",
                             graphicsDriverConfig = newCfg.toString(),
+                            dxwrapper = "dxvk",
                             emulator = "Box64",
                             box64Version = "0.3.7",
                             dxwrapperConfig = currentConfig.toString(),

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
@@ -202,9 +202,9 @@ fun GeneralTabContent(
                             listOf("0", "512", "1024", "2048", "4096").indexOf("4096").coerceAtLeast(0)
 
                         val currentConfig = KeyValueSet(config.dxwrapperConfig)
-                        currentConfig.put("version", "async-1.10.3")
-                        currentConfig.put("async", "1")
-                        currentConfig.put("asyncCache", "0")
+                        currentConfig.put("version", DefaultVersion.DXVK)
+                        currentConfig.put("async", DefaultVersion.ASYNC)
+                        currentConfig.put("asyncCache", DefaultVersion.ASYNC_CACHE)
                         state.config.value = config.copy(dxwrapperConfig = currentConfig.toString())
 
                         state.config.value = config.copy(
@@ -213,6 +213,7 @@ fun GeneralTabContent(
                             graphicsDriver = defaultBionicDriver,
                             graphicsDriverVersion = "",
                             graphicsDriverConfig = newCfg.toString(),
+                            emulator = "Box64",
                             box64Version = "0.3.7",
                             dxwrapperConfig = currentConfig.toString(),
                         )

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -88,6 +88,11 @@ object ContainerUtils {
         }
     }
 
+    private fun shouldResetXclipseWrapperVersion(version: String): Boolean {
+        val normalized = version.trim()
+        return normalized.isEmpty() || normalized.startsWith("turnip", ignoreCase = true)
+    }
+
     private fun normalizeXclipseDefaults() {
         val legacyEnvProfile =
             PrefManager.envVars.contains("deck_emu", ignoreCase = true) ||
@@ -103,11 +108,13 @@ object ContainerUtils {
         }
 
         val graphicsConfig = KeyValueSet(PrefManager.graphicsDriverConfig)
-        if (graphicsConfig.get("version").isEmpty() ||
-            graphicsConfig.get("version").startsWith("turnip", ignoreCase = true) ||
-            graphicsConfig.get("version").startsWith("v", ignoreCase = true)
-        ) {
+        if (shouldResetXclipseWrapperVersion(graphicsConfig.get("version"))) {
             graphicsConfig.put("version", DefaultVersion.WRAPPER)
+        }
+        if (PrefManager.graphicsDriver.equals("Wrapper", ignoreCase = true) &&
+            shouldResetXclipseWrapperVersion(PrefManager.graphicsDriverVersion)
+        ) {
+            PrefManager.graphicsDriverVersion = ""
         }
         if (graphicsConfig.get("presentMode").isEmpty()) graphicsConfig.put("presentMode", "mailbox")
         if (graphicsConfig.get("resourceType").isEmpty()) graphicsConfig.put("resourceType", "auto")

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -17,6 +17,7 @@ import com.winlator.container.ContainerManager
 import com.winlator.core.DefaultVersion
 import com.winlator.core.FileUtils
 import com.winlator.core.GPUInformation
+import com.winlator.core.KeyValueSet
 import com.winlator.core.WineRegistryEditor
 import com.winlator.core.WineThemeManager
 import com.winlator.fexcore.FEXCoreManager
@@ -33,6 +34,11 @@ import org.json.JSONObject
 import timber.log.Timber
 
 object ContainerUtils {
+    private const val XCLIPSE_ENV_VARS =
+        "WRAPPER_MAX_IMAGE_COUNT=0 ZINK_DESCRIPTORS=lazy ZINK_DEBUG=compact " +
+            "MESA_SHADER_CACHE_DISABLE=false MESA_SHADER_CACHE_MAX_SIZE=512MB " +
+            "mesa_glthread=true WINEESYNC=1 TU_DEBUG=noconform,sysmem"
+
     data class GpuInfo(
         val deviceId: Int,
         val vendorId: Int,
@@ -41,7 +47,19 @@ object ContainerUtils {
 
     fun setContainerDefaults(context: Context) {
         // Override default driver and DXVK version based on Turnip capability
-        if (GPUInformation.isTurnipCapable(context)) {
+        if (GPUInformation.isXclipseGPU(context)) {
+            DefaultVersion.VARIANT = Container.BIONIC
+            DefaultVersion.WINE_VERSION = "proton-9.0-arm64ec"
+            DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
+            DefaultVersion.DXVK = "1.11.1-sarek"
+            DefaultVersion.VKD3D = "2.14.1"
+            DefaultVersion.WRAPPER = "System"
+            DefaultVersion.STEAM_TYPE = Container.STEAM_TYPE_NORMAL
+            DefaultVersion.ASYNC = "0"
+            DefaultVersion.ASYNC_CACHE = "0"
+
+            normalizeXclipseDefaults()
+        } else if (GPUInformation.isTurnipCapable(context)) {
             DefaultVersion.VARIANT = Container.BIONIC
             DefaultVersion.WINE_VERSION = "proton-9.0-arm64ec"
             DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
@@ -67,6 +85,55 @@ object ContainerUtils {
             DefaultVersion.VKD3D = "2.14.1"
             DefaultVersion.STEAM_TYPE = Container.STEAM_TYPE_LIGHT
             DefaultVersion.ASYNC_CACHE = "0"
+        }
+    }
+
+    private fun normalizeXclipseDefaults() {
+        val legacyEnvProfile =
+            PrefManager.envVars.contains("deck_emu", ignoreCase = true) ||
+                PrefManager.envVars.contains("DXVK_FRAME_RATE=60", ignoreCase = true) ||
+                PrefManager.envVars == Container.DEFAULT_ENV_VARS
+
+        if (PrefManager.graphicsDriver.equals("vortek", ignoreCase = true)) {
+            PrefManager.graphicsDriver = "Wrapper"
+        }
+
+        if (legacyEnvProfile) {
+            PrefManager.envVars = XCLIPSE_ENV_VARS
+        }
+
+        val graphicsConfig = KeyValueSet(PrefManager.graphicsDriverConfig)
+        if (graphicsConfig.get("version").isEmpty() ||
+            graphicsConfig.get("version").startsWith("turnip", ignoreCase = true) ||
+            graphicsConfig.get("version").startsWith("v", ignoreCase = true)
+        ) {
+            graphicsConfig.put("version", DefaultVersion.WRAPPER)
+        }
+        if (graphicsConfig.get("presentMode").isEmpty()) graphicsConfig.put("presentMode", "mailbox")
+        if (graphicsConfig.get("resourceType").isEmpty()) graphicsConfig.put("resourceType", "auto")
+        if (graphicsConfig.get("bcnEmulation").isEmpty()) graphicsConfig.put("bcnEmulation", "auto")
+        if (graphicsConfig.get("bcnEmulationType").isEmpty()) graphicsConfig.put("bcnEmulationType", "compute")
+        if (graphicsConfig.get("bcnEmulationCache").isEmpty()) graphicsConfig.put("bcnEmulationCache", "0")
+        if (graphicsConfig.get("gpuName").isEmpty()) graphicsConfig.put("gpuName", "Device")
+        PrefManager.graphicsDriverConfig = graphicsConfig.toString()
+
+        val dxConfig = KeyValueSet(PrefManager.dxWrapperConfig)
+        if (dxConfig.get("version").isEmpty() || dxConfig.get("version").equals("async-1.10.3", ignoreCase = true)) {
+            dxConfig.put("version", DefaultVersion.DXVK)
+        }
+        dxConfig.put("async", DefaultVersion.ASYNC)
+        dxConfig.put("asyncCache", DefaultVersion.ASYNC_CACHE)
+        PrefManager.dxWrapper = "dxvk"
+        PrefManager.dxWrapperConfig = dxConfig.toString()
+
+        if (PrefManager.audioDriver.equals(Container.DEFAULT_AUDIO_DRIVER, ignoreCase = true)) {
+            PrefManager.audioDriver = "alsa"
+        }
+
+        PrefManager.emulator = "Box64"
+        PrefManager.xinputEnabled = true
+        if (legacyEnvProfile && PrefManager.dinputEnabled) {
+            PrefManager.dinputEnabled = false
         }
     }
 

--- a/app/src/main/java/com/winlator/core/GPUInformation.java
+++ b/app/src/main/java/com/winlator/core/GPUInformation.java
@@ -159,6 +159,11 @@ public abstract class GPUInformation {
         return r.contains("adreno") && r.matches(".*\\b8(3[0-9]|4[0-9]|5[0-9])\\b.*");
     }
 
+    public static boolean isXclipseGPU(Context context) {
+        String renderer = getRenderer(context).toLowerCase(Locale.ENGLISH);
+        return renderer.contains("xclipse");
+    }
+
     public static boolean isTurnipCapable(Context context) {
         String r = getRenderer(context).toLowerCase(Locale.ENGLISH);
         // match “adreno 610…699” or “adreno 710…799”


### PR DESCRIPTION
## What this changes

  This adds an Xclipse-specific default profile for GameNative’s bionic container path.

  For devices using Samsung Xclipse GPUs, GameNative now defaults to:
  - `Wrapper`
  - wrapper version `System`
  - `DXVK 1.11.1-sarek`
  - calmer default env vars closer to a known working Winlator profile
  - `Box64` as the default emulator instead of `FEXCore`

  It also updates the bionic container reset flow to use the selected DXVK defaults instead of hardcoding `async-
  1.10.3`.

  ## Why

  On Xclipse devices, the previous default profile was too heavily shaped around Steam/Adreno-oriented defaults. In
  practice this led to non-working default containers, while a simpler wrapper + DXVK + Box64 configuration was able to
  launch and run correctly.

  This change keeps the existing Adreno/Turnip paths intact and only introduces a separate default branch for Xclipse
  GPUs.

  ## Files changed

  - `app/src/main/java/com/winlator/core/GPUInformation.java`
    - add Xclipse GPU detection

  - `app/src/main/java/app/gamenative/utils/ContainerUtils.kt`
    - add Xclipse default selection
    - normalize stock defaults toward a safer wrapper/System + DXVK + Box64 profile

  - `app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt`
    - use default DXVK values during bionic reset
    - set `Box64` when resetting to the bionic profile

  ## Notes

  This is intentionally limited to the default/bootstrap path. It does not modify the core Steam integration or broader
  runtime architecture.

  ## Validation

  Tested locally by building the modified app and confirming that on Xclipse hardware the resulting working baseline is:
  - `Wrapper`
  - `System`
  - `DXVK`
  - `Box64`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Xclipse-specific default profile and makes `Box64` the default emulator on Samsung Xclipse GPUs. Also switches the bionic reset flow to the selected `DXVK` defaults and sets `dxwrapper`/`emulator` accordingly. Adreno/Turnip behavior is unchanged.

- **New Features**
  - Detect Xclipse GPUs and apply defaults: `Wrapper/System`, `DXVK 1.11.1-sarek`, `VKD3D 2.14.1`, `proton-9.0-arm64ec`; async off; tuned env vars; default `Box64`.
  - Bionic reset uses `DXVK` defaults and sets `dxwrapper=dxvk`, `emulator=Box64` (`box64` 0.3.7).

- **Bug Fixes**
  - Normalize existing Xclipse profiles: replace `vortek` with `Wrapper`, reset wrapper version and `DXVK` config, update env vars, set audio to `alsa`, enable `xinput` and disable `dinput` when needed.

<sup>Written for commit ade1f81cc4f8a125f176837e7657bef7c36fdf47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated support and automatic configuration for Xclipse GPUs.

* **Improvements**
  * Prioritizes Xclipse detection to apply tailored defaults.
  * Automatically normalizes graphics, wrapper, emulator, audio and input settings for Xclipse devices to improve compatibility.
  * Ensures recommended driver/wrapper versions and runtime flags are applied for better performance and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->