### PR TITLE
fix: match UFS save file globs case-insensitively

### DIFF
--- a/app/src/main/java/app/gamenative/utils/FileUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/FileUtils.kt
@@ -145,7 +145,7 @@ object FileUtils {
                 Timber.i("Checking $fileName for pattern $pattern")
                 var startIndex = 0
                 !patternParts.map {
-                    val index = fileName.indexOf(it, startIndex)
+                    val index = fileName.indexOf(it, startIndex, ignoreCase = true)
                     if (index >= 0) {
                         startIndex = index + it.length
                     }
@@ -170,7 +170,7 @@ object FileUtils {
         fun matches(fileName: String): Boolean {
             var startIndex = 0
             for (part in patternParts) {
-                val index = fileName.indexOf(part, startIndex)
+                val index = fileName.indexOf(part, startIndex, ignoreCase = true)
                 if (index < 0) return false
                 startIndex = index + part.length
             }


### PR DESCRIPTION
## Problem
I faced an issue when I tried to force sync cloud saves for a game called "Steins;Gate: Linear Bounded Phenogram".
Even though my saves had changed on my device, it still showed "save files are already up to date" message.
The logs showed that the save file named "SAVEDATA.DAT" wasn't considered for sync but other files like "config.dat" were.

## Why
 FileUtils.findFiles and findFilesRecursive used String.indexOf without ignoreCase, so patterns like "*.dat" failed to match files named "SAVEDATA.DAT" — only lowercase variants like "config.dat" were picked up.

Steam's UFS save-file patterns are authored against Windows filesystems, which are case-insensitive, so a game shipping pattern "*.dat" expects it to match any casing. On Android's case-sensitive filesystem the scanner silently skipped these files, causing SteamAutoCloud.syncUserFiles to see no local changes and report "already in sync" even when saves clearly needed uploading.

## Fix
Pass ignoreCase = true to indexOf in both matchers.

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make UFS save-file glob matching case-insensitive so Windows-style patterns (e.g., *.dat) work on Android. This ensures files like SAVEDATA.DAT are detected and prevents false “already in sync” messages.

- **Bug Fixes**
  - Use `indexOf(..., ignoreCase = true)` in the UFS glob matchers in `FileUtils`.
  - Patterns now match regardless of filename casing, so changed saves are picked up for upload.

<sup>Written for commit a1dd2109ccc9e2934c9cbcf5399a0738319dce74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File search operations now perform case-insensitive matching, enabling results to be found regardless of case variations in filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->