### PR TITLE
fix: Meta Quest 3/3s black screen on Turnip driver

### DIFF
--- a/app/src/main/java/app/gamenative/utils/BestConfigService.kt
+++ b/app/src/main/java/app/gamenative/utils/BestConfigService.kt
@@ -8,6 +8,7 @@ import com.winlator.box86_64.Box86_64PresetManager
 import com.winlator.container.Container
 import com.winlator.container.ContainerData
 import com.winlator.contents.ContentProfile
+import com.winlator.core.GPUInformation
 import com.winlator.fexcore.FEXCorePresetManager
 import com.winlator.core.KeyValueSet
 import kotlinx.coroutines.Dispatchers
@@ -729,10 +730,16 @@ object BestConfigService {
                     resultMap["graphicsDriver"] = filteredJson.optString("graphicsDriver", "")
                 }
                 if (filteredJson.has("graphicsDriverVersion") && !filteredJson.isNull("graphicsDriverVersion")) {
-                    resultMap["graphicsDriverVersion"] = filteredJson.optString("graphicsDriverVersion", "")
+                    val version = filteredJson.optString("graphicsDriverVersion", "")
+                    if (!version.contains("turnip") || !GPUInformation.isTurnipBlacklisted()) {
+                        resultMap["graphicsDriverVersion"] = version
+                    }
                 }
                 if (filteredJson.has("graphicsDriverConfig") && !filteredJson.isNull("graphicsDriverConfig")) {
-                    resultMap["graphicsDriverConfig"] = filteredJson.optString("graphicsDriverConfig", "")
+                    val config = filteredJson.optString("graphicsDriverConfig", "")
+                    if (!config.contains("turnip") || !GPUInformation.isTurnipBlacklisted()) {
+                        resultMap["graphicsDriverConfig"] = config
+                    }
                 }
                 if (filteredJson.has("dxwrapper") && !filteredJson.isNull("dxwrapper")) {
                     resultMap["dxwrapper"] = filteredJson.optString("dxwrapper", "")

--- a/app/src/main/java/app/gamenative/utils/BestConfigService.kt
+++ b/app/src/main/java/app/gamenative/utils/BestConfigService.kt
@@ -8,7 +8,7 @@ import com.winlator.box86_64.Box86_64PresetManager
 import com.winlator.container.Container
 import com.winlator.container.ContainerData
 import com.winlator.contents.ContentProfile
-import com.winlator.core.GPUInformation
+import com.winlator.core.GPUBlackist
 import com.winlator.fexcore.FEXCorePresetManager
 import com.winlator.core.KeyValueSet
 import kotlinx.coroutines.Dispatchers
@@ -731,13 +731,13 @@ object BestConfigService {
                 }
                 if (filteredJson.has("graphicsDriverVersion") && !filteredJson.isNull("graphicsDriverVersion")) {
                     val version = filteredJson.optString("graphicsDriverVersion", "")
-                    if (!version.contains("turnip") || !GPUInformation.isTurnipBlacklisted()) {
+                    if (!version.contains("turnip", ignoreCase = true) || !GPUBlackist.isTurnipBlacklisted()) {
                         resultMap["graphicsDriverVersion"] = version
                     }
                 }
                 if (filteredJson.has("graphicsDriverConfig") && !filteredJson.isNull("graphicsDriverConfig")) {
                     val config = filteredJson.optString("graphicsDriverConfig", "")
-                    if (!config.contains("turnip") || !GPUInformation.isTurnipBlacklisted()) {
+                    if (!config.contains("turnip", ignoreCase = true) || !GPUBlackist.isTurnipBlacklisted()) {
                         resultMap["graphicsDriverConfig"] = config
                     }
                 }

--- a/app/src/main/java/app/gamenative/utils/BestConfigService.kt
+++ b/app/src/main/java/app/gamenative/utils/BestConfigService.kt
@@ -183,6 +183,15 @@ object BestConfigService {
             filtered.remove("executablePath")
         }
 
+        if (config.toString().contains("turnip", ignoreCase = true) && GPUBlackist.isTurnipBlacklisted()) {
+            if (matchType == "exact_gpu_match" || matchType == "gpu_family_match" || matchType == "fallback_match") {
+                filtered.remove("graphicsDriver")
+                filtered.remove("graphicsDriverVersion")
+                filtered.remove("graphicsDriverConfig")
+                return JsonObject(filtered)
+            }
+        }
+
         if (matchType == "exact_gpu_match" || matchType == "gpu_family_match") {
             // Apply all fields
             return JsonObject(filtered)
@@ -730,16 +739,10 @@ object BestConfigService {
                     resultMap["graphicsDriver"] = filteredJson.optString("graphicsDriver", "")
                 }
                 if (filteredJson.has("graphicsDriverVersion") && !filteredJson.isNull("graphicsDriverVersion")) {
-                    val version = filteredJson.optString("graphicsDriverVersion", "")
-                    if (!version.contains("turnip", ignoreCase = true) || !GPUBlackist.isTurnipBlacklisted()) {
-                        resultMap["graphicsDriverVersion"] = version
-                    }
+                    resultMap["graphicsDriverVersion"] = filteredJson.optString("graphicsDriverVersion", "")
                 }
                 if (filteredJson.has("graphicsDriverConfig") && !filteredJson.isNull("graphicsDriverConfig")) {
-                    val config = filteredJson.optString("graphicsDriverConfig", "")
-                    if (!config.contains("turnip", ignoreCase = true) || !GPUBlackist.isTurnipBlacklisted()) {
-                        resultMap["graphicsDriverConfig"] = config
-                    }
+                    resultMap["graphicsDriverConfig"] = filteredJson.optString("graphicsDriverConfig", "")
                 }
                 if (filteredJson.has("dxwrapper") && !filteredJson.isNull("dxwrapper")) {
                     resultMap["dxwrapper"] = filteredJson.optString("dxwrapper", "")

--- a/app/src/main/java/com/winlator/core/GPUBlackist.java
+++ b/app/src/main/java/com/winlator/core/GPUBlackist.java
@@ -1,0 +1,23 @@
+package com.winlator.core;
+
+import android.os.Build;
+
+public class GPUBlackist {
+
+    public static boolean isTurnipBlacklisted() {
+        if ((Build.MANUFACTURER.compareToIgnoreCase("OCULUS") == 0) ||
+                (Build.MANUFACTURER.compareToIgnoreCase("META") == 0)) {
+            return switch (Build.PRODUCT) {
+                //Quest 1
+                case "monterey", "vr_monterey" -> false;
+                //Quest 2, Quest Pro
+                case "hollywood", "seacliff" -> false;
+                //Quest 3, Quest 3s
+                case "eureka", "stinson", "panther" -> true;
+                //future devices
+                default -> true;
+            };
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/com/winlator/core/GPUInformation.java
+++ b/app/src/main/java/com/winlator/core/GPUInformation.java
@@ -98,7 +98,7 @@ public abstract class GPUInformation {
             String gpuRenderer = Objects.toString(gl.glGetString(GL10.GL_RENDERER), "");
             String gpuVendor = Objects.toString(gl.glGetString(GL10.GL_VENDOR), "");
             String gpuVersion = Objects.toString(gl.glGetString(GL10.GL_VERSION), "");
-            if (isTurnipBlacklisted()) gpuRenderer += " - " + Build.MANUFACTURER;
+            if (GPUBlackist.isTurnipBlacklisted()) gpuRenderer += " - " + Build.MANUFACTURER;
 
             gpuInfo.put("renderer", gpuRenderer);
             gpuInfo.put("vendor", gpuVendor);
@@ -161,27 +161,10 @@ public abstract class GPUInformation {
         return r.contains("adreno") && r.matches(".*\\b8(3[0-9]|4[0-9]|5[0-9])\\b.*");
     }
 
-    public static boolean isTurnipBlacklisted() {
-        if ((Build.MANUFACTURER.compareToIgnoreCase("OCULUS") == 0) ||
-            (Build.MANUFACTURER.compareToIgnoreCase("META") == 0)) {
-            return switch (Build.PRODUCT) {
-                //Quest 1
-                case "monterey", "vr_monterey" -> false;
-                //Quest 2, Quest Pro
-                case "hollywood", "seacliff" -> false;
-                //Quest 3, Quest 3s
-                case "eureka", "stinson", "panther" -> true;
-                //future devices
-                default -> true;
-            };
-        }
-        return false;
-    }
-
     public static boolean isTurnipCapable(Context context) {
         String r = getRenderer(context).toLowerCase(Locale.ENGLISH);
         // match “adreno 610…699” or “adreno 710…799”
-        return r.contains("adreno") && r.matches(".*\\b[67][0-9]{2}\\b.*") && !isTurnipBlacklisted();
+        return r.contains("adreno") && r.matches(".*\\b[67][0-9]{2}\\b.*") && !GPUBlackist.isTurnipBlacklisted();
     }
 
     /**

--- a/app/src/main/java/com/winlator/core/GPUInformation.java
+++ b/app/src/main/java/com/winlator/core/GPUInformation.java
@@ -98,7 +98,7 @@ public abstract class GPUInformation {
             String gpuRenderer = Objects.toString(gl.glGetString(GL10.GL_RENDERER), "");
             String gpuVendor = Objects.toString(gl.glGetString(GL10.GL_VENDOR), "");
             String gpuVersion = Objects.toString(gl.glGetString(GL10.GL_VERSION), "");
-            if (GPUBlackist.isTurnipBlacklisted()) gpuRenderer += " - " + Build.MANUFACTURER;
+            if (GPUBlackist.isTurnipBlacklisted()) gpuRenderer = Build.MANUFACTURER + " " + gpuRenderer;
 
             gpuInfo.put("renderer", gpuRenderer);
             gpuInfo.put("vendor", gpuVendor);

--- a/app/src/main/java/com/winlator/core/GPUInformation.java
+++ b/app/src/main/java/com/winlator/core/GPUInformation.java
@@ -2,6 +2,7 @@ package com.winlator.core;
 
 import android.content.Context;
 import android.opengl.EGL14;
+import android.os.Build;
 import android.util.Log;
 
 import androidx.collection.ArrayMap;
@@ -97,6 +98,7 @@ public abstract class GPUInformation {
             String gpuRenderer = Objects.toString(gl.glGetString(GL10.GL_RENDERER), "");
             String gpuVendor = Objects.toString(gl.glGetString(GL10.GL_VENDOR), "");
             String gpuVersion = Objects.toString(gl.glGetString(GL10.GL_VERSION), "");
+            if (isTurnipBlacklisted()) gpuRenderer += " - " + Build.MANUFACTURER;
 
             gpuInfo.put("renderer", gpuRenderer);
             gpuInfo.put("vendor", gpuVendor);
@@ -159,10 +161,27 @@ public abstract class GPUInformation {
         return r.contains("adreno") && r.matches(".*\\b8(3[0-9]|4[0-9]|5[0-9])\\b.*");
     }
 
+    public static boolean isTurnipBlacklisted() {
+        if ((Build.MANUFACTURER.compareToIgnoreCase("OCULUS") == 0) ||
+            (Build.MANUFACTURER.compareToIgnoreCase("META") == 0)) {
+            return switch (Build.PRODUCT) {
+                //Quest 1
+                case "monterey", "vr_monterey" -> false;
+                //Quest 2, Quest Pro
+                case "hollywood", "seacliff" -> false;
+                //Quest 3, Quest 3s
+                case "eureka", "stinson", "panther" -> true;
+                //future devices
+                default -> true;
+            };
+        }
+        return false;
+    }
+
     public static boolean isTurnipCapable(Context context) {
         String r = getRenderer(context).toLowerCase(Locale.ENGLISH);
         // match “adreno 610…699” or “adreno 710…799”
-        return r.contains("adreno") && r.matches(".*\\b[67][0-9]{2}\\b.*");
+        return r.contains("adreno") && r.matches(".*\\b[67][0-9]{2}\\b.*") && !isTurnipBlacklisted();
     }
 
     /**


### PR DESCRIPTION
## Description
Meta Quest 3/3s has Adreno 740 which is normally Turnip compatible but Meta did there something on the driver level (around VR features like SpaceWarp) which made Turnip incompatible. The users starting games on that device see "GPU compatible" but when they start any 3D game, it just keeps crashing or getting black screen.

This PR blacklists Turnip on Meta Quest 3/3s and newer and report the GPU with manufacturer postfix (considering a company having a breaking change on a driver level usually spreads the change around own device portfolio). That means we generate only one additional GPU "Oculus Adreno (TM) 740" which will cover the mentioned devices.

This approach avoids making incorrect compatibility reports and applying Turnip on the blacklisted devices. I tried to write it as generic as possible to be able to cover similar future cases.

## Recording
Before the fix: https://github.com/user-attachments/assets/14819fdf-ce00-4d71-8ef0-28a7c7240c7d
With the fix: https://github.com/user-attachments/assets/9101636b-4af8-4bf3-b857-37d681e0a11f

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes black screens and crashes on Meta Quest 3/3s and newer by disabling Turnip and using the system graphics driver. Stops false “GPU compatible” messages and removes Turnip configs on blacklisted devices.

- **Bug Fixes**
  - Adds `GPUBlackist` to detect Meta/Oculus devices (by manufacturer + product); Turnip is blacklisted on Quest 3/3s and newer, allowed on Quest 1/2/Pro.
  - On blacklisted devices, appends `Build.MANUFACTURER` to the GPU renderer (e.g., “Adreno (TM) 740 - Meta”) to create a distinct GPU entry.
  - In `BestConfigService`, when a config references Turnip and the device is blacklisted, strips `graphicsDriver*` and returns filtered for exact/family/fallback matches.
  - In `GPUInformation`, `isTurnipCapable` now excludes blacklisted devices.

<sup>Written for commit dfdecef5618d94a7202b4c3048021d2dae44a9b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a device-specific GPU blacklist to avoid applying incompatible GPU driver settings on certain Meta/Oculus Quest devices, improving stability and preventing known rendering issues.
  * Improved GPU detection and reporting: manufacturer is now included in reported GPU details and capability checks exclude blacklisted devices so unsupported modes are not used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->