### PR TITLE
feat: add perf hud controller hotkey

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -307,6 +307,13 @@ object PrefManager {
             setPref(SHOW_FPS, value)
         }
 
+    private val PERFORMANCE_HUD_HOTKEY_ENABLED = booleanPreferencesKey("performance_hud_hotkey_enabled")
+    var performanceHudHotkeyEnabled: Boolean
+        get() = getPref(PERFORMANCE_HUD_HOTKEY_ENABLED, false)
+        set(value) {
+            setPref(PERFORMANCE_HUD_HOTKEY_ENABLED, value)
+        }
+
     private val PERFORMANCE_HUD_COMPACT_MODE = booleanPreferencesKey("performance_hud_compact_mode")
     var performanceHudCompactMode: Boolean
         get() = getPref(PERFORMANCE_HUD_COMPACT_MODE, false)

--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -220,6 +220,8 @@ fun QuickMenu(
     performanceHudConfig: PerformanceHudConfig = PerformanceHudConfig(),
     onPerformanceHudConfigChanged: (PerformanceHudConfig) -> Unit = {},
     hasPhysicalController: Boolean = false,
+    isPerformanceHudHotkeyEnabled: Boolean = false,
+    onPerformanceHudHotkeyToggled: () -> Unit = {},
     activeToggleIds: Set<Int> = emptySet(),
     modifier: Modifier = Modifier,
 ) {
@@ -462,6 +464,8 @@ fun QuickMenu(
                                                 onItemSelected(QuickMenuAction.PERFORMANCE_HUD)
                                             },
                                             onPerformanceHudConfigChanged = onPerformanceHudConfigChanged,
+                                            isHotkeyEnabled = isPerformanceHudHotkeyEnabled,
+                                            onHotkeyToggled = onPerformanceHudHotkeyToggled,
                                             scrollState = hudScrollState,
                                             focusRequester = hudItemFocusRequester,
                                             modifier = Modifier.fillMaxSize(),
@@ -543,6 +547,8 @@ private fun PerformanceHudQuickMenuTab(
     performanceHudConfig: PerformanceHudConfig,
     onTogglePerformanceHud: () -> Unit,
     onPerformanceHudConfigChanged: (PerformanceHudConfig) -> Unit,
+    isHotkeyEnabled: Boolean = false,
+    onHotkeyToggled: () -> Unit = {},
     scrollState: ScrollState,
     focusRequester: FocusRequester? = null,
     modifier: Modifier = Modifier,
@@ -562,6 +568,14 @@ private fun PerformanceHudQuickMenuTab(
             onToggle = onTogglePerformanceHud,
             accentColor = accentColor,
             focusRequester = focusRequester,
+        )
+
+        QuickMenuToggleRow(
+            title = stringResource(R.string.performance_hud_hotkey_toggle),
+            subtitle = stringResource(R.string.performance_hud_hotkey_description),
+            enabled = isHotkeyEnabled,
+            onToggle = onHotkeyToggled,
+            accentColor = accentColor,
         )
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
@@ -22,7 +22,9 @@ import java.util.TimerTask
 class PhysicalControllerHandler(
     private var profile: ControlsProfile?,
     private val xServer: XServer?,
-    private val onOpenNavigationMenu: (() -> Unit)? = null
+    private val onOpenNavigationMenu: (() -> Unit)? = null,
+    private val onTogglePerformanceHud: (() -> Unit)? = null,
+    private val isPerformanceHudHotkeyEnabled: () -> Boolean = { false },
 ) {
     private val TAG = "gncontrol"
     private val mouseMoveOffset = PointF(0f, 0f)
@@ -30,6 +32,18 @@ class PhysicalControllerHandler(
     // track which axis keycodes are currently "pressed" so we only release on actual transitions.
     // accessed only from main thread (MotionEvent dispatch + Compose lifecycle), no sync needed.
     private val activeAxisBindings = mutableSetOf<Int>()
+
+    // Track currently-held gamepad buttons for combo detection
+    private val heldButtons = mutableSetOf<Int>()
+
+    companion object {
+        private val COMBO_KEYCODES = setOf(
+            KeyEvent.KEYCODE_BUTTON_START,
+            KeyEvent.KEYCODE_BUTTON_SELECT,
+            KeyEvent.KEYCODE_BUTTON_L1,
+            KeyEvent.KEYCODE_BUTTON_R1,
+        )
+    }
 
     private fun releaseActiveAxes() {
         val controller = profile?.getController("*") ?: return
@@ -69,6 +83,18 @@ class PhysicalControllerHandler(
      * Extracted from InputControlsView.onKeyEvent()
      */
     fun onKeyEvent(event: KeyEvent): Boolean {
+        // Perf HUD hotkey combo detection
+        if (event.repeatCount == 0 && event.keyCode in COMBO_KEYCODES) {
+            if (event.action == KeyEvent.ACTION_DOWN) heldButtons.add(event.keyCode)
+            else if (event.action == KeyEvent.ACTION_UP) heldButtons.remove(event.keyCode)
+
+            if (heldButtons.containsAll(COMBO_KEYCODES) && isPerformanceHudHotkeyEnabled()) {
+                heldButtons.clear()
+                onTogglePerformanceHud?.invoke()
+                return true // consume all four buttons
+            }
+        }
+
         if (profile != null && event.repeatCount == 0) {
             val controller = profile?.getController(event.deviceId)
             if (controller != null) {

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1734,7 +1734,18 @@ fun XServerScreen(
                     Timber.d("=== Profile Loading Complete ===")
                     setProfile(targetProfile)
 
-                    physicalControllerHandler = PhysicalControllerHandler(targetProfile, xServerView.getxServer(), gameBack)
+                    physicalControllerHandler = PhysicalControllerHandler(
+                        targetProfile,
+                        xServerView.getxServer(),
+                        gameBack,
+                        onTogglePerformanceHud = {
+                            val enabled = !isPerformanceHudEnabled
+                            isPerformanceHudEnabled = enabled
+                            PrefManager.showFps = enabled
+                            updatePerformanceHud(enabled)
+                        },
+                        isPerformanceHudHotkeyEnabled = { PrefManager.performanceHudHotkeyEnabled },
+                    )
 
                     // Store profile for auto-show logic
                     loadedProfile = targetProfile
@@ -2040,6 +2051,10 @@ fun XServerScreen(
             performanceHudConfig = performanceHudConfig,
             onPerformanceHudConfigChanged = ::applyPerformanceHudConfig,
             hasPhysicalController = hasPhysicalController,
+            isPerformanceHudHotkeyEnabled = PrefManager.performanceHudHotkeyEnabled,
+            onPerformanceHudHotkeyToggled = {
+                PrefManager.performanceHudHotkeyEnabled = !PrefManager.performanceHudHotkeyEnabled
+            },
             activeToggleIds = buildSet {
                 if (areControlsVisible) add(QuickMenuAction.INPUT_CONTROLS)
             },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,6 +266,8 @@
     <string name="quick_menu_tab_controller">Controller</string>
     <string name="performance_hud">Performance HUD</string>
     <string name="performance_hud_description">Show or hide the in-game overlay.</string>
+    <string name="performance_hud_hotkey_toggle">Controller Hotkey</string>
+    <string name="performance_hud_hotkey_description">Start + Select + L + R to toggle HUD.</string>
     <string name="performance_hud_presets">Presets</string>
     <string name="performance_hud_presets_description">Quickly switch between common HUD layouts.</string>
     <string name="performance_hud_preset_fps_only">1</string>


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

adds optional button combo L + R + Start + Select to toggle perf hud on and off. 

this is helpful to streamline pulling up hud to see bottlenecks or fix up settings, then can easily dismiss to focus on the game without having to go into quick menu and resume game. 

also allowing the disabling of this in pref managed toggle in the off chance a game wants this exact combo and user doesn't want that to also touch hud. 

chose this combo as really any handheld should have LRStartSel even the most basic ones

## Recording
<!-- Attach a short recording/GIF showing the change -->

https://github.com/user-attachments/assets/3518441f-746d-4e2b-9c92-784806111df2


## Checklist
- [] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a controller hotkey to toggle the Performance HUD with Start + Select + L + R. This makes it fast to check performance and then hide the HUD without opening the Quick Menu.

- **New Features**
  - Detects Start + Select + L1 + R1 combo in the physical controller handler and toggles the HUD. Consumes the combo when triggered.
  - Adds a new pref `performance_hud_hotkey_enabled` (default off) in `PrefManager`.
  - Adds a toggle in the Performance HUD Quick Menu tab to enable/disable the hotkey, with labels and help text.
  - Wires the hotkey to update HUD visibility and `showFps` in `XServerScreen`.

<sup>Written for commit 0876048b204d9614a7d84f00380727539b0087a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controller hotkey support (Start + Select + L + R) to quickly toggle the Performance HUD display
  * Added a Quick Menu toggle to enable/disable the Performance HUD hotkey (disabled by default)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->