### PR TITLE
fix: correct steam game dlc licensing logic and enhance dlc display

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -837,13 +837,34 @@ class SteamService : Service(), IChallengeUrlChanged {
             val appInfo = getAppInfoOf(appId) ?: return emptyMap()
             val ownedDlc = runBlocking { getOwnedAppDlc(appId) }
             val hasSteamUnlockedBranch = runBlocking { getSteamUnlockedBranches(appId).isNotEmpty() }
-            val licensedDepots = getLicensedDepotIds(appId)
+            val licensedDepots = getLicensedDepotIds(appId).orEmpty().toMutableSet()
+
+            // Use the dlcAppID of the ownedDlc, to find the licensed depotIds from steam_license
+            val mapDlcDepotIds = mutableMapOf<Int, List<Int>>()
+            ownedDlc.forEach { (dlcAppId, info) ->
+                val dlcDepotIds = getPkgInfoOf(dlcAppId)?.depotIds.orEmpty()
+                mapDlcDepotIds[dlcAppId] = dlcDepotIds
+
+                // Make sure licensedDepots contains the dlc depots
+                licensedDepots.addAll(dlcDepotIds)
+            }
 
             val baseDepots = resolveDownloadableDepots(appInfo.depots, preferredLanguage, ownedDlc, licensedDepots, hasSteamUnlockedBranch)
             // parent app's arch applies to DLC arch selection
             val has64Bit = eligibleDepots(appInfo.depots, preferredLanguage, ownedDlc, licensedDepots)
                 .any { it.osArch == OSArch.Arch64 }
-            val map = baseDepots.toMutableMap()
+
+            // Find in the depots of mainApp, that if any of the depotID is actually belongs to another steam_app entry
+            // override the dlcAppId to the corresponding app id
+            // It should fix Don't Starve DLC list, and keeping existing DLC logic correct
+            // For existing DLC logic, two games checked Halo MCC, Cyberpunk 2077 to have correct data
+            val map = mutableMapOf<Int, DepotInfo>()
+            baseDepots.forEach { (depotId, info) ->
+                val foundDlcAppId = mapDlcDepotIds
+                    .filter { it.value.contains(info.depotId) }
+                    .keys.firstOrNull()
+                map[depotId] = info.copy(dlcAppId = foundDlcAppId ?: info.dlcAppId)
+            }
 
             val indirectDlcApps = getDownloadableDlcAppsOf(appId).orEmpty()
             indirectDlcApps.forEach { dlcApp ->

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -816,8 +816,33 @@ class SteamService : Service(), IChallengeUrlChanged {
             val appInfo = getAppInfoOf(appId) ?: return emptyMap()
             val ownedDlc = runBlocking { getOwnedAppDlc(appId) }
             val hasSteamUnlockedBranch = runBlocking { getSteamUnlockedBranches(appId).isNotEmpty() }
-            val licensedDepots = getLicensedDepotIds(appId)
-            return resolveDownloadableDepots(appInfo.depots, containerLanguage, ownedDlc, licensedDepots, hasSteamUnlockedBranch)
+            val licensedDepots = getLicensedDepotIds(appId).orEmpty().toMutableSet()
+
+            // Use the dlcAppID of the ownedDlc, to find the licensed depotIds from steam_license
+            val mapDlcDepotIds = mutableMapOf<Int, List<Int>>()
+            ownedDlc.forEach { (dlcAppId, info) ->
+                val dlcDepotIds = getPkgInfoOf(dlcAppId)?.depotIds.orEmpty()
+                mapDlcDepotIds[dlcAppId] = dlcDepotIds
+
+                // Make sure licensedDepots contains the dlc depots
+                licensedDepots.addAll(dlcDepotIds)
+            }
+
+            val baseDepots = resolveDownloadableDepots(appInfo.depots, containerLanguage, ownedDlc, licensedDepots, hasSteamUnlockedBranch)
+
+            // Find in the depots of mainApp, that if any of the depotID is actually belongs to another steam_app entry
+            // override the dlcAppId to the corresponding app id
+            // It should fix Don't Starve DLC list, and keeping existing DLC logic correct
+            // For existing DLC logic, two games checked Halo MCC, Cyberpunk 2077 to have correct data
+            val map = mutableMapOf<Int, DepotInfo>()
+            baseDepots.forEach { (depotId, info) ->
+                val foundDlcAppId = mapDlcDepotIds
+                    .filter { it.value.contains(info.depotId) }
+                    .keys.firstOrNull()
+                map[depotId] = info.copy(dlcAppId = foundDlcAppId ?: info.dlcAppId)
+            }
+
+            return map
         }
 
         /**
@@ -839,32 +864,11 @@ class SteamService : Service(), IChallengeUrlChanged {
             val hasSteamUnlockedBranch = runBlocking { getSteamUnlockedBranches(appId).isNotEmpty() }
             val licensedDepots = getLicensedDepotIds(appId).orEmpty().toMutableSet()
 
-            // Use the dlcAppID of the ownedDlc, to find the licensed depotIds from steam_license
-            val mapDlcDepotIds = mutableMapOf<Int, List<Int>>()
-            ownedDlc.forEach { (dlcAppId, info) ->
-                val dlcDepotIds = getPkgInfoOf(dlcAppId)?.depotIds.orEmpty()
-                mapDlcDepotIds[dlcAppId] = dlcDepotIds
+            val map = getMainAppDepots(appId, preferredLanguage).toMutableMap()
 
-                // Make sure licensedDepots contains the dlc depots
-                licensedDepots.addAll(dlcDepotIds)
-            }
-
-            val baseDepots = resolveDownloadableDepots(appInfo.depots, preferredLanguage, ownedDlc, licensedDepots, hasSteamUnlockedBranch)
             // parent app's arch applies to DLC arch selection
             val has64Bit = eligibleDepots(appInfo.depots, preferredLanguage, ownedDlc, licensedDepots)
                 .any { it.osArch == OSArch.Arch64 }
-
-            // Find in the depots of mainApp, that if any of the depotID is actually belongs to another steam_app entry
-            // override the dlcAppId to the corresponding app id
-            // It should fix Don't Starve DLC list, and keeping existing DLC logic correct
-            // For existing DLC logic, two games checked Halo MCC, Cyberpunk 2077 to have correct data
-            val map = mutableMapOf<Int, DepotInfo>()
-            baseDepots.forEach { (depotId, info) ->
-                val foundDlcAppId = mapDlcDepotIds
-                    .filter { it.value.contains(info.depotId) }
-                    .keys.firstOrNull()
-                map[depotId] = info.copy(dlcAppId = foundDlcAppId ?: info.dlcAppId)
-            }
 
             val indirectDlcApps = getDownloadableDlcAppsOf(appId).orEmpty()
             indirectDlcApps.forEach { dlcApp ->


### PR DESCRIPTION
## Description
In the previous PR #929, some of the dlc depots are skipped during install (e.g. Don't Starve) due to the data in the `steam_app` is very different.

This PR correct steam game dlc licensing logic and enhanced dlc display, cross-references resolved depots with owned DLC package information to ensure depots are attributed to the correct DLC app ID. This ensures accurate DLC identification for titles like Don't Starve, Halo MCC, and Cyberpunk 2077.

## Recording
<img width="1920" height="1080" alt="Screenshot_20260413_012753" src="https://github.com/user-attachments/assets/6cdf4f97-1f08-4b32-a924-5ec215421257" />
<img width="1920" height="1080" alt="Screenshot_20260413_012859" src="https://github.com/user-attachments/assets/16c140c3-9f6a-4a3d-bba8-9dc3498bb65a" />
<img width="1920" height="1080" alt="Screenshot_20260413_012920" src="https://github.com/user-attachments/assets/7a152692-7903-40f8-8f11-03e36916d051" />

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Steam DLC licensing and depot attribution so DLC depots are correctly detected and shown. Cross-references owned DLC packages to map depots to the right DLC app, fixing titles like Don't Starve, Halo MCC, and Cyberpunk 2077.

- **Bug Fixes**
  - Add owned DLC depot IDs to the licensed set to avoid skipped installs.
  - Remap main app depots to the correct `dlcAppId` when they belong to a DLC entry, improving DLC display and download accuracy.

- **Refactors**
  - Reuse `getMainAppDepots` inside `getDownloadableDepots` to centralize depot resolution logic.

<sup>Written for commit 32cf698c3ba547beaa4f28c5299fba7961b1399b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed depot resolution logic for game packages and downloadable content to ensure proper DLC association attribution.
  * Improved handling of cases where licensed depot data is unavailable by implementing fallback mechanisms.
  * Enhanced depot tracking to correctly identify which DLC owns specific depot packages, preventing misattribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->