### PR TITLE
fix: rename steam offline mode label, remove intent launch gate

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -212,14 +212,7 @@ private fun resolveGameAppId(context: Context, appId: String): GameResolutionRes
 private fun needsDeferLaunch(context: Context, appId: String): Boolean {
     val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
     return when (gameSource) {
-        GameSource.STEAM -> {
-            if (SteamService.isLoggedIn) return false
-            try {
-                !ContainerUtils.getContainer(context, appId).isSteamOfflineMode()
-            } catch (_: Exception) {
-                true // no container → needs login
-            }
-        }
+        GameSource.STEAM -> !SteamService.isLoggedIn
         GameSource.GOG -> !GOGService.isRunning
         GameSource.EPIC -> !EpicService.isRunning
         GameSource.AMAZON -> !AmazonService.isRunning

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -482,8 +482,8 @@
     <string name="force_dlc">Gennemtving DLC</string>
     <string name="force_dlc_description">Kun aktiver hvis DLC\'er ikke opdages, eller gemfiler med DLC ikke virker</string>
     <string name="launch_steam_client_beta">Start Steam-klient (Beta)</string>
-    <string name="steam_offline_mode">Steam Offline-tilstand</string>
-    <string name="steam_offline_mode_description">Start Steam-spil i offline-tilstand</string>
+    <string name="steam_offline_mode">Emulér Steam offline-tilstand</string>
+    <string name="steam_offline_mode_description">Steam-emulatoren i spillet deaktiverer onlinenetværket</string>
     <string name="achievement_unlocked">Præstation låst op</string>
     <string name="settings_achievement_notification_position">Placering af præstationsnotifikation</string>
     <string name="achievement_position_top_left">Øverst til venstre</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -622,8 +622,8 @@
     <string name="force_dlc">DLC erzwingen</string>
     <string name="force_dlc_description">Nur aktivieren, falls DLCs nicht erkannt werden oder Spielstände mit DLC nicht funktionieren</string>
     <string name="launch_steam_client_beta">Steam-Client starten (Beta)</string>
-    <string name="steam_offline_mode">Steam Offline-Modus</string>
-    <string name="steam_offline_mode_description">Steam-Spiele im Offlinemodus starten</string>
+    <string name="steam_offline_mode">Steam Offline-Modus emulieren</string>
+    <string name="steam_offline_mode_description">Der Steam-Emulator im Spiel deaktiviert die Online-Verbindung</string>
     <string name="achievement_unlocked">Erfolg freigeschaltet</string>
     <string name="settings_achievement_notification_position">Position der Erfolgsbenachrichtigung</string>
     <string name="achievement_position_top_left">Oben links</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -695,8 +695,8 @@
     <string name="force_dlc_description">Actívalo solo si los DLC no se detectan o los archivos de guardados con DLC no funcionan.</string>
     <string name="launch_steam_client_beta">Iniciar cliente de Steam (Beta)</string>
     <string name="launch_steam_client_description">Reduce el rendimiento y ralentiza el inicio.\nPermite el juego en línea y soluciona problemas de DRM y de mando.\nNo todos los juegos funcionan.</string>
-    <string name="steam_offline_mode">Modo sin conexión de Steam</string>
-    <string name="steam_offline_mode_description">Inicia juegos de Steam en modo sin conexión.</string>
+    <string name="steam_offline_mode">Emular modo sin conexión de Steam</string>
+    <string name="steam_offline_mode_description">El emulador de Steam en el juego desactivará la red en línea</string>
     <string name="achievement_unlocked">Logro desbloqueado</string>
     <string name="settings_achievement_notification_position">Posición de notificación de logro</string>
     <string name="achievement_position_top_left">Arriba izquierda</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -645,8 +645,8 @@
     <string name="force_dlc">Forcer les DLC</string>
     <string name="force_dlc_description">N\'activer que si les DLC ne sont pas détectés ou si les sauvegardes avec DLC ne fonctionnent pas</string>
     <string name="launch_steam_client_beta">Lancer le client Steam (Bêta)</string>
-    <string name="steam_offline_mode">Mode Hors Ligne Steam</string>
-    <string name="steam_offline_mode_description">Lancer les jeux Steam en mode hors ligne</string>
+    <string name="steam_offline_mode">Émuler le mode hors ligne Steam</string>
+    <string name="steam_offline_mode_description">L\'émulateur Steam intégré au jeu désactivera le réseau en ligne</string>
     <string name="achievement_unlocked">Succès débloqué</string>
     <string name="settings_achievement_notification_position">Position de la notification de succès</string>
     <string name="achievement_position_top_left">En haut à gauche</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -649,8 +649,8 @@
     <string name="force_dlc">Forza DLC</string>
     <string name="force_dlc_description">Abilita solo se i DLC non vengono rilevati o i salvataggi con DLC non funzionano</string>
     <string name="launch_steam_client_beta">Avvia Client Steam (Beta)</string>
-    <string name="steam_offline_mode">Modalità Offline Steam</string>
-    <string name="steam_offline_mode_description">Avvia i giochi Steam in modalità offline</string>
+    <string name="steam_offline_mode">Emula la modalità offline di Steam</string>
+    <string name="steam_offline_mode_description">L\'emulatore Steam nel gioco disabiliterà la rete online</string>
     <string name="achievement_unlocked">Obiettivo sbloccato</string>
     <string name="settings_achievement_notification_position">Posizione notifica obiettivo</string>
     <string name="achievement_position_top_left">In alto a sinistra</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -659,8 +659,8 @@
     <string name="force_dlc">DLC 강제</string>
     <string name="force_dlc_description">DLC가 감지되지 않거나 DLC가 있는 저장 파일이 작동하지 않는 경우에만 활성화</string>
     <string name="launch_steam_client_beta">Steam 클라이언트 실행(베타)</string>
-    <string name="steam_offline_mode">Steam 오프라인 모드</string>
-    <string name="steam_offline_mode_description">Steam 게임을 오프라인 모드로 실행</string>
+    <string name="steam_offline_mode">Steam 오프라인 모드 에뮬레이션</string>
+    <string name="steam_offline_mode_description">게임 내 Steam 에뮬레이터가 온라인 네트워크를 비활성화합니다</string>
     <string name="achievement_unlocked">업적 달성</string>
     <string name="settings_achievement_notification_position">업적 알림 위치</string>
     <string name="achievement_position_top_left">좌측 상단</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -658,8 +658,8 @@
     <string name="force_dlc">Wymuś DLC</string>
     <string name="force_dlc_description">Włącz tylko jeśli DLC nie są wykrywane lub zapisy z DLC nie działają</string>
     <string name="launch_steam_client_beta">Uruchom Klienta Steam (Beta)</string>
-    <string name="steam_offline_mode">Tryb Offline Steam</string>
-    <string name="steam_offline_mode_description">Uruchamiaj gry Steam w trybie offline</string>
+    <string name="steam_offline_mode">Emuluj tryb offline Steam</string>
+    <string name="steam_offline_mode_description">Emulator Steam w grze wyłączy połączenie sieciowe</string>
     <string name="achievement_unlocked">Osiągnięcie odblokowane</string>
     <string name="settings_achievement_notification_position">Pozycja powiadomienia o osiągnięciu</string>
     <string name="achievement_position_top_left">Lewy górny</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -482,8 +482,8 @@
     <string name="force_dlc">Forçar DLC</string>
     <string name="force_dlc_description">Ative somente se os DLCs não forem detectados ou os saves com DLC não estiverem funcionando</string>
     <string name="launch_steam_client_beta">Iniciar o cliente Steam (Beta)</string>
-    <string name="steam_offline_mode">Modo Offline do Steam</string>
-    <string name="steam_offline_mode_description">Iniciar jogos Steam no modo offline</string>
+    <string name="steam_offline_mode">Emular modo offline do Steam</string>
+    <string name="steam_offline_mode_description">O emulador Steam no jogo desativará a rede online</string>
     <string name="achievement_unlocked">Conquista desbloqueada</string>
     <string name="settings_achievement_notification_position">Posição da notificação de conquista</string>
     <string name="achievement_position_top_left">Superior esquerdo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -650,8 +650,8 @@
 	<string name="force_dlc">Forțează DLC</string>
 	<string name="force_dlc_description">Activează doar dacă DLC‑urile nu sunt detectate sau salvările cu DLC nu funcționează</string>
 	<string name="launch_steam_client_beta">Pornește Steam Client (Beta)</string>
-	<string name="steam_offline_mode">Mod Offline Steam</string>
-	<string name="steam_offline_mode_description">Pornește jocurile Steam în mod offline</string>
+	<string name="steam_offline_mode">Emulează modul offline Steam</string>
+	<string name="steam_offline_mode_description">Emulatorul Steam din joc va dezactiva rețeaua online</string>
 	<string name="achievement_unlocked">Realizare deblocată</string>
 	<string name="settings_achievement_notification_position">Poziția notificării realizării</string>
 	<string name="achievement_position_top_left">Stânga sus</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1079,8 +1079,8 @@ https://gamenative.app
 	Доступное место: %3$s</string>
     <string name="steam_never">Никогда</string>
     <string name="steam_not_logged_in">Вы должны войти в Steam, чтобы использовать эту функцию</string>
-    <string name="steam_offline_mode">Автономный режим Steam</string>
-    <string name="steam_offline_mode_description">Запускать игры Steam в автономном режиме</string>
+    <string name="steam_offline_mode">Эмуляция автономного режима Steam</string>
+    <string name="steam_offline_mode_description">Эмулятор Steam в игре отключит онлайн-сеть</string>
     <string name="steam_reset_container_message">Это восстановит ваш контейнер к конфигурации по умолчанию.</string>
     <string name="steam_reset_container_title">Сбросить контейнер</string>
     <string name="steam_sign_in">Войти в Steam</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -640,8 +640,8 @@
     <string name="force_dlc">Примусити DLC</string>
     <string name="force_dlc_description">Увімкнути лише тоді, якщо не виявлено DLC або не працюють збереження з DLC</string>
     <string name="launch_steam_client_beta">Запустити клієнт Steam (Бета)</string>
-    <string name="steam_offline_mode">Режим Офлайн Steam</string>
-    <string name="steam_offline_mode_description">Запускати ігри Steam в офлайн режимі</string>
+    <string name="steam_offline_mode">Емуляція офлайн-режиму Steam</string>
+    <string name="steam_offline_mode_description">Емулятор Steam у грі вимкне мережевий доступ</string>
     <string name="achievement_unlocked">Досягнення розблоковано</string>
     <string name="settings_achievement_notification_position">Позиція сповіщення про досягнення</string>
     <string name="achievement_position_top_left">Лівий верхній</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -640,8 +640,8 @@
     <string name="force_dlc">强制开启DLC</string>
     <string name="force_dlc_description">仅在未检测到 DLC 或包含 DLC 的存档无法运作时启用</string>
     <string name="launch_steam_client_beta">启动 Steam 客户端（Beta）</string>
-    <string name="steam_offline_mode">Steam 离线模式</string>
-    <string name="steam_offline_mode_description">以离线模式启动 Steam 游戏</string>
+    <string name="steam_offline_mode">模拟 Steam 离线模式</string>
+    <string name="steam_offline_mode_description">游戏内 Steam 模拟器将禁用在线网络功能</string>
     <string name="achievement_unlocked">成就已解锁</string>
     <string name="settings_achievement_notification_position">成就通知位置</string>
     <string name="achievement_position_top_left">左上</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -642,8 +642,8 @@
     <string name="force_dlc">強制開啟DLC</string>
     <string name="force_dlc_description">僅在未偵測到 DLC 或包含 DLC 的存檔無法運作時啟用</string>
     <string name="launch_steam_client_beta">啟動 Steam 用戶端 (Beta)</string>
-    <string name="steam_offline_mode">Steam 離線模式</string>
-    <string name="steam_offline_mode_description">以離線模式啟動 Steam 遊戲</string>
+    <string name="steam_offline_mode">模擬 Steam 離線模式</string>
+    <string name="steam_offline_mode_description">遊戲內 Steam 模擬器將停用線上網路功能</string>
     <string name="achievement_unlocked">成就已解鎖</string>
     <string name="settings_achievement_notification_position">成就通知位置</string>
     <string name="achievement_position_top_left">左上</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -650,8 +650,8 @@
     <string name="local_saves_only_description">Disable cloud save sync for this game and keep saves on device only</string>
     <string name="launch_steam_client_beta">Launch Steam Client (Beta)</string>
     <string name="launch_steam_client_description">Reduces performance and slows down launch\nAllows online play and fixes DRM and controller issues\nNot all games work</string>
-    <string name="steam_offline_mode">Steam Offline Mode</string>
-    <string name="steam_offline_mode_description">Launch Steam games in offline mode</string>
+    <string name="steam_offline_mode">Emulate Steam Offline Mode</string>
+    <string name="steam_offline_mode_description">The in-game Steam emulator will disable online networking</string>
     <string name="achievement_unlocked">Achievement Unlocked</string>
     <string name="settings_achievement_notification_position">Achievement Notification Position</string>
     <string name="achievement_position_top_left">Top Left</string>


### PR DESCRIPTION
## Description
<!-- What changed and why? -->
Intent-launched Steam games fail to launch when offline if the "Steam Offline Mode" container preference is disabled — `needsDeferLaunch` checked `isSteamOfflineMode()` and deferred waiting for a login that never comes.

- Remove `isSteamOfflineMode()` gate from `needsDeferLaunch` — both offline-mode-on and off now defer only on `!isLoggedIn`; actual offline config still applied at launch time in `SteamUtils`
- Rename label to "Emulate Steam Offline Mode" with clarified description across all 14 locales

Closes #1192

## Recording
<!-- Attach a short recording/GIF showing the change -->
n/a — label rename + backend logic change

## Test plan
- [ ] Intent launch with Steam logged in — launches immediately regardless of offline mode setting
- [ ] Intent launch with Steam not logged in, offline — defers and resolves after login
- [ ] Offline mode toggle still applies at game launch time (check emulator config)
- [ ] Label shows "Emulate Steam Offline Mode" in English and at least one other locale

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have NOT attached a recording of the change (it's backend & a label rename).
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Steam intent launches failing when offline by deferring only on login state, not the offline-mode setting. Also renames the setting to clarify it toggles the in-game Steam emulator’s networking.

- **Bug Fixes**
  - In `needsDeferLaunch`, Steam now defers only when `SteamService.isLoggedIn` is false; the offline-mode preference no longer blocks intent launches. Offline networking still applies at game start via the in-game Steam emulator.
  - Rename label to "Emulate Steam Offline Mode" with a clearer description across all locales.

<sup>Written for commit 032984ccf16dab46e92d2df4d903ea64054330a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Steam offline mode setting descriptions across all languages to clarify that the feature emulates Steam offline mode and the in-game Steam emulator will disable online networking.

* **Chores**
  * Simplified Steam login deferral logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->