### PR TITLE
fix: kill stale wine processes before launch

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -2,6 +2,7 @@ package app.gamenative.ui
 
 import android.content.Context
 import android.content.Intent
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
@@ -1094,6 +1095,10 @@ fun PluviaMain(
             // snackbar dismissed (timeout or new message) — reset exit flag
             exitSnackbarVisible = false
         }
+    }
+
+    BackHandler(enabled = state.loadingDialogVisible && !SteamService.keepAlive) {
+        // TODO: Make prelaunch/loading operations cancellable so Back can exit safely.
     }
 
     PluviaTheme(

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2533,6 +2533,34 @@ private fun shiftXEnvironmentToContext(
 
     return environment
 }
+
+private fun hardKillStaleWineProcessesBeforeLaunch() {
+    val staleWinePids = ProcessHelper.listRunningWineProcesses()
+        .mapNotNull { it.toIntOrNull() }
+        .distinct()
+
+    if (staleWinePids.isEmpty()) {
+        return
+    }
+
+    Timber.w(
+        "Found %d stale Wine process(es) before launch; hard-killing them: %s",
+        staleWinePids.size,
+        staleWinePids.joinToString(),
+    )
+    ProcessHelper.killAllWineProcesses()
+
+    val remainingWinePids = ProcessHelper.listRunningWineProcesses()
+        .mapNotNull { it.toIntOrNull() }
+        .distinct()
+    if (remainingWinePids.isNotEmpty()) {
+        Timber.w(
+            "Wine processes still present after hard-kill attempt: %s",
+            remainingWinePids.joinToString(),
+        )
+    }
+}
+
 private fun setupXEnvironment(
     context: Context,
     appId: String,
@@ -2550,6 +2578,8 @@ private fun setupXEnvironment(
     onGameLaunchError: ((String) -> Unit)? = null,
     navigateBack: () -> Unit,
 ): XEnvironment {
+    hardKillStaleWineProcessesBeforeLaunch()
+
     val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
     val lc_all = container!!.lC_ALL
     val imageFs = ImageFs.find(context)

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2535,6 +2535,7 @@ private fun shiftXEnvironmentToContext(
 }
 
 private fun hardKillStaleWineProcessesBeforeLaunch() {
+    val deadlineMs = System.currentTimeMillis() + 5_000
     val staleWinePids = ProcessHelper.listRunningWineProcesses()
         .mapNotNull { it.toIntOrNull() }
         .distinct()
@@ -2550,13 +2551,21 @@ private fun hardKillStaleWineProcessesBeforeLaunch() {
     )
     ProcessHelper.killAllWineProcesses()
 
-    val remainingWinePids = ProcessHelper.listRunningWineProcesses()
-        .mapNotNull { it.toIntOrNull() }
-        .distinct()
+    var remainingWinePids: List<Int>
+    do {
+        Thread.sleep(100)
+        remainingWinePids = ProcessHelper.listRunningWineProcesses()
+            .mapNotNull { it.toIntOrNull() }
+            .distinct()
+    } while (remainingWinePids.isNotEmpty() && System.currentTimeMillis() < deadlineMs)
+
     if (remainingWinePids.isNotEmpty()) {
         Timber.w(
             "Wine processes still present after hard-kill attempt: %s",
             remainingWinePids.joinToString(),
+        )
+        throw IllegalStateException(
+            "Wine processes still present after hard-kill attempt: ${remainingWinePids.joinToString()}"
         )
     }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2534,42 +2534,6 @@ private fun shiftXEnvironmentToContext(
     return environment
 }
 
-private fun hardKillStaleWineProcessesBeforeLaunch() {
-    val deadlineMs = System.currentTimeMillis() + 5_000
-    val staleWinePids = ProcessHelper.listRunningWineProcesses()
-        .mapNotNull { it.toIntOrNull() }
-        .distinct()
-
-    if (staleWinePids.isEmpty()) {
-        return
-    }
-
-    Timber.w(
-        "Found %d stale Wine process(es) before launch; hard-killing them: %s",
-        staleWinePids.size,
-        staleWinePids.joinToString(),
-    )
-    ProcessHelper.killAllWineProcesses()
-
-    var remainingWinePids: List<Int>
-    do {
-        Thread.sleep(100)
-        remainingWinePids = ProcessHelper.listRunningWineProcesses()
-            .mapNotNull { it.toIntOrNull() }
-            .distinct()
-    } while (remainingWinePids.isNotEmpty() && System.currentTimeMillis() < deadlineMs)
-
-    if (remainingWinePids.isNotEmpty()) {
-        Timber.w(
-            "Wine processes still present after hard-kill attempt: %s",
-            remainingWinePids.joinToString(),
-        )
-        throw IllegalStateException(
-            "Wine processes still present after hard-kill attempt: ${remainingWinePids.joinToString()}"
-        )
-    }
-}
-
 private fun setupXEnvironment(
     context: Context,
     appId: String,
@@ -2587,7 +2551,7 @@ private fun setupXEnvironment(
     onGameLaunchError: ((String) -> Unit)? = null,
     navigateBack: () -> Unit,
 ): XEnvironment {
-    hardKillStaleWineProcessesBeforeLaunch()
+    ProcessHelper.hardKillStaleWineProcesses()
 
     val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
     val lc_all = container!!.lC_ALL

--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -37,9 +37,19 @@ public abstract class ProcessHelper {
 //        Log.d("ProcessHelper", "Process terminated with pid: " + pid);
     }
 
+    public static void killProcess(int pid) {
+        Process.sendSignal(pid, SIGKILL);
+    }
+
     public static void terminateAllWineProcesses() {
         for (String process : listRunningWineProcesses()) {
             terminateProcess(Integer.parseInt(process));
+        }
+    }
+
+    public static void killAllWineProcesses() {
+        for (String process : listRunningWineProcesses()) {
+            killProcess(Integer.parseInt(process));
         }
     }
 

--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -53,6 +53,35 @@ public abstract class ProcessHelper {
         }
     }
 
+    public static void hardKillStaleWineProcesses() throws InterruptedException {
+        long deadlineMs = System.currentTimeMillis() + 5000;
+        List<String> stalePids = listRunningWineProcesses();
+
+        if (stalePids.isEmpty()) {
+            return;
+        }
+
+        Log.w("ProcessHelper", String.format(
+            "Found %d stale Wine process(es) before launch; hard-killing: %s",
+            stalePids.size(), String.join(", ", stalePids)));
+
+        killAllWineProcesses();
+
+        List<String> remaining;
+        do {
+            Thread.sleep(100);
+            remaining = listRunningWineProcesses();
+        } while (!remaining.isEmpty() && System.currentTimeMillis() < deadlineMs);
+
+        if (!remaining.isEmpty()) {
+            Log.w("ProcessHelper", String.format(
+                "Wine processes still present after hard-kill: %s",
+                String.join(", ", remaining)));
+            throw new IllegalStateException(
+                "Wine processes still present after hard-kill attempt: " + String.join(", ", remaining));
+        }
+    }
+
     public static void pauseAllWineProcesses() {
         for (String process : listRunningWineProcesses()) {
             suspendProcess(Integer.parseInt(process));


### PR DESCRIPTION
## Description

fixes the case where users swipe app away while a game is running, then relaunch the app to have infinite booting screen because a stray wine proc is running. This acts as a hammer to see if any wine pros exist on a game launch, and clear them out if exists.

## Recording
<!-- Attach a short recording/GIF showing the change -->



## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Kill stale Wine processes before starting the X environment and wait up to 5s for them to exit to prevent conflicts. Also blocks Back during prelaunch so cleanup can finish; fails fast if any Wine PIDs remain.

- **Bug Fixes**
  - Centralized prelaunch cleanup in `ProcessHelper.hardKillStaleWineProcesses()`; `XServerScreen` calls it before starting X. Sends SIGKILL to Wine PIDs, waits up to 5s, logs warnings, and throws if any remain.
  - Added `ProcessHelper.killProcess`, `ProcessHelper.killAllWineProcesses`, and `ProcessHelper.hardKillStaleWineProcesses` to support the cleanup.
  - Blocked Back via `BackHandler` in `PluviaMain` while the loading dialog is visible and `SteamService.keepAlive` is false to avoid interrupting prelaunch.

<sup>Written for commit ea948b5a0dd20bfd904720e565c3f1ee80a0232f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launch stability by forcibly clearing stale Wine processes before startup, waiting briefly to confirm they exit; launch aborts and logs a warning if they persist.
* **New Features**
  * Disabled the back action while the loading dialog is visible to prevent accidental interruption during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->