### PR TITLE
fix: preserve file timestamps during Steam Cloud download

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -46,6 +46,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import timber.log.Timber
 import java.io.OutputStream
 import java.net.SocketTimeoutException
+import java.nio.file.attribute.FileTime
 
 /**
  * [Steam Auto Cloud](https://partner.steamgames.com/doc/features/cloud#steam_auto-cloud)
@@ -434,6 +435,17 @@ object SteamAutoCloud {
                                                 lastReportedProgress = currentProgress
                                             }
                                         }
+                                    }
+
+                                    // Preserve file timestamp from steamcloud, could fix game save loading, tested Skyrim
+                                    try {
+                                        // Ensure your fileDownloadInfo actually contains a timestamp (Long)
+                                        fileDownloadInfo.timestamp.let { timestamp ->
+                                            val fileTime = FileTime.fromMillis(timestamp.time)
+                                            Files.setLastModifiedTime(actualFilePath, fileTime)
+                                        }
+                                    } catch (e: Exception) {
+                                        Timber.w("Failed to set lastModified for $actualFilePath: ${e.message}")
                                     }
 
                                     if (totalBytesRead != totalFileSize) {


### PR DESCRIPTION
## Description
Maintains the original modification time from Steam Cloud for downloaded files. This ensures that games which rely on file timestamps for save loading and ordering, such as Skyrim, function correctly.

Game tested:
- The Elder Scrolls V: Skyrim Special Edition
- Fallout 4

## Recording
None

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves original modification times for files downloaded from Steam Cloud so games that rely on timestamps load and order saves correctly. Helps titles like Skyrim and Fallout 4.

- **Bug Fixes**
  - After download, sets file mtime from the cloud timestamp via `FileTime.fromMillis` and `Files.setLastModifiedTime`.
  - On failure, logs a warning and continues. Verified with Skyrim SE and Fallout 4.

<sup>Written for commit e89e69bf92ef83328be37ba2f57173def5a90f6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Steam Cloud downloads now correctly preserve the original file modification timestamps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->