### PR TITLE
fix: GOG cloud save fetch failure handling

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
@@ -9,16 +9,13 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.OkHttpClient
 import org.json.JSONArray
-import org.json.JSONObject
 import timber.log.Timber
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.security.MessageDigest
 import java.time.Instant
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
-import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 import java.util.concurrent.TimeUnit
 
@@ -36,6 +33,7 @@ class GOGCloudSavesManager(
         private const val CLOUD_STORAGE_BASE_URL = "https://cloudstorage.gog.com"
         private const val USER_AGENT = "GOGGalaxyCommunicationService/2.0.13.27 (Windows_32bit) dont_sync_marker/true installation_source/gog"
         private const val DELETION_MD5 = "aadd86936a80ee8a369579c3926f1b3c"
+
     }
 
     enum class SyncAction {
@@ -174,7 +172,10 @@ class GOGCloudSavesManager(
 
             // Get cloud files using game-specific clientId in URL path
             Timber.tag("GOG").d("[Cloud Saves] Fetching cloud file list for dirname: $dirname")
-            val cloudFiles = getCloudFiles(credentials.userId, clientId, dirname, credentials.accessToken)
+            val cloudFiles = getCloudFiles(credentials.userId, clientId, dirname, credentials.accessToken) ?: run {
+                Timber.tag("GOG-CloudSaves").e("Failed to fetch cloud files, aborting sync")
+                return@withContext 0L
+            }
             Timber.tag("GOG").d("[Cloud Saves] Retrieved ${cloudFiles.size} total cloud files")
             val downloadableCloud = cloudFiles.filter { !it.isDeleted }
             Timber.tag("GOG").i("[Cloud Saves] Found ${downloadableCloud.size} downloadable cloud file(s) (excluding deleted)")
@@ -356,14 +357,16 @@ class GOGCloudSavesManager(
     }
 
     /**
-     * Get cloud files list from GOG API
+     * Returns the list of cloud files for this dirname, or null if the request failed
+     * (network error, HTTP error, parse error). A successful but empty response returns
+     * an empty list — callers must distinguish null (unknown) from empty (no cloud files).
      */
     private suspend fun getCloudFiles(
         userId: String,
         clientId: String,
         dirname: String,
         authToken: String
-    ): List<CloudFile> = withContext(Dispatchers.IO) {
+    ): List<CloudFile>? = withContext(Dispatchers.IO) {
         try {
             // List all files (don't include dirname in URL - it's used as a prefix filter)
             val url = "$CLOUD_STORAGE_BASE_URL/v1/$userId/$clientId"
@@ -383,7 +386,7 @@ class GOGCloudSavesManager(
                     val errorBody = response.body?.string() ?: "No response body"
                     Timber.tag("GOG").e("[Cloud Saves] Failed to fetch cloud files: HTTP ${response.code}")
                     Timber.tag("GOG").e("[Cloud Saves] Response body: $errorBody")
-                    return@withContext emptyList()
+                    return@withContext null
                 }
 
                 val responseBody = response.body?.string() ?: ""
@@ -397,7 +400,7 @@ class GOGCloudSavesManager(
                 } catch (e: Exception) {
                     Timber.tag("GOG").e(e, "[Cloud Saves] Failed to parse JSON array response")
                     Timber.tag("GOG").e("[Cloud Saves] Response was: $responseBody")
-                    return@withContext emptyList()
+                    return@withContext null
                 }
 
                 Timber.tag("GOG").d("[Cloud Saves] Found ${items.length()} total items in cloud storage")
@@ -413,9 +416,11 @@ class GOGCloudSavesManager(
 
                     // Filter files that belong to this save location (name starts with dirname/)
                     if (name.isNotEmpty() && hash.isNotEmpty() && name.startsWith("$dirname/")) {
+                        // GOG cloud storage returns ISO 8601 timestamps with a UTC offset, e.g.
+                        // "2026-04-02T20:34:00.123456+00:00". OffsetDateTime also accepts "Z".
                         val timestamp = try {
-                            Instant.parse(lastModified).epochSecond
-                        } catch (e: Exception) {
+                            java.time.OffsetDateTime.parse(lastModified).toInstant().epochSecond
+                        } catch (e: java.time.format.DateTimeParseException) {
                             null
                         }
 
@@ -434,7 +439,7 @@ class GOGCloudSavesManager(
 
         } catch (e: Exception) {
             Timber.tag("GOG-CloudSaves").e(e, "Failed to get cloud files")
-            emptyList()
+            null
         }
     }
 

--- a/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
@@ -15,6 +15,8 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.security.MessageDigest
 import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.format.DateTimeParseException
 import java.time.format.DateTimeFormatter
 import java.util.zip.GZIPOutputStream
 import java.util.concurrent.TimeUnit
@@ -395,42 +397,9 @@ class GOGCloudSavesManager(
                     return@withContext emptyList()
                 }
 
-                val items = try {
-                    JSONArray(responseBody)
-                } catch (e: Exception) {
-                    Timber.tag("GOG").e(e, "[Cloud Saves] Failed to parse JSON array response")
+                val files = parseCloudFilesResponse(responseBody, dirname) ?: run {
                     Timber.tag("GOG").e("[Cloud Saves] Response was: $responseBody")
                     return@withContext null
-                }
-
-                Timber.tag("GOG").d("[Cloud Saves] Found ${items.length()} total items in cloud storage")
-
-                val files = mutableListOf<CloudFile>()
-                for (i in 0 until items.length()) {
-                    val fileObj = items.getJSONObject(i)
-                    val name = fileObj.optString("name", "")
-                    val hash = fileObj.optString("hash", "")
-                    val lastModified = fileObj.optString("last_modified")
-
-                    Timber.tag("GOG").d("[Cloud Saves]   Examining item $i: name='$name', dirname='$dirname'")
-
-                    // Filter files that belong to this save location (name starts with dirname/)
-                    if (name.isNotEmpty() && hash.isNotEmpty() && name.startsWith("$dirname/")) {
-                        // GOG cloud storage returns ISO 8601 timestamps with a UTC offset, e.g.
-                        // "2026-04-02T20:34:00.123456+00:00". OffsetDateTime also accepts "Z".
-                        val timestamp = try {
-                            java.time.OffsetDateTime.parse(lastModified).toInstant().epochSecond
-                        } catch (e: java.time.format.DateTimeParseException) {
-                            null
-                        }
-
-                        // Remove the dirname prefix to get relative path
-                        val relativePath = name.removePrefix("$dirname/")
-                        files.add(CloudFile(relativePath, hash, lastModified, timestamp))
-                        Timber.tag("GOG").d("[Cloud Saves]     ✓ Matched: relativePath='$relativePath'")
-                    } else {
-                        Timber.tag("GOG").d("[Cloud Saves]     ✗ Skipped (doesn't match dirname or missing data)")
-                    }
                 }
 
                 Timber.tag("GOG").i("[Cloud Saves] Retrieved ${files.size} cloud files for dirname '$dirname'")
@@ -442,6 +411,52 @@ class GOGCloudSavesManager(
             null
         }
     }
+
+    internal fun parseCloudFilesResponse(responseBody: String, dirname: String): List<CloudFile>? {
+        val items = try {
+            JSONArray(responseBody)
+        } catch (e: Exception) {
+            Timber.tag("GOG").e(e, "[Cloud Saves] Failed to parse JSON array response")
+            return null
+        }
+
+        Timber.tag("GOG").d("[Cloud Saves] Found ${items.length()} total items in cloud storage")
+
+        val files = mutableListOf<CloudFile>()
+        for (i in 0 until items.length()) {
+            val fileObj = items.getJSONObject(i)
+            val name = fileObj.optString("name", "")
+            val hash = fileObj.optString("hash", "")
+            val lastModified = fileObj.optString("last_modified")
+
+            Timber.tag("GOG").d("[Cloud Saves]   Examining item $i: name='$name', dirname='$dirname'")
+
+            if (name.isNotEmpty() && hash.isNotEmpty() && name.startsWith("$dirname/")) {
+                val relativePath = name.removePrefix("$dirname/")
+                files.add(
+                    CloudFile(
+                        relativePath = relativePath,
+                        md5Hash = hash,
+                        updateTime = lastModified,
+                        updateTimestamp = parseCloudTimestamp(lastModified),
+                    ),
+                )
+                Timber.tag("GOG").d("[Cloud Saves]     ✓ Matched: relativePath='$relativePath'")
+            } else {
+                Timber.tag("GOG").d("[Cloud Saves]     ✗ Skipped (doesn't match dirname or missing data)")
+            }
+        }
+
+        return files
+    }
+
+    internal fun parseCloudTimestamp(lastModified: String): Long? =
+        try {
+            // GOG returns timestamps like "2026-04-02T20:34:00.123456+00:00".
+            OffsetDateTime.parse(lastModified).toInstant().epochSecond
+        } catch (_: DateTimeParseException) {
+            null
+        }
 
     /**
      * Upload file to GOG cloud storage

--- a/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
@@ -1,53 +1,33 @@
 package app.gamenative.service.gog
 
 import android.content.Context
-import android.net.Uri
-import androidx.core.net.toUri
 import app.gamenative.PluviaApp
-import app.gamenative.data.DownloadInfo
 import app.gamenative.data.GOGCloudSavesLocation
 import app.gamenative.data.GOGCloudSavesLocationTemplate
 import app.gamenative.data.GOGGame
 import app.gamenative.data.GameSource
 import app.gamenative.data.LaunchInfo
 import app.gamenative.data.LibraryItem
-import app.gamenative.data.PostSyncInfo
-import app.gamenative.data.SteamApp
 import app.gamenative.db.dao.GOGGameDao
-import app.gamenative.enums.AppType
-import app.gamenative.enums.ControllerSupport
 import app.gamenative.enums.Marker
-import app.gamenative.enums.OS
 import app.gamenative.enums.PathType
-import app.gamenative.enums.ReleaseState
-import app.gamenative.enums.SyncResult
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.FileUtils
 import app.gamenative.utils.MarkerUtils
 import app.gamenative.utils.Net
-import app.gamenative.utils.StorageUtils
 import com.winlator.container.Container
 import com.winlator.core.envvars.EnvVars
 import com.winlator.core.FileUtils as WinlatorFileUtils
 import com.winlator.xenvironment.components.GuestProgramLauncherComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
-import java.util.EnumSet
-import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import okhttp3.Request
-import org.json.JSONArray
 import org.json.JSONObject
 import timber.log.Timber
 
@@ -1099,21 +1079,19 @@ class GOGManager @Inject constructor(
             Timber.tag("GOG").d("[Cloud Saves] Fetching save locations from API")
             val result = getSaveSyncLocation(context, appId, installPath)
 
-            val clientSecret: String
-            val locations: List<GOGCloudSavesLocationTemplate>
-
-            // If no locations from API, use default Windows path
             if (result == null || result.second.isEmpty()) {
-                clientSecret = ""
-                Timber.tag("GOG").d("[Cloud Saves] No save locations from API, using default for game $gameId")
-                val defaultLocation = "%LOCALAPPDATA%/GOG.com/Galaxy/Applications/$clientId/Storage/Shared/Files"
-                Timber.tag("GOG").d("[Cloud Saves] Using default location: $defaultLocation")
-                locations = listOf(GOGCloudSavesLocationTemplate("__default", defaultLocation))
-            } else {
-                clientSecret = result.first
-                locations = result.second
-                Timber.tag("GOG").i("[Cloud Saves] Retrieved ${locations.size} save location(s) from API")
+                // The remote config API returned no locations, meaning this game either has cloud
+                // saves disabled or no save paths configured. We don't fall back to the default
+                // GOG Galaxy path (%LOCALAPPDATA%/GOG.com/Galaxy/Applications/<clientId>/Storage/…)
+                // because clientSecret also comes from the API — without it, the token exchange
+                // always fails and we'd just show a false "Offline" status.
+                Timber.tag("GOG").d("[Cloud Saves] No save locations from API for game $gameId, cloud saves not supported")
+                return@withContext null
             }
+
+            val clientSecret = result.first
+            val locations = result.second
+            Timber.tag("GOG").i("[Cloud Saves] Retrieved ${locations.size} save location(s) from API")
 
             // Resolve each location
             val resolvedLocations = mutableListOf<GOGCloudSavesLocation>()

--- a/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
@@ -1083,8 +1083,8 @@ class GOGManager @Inject constructor(
                 // The remote config API returned no locations, meaning this game either has cloud
                 // saves disabled or no save paths configured. We don't fall back to the default
                 // GOG Galaxy path (%LOCALAPPDATA%/GOG.com/Galaxy/Applications/<clientId>/Storage/…)
-                // because clientSecret also comes from the API — without it, the token exchange
-                // always fails and we'd just show a false "Offline" status.
+                // because clientSecret also comes from the API — without it, cloud auth cannot
+                // succeed and the fallback path can never be used for a real sync.
                 Timber.tag("GOG").d("[Cloud Saves] No save locations from API for game $gameId, cloud saves not supported")
                 return@withContext null
             }

--- a/app/src/test/java/app/gamenative/service/gog/GOGCloudSavesManagerTest.kt
+++ b/app/src/test/java/app/gamenative/service/gog/GOGCloudSavesManagerTest.kt
@@ -1,0 +1,53 @@
+package app.gamenative.service.gog
+
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class GOGCloudSavesManagerTest {
+    private val context: Context = mock()
+    private val manager = GOGCloudSavesManager(context)
+
+    @Test
+    fun parseCloudTimestamp_accepts_gog_offset_format() {
+        val timestamp = manager.parseCloudTimestamp("2026-04-02T20:34:00.123456+00:00")
+
+        assertEquals(1_775_162_040L, timestamp)
+    }
+
+    @Test
+    fun parseCloudFilesResponse_returns_null_for_invalid_json_instead_of_empty_list() {
+        val files = manager.parseCloudFilesResponse("not-json", "__default")
+
+        assertNull(files)
+    }
+
+    @Test
+    fun parseCloudFilesResponse_parses_matching_files_and_preserves_offset_timestamp() {
+        val files = manager.parseCloudFilesResponse(
+            """
+            [
+              {
+                "name": "__default/save-1.sav",
+                "hash": "abc123",
+                "last_modified": "2026-04-02T20:34:00.123456+00:00"
+              },
+              {
+                "name": "other-dir/save-2.sav",
+                "hash": "ignored",
+                "last_modified": "2026-04-02T21:00:00+00:00"
+              }
+            ]
+            """.trimIndent(),
+            "__default",
+        )
+
+        assertNotNull(files)
+        assertEquals(1, files!!.size)
+        assertEquals("save-1.sav", files.single().relativePath)
+        assertEquals(1_775_162_040L, files.single().updateTimestamp)
+    }
+}


### PR DESCRIPTION
## Description
This is a split-out PR from #1094 focused on the GOG cloud save fetch and timestamp fixes.

Fixes two bugs in GOG cloud save sync and one related issue in save-location resolution:

- `getCloudFiles()` was treating request or parse failures the same as a valid empty cloud result, which could make sync logic believe the cloud was empty and incorrectly choose an upload path.
- GOG `last_modified` timestamps were parsed with `Instant.parse(...)`, which does not handle the offset-based format GOG returns — so remote timestamps could be dropped during sync decisions.
- Removes the fake default GOG cloud-save path fallback when the API returns no save locations. That fallback is not useful because in the same case there is also no `clientSecret`, so cloud auth cannot succeed and the path can never be used for a real sync.

**Changes:**
- Return `null` from GOG cloud file listing on HTTP or parse failure instead of `emptyList()`
- Abort sync when cloud file listing fails instead of treating the failure as "cloud is empty"
- Parse GOG cloud timestamps with `OffsetDateTime.parse(...).toInstant()`
- Stop falling back to a fake default cloud-save location when the API reports no save locations
- Add regression tests covering offset timestamp parsing and failure-vs-empty cloud responses

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.