### PR TITLE
fix crashes on migrateGSESavesToSteamUserdata

### DIFF
--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -37,7 +37,9 @@ import timber.log.Timber
 import okhttp3.*
 import org.json.JSONObject
 import java.net.URLEncoder
+import java.nio.file.attribute.FileTime
 import java.util.concurrent.TimeUnit
+import kotlin.io.path.setLastModifiedTime
 
 object SteamUtils {
 
@@ -921,18 +923,22 @@ object SteamUtils {
                 try {
                     Files.createDirectories(targetFile.parent)
 
+                    val fileTimestamp = file.lastModified()
+
                     // As Files.move use linux rename syscall (or simply mv command we know, no need to manually remove the target file)
                     Files.move(
                         file.toPath(),
                         targetFile,
                         StandardCopyOption.REPLACE_EXISTING,
-                        StandardCopyOption.COPY_ATTRIBUTES, // Preserve file attributes like timestamp and permission
                         StandardCopyOption.ATOMIC_MOVE   // will throw if the FS can’t guarantee atomicity
                     )
 
+                    // Preserve file timestamp
+                    targetFile.setLastModifiedTime(FileTime.fromMillis(fileTimestamp))
+
                     Timber.tag("migrateGSESavesToSteamUserdata").i("Migrated ${file.name} from GSE saves to Steam userdata")
                     migratedCount++
-                } catch (e: IOException) {
+                } catch (e: Exception) {
                     migrationFailed = true
                     Timber.tag("migrateGSESavesToSteamUserdata").w(e, "Failed to migrate ${file.name}")
                 }


### PR DESCRIPTION
## Description
Quote from discord: COPY_ATTRIBUTES is not a valid/supported option for Files.move on Android’s NIO implementation, so Files.move throws UnsupportedOperationException immediately. The code only catches IOException, so the exception escapes and crashes the app.

## Recording
None

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes when migrating GSE saves to Steam userdata on Android. Removes an unsupported move option, preserves file timestamps manually, and hardens error handling.

- **Bug Fixes**
  - Removed `StandardCopyOption.COPY_ATTRIBUTES` from `Files.move` (unsupported on Android); set timestamp via `setLastModifiedTime`.
  - Catch `Exception` instead of only `IOException` so `UnsupportedOperationException` is handled and migration continues.
  - Keep `StandardCopyOption.ATOMIC_MOVE` and create parent directories before moving.

<sup>Written for commit fa5ef46bc3335e53b69bb55d9a5546d777df5656. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved save file migration to better preserve file metadata during transfers to Steam directories.
  * Enhanced error handling during save migration to catch a broader range of issues and provide more reliable failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->