### PR TITLE
fix: late release single tap in touchscreen mode to fix clicking in some games

### DIFF
--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -769,6 +769,12 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
         // Simple tap — only if finger stayed within tap tolerance
         if (gestureConfig.getTapEnabled() && !movedBeyondTapThreshold) {
+            if (delayedPress != null) {
+                // If there's a new single tap within 'CLICK_DELAYED_TIME' ms
+                // Immediately release the previous down click
+                removeCallbacks(delayedPress);
+                injectRelease(TouchGestureConfig.ACTION_LEFT_CLICK);
+            }
             moveCursorTo((int) pt[0], (int) pt[1]);
             injectClick(TouchGestureConfig.ACTION_LEFT_CLICK);
             delayedPress = () -> injectRelease(TouchGestureConfig.ACTION_LEFT_CLICK);

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -777,7 +777,10 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
             }
             moveCursorTo((int) pt[0], (int) pt[1]);
             injectClick(TouchGestureConfig.ACTION_LEFT_CLICK);
-            delayedPress = () -> injectRelease(TouchGestureConfig.ACTION_LEFT_CLICK);
+            delayedPress = () -> {
+                injectRelease(TouchGestureConfig.ACTION_LEFT_CLICK);
+                delayedPress = null;
+            };
             postDelayed(delayedPress, CLICK_DELAYED_TIME);
         }
 

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -539,6 +539,8 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
     // ── Primary finger down ──────────────────────────────────────────
     private void handleTsDown(MotionEvent event) {
+        flushPendingTapRelease();
+
         float[] pt = XForm.transformPoint(xform, event.getX(), event.getY());
         int x = (int) pt[0];
         int y = (int) pt[1];
@@ -769,12 +771,6 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
         // Simple tap — only if finger stayed within tap tolerance
         if (gestureConfig.getTapEnabled() && !movedBeyondTapThreshold) {
-            if (delayedPress != null) {
-                // If there's a new single tap within 'CLICK_DELAYED_TIME' ms
-                // Immediately release the previous down click
-                removeCallbacks(delayedPress);
-                injectRelease(TouchGestureConfig.ACTION_LEFT_CLICK);
-            }
             moveCursorTo((int) pt[0], (int) pt[1]);
             injectClick(TouchGestureConfig.ACTION_LEFT_CLICK);
             delayedPress = () -> {
@@ -810,6 +806,16 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     }
 
     // ── Helpers ──────────────────────────────────────────────────────
+
+    private void flushPendingTapRelease() {
+        if (delayedPress != null) {
+            // If there's a new single tap within 'CLICK_DELAYED_TIME' ms
+            // Immediately release the previous down click
+            removeCallbacks(delayedPress);
+            injectRelease(TouchGestureConfig.ACTION_LEFT_CLICK);
+            delayedPress = null;
+        }
+    }
 
     private void cancelLongPressTimer() {
         if (longPressRunnable != null) {

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -771,7 +771,8 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         if (gestureConfig.getTapEnabled() && !movedBeyondTapThreshold) {
             moveCursorTo((int) pt[0], (int) pt[1]);
             injectClick(TouchGestureConfig.ACTION_LEFT_CLICK);
-            injectRelease(TouchGestureConfig.ACTION_LEFT_CLICK);
+            delayedPress = () -> injectRelease(TouchGestureConfig.ACTION_LEFT_CLICK);
+            postDelayed(delayedPress, CLICK_DELAYED_TIME);
         }
 
         // Record for double-tap detection (even if tap itself is disabled,


### PR DESCRIPTION
## Description
Delay the release button for the mouse click to fix single tap in Touchscreen Mode

I suspect this fixes the issue with Touchscreen Mode because a click down and up are being sent to games too quickly, likely reaching the game within the same frame window, so for example, if games do something like

```
if mouse click 1 is down
...
else if mouse click 1 is up
...
```

then click 1 up code is never executed

should fix these bug reports:
https://discord.com/channels/1378308569287622737/1482564848477929602
https://discord.com/channels/1378308569287622737/1490005595175125002
https://discord.com/channels/1378308569287622737/1479373032379125860


## Recording

https://github.com/user-attachments/assets/adf292c2-038b-4f33-a87e-c01af88ef087



## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delay the left-click release after a single tap in Touchscreen Mode so down and up aren’t sent in the same frame. If a new tap starts within the delay window, immediately release the previous click.

- **Bug Fixes**
  - On single tap up, schedule release with postDelayed(CLICK_DELAYED_TIME) via delayedPress in TouchpadView.handleTsUp; clear delayedPress after it runs; cursor move and press stay immediate.
  - On new tap down, flush any pending single-tap release by canceling delayedPress and injecting release in TouchpadView.handleTsDown (via flushPendingTapRelease).

<sup>Written for commit 218da26c330e6abbcf003210c425c02d7b7f5707. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touchpad tap behavior: the click release is now delayed to better distinguish taps from drags. Consecutive taps properly cancel or complete pending releases, reducing accidental double-clicks and improving responsiveness and reliability of single- and multi-tap interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->