### PR TITLE
fix: preserve aspect-correct viewport for screen effects

### DIFF
--- a/app/src/main/java/com/winlator/renderer/EffectComposer.java
+++ b/app/src/main/java/com/winlator/renderer/EffectComposer.java
@@ -89,6 +89,7 @@ public class EffectComposer {
 
         GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, sceneBuffer.getFramebuffer());
         GLES20.glViewport(0, 0, sceneWidth, sceneHeight);
+        renderer.setViewportNeedsUpdate(true);
         if (scaledScene) {
             renderer.setRenderTargetSizeOverride(sceneWidth, sceneHeight);
         }


### PR DESCRIPTION
## Description
prevents screen effects from incorrectly altering aspect ratio when applied, fix up from internal and external resolution decouple with FSR work

## Recording
<!-- Attach a short recording/GIF showing the change -->

<img width="620" height="353" alt="image" src="https://github.com/user-attachments/assets/e19c8672-3249-436d-ba48-7e25ad82fcee" />


## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the aspect-correct viewport when screen effects are enabled. Marks the viewport as dirty so the renderer restores the scene viewport each frame and non-scaling effects no longer stretch to the full surface.

- **Bug Fixes**
  - In `EffectComposer.render()`, call `renderer.setViewportNeedsUpdate(true)` after binding the scene FBO and setting `glViewport`, so `GLRenderer.drawScene()` reapplies the aspect-correct viewport after effect passes override it.
  - Fixes stretching with non-scaling effects (CRT/NTSC/Vivid).

<sup>Written for commit c060ba73be36d7c3f568bdf5f2d73d69c2913720. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved viewport handling during scene rendering to ensure proper display updates in the graphics pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->