### PR TITLE
Fix: GOG chunk URL broken when CDN token is in query string

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -630,7 +630,7 @@ class GOGDownloadManager @Inject constructor(
 
             // Gen 1: one main.bin URL per product; each file is fetched with Range: bytes=offset-(offset+size-1)
             val mainBinUrlByProduct = productUrlMap.mapValues { (_, urls) ->
-                (urls.firstOrNull()?.trimEnd('/') ?: "") + "/main.bin"
+                buildGen1MainBinUrl(urls.firstOrNull())
             }
 
             fun downloadOneFile(f: FileWithProduct, baseDir: File): Result<Unit> {
@@ -740,6 +740,18 @@ class GOGDownloadManager @Inject constructor(
             )
             Result.failure(e)
         }
+    }
+
+    internal fun buildGen1MainBinUrl(baseUrl: String?): String {
+        val safeBase = baseUrl?.trim().orEmpty()
+        require(safeBase.isNotEmpty()) { "Missing Gen 1 secure link URL" }
+
+        val queryIndex = safeBase.indexOf('?')
+        val pathBase = if (queryIndex >= 0) safeBase.substring(0, queryIndex) else safeBase
+        val querySuffix = if (queryIndex >= 0) safeBase.substring(queryIndex) else ""
+        val normalizedPathBase = pathBase.trimEnd('/')
+
+        return "$normalizedPathBase/main.bin$querySuffix"
     }
 
     /**
@@ -969,7 +981,7 @@ class GOGDownloadManager @Inject constructor(
                 val chunkHashes = parser.extractChunkHashes(depotFiles)
 
                 // Build chunk URL map using dependency base URLs
-                val chunkUrlMap = buildChunkUrlMap(chunkHashes, dependencyBaseUrls)
+                val chunkUrlMap = parser.buildChunkUrlMap(chunkHashes, dependencyBaseUrls)
 
                 // Create cache directory for this dependency
                 val depotCacheDir = File(installBaseDir, ".gog_dep_${depot.dependencyId}")
@@ -1046,28 +1058,6 @@ class GOGDownloadManager @Inject constructor(
             onProgress?.invoke(1f)
         }
         result
-    }
-
-    /**
-     * Build chunk URL map using base URLs
-     */
-    private fun buildChunkUrlMap(chunkHashes: List<String>, baseUrls: List<String>): Map<String, String> {
-        val chunkUrlMap = mutableMapOf<String, String>()
-        val baseUrl = baseUrls.firstOrNull() ?: return emptyMap()
-        // Ensure base URL ends with / for proper concatenation
-        val normalizedBaseUrl = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
-
-        chunkHashes.forEach { hash ->
-            // Build GOG Galaxy path format: AA/BB/CCDD...
-            val galaxyPath = if (hash.length >= 4) {
-                "${hash.substring(0, 2)}/${hash.substring(2, 4)}/$hash"
-            } else {
-                hash
-            }
-            chunkUrlMap[hash] = "$normalizedBaseUrl$galaxyPath"
-        }
-
-        return chunkUrlMap
     }
 
     /**

--- a/app/src/main/java/app/gamenative/service/gog/api/GOGManifestParser.kt
+++ b/app/src/main/java/app/gamenative/service/gog/api/GOGManifestParser.kt
@@ -219,16 +219,8 @@ class GOGManifestParser @Inject constructor() {
         // Use the first (highest priority) CDN URL as base
         val baseCdnUrl = baseUrls.first()
 
-        // Build full URL for each chunk: baseUrl/aa/bb/aabbccdd...
-        // Where aa/bb are first 4 chars of MD5 hash
         return chunks.associateWith { chunkMd5 ->
-            if (chunkMd5.length >= 4) {
-                val first2 = chunkMd5.substring(0, 2)
-                val next2 = chunkMd5.substring(2, 4)
-                "$baseCdnUrl/$first2/$next2/$chunkMd5"
-            } else {
-                "$baseCdnUrl/$chunkMd5"
-            }
+            buildChunkUrl(baseCdnUrl, chunkMd5)
         }
     }
 
@@ -264,21 +256,37 @@ class GOGManifestParser @Inject constructor() {
             // Use the first (highest priority) CDN URL for this product
             val baseCdnUrl = productUrls.first()
 
-            // Build full URL for chunk: baseUrl/aa/bb/aabbccdd...
-            // Where aa/bb are first 4 chars of MD5 hash
-            val chunkUrl = if (chunkMd5.length >= 4) {
-                val first2 = chunkMd5.substring(0, 2)
-                val next2 = chunkMd5.substring(2, 4)
-                "$baseCdnUrl/$first2/$next2/$chunkMd5"
-            } else {
-                "$baseCdnUrl/$chunkMd5"
-            }
+            val chunkUrl = buildChunkUrl(baseCdnUrl, chunkMd5)
 
             chunkUrlMap[chunkMd5] = chunkUrl
         }
 
         Timber.tag(TAG).d("Built ${chunkUrlMap.size} chunk URLs from ${productUrlMap.size} product(s)")
         return chunkUrlMap
+    }
+
+    private fun buildChunkUrl(baseCdnUrl: String, chunkMd5: String): String {
+        val chunkPath = if (chunkMd5.length >= 4) {
+            val first2 = chunkMd5.substring(0, 2)
+            val next2 = chunkMd5.substring(2, 4)
+            "$first2/$next2/$chunkMd5"
+        } else {
+            chunkMd5
+        }
+
+        return appendPathBeforeQuery(baseCdnUrl, chunkPath)
+    }
+
+    /**
+     * Preserve secure-link query params (e.g. ?__token__=...) by inserting chunk paths before query.
+     */
+    private fun appendPathBeforeQuery(baseUrl: String, path: String): String {
+        val queryIndex = baseUrl.indexOf('?')
+        val pathBase = if (queryIndex >= 0) baseUrl.substring(0, queryIndex) else baseUrl
+        val querySuffix = if (queryIndex >= 0) baseUrl.substring(queryIndex) else ""
+        val normalizedPathBase = pathBase.trimEnd('/')
+        val normalizedPath = path.trimStart('/')
+        return "$normalizedPathBase/$normalizedPath$querySuffix"
     }
 
     /**

--- a/app/src/test/java/app/gamenative/service/gog/GOGDownloadManagerTest.kt
+++ b/app/src/test/java/app/gamenative/service/gog/GOGDownloadManagerTest.kt
@@ -19,6 +19,8 @@ import java.nio.file.Files
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -258,6 +260,43 @@ class GOGDownloadManagerTest {
 
         installPath.deleteRecursively()
         supportDir.deleteRecursively()
+    }
+
+    @Test
+    fun buildGen1MainBinUrl_insertsPathBeforeQueryToken() {
+        val baseUrl = "https://cdn.gog.com/store/1451150270?__token__=exp=123~acl=*"
+
+        val result = manager.buildGen1MainBinUrl(baseUrl)
+
+        assertEquals(
+            "https://cdn.gog.com/store/1451150270/main.bin?__token__=exp=123~acl=*",
+            result,
+        )
+    }
+
+    @Test
+    fun buildGen1MainBinUrl_appendsPathWithoutQuery() {
+        val result = manager.buildGen1MainBinUrl("https://cdn.gog.com/store/1451150270/")
+
+        assertEquals("https://cdn.gog.com/store/1451150270/main.bin", result)
+    }
+
+    @Test
+    fun buildGen1MainBinUrl_throwsWhenBaseUrlIsNull() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            manager.buildGen1MainBinUrl(null)
+        }
+
+        assertTrue(exception.message?.contains("Missing Gen 1 secure link URL") == true)
+    }
+
+    @Test
+    fun buildGen1MainBinUrl_throwsWhenBaseUrlIsBlank() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            manager.buildGen1MainBinUrl("   ")
+        }
+
+        assertTrue(exception.message?.contains("Missing Gen 1 secure link URL") == true)
     }
 
     private fun depotFile(path: String, support: Boolean): DepotFile {

--- a/app/src/test/java/app/gamenative/service/gog/api/GOGManifestParserTest.kt
+++ b/app/src/test/java/app/gamenative/service/gog/api/GOGManifestParserTest.kt
@@ -327,6 +327,19 @@ class GOGManifestParserTest {
     }
 
     @Test
+    fun testBuildChunkUrlMap_insertsChunkPathBeforeQueryToken() {
+        val chunks = listOf("aabbccdd11223344")
+        val baseUrls = listOf("https://cdn.gog.com/store/1451150270?__token__=exp=123~acl=*")
+
+        val result = parser.buildChunkUrlMap(chunks, baseUrls)
+
+        assertEquals(
+            "https://cdn.gog.com/store/1451150270/aa/bb/aabbccdd11223344?__token__=exp=123~acl=*",
+            result["aabbccdd11223344"],
+        )
+    }
+
+    @Test
     fun testBuildChunkUrlMapWithProducts() {
         val chunks = listOf("aabbccdd11223344", "11223344aabbccdd")
         val chunkToProductMap = mapOf(
@@ -354,6 +367,22 @@ class GOGManifestParserTest {
         val result = parser.buildChunkUrlMapWithProducts(chunks, chunkToProductMap, productUrlMap)
 
         assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun testBuildChunkUrlMapWithProducts_insertsChunkPathBeforeQueryToken() {
+        val chunks = listOf("aabbccdd11223344")
+        val chunkToProductMap = mapOf("aabbccdd11223344" to "12345")
+        val productUrlMap = mapOf(
+            "12345" to listOf("https://cdn.gog.com/store/1451150270?__token__=exp=123~acl=*")
+        )
+
+        val result = parser.buildChunkUrlMapWithProducts(chunks, chunkToProductMap, productUrlMap)
+
+        assertEquals(
+            "https://cdn.gog.com/store/1451150270/aa/bb/aabbccdd11223344?__token__=exp=123~acl=*",
+            result["aabbccdd11223344"],
+        )
     }
 
     @Test


### PR DESCRIPTION
## Description
A fix applied in another project, but the fix applies to us as well. Tested and still works.

## Recording
https://github.com/The412Banner/BannerHub/commit/4f3c515b577387693c95cc393935f8e9b22442ef

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix GOG chunk and Gen1 main.bin URLs when CDN tokens are in the query string. We now insert paths before the query to preserve Akamai `__token__` params and avoid 403s.

- **Bug Fixes**
  - Insert chunk path before query string in `GOGManifestParser` for both global and per-product maps.
  - Add `buildGen1MainBinUrl` in `GOGDownloadManager` to place `/main.bin` before query; trims input and throws if URL is missing.
  - Delegate chunk URL map construction to `GOGManifestParser` and add tests for tokenized URLs and `main.bin` edge cases.

<sup>Written for commit 34a8e96ccb36aecbef7e05cb259ae22baa302fd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed download URL construction to insert file paths before existing query strings and normalize slashes, ensuring authentication tokens and query parameters are preserved.

* **Tests**
  * Added tests covering query-parameter handling and URL path normalization to prevent regressions in download operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->