### PR TITLE
feat: DVD bounce mode easter egg with achievement unlock

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -1184,4 +1184,15 @@ object PrefManager {
     var warnBeforeExit: Boolean
         get() = getPref(WARN_BEFORE_EXIT, false)
         set(value) { setPref(WARN_BEFORE_EXIT, value) }
+
+    // DVD bounce mode easter egg
+    private val DVD_MODE_UNLOCKED = booleanPreferencesKey("dvd_mode_unlocked")
+    var dvdModeUnlocked: Boolean
+        get() = getPref(DVD_MODE_UNLOCKED, false)
+        set(value) { setPref(DVD_MODE_UNLOCKED, value) }
+
+    private val DVD_MODE_DEFAULT = booleanPreferencesKey("dvd_mode_default")
+    var dvdModeDefault: Boolean
+        get() = getPref(DVD_MODE_DEFAULT, false)
+        set(value) { setPref(DVD_MODE_DEFAULT, value) }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/ambient/AmbientDownloadOverlay.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/ambient/AmbientDownloadOverlay.kt
@@ -33,8 +33,11 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.gamenative.PrefManager
 import app.gamenative.PluviaApp
+import app.gamenative.R
 import app.gamenative.events.AndroidEvent
+import app.gamenative.ui.util.AchievementNotificationManager
 import app.gamenative.ui.screen.library.components.ambient.AmbientModeConstants.BAR_HEIGHT_DP
 import app.gamenative.ui.screen.library.components.ambient.AmbientModeConstants.DRIFT_AMPLITUDE_PX
 import app.gamenative.ui.screen.library.components.ambient.AmbientModeConstants.DRIFT_PERIOD_MS
@@ -74,6 +77,7 @@ internal fun AmbientDownloadOverlay(
 
     LaunchedEffect(interactionCounter) {
         delay(IDLE_TIMEOUT_MS)
+        if (PrefManager.dvdModeDefault) isDvdMode = true
         isIdle = true
     }
 
@@ -113,6 +117,13 @@ internal fun AmbientDownloadOverlay(
 
         val shakeDetector = ShakeDetector(context) {
             isDvdMode = !isDvdMode
+            if (!PrefManager.dvdModeUnlocked) {
+                PrefManager.dvdModeUnlocked = true
+                AchievementNotificationManager.show(
+                    name = context.getString(R.string.easter_egg_dvd_mode),
+                    iconUrl = "android.resource://${context.packageName}/${R.mipmap.ic_launcher}",
+                )
+            }
         }
         shakeDetector.start()
 

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
@@ -226,6 +226,20 @@ fun SettingsGroupInterface(
             colors = settingsTileColorsAlt(),
         )
 
+        if (PrefManager.dvdModeUnlocked) {
+            var dvdModeDefault by rememberSaveable { mutableStateOf(PrefManager.dvdModeDefault) }
+            SettingsSwitch(
+                colors = settingsTileColorsAlt(),
+                title = { Text(text = stringResource(R.string.settings_dvd_mode_title)) },
+                subtitle = { Text(text = stringResource(R.string.settings_dvd_mode_subtitle)) },
+                state = dvdModeDefault,
+                onCheckedChange = {
+                    dvdModeDefault = it
+                    PrefManager.dvdModeDefault = it
+                },
+            )
+        }
+
         SettingsSwitch(
             colors = settingsTileColorsAlt(),
             title = { Text(text = stringResource(R.string.settings_interface_external_links_title)) },

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1232,4 +1232,7 @@
     <string name="workshop_processing">Behandler mods…</string>
     <string name="workshop_failed_count">%1$d workshop-mod(s) kunne ikke opdateres</string>
     <string name="workshop_download_failed">Download mislykkedes</string>
+    <string name="easter_egg_dvd_mode">Rystet, ikke rørt</string>
+    <string name="settings_dvd_mode_title">DVD-bounce-tilstand</string>
+    <string name="settings_dvd_mode_subtitle">Vis hoppende ikon som standard under downloads</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1302,4 +1302,7 @@
     <string name="workshop_processing">Mods werden verarbeitet…</string>
     <string name="workshop_failed_count">%1$d Workshop-Mod(s) konnten nicht aktualisiert werden</string>
     <string name="workshop_download_failed">Download fehlgeschlagen</string>
+    <string name="easter_egg_dvd_mode">Geschüttelt, nicht gerührt</string>
+    <string name="settings_dvd_mode_title">DVD-Bounce-Modus</string>
+    <string name="settings_dvd_mode_subtitle">Springendes Symbol während Downloads standardmäßig anzeigen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1368,4 +1368,7 @@
     <string name="workshop_processing">Procesando mods…</string>
     <string name="workshop_failed_count">%1$d mod(s) del Workshop no se pudieron actualizar</string>
     <string name="workshop_download_failed">Error en la descarga</string>
+    <string name="easter_egg_dvd_mode">Agitado, no revuelto</string>
+    <string name="settings_dvd_mode_title">Modo rebote DVD</string>
+    <string name="settings_dvd_mode_subtitle">Mostrar icono rebotando por defecto durante las descargas</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1362,4 +1362,7 @@
     <string name="workshop_processing">Traitement des mods…</string>
     <string name="workshop_failed_count">%1$d mod(s) Workshop n\'ont pas pu être mis à jour</string>
     <string name="workshop_download_failed">Échec du téléchargement</string>
+    <string name="easter_egg_dvd_mode">Secoué, pas remué</string>
+    <string name="settings_dvd_mode_title">Mode rebond DVD</string>
+    <string name="settings_dvd_mode_subtitle">Afficher l\'icône rebondissante par défaut pendant les téléchargements</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1358,4 +1358,7 @@
     <string name="workshop_processing">Elaborazione mod…</string>
     <string name="workshop_failed_count">%1$d mod del Workshop non aggiornati</string>
     <string name="workshop_download_failed">Download non riuscito</string>
+    <string name="easter_egg_dvd_mode">Agitato, non mescolato</string>
+    <string name="settings_dvd_mode_title">Modalità rimbalzo DVD</string>
+    <string name="settings_dvd_mode_subtitle">Mostra icona rimbalzante di default durante i download</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1366,4 +1366,7 @@
     <string name="workshop_processing">모드 처리 중…</string>
     <string name="workshop_failed_count">%1$d개의 워크숍 모드를 업데이트하지 못했습니다</string>
     <string name="workshop_download_failed">다운로드 실패</string>
+    <string name="easter_egg_dvd_mode">젓지 말고 흔들어서</string>
+    <string name="settings_dvd_mode_title">DVD 바운스 모드</string>
+    <string name="settings_dvd_mode_subtitle">다운로드 중 기본적으로 튕기는 아이콘 표시</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1365,4 +1365,7 @@
     <string name="workshop_processing">Przetwarzanie modów…</string>
     <string name="workshop_failed_count">Nie udało się zaktualizować %1$d modów z Warsztatu</string>
     <string name="workshop_download_failed">Pobieranie nie powiodło się</string>
+    <string name="easter_egg_dvd_mode">Wstrząśnięte, nie mieszane</string>
+    <string name="settings_dvd_mode_title">Tryb odbijania DVD</string>
+    <string name="settings_dvd_mode_subtitle">Domyślnie pokazuj odbijającą się ikonę podczas pobierania</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1232,4 +1232,7 @@
     <string name="workshop_processing">Processando mods…</string>
     <string name="workshop_failed_count">%1$d mod(s) da Oficina não puderam ser atualizados</string>
     <string name="workshop_download_failed">Falha no download</string>
+    <string name="easter_egg_dvd_mode">Batido, não mexido</string>
+    <string name="settings_dvd_mode_title">Modo ricochete DVD</string>
+    <string name="settings_dvd_mode_subtitle">Mostrar ícone quicando por padrão durante downloads</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1367,4 +1367,7 @@
     <string name="workshop_processing">Se procesează modurile…</string>
     <string name="workshop_failed_count">%1$d mod(uri) Workshop nu au putut fi actualizate</string>
     <string name="workshop_download_failed">Descărcarea a eșuat</string>
+    <string name="easter_egg_dvd_mode">Agitat, nu amestecat</string>
+    <string name="settings_dvd_mode_title">Mod ricoșeu DVD</string>
+    <string name="settings_dvd_mode_subtitle">Afișează implicit pictograma săltăreață în timpul descărcărilor</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1295,4 +1295,7 @@ https://gamenative.app
     <string name="workshop_processing">Обработка модов…</string>
     <string name="workshop_failed_count">Не удалось обновить %1$d мод(ов) Мастерской</string>
     <string name="workshop_download_failed">Ошибка загрузки</string>
+    <string name="easter_egg_dvd_mode">Взболтать, но не смешивать</string>
+    <string name="settings_dvd_mode_title">Режим отскока DVD</string>
+    <string name="settings_dvd_mode_subtitle">По умолчанию показывать прыгающую иконку при загрузках</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1361,4 +1361,7 @@
     <string name="workshop_processing">Обробка модів…</string>
     <string name="workshop_failed_count">Не вдалося оновити %1$d мод(ів) Майстерні</string>
     <string name="workshop_download_failed">Помилка завантаження</string>
+    <string name="easter_egg_dvd_mode">Збовтати, але не змішувати</string>
+    <string name="settings_dvd_mode_title">Режим відскоку DVD</string>
+    <string name="settings_dvd_mode_subtitle">За замовчуванням показувати стрибаючу іконку під час завантажень</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1355,4 +1355,7 @@
     <string name="workshop_processing">正在处理模组…</string>
     <string name="workshop_failed_count">%1$d 个创意工坊模组更新失败</string>
     <string name="workshop_download_failed">下载失败</string>
+    <string name="easter_egg_dvd_mode">摇匀，不要搅拌</string>
+    <string name="settings_dvd_mode_title">DVD 弹跳模式</string>
+    <string name="settings_dvd_mode_subtitle">下载时默认显示弹跳图标</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1358,4 +1358,7 @@
     <string name="workshop_processing">正在處理模組…</string>
     <string name="workshop_failed_count">%1$d 個創意工坊模組更新失敗</string>
     <string name="workshop_download_failed">下載失敗</string>
+    <string name="easter_egg_dvd_mode">搖勻，不要攪拌</string>
+    <string name="settings_dvd_mode_title">DVD 彈跳模式</string>
+    <string name="settings_dvd_mode_subtitle">下載時預設顯示彈跳圖示</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -881,6 +881,9 @@
 
     <!-- Settings: Interface Group -->
     <string name="settings_interface_title">Interface</string>
+    <string name="easter_egg_dvd_mode">Shaken, Not Stirred</string>
+    <string name="settings_dvd_mode_title">DVD bounce mode</string>
+    <string name="settings_dvd_mode_subtitle">Show bouncing icon by default during downloads</string>
     <string name="settings_interface_external_links_title">Open web links externally</string>
     <string name="settings_interface_external_links_subtitle">Links open with your main web browser</string>
     <string name="settings_interface_hide_statusbar_title">Hide status bar when not in game</string>


### PR DESCRIPTION
## Description
Adds a preference for using "DVD bounce mode" by default, but hiding it behind an easter egg for fun. On the download ambient screen, shaking the device during idle download triggers "DVD bounce mode" (added by @Producdevity). Now, that also triggers a "Shaken, Not Stirred" achievement notification (first-time only) and unlocks a hidden "DVD bounce mode" toggle in Interface settings.

- First shake shows achievement with app icon, sets `dvdModeUnlocked` pref
- Unlocked toggle appears in Settings > Interface to make bounce mode the default
- When enabled, idle downloads auto-enter DVD bounce mode after the existing idle timeout
- Achievement name localized across all 14 locales (Bond reference)

## Recording

https://github.com/user-attachments/assets/8691be22-7d74-408b-8f65-43ffff1a552c

## Test plan
- [ ] Start a download, wait for idle, shake device → achievement shows with app icon
- [ ] Shake again → no achievement (first-time only), toggles DVD/normal mode
- [ ] Settings > Interface → "DVD bounce mode" toggle visible after unlock
- [ ] Enable toggle, start new download → bounce mode activates after idle timeout
- [ ] Disable toggle → normal ambient download screen resumes
- [ ] Verify fade-in shows normal progress text (no black screen)

## Checklist
- [x] If I have access to \`#code-changes\`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in \`CONTRIBUTING.md\`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hidden “DVD bounce mode” easter egg to the ambient download screen. Shaking the device while idle toggles bounce, shows a one-time “Shaken, Not Stirred” achievement, and unlocks a Settings toggle to make bounce mode the default.

- **New Features**
  - First shake during idle toggles bounce; shows the achievement and unlocks the setting.
  - Achievement uses the app icon; text localized across 14 locales.
  - New prefs `dvdModeUnlocked` and `dvdModeDefault`; toggle appears in Settings > Interface after unlock.
  - When `dvdModeDefault` is on, idle downloads auto-enter bounce mode after the existing timeout.

<sup>Written for commit 3ad47fe9fbc057d3469fd4f1399ed113ba2539bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a hidden DVD Mode easter egg that unlocks via shake gesture
  * Once unlocked, a new toggle appears in settings to enable DVD Mode by default
  * When active, displays an animated bouncing icon during downloads
  * Full localization support added across 14+ languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->