### PR TITLE
feat: Parallelize Steam cloud save downloads

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -1,6 +1,8 @@
 package app.gamenative.service
 
 import androidx.room.withTransaction
+import app.gamenative.PrefManager
+import app.gamenative.R
 import app.gamenative.data.PostSyncInfo
 import app.gamenative.data.SaveFilePattern
 import app.gamenative.data.SteamApp
@@ -14,6 +16,7 @@ import app.gamenative.service.SteamService.Companion.FileChanges
 import app.gamenative.service.SteamService.Companion.getAppDirPath
 import app.gamenative.utils.CURRENT_UFS_PARSE_VERSION
 import app.gamenative.utils.FileUtils
+import app.gamenative.utils.Net
 import app.gamenative.utils.SteamUtils
 import `in`.dragonbra.javasteam.enums.EResult
 import `in`.dragonbra.javasteam.steam.handlers.steamcloud.AppFileChangeList
@@ -37,7 +40,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.future.await
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withTimeout
 import okhttp3.Headers
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -47,6 +54,8 @@ import timber.log.Timber
 import java.io.OutputStream
 import java.net.SocketTimeoutException
 import java.nio.file.attribute.FileTime
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * [Steam Auto Cloud](https://partner.steamgames.com/doc/features/cloud#steam_auto-cloud)
@@ -74,8 +83,8 @@ object SteamAutoCloud {
     private inline fun InputStream.copyTo(
         out: OutputStream,
         bufferSize: Int = 8 * 1024,
-        progress: (Long) -> Unit,
-    ) {
+        progress: (chunkBytes: Long, totalBytes: Long) -> Unit,
+    ): Long {
         val buf = ByteArray(bufferSize)
         var bytesRead: Int
         var total = 0L
@@ -83,8 +92,9 @@ object SteamAutoCloud {
             if (bytesRead == 0) continue
             out.write(buf, 0, bytesRead)
             total += bytesRead
-            progress(total)
+            progress(bytesRead.toLong(), total)
         }
+        return total
     }
 
     fun syncUserFiles(
@@ -372,33 +382,63 @@ object SteamAutoCloud {
 
         val downloadFiles: (AppFileChangeList, CoroutineScope) -> Deferred<UserFilesDownloadResult> = { fileList, parentScope ->
             parentScope.async {
-                var filesDownloaded = 0
-                var bytesDownloaded = 0L
+                val filesDownloaded = AtomicInteger(0)
+                val bytesDownloaded = AtomicLong(0L)
                 val totalFiles = fileList.files.size
-
-                fileList.files.forEach { file ->
-                    val result = downloadSingleFile(
-                        appInfo = appInfo,
-                        steamCloud = steamCloud,
-                        steamInstance = steamInstance,
-                        file = file,
-                        fileList = fileList,
-                        getFilePrefixPath = getFilePrefixPath,
-                        getFullFilePath = getFullFilePath,
-                        buildUrl = buildUrl,
-                        onProgress = onProgress,
+                val parallelism = PrefManager.downloadSpeed.coerceAtLeast(1)
+                // A new client (and its Dispatcher thread pool) is created intentionally per sync,
+                // since cloud saves are downloaded at most once per game launch.
+                val downloadHttpClient = Net.httpForParallelDownloads(parallelism)
+                val semaphore = Semaphore(parallelism)
+                val completedFiles = AtomicInteger(0)
+                val totalRawBytes = fileList.files.sumOf { it.rawFileSize.toLong() }
+                // downloadedRawBytes tracks bytes as they stream in (per-chunk) for live progress.
+                // bytesDownloaded accumulates rawFileSize per completed file for final accounting.
+                val downloadedRawBytes = AtomicLong(0L)
+                val lastReportedPercent = AtomicInteger(-1)
+                val progressMessage: (Int) -> String = { finishedFiles ->
+                    steamInstance.getString(
+                        R.string.steam_cloud_sync_downloading_save_files,
+                        finishedFiles,
+                        totalFiles,
                     )
-                    if (result != null) {
-                        filesDownloaded += result.filesDownloaded
-                        bytesDownloaded += result.bytesDownloaded
-                    }
+                }
+
+                coroutineScope {
+                    fileList.files.map { file ->
+                        async {
+                            semaphore.withPermit {
+                                val result = downloadSingleFile(
+                                    appInfo = appInfo,
+                                    steamCloud = steamCloud,
+                                    file = file,
+                                    fileList = fileList,
+                                    getFilePrefixPath = getFilePrefixPath,
+                                    getFullFilePath = getFullFilePath,
+                                    buildUrl = buildUrl,
+                                    httpClient = downloadHttpClient,
+                                    totalRawBytes = totalRawBytes,
+                                    downloadedRawBytes = downloadedRawBytes,
+                                    lastReportedPercent = lastReportedPercent,
+                                    completedFiles = completedFiles,
+                                    totalFiles = totalFiles,
+                                    progressMessage = progressMessage,
+                                    onProgress = onProgress,
+                                )
+                                if (result != null) {
+                                    filesDownloaded.addAndGet(result.filesDownloaded)
+                                    bytesDownloaded.addAndGet(result.bytesDownloaded)
+                                }
+                            }
+                        }
+                    }.awaitAll()
                 }
 
                 if (totalFiles > 0) {
                     onProgress?.invoke("Download complete", 1.0f)
                 }
 
-                UserFilesDownloadResult(filesDownloaded, bytesDownloaded)
+                UserFilesDownloadResult(filesDownloaded.get(), bytesDownloaded.get())
             }
         }
 
@@ -926,13 +966,19 @@ object SteamAutoCloud {
     private suspend fun downloadSingleFile(
         appInfo: SteamApp,
         steamCloud: SteamCloud,
-        steamInstance: SteamService,
         file: AppFileInfo,
         fileList: AppFileChangeList,
         getFilePrefixPath: (AppFileInfo, AppFileChangeList) -> String,
         getFullFilePath: (AppFileInfo, AppFileChangeList) -> Path,
         buildUrl: (Boolean, String, String) -> String,
-        onProgress: ((message: String, progress: Float) -> Unit)?,
+        httpClient: okhttp3.OkHttpClient,
+        totalRawBytes: Long,
+        downloadedRawBytes: AtomicLong,
+        lastReportedPercent: AtomicInteger,
+        completedFiles: AtomicInteger,
+        totalFiles: Int,
+        progressMessage: (Int) -> String,
+        onProgress: ((message: String, progress: Float) -> Unit)?, // invoked from IO thread
     ): UserFilesDownloadResult? {
         val prefixedPath = getFilePrefixPath(file, fileList)
         val actualFilePath = getFullFilePath(file, fileList)
@@ -946,7 +992,6 @@ object SteamAutoCloud {
             return null
         }
 
-        onProgress?.invoke("Downloading ${file.filename}", -1f)
         val httpUrl = with(fileDownloadInfo) {
             buildUrl(useHttps, urlHost, urlPath)
         }
@@ -965,10 +1010,12 @@ object SteamAutoCloud {
             .headers(headers)
             .build()
 
-        val httpClient = steamInstance.steamClient!!.configuration.httpClient
-
         val response = withTimeout(SteamService.requestTimeout) {
             httpClient.newCall(request).execute()
+        }
+
+        if (response == null) {
+            return null
         }
 
         if (!response.isSuccessful) {
@@ -979,21 +1026,26 @@ object SteamAutoCloud {
 
         try {
             val totalFileSize = fileDownloadInfo.rawFileSize.toLong()
-            var totalBytesRead = 0L
-            var lastReportedProgress = -1f
-            val progressThreshold = 0.01f // Update every 1%
 
             val copyToFile: (InputStream) -> Unit = { input ->
                 Files.createDirectories(actualFilePath.parent)
 
                 FileOutputStream(actualFilePath.toString()).use { fs ->
-                    input.copyTo(fs, 8 * 1024) { bytesRead ->
-                        totalBytesRead = bytesRead
-                        if (totalFileSize > 0) {
-                            val currentProgress = (totalBytesRead.toFloat() / totalFileSize).coerceIn(0f, 1f)
-                            if (currentProgress - lastReportedProgress >= progressThreshold || currentProgress >= 1f) {
-                                onProgress?.invoke("Downloading ${file.filename}", currentProgress)
-                                lastReportedProgress = currentProgress
+                    val totalBytesRead = input.copyTo(fs, 8 * 1024) { chunkBytes, _ ->
+                        if (totalRawBytes > 0L) {
+                            val currentPercent = (
+                                downloadedRawBytes.addAndGet(chunkBytes) * 100 / totalRawBytes
+                                ).toInt().coerceIn(0, 100)
+                            while (true) {
+                                val previousPercent = lastReportedPercent.get()
+                                if (currentPercent <= previousPercent) break
+                                if (lastReportedPercent.compareAndSet(previousPercent, currentPercent)) {
+                                    onProgress?.invoke(
+                                        progressMessage(completedFiles.get()),
+                                        currentPercent / 100f,
+                                    )
+                                    break
+                                }
                             }
                         }
                     }
@@ -1040,11 +1092,21 @@ object SteamAutoCloud {
                 }
             }
 
-            return UserFilesDownloadResult(1, fileDownloadInfo.fileSize.toLong())
+            val finishedFiles = completedFiles.incrementAndGet()
+            val finalProgress = if (totalRawBytes > 0L) {
+                (downloadedRawBytes.get().toFloat() / totalRawBytes).coerceIn(0f, 1f)
+            } else {
+                finishedFiles.toFloat() / totalFiles
+            }
+            onProgress?.invoke(progressMessage(finishedFiles), finalProgress)
+
+            return UserFilesDownloadResult(1, fileDownloadInfo.rawFileSize.toLong())
         } catch (e: FileSystemException) {
             Timber.w("Could not download $actualFilePath: %s", e.message)
             return null
         } catch (e: SocketTimeoutException) {
+            // Distinct from the outer SocketTimeoutException catch above: that one covers the
+            // connection/response phase; this one covers a timeout during the streaming read.
             Timber.w("Could not download $actualFilePath: %s", e.message)
             return null
         } finally {

--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -376,121 +376,21 @@ object SteamAutoCloud {
                 var bytesDownloaded = 0L
                 val totalFiles = fileList.files.size
 
-                fileList.files.forEachIndexed { index, file ->
-                    val prefixedPath = getFilePrefixPath(file, fileList)
-                    val actualFilePath = getFullFilePath(file, fileList)
-
-                    Timber.i("$prefixedPath -> $actualFilePath")
-
-                    val fileDownloadInfo = steamCloud.clientFileDownload(appInfo.id, prefixedPath).await()
-
-                    if (fileDownloadInfo.urlHost.isNotEmpty()) {
-                        onProgress?.invoke("Downloading ${file.filename}", -1f)
-                        val httpUrl = with(fileDownloadInfo) {
-                            buildUrl(useHttps, urlHost, urlPath)
-                        }
-
-                        Timber.i("Downloading $httpUrl")
-
-                        val headers = Headers.headersOf(
-                            *fileDownloadInfo.requestHeaders
-                                .map { listOf(it.name, it.value) }
-                                .flatten()
-                                .toTypedArray(),
-                        )
-
-                        val request = Request.Builder()
-                            .url(httpUrl)
-                            .headers(headers)
-                            .build()
-
-                        val httpClient = steamInstance.steamClient!!.configuration.httpClient
-
-                        val response = withTimeout(SteamService.requestTimeout) {
-                            httpClient.newCall(request).execute()
-                        }
-
-                        if (!response.isSuccessful) {
-                            Timber.w("File download of $prefixedPath was unsuccessful")
-                            response.close()
-                            return@forEachIndexed
-                        }
-
-                        try {
-                            val totalFileSize = fileDownloadInfo.rawFileSize.toLong()
-                            var totalBytesRead = 0L
-                            var lastReportedProgress = -1f
-                            val progressThreshold = 0.01f // Update every 1%
-
-                            val copyToFile: (InputStream) -> Unit = { input ->
-                                Files.createDirectories(actualFilePath.parent)
-
-                                FileOutputStream(actualFilePath.toString()).use { fs ->
-                                    input.copyTo(fs, 8 * 1024) { bytesRead ->
-                                        totalBytesRead = bytesRead
-                                        if (totalFileSize > 0) {
-                                            val currentProgress = (totalBytesRead.toFloat() / totalFileSize).coerceIn(0f, 1f)
-                                            if (currentProgress - lastReportedProgress >= progressThreshold || currentProgress >= 1f) {
-                                                onProgress?.invoke("Downloading ${file.filename}", currentProgress)
-                                                lastReportedProgress = currentProgress
-                                            }
-                                        }
-                                    }
-
-                                    // Preserve file timestamp from steamcloud, could fix game save loading, tested Skyrim
-                                    try {
-                                        // Ensure your fileDownloadInfo actually contains a timestamp (Long)
-                                        fileDownloadInfo.timestamp.let { timestamp ->
-                                            val fileTime = FileTime.fromMillis(timestamp.time)
-                                            Files.setLastModifiedTime(actualFilePath, fileTime)
-                                        }
-                                    } catch (e: Exception) {
-                                        Timber.w("Failed to set lastModified for $actualFilePath: ${e.message}")
-                                    }
-
-                                    if (totalBytesRead != totalFileSize) {
-                                        Timber.w("Bytes read from stream of $prefixedPath does not match expected size")
-                                    }
-                                }
-                            }
-
-                            withTimeout(SteamService.responseTimeout) {
-                                if (fileDownloadInfo.fileSize != fileDownloadInfo.rawFileSize) {
-                                    response.body?.byteStream()?.use { inputStream ->
-                                        ZipInputStream(inputStream).use { zipInput ->
-                                            val entry = zipInput.nextEntry
-
-                                            if (entry == null) {
-                                                Timber.w("Downloaded user file $prefixedPath has no zip entries")
-                                                return@withTimeout
-                                            }
-
-                                            copyToFile(zipInput)
-
-                                            if (zipInput.nextEntry != null) {
-                                                Timber.e("Downloaded user file $prefixedPath has more than one zip entry")
-                                            }
-                                        }
-                                    }
-                                } else {
-                                    response.body?.byteStream()?.use { inputStream ->
-                                        copyToFile(inputStream)
-                                    }
-                                }
-
-                                filesDownloaded++
-
-                                bytesDownloaded += fileDownloadInfo.fileSize
-                            }
-                        } catch (e: FileSystemException) {
-                            Timber.w("Could not download $actualFilePath: %s", e.message);
-                        } catch (e: SocketTimeoutException) {
-                            Timber.w("Could not download $actualFilePath: %s", e.message);
-                        }
-
-                        response.close()
-                    } else {
-                        Timber.w("URL host of $prefixedPath was empty")
+                fileList.files.forEach { file ->
+                    val result = downloadSingleFile(
+                        appInfo = appInfo,
+                        steamCloud = steamCloud,
+                        steamInstance = steamInstance,
+                        file = file,
+                        fileList = fileList,
+                        getFilePrefixPath = getFilePrefixPath,
+                        getFullFilePath = getFullFilePath,
+                        buildUrl = buildUrl,
+                        onProgress = onProgress,
+                    )
+                    if (result != null) {
+                        filesDownloaded += result.filesDownloaded
+                        bytesDownloaded += result.bytesDownloaded
                     }
                 }
 
@@ -1021,6 +921,135 @@ object SteamAutoCloud {
         )
 
         postSyncInfo
+    }
+
+    private suspend fun downloadSingleFile(
+        appInfo: SteamApp,
+        steamCloud: SteamCloud,
+        steamInstance: SteamService,
+        file: AppFileInfo,
+        fileList: AppFileChangeList,
+        getFilePrefixPath: (AppFileInfo, AppFileChangeList) -> String,
+        getFullFilePath: (AppFileInfo, AppFileChangeList) -> Path,
+        buildUrl: (Boolean, String, String) -> String,
+        onProgress: ((message: String, progress: Float) -> Unit)?,
+    ): UserFilesDownloadResult? {
+        val prefixedPath = getFilePrefixPath(file, fileList)
+        val actualFilePath = getFullFilePath(file, fileList)
+
+        Timber.i("$prefixedPath -> $actualFilePath")
+
+        val fileDownloadInfo = steamCloud.clientFileDownload(appInfo.id, prefixedPath).await()
+
+        if (fileDownloadInfo.urlHost.isEmpty()) {
+            Timber.w("URL host of $prefixedPath was empty")
+            return null
+        }
+
+        onProgress?.invoke("Downloading ${file.filename}", -1f)
+        val httpUrl = with(fileDownloadInfo) {
+            buildUrl(useHttps, urlHost, urlPath)
+        }
+
+        Timber.i("Downloading $httpUrl")
+
+        val headers = Headers.headersOf(
+            *fileDownloadInfo.requestHeaders
+                .map { listOf(it.name, it.value) }
+                .flatten()
+                .toTypedArray(),
+        )
+
+        val request = Request.Builder()
+            .url(httpUrl)
+            .headers(headers)
+            .build()
+
+        val httpClient = steamInstance.steamClient!!.configuration.httpClient
+
+        val response = withTimeout(SteamService.requestTimeout) {
+            httpClient.newCall(request).execute()
+        }
+
+        if (!response.isSuccessful) {
+            Timber.w("File download of $prefixedPath was unsuccessful")
+            response.close()
+            return null
+        }
+
+        try {
+            val totalFileSize = fileDownloadInfo.rawFileSize.toLong()
+            var totalBytesRead = 0L
+            var lastReportedProgress = -1f
+            val progressThreshold = 0.01f // Update every 1%
+
+            val copyToFile: (InputStream) -> Unit = { input ->
+                Files.createDirectories(actualFilePath.parent)
+
+                FileOutputStream(actualFilePath.toString()).use { fs ->
+                    input.copyTo(fs, 8 * 1024) { bytesRead ->
+                        totalBytesRead = bytesRead
+                        if (totalFileSize > 0) {
+                            val currentProgress = (totalBytesRead.toFloat() / totalFileSize).coerceIn(0f, 1f)
+                            if (currentProgress - lastReportedProgress >= progressThreshold || currentProgress >= 1f) {
+                                onProgress?.invoke("Downloading ${file.filename}", currentProgress)
+                                lastReportedProgress = currentProgress
+                            }
+                        }
+                    }
+
+                    // Preserve file timestamp from steamcloud, could fix game save loading, tested Skyrim
+                    try {
+                        // Ensure your fileDownloadInfo actually contains a timestamp (Long)
+                        fileDownloadInfo.timestamp.let { timestamp ->
+                            val fileTime = FileTime.fromMillis(timestamp.time)
+                            Files.setLastModifiedTime(actualFilePath, fileTime)
+                        }
+                    } catch (e: Exception) {
+                        Timber.w("Failed to set lastModified for $actualFilePath: ${e.message}")
+                    }
+
+                    if (totalBytesRead != totalFileSize) {
+                        Timber.w("Bytes read from stream of $prefixedPath does not match expected size")
+                    }
+                }
+            }
+
+            withTimeout(SteamService.responseTimeout) {
+                if (fileDownloadInfo.fileSize != fileDownloadInfo.rawFileSize) {
+                    response.body?.byteStream()?.use { inputStream ->
+                        ZipInputStream(inputStream).use { zipInput ->
+                            val entry = zipInput.nextEntry
+
+                            if (entry == null) {
+                                Timber.w("Downloaded user file $prefixedPath has no zip entries")
+                                return@withTimeout
+                            }
+
+                            copyToFile(zipInput)
+
+                            if (zipInput.nextEntry != null) {
+                                Timber.e("Downloaded user file $prefixedPath has more than one zip entry")
+                            }
+                        }
+                    }
+                } else {
+                    response.body?.byteStream()?.use { inputStream ->
+                        copyToFile(inputStream)
+                    }
+                }
+            }
+
+            return UserFilesDownloadResult(1, fileDownloadInfo.fileSize.toLong())
+        } catch (e: FileSystemException) {
+            Timber.w("Could not download $actualFilePath: %s", e.message)
+            return null
+        } catch (e: SocketTimeoutException) {
+            Timber.w("Could not download $actualFilePath: %s", e.message)
+            return null
+        } finally {
+            response.close()
+        }
     }
 
     private fun AppFileChangeList.printFileChangeList(appInfo: SteamApp) {

--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -28,6 +28,7 @@ import java.io.InputStream
 import java.io.RandomAccessFile
 import java.security.MessageDigest
 import java.nio.file.Files
+import java.nio.file.FileSystemException
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Date
@@ -406,34 +407,43 @@ object SteamAutoCloud {
                     )
                 }
 
-                coroutineScope {
-                    fileList.files.map { file ->
-                        async {
-                            semaphore.withPermit {
-                                val result = downloadSingleFile(
-                                    appInfo = appInfo,
-                                    steamCloud = steamCloud,
-                                    file = file,
-                                    fileList = fileList,
-                                    getFilePrefixPath = getFilePrefixPath,
-                                    getFullFilePath = getFullFilePath,
-                                    buildUrl = buildUrl,
-                                    httpClient = downloadHttpClient,
-                                    totalRawBytes = totalRawBytes,
-                                    downloadedRawBytes = downloadedRawBytes,
-                                    lastReportedPercent = lastReportedPercent,
-                                    completedFiles = completedFiles,
-                                    totalFiles = totalFiles,
-                                    progressMessage = progressMessage,
-                                    onProgress = onProgress,
-                                )
-                                if (result != null) {
-                                    filesDownloaded.addAndGet(result.filesDownloaded)
-                                    bytesDownloaded.addAndGet(result.bytesDownloaded)
+                try {
+                    coroutineScope {
+                        fileList.files.map { file ->
+                            async {
+                                semaphore.withPermit {
+                                    val result = downloadSingleFile(
+                                        appInfo = appInfo,
+                                        steamCloud = steamCloud,
+                                        file = file,
+                                        fileList = fileList,
+                                        getFilePrefixPath = getFilePrefixPath,
+                                        getFullFilePath = getFullFilePath,
+                                        buildUrl = buildUrl,
+                                        httpClient = downloadHttpClient,
+                                        totalRawBytes = totalRawBytes,
+                                        downloadedRawBytes = downloadedRawBytes,
+                                        lastReportedPercent = lastReportedPercent,
+                                        completedFiles = completedFiles,
+                                        totalFiles = totalFiles,
+                                        progressMessage = progressMessage,
+                                        onProgress = onProgress,
+                                    )
+                                    if (result != null) {
+                                        filesDownloaded.addAndGet(result.filesDownloaded)
+                                        bytesDownloaded.addAndGet(result.bytesDownloaded)
+                                    }
                                 }
                             }
-                        }
-                    }.awaitAll()
+                        }.awaitAll()
+                    }
+                } finally {
+                    runCatching {
+                        downloadHttpClient.dispatcher.executorService.shutdown()
+                    }
+                    runCatching {
+                        downloadHttpClient.connectionPool.evictAll()
+                    }
                 }
 
                 if (totalFiles > 0 && filesDownloaded.get() == totalFiles) {
@@ -987,7 +997,14 @@ object SteamAutoCloud {
 
         Timber.i("$prefixedPath -> $actualFilePath")
 
-        val fileDownloadInfo = steamCloud.clientFileDownload(appInfo.id, prefixedPath).await()
+        val fileDownloadInfo = try {
+            steamCloud.clientFileDownload(appInfo.id, prefixedPath).await()
+        } catch (e: java.util.concurrent.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to fetch download info for %s", prefixedPath)
+            return null
+        }
 
         if (fileDownloadInfo.urlHost.isEmpty()) {
             Timber.w("URL host of $prefixedPath was empty")
@@ -1108,7 +1125,6 @@ object SteamAutoCloud {
             }
 
             if (!downloaded) {
-                Files.deleteIfExists(actualFilePath)
                 return null
             }
 

--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -45,12 +45,14 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import okhttp3.Headers
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import timber.log.Timber
+import java.io.IOException
 import java.io.OutputStream
 import java.net.SocketTimeoutException
 import java.nio.file.attribute.FileTime
@@ -1010,8 +1012,16 @@ object SteamAutoCloud {
             .headers(headers)
             .build()
 
-        val response = withTimeout(SteamService.requestTimeout) {
-            httpClient.newCall(request).execute()
+        val response = try {
+            withTimeout(SteamService.requestTimeout) {
+                httpClient.newCall(request).execute()
+            }
+        } catch (e: SocketTimeoutException) {
+            Timber.w("Could not download $actualFilePath: %s", e.message)
+            null
+        } catch (e: IOException) {
+            Timber.w("Could not download $actualFilePath: %s", e.message)
+            null
         }
 
         if (response == null) {
@@ -1020,7 +1030,6 @@ object SteamAutoCloud {
 
         if (!response.isSuccessful) {
             Timber.w("File download of $prefixedPath was unsuccessful")
-            response.close()
             return null
         }
 
@@ -1052,7 +1061,6 @@ object SteamAutoCloud {
 
                     // Preserve file timestamp from steamcloud, could fix game save loading, tested Skyrim
                     try {
-                        // Ensure your fileDownloadInfo actually contains a timestamp (Long)
                         fileDownloadInfo.timestamp.let { timestamp ->
                             val fileTime = FileTime.fromMillis(timestamp.time)
                             Files.setLastModifiedTime(actualFilePath, fileTime)
@@ -1067,7 +1075,7 @@ object SteamAutoCloud {
                 }
             }
 
-            withTimeout(SteamService.responseTimeout) {
+            val downloaded = withTimeout(SteamService.responseTimeout) {
                 if (fileDownloadInfo.fileSize != fileDownloadInfo.rawFileSize) {
                     response.body?.byteStream()?.use { inputStream ->
                         ZipInputStream(inputStream).use { zipInput ->
@@ -1075,7 +1083,7 @@ object SteamAutoCloud {
 
                             if (entry == null) {
                                 Timber.w("Downloaded user file $prefixedPath has no zip entries")
-                                return@withTimeout
+                                return@withTimeout false
                             }
 
                             copyToFile(zipInput)
@@ -1084,12 +1092,17 @@ object SteamAutoCloud {
                                 Timber.e("Downloaded user file $prefixedPath has more than one zip entry")
                             }
                         }
-                    }
+                    } ?: return@withTimeout false
                 } else {
                     response.body?.byteStream()?.use { inputStream ->
                         copyToFile(inputStream)
-                    }
+                    } ?: return@withTimeout false
                 }
+                true
+            }
+
+            if (!downloaded) {
+                return null
             }
 
             val finishedFiles = completedFiles.incrementAndGet()
@@ -1107,6 +1120,9 @@ object SteamAutoCloud {
         } catch (e: SocketTimeoutException) {
             // Distinct from the outer SocketTimeoutException catch above: that one covers the
             // connection/response phase; this one covers a timeout during the streaming read.
+            Timber.w("Could not download $actualFilePath: %s", e.message)
+            return null
+        } catch (e: IOException) {
             Timber.w("Could not download $actualFilePath: %s", e.message)
             return null
         } finally {

--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -436,7 +436,7 @@ object SteamAutoCloud {
                     }.awaitAll()
                 }
 
-                if (totalFiles > 0) {
+                if (totalFiles > 0 && filesDownloaded.get() == totalFiles) {
                     onProgress?.invoke("Download complete", 1.0f)
                 }
 
@@ -1016,6 +1016,9 @@ object SteamAutoCloud {
             withTimeout(SteamService.requestTimeout) {
                 httpClient.newCall(request).execute()
             }
+        } catch (e: TimeoutCancellationException) {
+            Timber.w(e, "Timed out downloading %s", actualFilePath)
+            null
         } catch (e: SocketTimeoutException) {
             Timber.w("Could not download $actualFilePath: %s", e.message)
             null
@@ -1030,13 +1033,14 @@ object SteamAutoCloud {
 
         if (!response.isSuccessful) {
             Timber.w("File download of $prefixedPath was unsuccessful")
+            response.close()
             return null
         }
 
         try {
             val totalFileSize = fileDownloadInfo.rawFileSize.toLong()
 
-            val copyToFile: (InputStream) -> Unit = { input ->
+            val copyToFile: (InputStream) -> Boolean = { input ->
                 Files.createDirectories(actualFilePath.parent)
 
                 FileOutputStream(actualFilePath.toString()).use { fs ->
@@ -1071,7 +1075,9 @@ object SteamAutoCloud {
 
                     if (totalBytesRead != totalFileSize) {
                         Timber.w("Bytes read from stream of $prefixedPath does not match expected size")
+                        return@use false
                     }
+                    true
                 }
             }
 
@@ -1086,7 +1092,7 @@ object SteamAutoCloud {
                                 return@withTimeout false
                             }
 
-                            copyToFile(zipInput)
+                            if (!copyToFile(zipInput)) return@withTimeout false
 
                             if (zipInput.nextEntry != null) {
                                 Timber.e("Downloaded user file $prefixedPath has more than one zip entry")
@@ -1095,13 +1101,14 @@ object SteamAutoCloud {
                     } ?: return@withTimeout false
                 } else {
                     response.body?.byteStream()?.use { inputStream ->
-                        copyToFile(inputStream)
+                        if (!copyToFile(inputStream)) return@withTimeout false
                     } ?: return@withTimeout false
                 }
                 true
             }
 
             if (!downloaded) {
+                Files.deleteIfExists(actualFilePath)
                 return null
             }
 
@@ -1114,6 +1121,9 @@ object SteamAutoCloud {
             onProgress?.invoke(progressMessage(finishedFiles), finalProgress)
 
             return UserFilesDownloadResult(1, fileDownloadInfo.rawFileSize.toLong())
+        } catch (e: TimeoutCancellationException) {
+            Timber.w(e, "Timed out downloading %s", actualFilePath)
+            return null
         } catch (e: FileSystemException) {
             Timber.w("Could not download $actualFilePath: %s", e.message)
             return null

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -36,6 +36,7 @@
     <string name="delete_prompt_title">Slet app</string>
     <string name="cancel_download_prompt_title">Annullér download</string>
     <string name="acknowledge">OK</string>
+    <string name="steam_cloud_sync_downloading_save_files">Downloader gemfiler %1$d/%2$d</string>
     <string name="yes">Ja</string>
     <string name="no">Nej</string>
     <string name="not_enough_space">Ikke nok plads</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -26,6 +26,7 @@
     <string name="base_app_reset_container_confirm">Zurücksetzen</string>
     <string name="steam_verify_files_title">Dateien überprüfen</string>
     <string name="steam_verify_files_message">Stelle bitte sicher, dass deine Spielstände vorher in die Cloud hochgeladen oder gesichert wurden, da sie sonst überschrieben werden können.</string>
+    <string name="steam_cloud_sync_downloading_save_files">Speicherstände werden heruntergeladen %1$d/%2$d</string>
     <string name="steam_update_title">Aktualisieren</string>
     <string name="steam_update_message">Stelle sicher, dass deine Speicherstände vor dem Aktualisieren in der Cloud gesichert oder gebackupt sind, um ein Überschreiben zu verhindern.</string>
     <string name="steam_not_logged_in">Du musst bei Steam angemeldet sein, um diese Funktion zu nutzen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -27,6 +27,7 @@
     <string name="base_app_reset_container_confirm">Restablecer</string>
     <string name="steam_verify_files_title">Verificar archivos</string>
     <string name="steam_verify_files_message">Asegúrate de que tus archivos de guardado están en la nube o respaldados antes de verificar, ya que podrían sobrescribirse.</string>
+    <string name="steam_cloud_sync_downloading_save_files">Descargando archivos de guardado %1$d/%2$d</string>
     <string name="steam_update_title">Actualizar</string>
     <string name="steam_update_message">Asegúrate de que tus archivos de guardado están en la nube o respaldados antes de actualizar, ya que podrían sobrescribirse.</string>
     <string name="steam_not_logged_in">Debes iniciar sesión en Steam para usar esta función.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -27,6 +27,7 @@
     <string name="base_app_reset_container_confirm">Réinitialiser</string>
     <string name="steam_verify_files_title">Vérifier les fichiers</string>
     <string name="steam_verify_files_message">Veuillez vous assurer que vos sauvegardes sont téléchargées dans le cloud ou sauvegardées avant de vérifier, car elles peuvent être écrasées.</string>
+    <string name="steam_cloud_sync_downloading_save_files">Téléchargement des fichiers de sauvegarde %1$d/%2$d</string>
     <string name="steam_update_title">Mettre à jour</string>
     <string name="steam_update_message">Veuillez vous assurer que vos sauvegardes sont téléchargées dans le cloud ou sauvegardées avant de mettre à jour, car elles peuvent être écrasées.</string>
     <string name="steam_not_logged_in">Vous devez être connecté à Steam pour utiliser cette fonctionnalité</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -27,6 +27,7 @@
     <string name="base_app_reset_container_confirm">Reimposta</string>
     <string name="steam_verify_files_title">Verifica File</string>
     <string name="steam_verify_files_message">Assicurati che i tuoi salvataggi siano caricati sul cloud o sottoposti a backup prima della verifica, altrimenti potrebbero essere sovrascritti.</string>
+    <string name="steam_cloud_sync_downloading_save_files">Download dei file di salvataggio %1$d/%2$d</string>
     <string name="steam_update_title">Aggiorna</string>
     <string name="steam_update_message">Assicurati che i tuoi salvataggi siano caricati sul cloud o sottoposti a backup prima dell\'aggiornamento, altrimenti potrebbero essere sovrascritti.</string>
     <string name="steam_not_logged_in">Devi aver effettuato l\'accesso a Steam per utilizzare questa funzione</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -27,6 +27,7 @@
     <string name="base_app_reset_container_confirm">초기화</string>
     <string name="steam_verify_files_title">파일 검증</string>
     <string name="steam_verify_files_message">검증하기 전에 저장 파일이 클라우드에 업로드되었거나 백업되었는지 확인하세요. 그렇지 않으면 덮어쓰기될 수 있습니다.</string>
+    <string name="steam_cloud_sync_downloading_save_files">저장 파일 다운로드 중 %1$d/%2$d</string>
     <string name="steam_update_title">업데이트</string>
     <string name="steam_update_message">업데이트하기 전에 저장 파일이 클라우드에 업로드되었거나 백업되었는지 확인하세요. 그렇지 않으면 덮어쓰기될 수 있습니다.</string>
     <string name="steam_not_logged_in">이 기능을 사용하려면 Steam에 로그인해야 합니다</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -27,6 +27,7 @@
     <string name="base_app_reset_container_confirm">Resetuj</string>
     <string name="steam_verify_files_title">Zweryfikuj pliki</string>
     <string name="steam_verify_files_message">Upewnij się, że Twoje zapisy są przesłane do chmury lub utworzono ich kopię zapasową przed weryfikacją, w przeciwnym razie mogą zostać nadpisane.</string>
+    <string name="steam_cloud_sync_downloading_save_files">Pobieranie plików zapisów %1$d/%2$d</string>
     <string name="steam_update_title">Aktualizuj</string>
     <string name="steam_update_message">Upewnij się, że Twoje zapisy są przesłane do chmury lub utworzono ich kopię zapasową przed aktualizacją, w przeciwnym razie mogą zostać nadpisane.</string>
     <string name="steam_not_logged_in">Musisz być zalogowany do Steam, aby użyć tej funkcji</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -32,6 +32,7 @@
     <string name="delete_prompt_title">Deletar App</string>
     <string name="cancel_download_prompt_title">Cancelar Download</string>
     <string name="acknowledge">OK</string>
+    <string name="steam_cloud_sync_downloading_save_files">Baixando arquivos de salvamento %1$d/%2$d</string>
     <string name="yes">Sim</string>
     <string name="no">Não</string>
     <string name="not_enough_space">Sem espaço suficiente</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -27,6 +27,7 @@
     <string name="base_app_reset_container_confirm">Resetează</string>
     <string name="steam_verify_files_title">Verificare fișiere</string>
     <string name="steam_verify_files_message">Asigură-te că salvările sunt încărcate în cloud sau copiate în altă parte înainte de verificare, deoarece pot fi suprascrise.</string>
+    <string name="steam_cloud_sync_downloading_save_files">Se descarcă fișierele de salvare %1$d/%2$d</string>
     <string name="steam_update_title">Actualizare</string>
     <string name="steam_update_message">Asigură-te că salvările sunt încărcate în cloud sau copiate în altă parte înainte de actualizare, deoarece pot fi suprascrise.</string>
     <string name="steam_not_logged_in">Trebuie să fii autentificat în Steam pentru a folosi această funcție</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -21,6 +21,7 @@
     <string name="abc_toolbar_collapse_description">Свернуть</string>
     <string name="about">О программе</string>
     <string name="acknowledge">ОК</string>
+    <string name="steam_cloud_sync_downloading_save_files">Загрузка файлов сохранения %1$d/%2$d</string>
     <string name="action_add_game">Добавить игру</string>
     <string name="action_details">Подробности</string>
     <string name="action_refresh">Обновить</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -27,6 +27,7 @@
     <string name="base_app_reset_container_confirm">Скинути</string>
     <string name="steam_verify_files_title">Перевірити файли</string>
     <string name="steam_verify_files_message">Будь ласка, переконайтеся, що ваші збереження завантажено у хмару або створено їхню резервну копію перед перевіркою, оскільки інакше вони можуть бути перезаписані.</string>
+    <string name="steam_cloud_sync_downloading_save_files">Завантаження файлів збережень %1$d/%2$d</string>
     <string name="steam_update_title">Оновити</string>
     <string name="steam_update_message">Будь ласка, переконайтеся, що ваші збереження завантажено у хмару або створено їхню резервну копію перед оновленням, оскільки інакше вони можуть бути перезаписані.</string>
     <string name="steam_not_logged_in">Ви повинні увійти в Steam, щоб використовувати цю функцію</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -27,6 +27,7 @@
     <string name="base_app_reset_container_confirm">重置</string>
     <string name="steam_verify_files_title">验证文件</string>
     <string name="steam_verify_files_message">验证前请确保存档已上传至云端或已备份，否则存档可能会被覆盖</string>
+    <string name="steam_cloud_sync_downloading_save_files">正在下载存档文件 %1$d/%2$d</string>
     <string name="steam_update_title">更新</string>
     <string name="steam_update_message">更新前请确保存档已上传至云端或已备份，否则存档可能会被覆盖</string>
     <string name="steam_storage_permission_required">需要存储权限</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -27,6 +27,7 @@
     <string name="base_app_reset_container_confirm">重置</string>
     <string name="steam_verify_files_title">驗證檔案</string>
     <string name="steam_verify_files_message">請確保您的存檔已上傳至雲端或已備份, 然後再進行驗證, 否則存檔可能會被覆蓋</string>
+    <string name="steam_cloud_sync_downloading_save_files">正在下載存檔檔案 %1$d/%2$d</string>
     <string name="steam_update_title">更新</string>
     <string name="steam_update_message">請確保您的存檔已上傳至雲端或已備份, 然後再進行驗證, 否則存檔可能會被覆蓋</string>
     <string name="steam_storage_permission_required">需要存儲權限</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="base_app_reset_container_confirm">Reset</string>
     <string name="steam_verify_files_title">Verify Files</string>
     <string name="steam_verify_files_message">Please ensure your saves are uploaded to the cloud or backed up before verifying, as they may be overwritten otherwise.</string>
+    <string name="steam_cloud_sync_downloading_save_files">Downloading save files %1$d/%2$d</string>
     <string name="steam_update_title">Update</string>
     <string name="steam_update_message">Please ensure your saves are uploaded to the cloud or backed up before updating, as they may be overwritten otherwise.</string>
     <string name="steam_not_logged_in">You must be logged into Steam to use this feature</string>

--- a/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
+++ b/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
@@ -15,6 +15,7 @@ import app.gamenative.enums.OS
 import app.gamenative.enums.PathType
 import app.gamenative.enums.ReleaseState
 import app.gamenative.enums.SaveLocation
+import app.gamenative.utils.Net
 import app.gamenative.service.DownloadService
 import app.gamenative.service.SteamService
 import com.winlator.container.Container
@@ -40,8 +41,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runBlockingTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -63,12 +65,19 @@ class SteamAutoCloudTest {
     private lateinit var db: PluviaDatabase
     private lateinit var mockSteamService: SteamService
     private lateinit var mockSteamCloud: SteamCloud
+    private lateinit var mockParallelHttpClient: OkHttpClient
     private val testAppId = "STEAM_123456"
     private val steamAppId = 123456
     private val clientId = 1L
 
     @Before
     fun setUp() {
+        mockkObject(Net)
+        mockParallelHttpClient = mockk(relaxed = true)
+        // Safe default: relaxed client returns null for newCall(), causing downloads to no-op.
+        // Tests that exercise the download path override this stub with a test-specific mock.
+        every { Net.httpForParallelDownloads(any()) } returns mockParallelHttpClient
+
         context = ApplicationProvider.getApplicationContext()
         tempDir = File.createTempFile("steam_autocloud_test_", null)
         tempDir.delete()
@@ -235,6 +244,8 @@ class SteamAutoCloudTest {
 
     @After
     fun tearDown() {
+        unmockkObject(Net)
+
         // Clean up ImageFs directory first (files created in wineprefix)
         // This is critical because ImageFs uses context.getFilesDir() which is inside Robolectric's temp directory
         try {
@@ -418,6 +429,7 @@ class SteamAutoCloudTest {
 
         // Mock HTTP client to return file content
         val mockHttpClient = mock<OkHttpClient>()
+        every { Net.httpForParallelDownloads(any()) } returns mockHttpClient
         val mockCall = mock<Call>()
         whenever(mockHttpClient.newCall(any())).thenReturn(mockCall)
 
@@ -956,54 +968,57 @@ class SteamAutoCloudTest {
                 val downloadInfo = mock<FileDownloadInfo>()
                 whenever(downloadInfo.urlHost).thenReturn("test.example.com")
                 whenever(downloadInfo.urlPath).thenReturn("/download/file$it")
+                whenever(downloadInfo.useHttps).thenReturn(true)
                 whenever(downloadInfo.requestHeaders).thenReturn(emptyList())
                 whenever(downloadInfo.fileSize).thenReturn(contents[it].size)
                 whenever(downloadInfo.rawFileSize).thenReturn(contents[it].size)
                 downloadInfo
             }
 
-        // Mock clientFileDownload to return appropriate download info based on filename in the path
-        var downloadCallCount = -1
+        val downloadInfoByFilename = (0..<count).associate { index ->
+            "%GameInstall%/save$index.dat" to mockDownloadFiles[index]
+        }
+
         every { mockSteamCloud.clientFileDownload(any(), any()) } answers {
-            ++downloadCallCount
-            CompletableFuture.completedFuture(mockDownloadFiles[downloadCallCount])
+            val filename = secondArg<String>()
+            CompletableFuture.completedFuture(
+                downloadInfoByFilename[filename] ?: error("Unexpected filename: $filename"),
+            )
         }
 
         every { mockSteamCloud.clientFileDownload(any(), any(), any(), any(), any()) } answers {
-            ++downloadCallCount
-            CompletableFuture.completedFuture(mockDownloadFiles[downloadCallCount])
+            val filename = secondArg<String>()
+            CompletableFuture.completedFuture(
+                downloadInfoByFilename[filename] ?: error("Unexpected filename: $filename"),
+            )
         }
 
         // Mock HTTP client to return file content
         val mockHttpClient = mock<OkHttpClient>()
-        val mockCall = mock<Call>()
-        whenever(mockHttpClient.newCall(any())).thenReturn(mockCall)
+        every { Net.httpForParallelDownloads(any()) } returns mockHttpClient
+        val callsByPath = (0..<count).associate { index ->
+            val call = mock<Call>()
+            whenever(call.execute()).thenReturn(
+                Response.Builder()
+                    .request(okhttp3.Request.Builder().url("https://test.example.com/download/file$index").build())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body(contents[index].toResponseBody(null))
+                    .build(),
+            )
+            "/download/file$index" to call
+        }
+        whenever(mockHttpClient.newCall(any())).thenAnswer { invocation ->
+            val request = invocation.getArgument<okhttp3.Request>(0)
+            callsByPath[request.url.encodedPath] ?: error("Unexpected URL: ${request.url}")
+        }
 
         // Set up HTTP client on the existing mock steam client
         val mockSteamClient = mockSteamService.steamClient!!
         val mockConfig = mock<SteamConfiguration>()
         whenever(mockSteamClient.configuration).thenReturn(mockConfig)
         whenever(mockConfig.httpClient).thenReturn(mockHttpClient)
-
-        val responseBodies = (0..<count).toList()
-            .map { contents[it].toResponseBody(null) }
-        val responses = (0..<count).toList()
-            .map {
-                Response.Builder()
-                    .request(okhttp3.Request.Builder().url("https://test.example.com/download/file$it").build())
-                    .protocol(Protocol.HTTP_1_1)
-                    .code(200)
-                    .message("OK")
-                    .body(responseBodies[it])
-                    .build()
-            }
-
-        // Return responses in order
-        var callCount = 0
-        whenever(mockCall.execute()).thenAnswer {
-            callCount++
-            responses[callCount - 1]
-        }
 
         // Create prefixToPath function
         val prefixToPath: (String) -> String = { prefix ->
@@ -1577,6 +1592,7 @@ class SteamAutoCloudTest {
             CompletableFuture.completedFuture(mockDownloadInfo)
 
         val mockHttpClient = mock<OkHttpClient>()
+        every { Net.httpForParallelDownloads(any()) } returns mockHttpClient
         val mockCall = mock<Call>()
         whenever(mockHttpClient.newCall(any())).thenReturn(mockCall)
         val response = Response.Builder()
@@ -1642,10 +1658,11 @@ class SteamAutoCloudTest {
         )
         val contents = listOf(file1Content, file2Content, file3Content)
 
+        val pathPrefix = "%WinMyDocuments%/My Games/TestGame/Steam/76561198025127569/SaveGames"
         val cloudFileChangeList = makeCloudFileChangeList(
             cloudChangeNumber = 5,
             files = cloudFiles,
-            pathPrefixes = listOf("%WinMyDocuments%/My Games/TestGame/Steam/76561198025127569/SaveGames"),
+            pathPrefixes = listOf(pathPrefix),
         )
         every { mockSteamCloud.getAppFileListChange(any(), any(), any()) } returns
             CompletableFuture.completedFuture(cloudFileChangeList)
@@ -1662,27 +1679,39 @@ class SteamAutoCloudTest {
             }
         }
 
-        // must match all 5 JVM params (Kotlin default-param bridge)
-        var dlCount = 0
+        val downloadInfoByPath = mapOf(
+            "$pathPrefix/${cloudFiles[0].filename}" to downloadInfos[0],
+            "$pathPrefix/${cloudFiles[1].filename}" to downloadInfos[1],
+            "$pathPrefix/${cloudFiles[2].filename}" to downloadInfos[2],
+        )
+
         every { mockSteamCloud.clientFileDownload(any(), any(), any(), any(), any()) } answers {
-            CompletableFuture.completedFuture(downloadInfos[dlCount++])
+            val path = secondArg<String>()
+            CompletableFuture.completedFuture(
+                downloadInfoByPath[path] ?: error("Unexpected path: $path"),
+            )
         }
 
         // mock HTTP responses
         val mockHttpClient = mock<OkHttpClient>()
-        val mockCall = mock<Call>()
-        whenever(mockHttpClient.newCall(any())).thenReturn(mockCall)
-
-        var httpCount = 0
-        whenever(mockCall.execute()).thenAnswer {
-            val content = contents[httpCount++]
-            Response.Builder()
-                .request(okhttp3.Request.Builder().url("https://test.example.com/download/file$httpCount").build())
-                .protocol(Protocol.HTTP_1_1)
-                .code(200)
-                .message("OK")
-                .body(content.toResponseBody())
-                .build()
+        every { Net.httpForParallelDownloads(any()) } returns mockHttpClient
+        val callsByPath = contents.mapIndexed { index, content ->
+            val path = "/download/file${index + 1}"
+            val call = mock<Call>()
+            whenever(call.execute()).thenReturn(
+                Response.Builder()
+                    .request(okhttp3.Request.Builder().url("https://test.example.com$path").build())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body(content.toResponseBody())
+                    .build(),
+            )
+            path to call
+        }.toMap()
+        whenever(mockHttpClient.newCall(any())).thenAnswer { invocation ->
+            val request = invocation.getArgument<okhttp3.Request>(0)
+            callsByPath[request.url.encodedPath] ?: error("Unexpected URL: ${request.url}")
         }
 
         val mockSteamClient = mockSteamService.steamClient!!
@@ -1825,6 +1854,7 @@ class SteamAutoCloudTest {
             CompletableFuture.completedFuture(mockDownloadInfo)
 
         val mockHttpClient = mock<OkHttpClient>()
+        every { Net.httpForParallelDownloads(any()) } returns mockHttpClient
         val mockCall = mock<Call>()
         whenever(mockHttpClient.newCall(any())).thenReturn(mockCall)
         val response = Response.Builder()
@@ -2070,6 +2100,7 @@ class SteamAutoCloudTest {
             CompletableFuture.completedFuture(mockDownloadInfo)
 
         val mockHttpClient = mock<OkHttpClient>()
+        every { Net.httpForParallelDownloads(any()) } returns mockHttpClient
         val mockCall = mock<Call>()
         whenever(mockHttpClient.newCall(any())).thenReturn(mockCall)
         val response = Response.Builder()
@@ -2138,6 +2169,7 @@ class SteamAutoCloudTest {
             CompletableFuture.completedFuture(mockDownloadInfo)
 
         val mockHttpClient = mock<OkHttpClient>()
+        every { Net.httpForParallelDownloads(any()) } returns mockHttpClient
         val mockCall = mock<Call>()
         whenever(mockHttpClient.newCall(any())).thenReturn(mockCall)
         val response = Response.Builder()
@@ -2249,4 +2281,3 @@ class SteamAutoCloudTest {
         )
     }
 }
-

--- a/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
+++ b/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
@@ -52,6 +52,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import java.io.File
+import java.io.IOException
 import java.lang.reflect.Field
 import java.util.EnumSet
 import java.util.concurrent.CompletableFuture
@@ -2199,6 +2200,87 @@ class SteamAutoCloudTest {
         assertNotNull(result)
         assertEquals(SyncResult.Success, result!!.syncResult)
         assertTrue("Should have downloaded files", result.filesDownloaded > 0)
+    }
+
+    @Test
+    fun synced_cloudAdvanced_metadataFailure_doesNotCancelSiblingDownloads() = runBlocking {
+        val localCn = 5L
+        cacheCurrentLocalFiles(localCn)
+
+        val successfulCloudContent = "fresh autosave from cloud".toByteArray()
+        val successfulFile = mock<AppFileInfo>()
+        whenever(successfulFile.filename).thenReturn("SaveGames/AutoSaveData.sav")
+        whenever(successfulFile.shaFile).thenReturn(sha1(successfulCloudContent))
+        whenever(successfulFile.pathPrefixIndex).thenReturn(0)
+        whenever(successfulFile.timestamp).thenReturn(Date())
+        whenever(successfulFile.rawFileSize).thenReturn(successfulCloudContent.size)
+
+        val metadataFailureFile = mock<AppFileInfo>()
+        whenever(metadataFailureFile.filename).thenReturn("SaveGames/SaveData_0.sav")
+        whenever(metadataFailureFile.shaFile).thenReturn(sha1("savedata0 content".toByteArray()))
+        whenever(metadataFailureFile.pathPrefixIndex).thenReturn(0)
+        whenever(metadataFailureFile.timestamp).thenReturn(Date())
+        whenever(metadataFailureFile.rawFileSize).thenReturn("savedata0 content".toByteArray().size)
+
+        val pathPrefix = "%WinMyDocuments%/My Games/TestGame/Steam/76561198025127569"
+        val cloudFileChangeList = makeCloudFileChangeList(
+            cloudChangeNumber = localCn + 1,
+            files = listOf(successfulFile, metadataFailureFile),
+            pathPrefixes = listOf(pathPrefix),
+        )
+        every { mockSteamCloud.getAppFileListChange(any(), any(), any()) } returns
+            CompletableFuture.completedFuture(cloudFileChangeList)
+
+        val successfulDownloadInfo = mock<FileDownloadInfo>()
+        whenever(successfulDownloadInfo.urlHost).thenReturn("test.example.com")
+        whenever(successfulDownloadInfo.urlPath).thenReturn("/download/autosave")
+        whenever(successfulDownloadInfo.useHttps).thenReturn(true)
+        whenever(successfulDownloadInfo.requestHeaders).thenReturn(emptyList())
+        whenever(successfulDownloadInfo.fileSize).thenReturn(successfulCloudContent.size)
+        whenever(successfulDownloadInfo.rawFileSize).thenReturn(successfulCloudContent.size)
+
+        every { mockSteamCloud.clientFileDownload(any(), any(), any(), any(), any()) } answers {
+            when (val path = secondArg<String>()) {
+                "$pathPrefix/SaveGames/AutoSaveData.sav" -> CompletableFuture.completedFuture(successfulDownloadInfo)
+                "$pathPrefix/SaveGames/SaveData_0.sav" -> CompletableFuture<FileDownloadInfo>().also {
+                    it.completeExceptionally(IOException("metadata lookup failed"))
+                }
+                else -> error("Unexpected path: $path")
+            }
+        }
+
+        val mockHttpClient = mock<OkHttpClient>()
+        every { Net.httpForParallelDownloads(any()) } returns mockHttpClient
+        val successfulCall = mock<Call>()
+        whenever(mockHttpClient.newCall(any())).thenReturn(successfulCall)
+        whenever(successfulCall.execute()).thenReturn(
+            Response.Builder()
+                .request(okhttp3.Request.Builder().url("https://test.example.com/download/autosave").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(successfulCloudContent.toResponseBody())
+                .build(),
+        )
+
+        val testApp = db.steamAppDao().findApp(steamAppId)!!
+        val result = SteamAutoCloud.syncUserFiles(
+            appInfo = testApp,
+            clientId = clientId,
+            steamInstance = mockSteamService,
+            steamCloud = mockSteamCloud,
+            preferredSave = SaveLocation.None,
+            prefixToPath = makePrefixToPath(),
+        ).await()
+
+        assertNotNull(result)
+        assertEquals(SyncResult.Success, result!!.syncResult)
+        assertEquals("Only the healthy file should count as downloaded", 1, result.filesDownloaded)
+        assertEquals(
+            "Successful sibling download should still update local file",
+            successfulCloudContent.contentToString(),
+            File(saveFilesDir, "AutoSaveData.sav").readBytes().contentToString(),
+        )
     }
 
     // ── Scenario 16: DB cache wiped by destructive migration, local == remote ──


### PR DESCRIPTION
## Description

Parallelizes Steam cloud save downloads and improves download progress reporting.

- **Parallel downloads**: Cloud save files are now downloaded concurrently rather than sequentially, reducing total sync time especially for users with multiple save files or high-latency connections.
- **Progress improvements**: Download progress is tuned and better reflected during the sync phase. The numbers at the top show a file count, while the progress bar shows bytes. IMHO filenames are not relevant to the user :smile: 
- **Refactored download flow**: `SteamAutoCloud` download logic was restructured for clarity and correctness.
- **Localization**: Added a new string across all supported locales.
- **Pre-existing bug fixes**: While working on this, a few pre-existing bugs in the download flow were fixed — files with a null response body were silently counted as successful, and "Download complete" progress was emitted even when some files failed. Also fixed a regression introduced by the refactor where an empty zip response was incorrectly counted as a successful download.

### Tests

The test changes are a side-effect of parallelization. The old mocks used a shared counter to hand out responses in order — which only works reliably for serial execution. Now that downloads run concurrently, the mocks were updated to dispatch by identity (filename / URL path) rather than by call order, so they work correctly regardless of which download fires first.

## Recording

https://github.com/user-attachments/assets/f22c194b-51b0-462e-bf22-ecbf0490a69c



## Type of Change
- [ ] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Faster, more reliable Steam cloud sync with concurrent downloads, better timeouts and cleanup on failure.
* **New Features**
  * Global, real‑time download progress using streaming updates and a current/total file counter; clearer per-file completion handling.
* **Localization**
  * Added "Downloading save files %1$d/%2$d" in English and 13+ locales (DA, DE, ES, FR, IT, KO, PL, PT‑BR, RO, RU, UK, ZH‑CN, ZH‑TW).
* **Tests**
  * Updated tests to cover parallel download scenarios and new download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->