### PR TITLE
fix: skip spurious conflict when cache wiped but local matches cloud

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -881,21 +881,52 @@ object SteamAutoCloud {
                     }.inWholeMicroseconds
 
                     val hasUncachedLocalFiles = cacheIsAbsentOrEmpty && allLocalUserFiles.isNotEmpty()
+                    var rehydratedSilently = false
                     if (hasUncachedLocalFiles) {
-                        if (localAppChangeNumber < 0) {
-                            // first offline play: never synced, no cache, but local
-                            // files exist — cloud would silently overwrite them
-                            hasLocalChanges = true
-                            conflictUfsVersion = CURRENT_UFS_PARSE_VERSION
+                        // no cache but local files exist. before declaring conflict,
+                        // check if local state is byte-identical to remote — this is
+                        // the "cache-wiped by destructive migration, nothing actually
+                        // changed" case and should be silent. key by absolute filesystem
+                        // path: cloud stores files as (pathPrefixIndex, basename) while
+                        // local scan stores filename as subdir-relative path with a
+                        // single pattern prefix, so basename-only keys won't match for
+                        // nested files.
+                        // windows paths are case-insensitive; steam cloud and wine may
+                        // disagree on case. lowercase the keys so content-identical
+                        // files compare equal regardless.
+                        val localByPath = allLocalUserFiles.associate {
+                            it.getAbsPath(prefixToPath).toString().lowercase() to it.sha
+                        }
+                        val remoteByPath = appFileListChange.files.associate {
+                            getFullFilePath(it, appFileListChange).toString().lowercase() to it.shaFile
+                        }
+                        val localMatchesRemote = localByPath.keys == remoteByPath.keys &&
+                            localByPath.all { (path, sha) ->
+                                sha.contentEquals(remoteByPath[path])
+                            }
+
+                        if (localMatchesRemote) {
+                            Timber.i("Cache absent but local matches remote — rehydrating cache silently")
+                            with(steamInstance) {
+                                db.withTransaction {
+                                    fileChangeListsDao.insert(appInfo.id, allLocalUserFiles)
+                                    changeNumbersDao.insert(appInfo.id, cloudAppChangeNumber)
+                                }
+                            }
+                            syncResult = SyncResult.UpToDate
+                            filesManaged = allLocalUserFiles.size
+                            rehydratedSilently = true
                         } else {
-                            // app update cleared the cache but a prior sync was
-                            // recorded — can't tell if local files changed
                             hasLocalChanges = true
                             conflictUfsVersion = CURRENT_UFS_PARSE_VERSION
+                            remoteTimestamp = appFileListChange.files.map { it.timestamp.time }.maxOrNull() ?: 0L
+                            localTimestamp = allLocalUserFiles.map { it.timestamp }.maxOrNull() ?: 0L
                         }
                     }
 
-                    if (!hasLocalChanges) {
+                    if (rehydratedSilently) {
+                        // nothing to do — cache is now consistent with cloud
+                    } else if (!hasLocalChanges) {
                         // we can safely download the new changes since no changes have been
                         // made locally
 

--- a/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
+++ b/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
@@ -2168,5 +2168,85 @@ class SteamAutoCloudTest {
         assertEquals(SyncResult.Success, result!!.syncResult)
         assertTrue("Should have downloaded files", result.filesDownloaded > 0)
     }
+
+    // ── Scenario 16: DB cache wiped by destructive migration, local == remote ──
+    // Repro of the "every steam game reports conflict post-update" bug. When
+    // fallbackToDestructiveMigration wipes file_change_lists but local save files
+    // are byte-identical to the cloud manifest, we must rehydrate the cache
+    // silently and NOT show a conflict dialog.
+    @Test
+    fun dbCleared_localMatchesRemote_rehydratesSilently_noConflict() = runBlocking {
+        db.appChangeNumbersDao().deleteByAppId(steamAppId)
+        db.appFileChangeListsDao().deleteByAppId(steamAppId)
+
+        // the 5 files created in setUp() — cloud manifest must match exactly.
+        // local scan basePath = %WinMyDocuments%/My Games/TestGame/Steam/{id},
+        // files live under SaveGames/ → filename (relativized) includes that prefix.
+        val localFiles = mapOf(
+            "SaveGames/AutoSaveData.sav" to "autosave content".toByteArray(),
+            "SaveGames/SaveData_0.sav" to "savedata0 content".toByteArray(),
+            "SaveGames/ContinueSaveData.sav" to "continue content".toByteArray(),
+            "SaveGames/SaveData_1.sav" to "savedata1 content".toByteArray(),
+            "SaveGames/SystemData_0.sav" to "systemdata content".toByteArray(),
+        )
+
+        assertTrue("Precondition: local save files exist", saveFilesDir.listFiles()!!.isNotEmpty())
+
+        val cloudFiles = localFiles.map { (name, content) ->
+            val m = mock<AppFileInfo>()
+            whenever(m.filename).thenReturn(name)
+            whenever(m.shaFile).thenReturn(sha1(content))
+            whenever(m.pathPrefixIndex).thenReturn(0)
+            whenever(m.timestamp).thenReturn(Date())
+            whenever(m.rawFileSize).thenReturn(content.size)
+            m
+        }
+
+        val cloudFileChangeList = makeCloudFileChangeList(
+            cloudChangeNumber = 5,
+            files = cloudFiles,
+            pathPrefixes = listOf("%WinMyDocuments%/My Games/TestGame/Steam/76561198025127569"),
+        )
+        every { mockSteamCloud.getAppFileListChange(any(), any(), any()) } returns
+            CompletableFuture.completedFuture(cloudFileChangeList)
+
+        val testApp = db.steamAppDao().findApp(steamAppId)!!
+        val result = SteamAutoCloud.syncUserFiles(
+            appInfo = testApp,
+            clientId = clientId,
+            steamInstance = mockSteamService,
+            steamCloud = mockSteamCloud,
+            preferredSave = SaveLocation.None,
+            prefixToPath = makePrefixToPath(),
+        ).await()
+
+        assertNotNull(result)
+        assertEquals(
+            "local matches remote exactly — should be UpToDate, not Conflict",
+            SyncResult.UpToDate,
+            result!!.syncResult,
+        )
+        assertNull(
+            "no conflict dialog — conflictUfsVersion must be null",
+            result.conflictUfsVersion,
+        )
+        assertEquals("no downloads", 0, result.filesDownloaded)
+        assertEquals("no uploads", 0, result.filesUploaded)
+
+        // cache must be rehydrated so next launch doesn't trip the same path
+        val rehydrated = db.appFileChangeListsDao().getByAppId(steamAppId)
+        assertNotNull("cache should be rehydrated", rehydrated)
+        assertEquals(
+            "rehydrated cache should contain all 5 local files",
+            5,
+            rehydrated!!.userFileInfo.size,
+        )
+        val rehydratedCn = db.appChangeNumbersDao().getByAppId(steamAppId)
+        assertEquals(
+            "rehydrated change number should match cloud",
+            5L,
+            rehydratedCn!!.changeNumber,
+        )
+    }
 }
 


### PR DESCRIPTION
## Description

A destructive Room migration (e.g. when an auto-migration is missing and `fallbackToDestructiveMigration` fires) wipes the `file_change_lists` cache while leaving save files on disk intact. On next launch of any Steam game, the code detected "cache absent + local files present" and unconditionally declared a conflict, surfacing the save-conflict dialog with epoch timestamps (`Date(0)` on both sides). Users saw every game report a conflict after an app update, with identical dates, even though nothing had changed locally.

This PR checks whether local state is byte-identical to the cloud manifest before declaring a conflict. If it matches, we rehydrate the cache silently and report `UpToDate`. If it doesn't, we still declare a conflict — but now populate real timestamps.

- Compare local vs cloud by absolute filesystem path (resilient to the fact that cloud stores `(pathPrefixIndex, basename)` while local scan stores subpath-relative filenames). Keys are lowercased since Windows paths are case-insensitive and wine/cloud may disagree on case.
- On match: insert local `UserFileInfo`s into `FileChangeListsDao` and the cloud change number into `ChangeNumbersDao`, set `UpToDate`, skip further work.
- On mismatch: populate `remoteTimestamp`/`localTimestamp` from the cloud manifest + local mtimes so the dialog renders real dates instead of the epoch.

## Recording

n/a — backend-only, no UI change on the happy path (dialog is suppressed when it previously fired). The user-visible effect on the conflict path is the dialog showing real dates instead of "Thu Jan 01 01:00:00 1970" on both sides.

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Test plan
- [x] Added unit test `dbCleared_localMatchesRemote_rehydratesSilently_noConflict` that wipes both cache tables, asserts `UpToDate` + silent rehydrate. Verified it fails cleanly (fast) against `origin/master`.
- [x] Manually reproduced on-device: wipe DB files with `run-as ... rm databases/pluvia.db*`, relaunch, open any Steam game. Before: every game shows conflict with epoch dates. After: silent rehydrate when state actually matches; real dates when it doesn't.

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR.
- [x] This change aligns with the current project scope (core functionality, stability, or performance).
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents false Steam Cloud conflicts after a destructive DB migration by verifying local saves match the cloud and silently rebuilding the cache when they do. No more blanket conflict dialogs after updates; real conflicts now show real timestamps.

- **Bug Fixes**
  - When cache is empty but local files exist, compare local and cloud by absolute, case-insensitive path and SHA.
  - If identical, silently rebuild the cache and change number, mark UpToDate, and skip the dialog.
  - If different, raise a conflict and populate accurate local/remote timestamps for the dialog.

<sup>Written for commit 5021ecbe04be935aa652c61433ca7234c0fa4112. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud save synchronization to prevent false conflict warnings when the local cache is cleared but files match the cloud version.
  * Automatically recovers cache state when files are verified as identical to remote copies.

* **Tests**
  * Added test coverage for cache recovery scenarios with matching local and remote files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->