### PR TITLE
fix: Prevent overwriting valid package IDs during PICS updates

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -3907,7 +3907,11 @@ class SteamService : Service(), IChallengeUrlChanged {
                                     val steamApp = appDao.findApp(appid)?.let { existingApp ->
                                         val currentLicense = licenseDao.findLicense(existingApp.packageId)
                                         existingApp.copy(
-                                            packageId = if (currentLicense != null && ELicenseFlags.code(currentLicense.licenseFlags) and 8 == 0) {
+                                            packageId = if (
+                                                currentLicense != null &&
+                                                ELicenseFlags.code(currentLicense.licenseFlags) and 8 == 0 &&
+                                                currentLicense.appIds.contains(appid)
+                                            ) {
                                                 existingApp.packageId
                                             } else {
                                                 pkg.id

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -3904,7 +3904,16 @@ class SteamService : Service(), IChallengeUrlChanged {
 
                                 // Insert a stub row (or update) of SteamApps to the database.
                                 appIds.forEach { appid ->
-                                    val steamApp = appDao.findApp(appid)?.copy(packageId = pkg.id)
+                                    val steamApp = appDao.findApp(appid)?.let { existingApp ->
+                                        val currentLicense = licenseDao.findLicense(existingApp.packageId)
+                                        existingApp.copy(
+                                            packageId = if (currentLicense != null && ELicenseFlags.code(currentLicense.licenseFlags) and 8 == 0) {
+                                                existingApp.packageId
+                                            } else {
+                                                pkg.id
+                                            },
+                                        )
+                                    }
                                     if (steamApp != null) {
                                         appDao.update(steamApp)
                                     } else {


### PR DESCRIPTION
## Description
Fixes a Steam library ownership issue caused by `steam_app.package_id` being overwritten by the last package processed during PICS sync.

Some apps belong to multiple Steam packages. In cases like [Unrailed!](https://steamdb.info/app/1016920/) (`appid 1016920`), the app could flip between a valid owned package and an expired/free-weekend package. When the invalid package won, the app disappeared from the library.

## Recording
https://github.com/user-attachments/assets/8315308d-4977-426b-ab28-3c83b21c3245

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent overwriting a game's existing package ID during PICS sync when the current package has a valid, non‑expired license that covers the app. If the current license is missing, expired, or doesn’t include the app, we now switch to the new package to avoid stale IDs and stop multi‑package titles disappearing from the library.

<sup>Written for commit 721b509006e6eb0be4655d096724f1c827d36749. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Steam app package associations during package result processing. Existing package links are now preserved when appropriate instead of being unconditionally overwritten, reducing incorrect package assignments and improving data accuracy and consistency across app records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->