### PR TITLE
Add a dual-cell battery setting

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -1192,4 +1192,9 @@ object PrefManager {
     var warnBeforeExit: Boolean
         get() = getPref(WARN_BEFORE_EXIT, false)
         set(value) { setPref(WARN_BEFORE_EXIT, value) }
+
+    private val DUAL_CELL_ENABLED = booleanPreferencesKey("dual_cell_enabled")
+    var dualCellEnabled: Boolean
+        get() = getPref(DUAL_CELL_ENABLED, false)
+        set(value) { setPref(DUAL_CELL_ENABLED, value) }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
@@ -112,6 +112,7 @@ fun SettingsGroupInterface(
     var showStatusBarLoadingDialog by rememberSaveable { mutableStateOf(false) }
     var hideStatusBar by rememberSaveable { mutableStateOf(PrefManager.hideStatusBarWhenNotInGame) }
     var swapFaceButtons by rememberSaveable { mutableStateOf(PrefManager.swapFaceButtons) }
+    var dualCellEnabled by rememberSaveable { mutableStateOf(PrefManager.dualCellEnabled) }
 
     // Controller/gamepad hints visibility
     var showGamepadHints by rememberSaveable { mutableStateOf(PrefManager.showGamepadHints) }
@@ -274,6 +275,17 @@ fun SettingsGroupInterface(
             onCheckedChange = {
                 warnBeforeExit = it
                 PrefManager.warnBeforeExit = it
+            },
+        )
+
+        SettingsSwitch(
+            colors = settingsTileColorsAlt(),
+            title = { Text(text = "Dual Cell") },
+            subtitle = { Text(text = "When enabled, battery power draw in the HUD is displayed as 2x") },
+            state = dualCellEnabled,
+            onCheckedChange = {
+                dualCellEnabled = it
+                PrefManager.dualCellEnabled = it
             },
         )
 

--- a/app/src/main/java/app/gamenative/ui/widget/PerformanceHudView.kt
+++ b/app/src/main/java/app/gamenative/ui/widget/PerformanceHudView.kt
@@ -20,6 +20,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
+import app.gamenative.PrefManager
 import app.gamenative.ui.data.PerformanceHudConfig
 import app.gamenative.ui.data.PerformanceHudSize
 import app.gamenative.utils.DateTimeUtils.formatRuntimeHours
@@ -282,6 +283,7 @@ class PerformanceHudView(
         val cpuPercent = readCpuUsagePercent()
         val gpuPercent = readGpuUsagePercent()
         val batterySnapshot = collectBatterySnapshot()
+        val powerMultiplier = if (PrefManager.dualCellEnabled) 2.0 else 1.0
         return HudSnapshot(
             fpsValue = currentFps,
             cpuValue = cpuPercent?.toFloat(),
@@ -292,7 +294,7 @@ class PerformanceHudView(
             ram = "RAM ${readUsedRamText()}",
             battery = batterySnapshot.percent?.let { "BAT $it%" },
             power = batterySnapshot.powerWatts?.let { watts ->
-                String.format(Locale.US, "PWR %.1fW", watts)
+                String.format(Locale.US, "PWR %.1fW", watts * powerMultiplier)
             },
             runtime = batterySnapshot.runtimeText,
             batteryTemp = batterySnapshot.temperatureC?.let { "BAT TEMP ${it}°C" },


### PR DESCRIPTION
## Description

This PR adds support for dual-cell battery power draw display in the Performance HUD. When the "Dual Cell" setting is enabled, the battery power draw shown in the HUD is displayed as 2x the actual value, accounting for devices with dual-cell battery configurations (such as the Odin or other handheld consoles with dual batteries).

### Changes Made

1. **PrefManager.kt**: Added new preference key `DUAL_CELL_ENABLED` to persist the dual-cell setting state
2. **SettingsGroupInterface.kt**: Added a new switch toggle in the Interface settings to allow users to enable/disable the dual-cell mode
3. **PerformanceHudView.kt**: Updated the power draw calculation to multiply by 2x when dual-cell mode is enabled

This feature is useful for devices where the power monitoring system reports per-cell consumption rather than total consumption, allowing users to see the accurate total power draw in the performance overlay.

## Recording

<!-- Recording/GIF will be attached by the user -->

## Type of Change

- [x] Feature/Performance improvement
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist

- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Dual Cell” setting that doubles the battery power shown in the Performance HUD for devices with dual-cell batteries. This shows total power draw when the system reports per-cell watts.

- **New Features**
  - Added `dualCellEnabled` preference in `PrefManager` (default off).
  - Added “Dual Cell” toggle in Interface settings.
  - Updated `PerformanceHudView` to display watts ×2 when `dualCellEnabled` is on.

<sup>Written for commit 646864b65aca1837c9ca02635a2666ea9e7654cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Dual Cell" toggle in the settings menu for user configuration
  * Power reading in the performance HUD is now multiplied by 2x when the feature is enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->