### PR TITLE
feat: add Steam save import/export with multi-root discovery

### DIFF
--- a/app/src/main/java/app/gamenative/ui/enums/AppOptionMenuType.kt
+++ b/app/src/main/java/app/gamenative/ui/enums/AppOptionMenuType.kt
@@ -13,6 +13,8 @@ enum class AppOptionMenuType(val text: String) {
     UseKnownConfig("Use known config"),
     ImportConfig("Import config"),
     ExportConfig("Export config"),
+    ImportSaves("Import saves"),
+    ExportSaves("Export saves"),
     Uninstall("Uninstall"),
     VerifyFiles("Verify files"),
     Update("Update"),

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -134,6 +134,8 @@ abstract class BaseAppScreen {
         private val installDialogStates = mutableStateMapOf<String, app.gamenative.ui.component.dialog.state.MessageDialogState>()
         private val exportConfigRequests = mutableStateMapOf<String, Boolean>()
         private val importConfigRequests = mutableStateMapOf<String, Boolean>()
+        private val exportSavesRequests = mutableStateMapOf<String, Boolean>()
+        private val importSavesRequests = mutableStateMapOf<String, Boolean>()
         private val knownConfigInstallStates = mutableStateMapOf<Int, KnownConfigInstallState>()
 
         fun showInstallDialog(appId: String, state: app.gamenative.ui.component.dialog.state.MessageDialogState) {
@@ -170,6 +172,30 @@ abstract class BaseAppScreen {
 
         fun shouldImportConfig(appId: String): Boolean {
             return importConfigRequests[appId] == true
+        }
+
+        fun requestExportSaves(appId: String) {
+            exportSavesRequests[appId] = true
+        }
+
+        fun clearExportSavesRequest(appId: String) {
+            exportSavesRequests.remove(appId)
+        }
+
+        fun shouldExportSaves(appId: String): Boolean {
+            return exportSavesRequests[appId] == true
+        }
+
+        fun requestImportSaves(appId: String) {
+            importSavesRequests[appId] = true
+        }
+
+        fun clearImportSavesRequest(appId: String) {
+            importSavesRequests.remove(appId)
+        }
+
+        fun shouldImportSaves(appId: String): Boolean {
+            return importSavesRequests[appId] == true
         }
 
         fun showKnownConfigInstallState(gameId: Int, state: KnownConfigInstallState) {
@@ -459,6 +485,48 @@ abstract class BaseAppScreen {
         )
     }
 
+    @Composable
+    protected open fun getExportSavesOption(
+        context: Context,
+        libraryItem: LibraryItem,
+    ): AppMenuOption? {
+        if (!supportsSaveTransfer(libraryItem)) return null
+        return AppMenuOption(
+            optionType = AppOptionMenuType.ExportSaves,
+            onClick = {
+                requestExportSaves(libraryItem.appId)
+            },
+        )
+    }
+
+    @Composable
+    protected open fun getImportSavesOption(
+        context: Context,
+        libraryItem: LibraryItem,
+    ): AppMenuOption? {
+        if (!supportsSaveTransfer(libraryItem)) return null
+        return AppMenuOption(
+            optionType = AppOptionMenuType.ImportSaves,
+            onClick = {
+                requestImportSaves(libraryItem.appId)
+            },
+        )
+    }
+
+    protected open fun supportsSaveTransfer(libraryItem: LibraryItem): Boolean = false
+
+    protected open suspend fun exportSaves(
+        context: Context,
+        libraryItem: LibraryItem,
+        uri: android.net.Uri,
+    ): Boolean = false
+
+    protected open suspend fun importSaves(
+        context: Context,
+        libraryItem: LibraryItem,
+        uri: android.net.Uri,
+    ): Boolean = false
+
     /**
      * Get config-related menu options (e.g. Export config, Import config).
      * By default returns only Export config when supported; sources can override
@@ -469,7 +537,7 @@ abstract class BaseAppScreen {
         context: Context,
         libraryItem: LibraryItem,
     ): List<AppMenuOption> {
-        return if (supportsContainerConfig()) {
+        val configOptions = if (supportsContainerConfig()) {
             listOfNotNull(
                 getUseKnownConfigOption(context, libraryItem),
                 getExportConfigOption(context, libraryItem),
@@ -478,6 +546,11 @@ abstract class BaseAppScreen {
         } else {
             emptyList()
         }
+
+        return configOptions + listOfNotNull(
+            getExportSavesOption(context, libraryItem),
+            getImportSavesOption(context, libraryItem),
+        )
     }
 
     /**
@@ -953,6 +1026,83 @@ abstract class BaseAppScreen {
             if (importConfigRequested) {
                 importConfigLauncher.launch(
                     arrayOf("application/json", "text/json", "text/plain"),
+                )
+            }
+        }
+
+        var exportSavesRequested by remember(appId) {
+            mutableStateOf(shouldExportSaves(appId))
+        }
+
+        LaunchedEffect(appId) {
+            snapshotFlow { shouldExportSaves(appId) }
+                .collect { shouldRequest ->
+                    exportSavesRequested = shouldRequest
+                }
+        }
+
+        val exportSavesLauncher =
+            rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.CreateDocument("application/zip"),
+            ) { uri ->
+                if (uri == null) {
+                    clearExportSavesRequest(appId)
+                    return@rememberLauncherForActivityResult
+                }
+
+                uiScope.launch {
+                    try {
+                        exportSaves(context, libraryItem, uri)
+                    } finally {
+                        clearExportSavesRequest(appId)
+                    }
+                }
+            }
+
+        LaunchedEffect(exportSavesRequested) {
+            if (exportSavesRequested) {
+                val gameName = displayInfo.name.ifBlank { "game" }
+                exportSavesLauncher.launch("${gameName}_saves.zip")
+            }
+        }
+
+        var importSavesRequested by remember(appId) {
+            mutableStateOf(shouldImportSaves(appId))
+        }
+
+        LaunchedEffect(appId) {
+            snapshotFlow { shouldImportSaves(appId) }
+                .collect { shouldRequest ->
+                    importSavesRequested = shouldRequest
+                }
+        }
+
+        val importSavesLauncher =
+            rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.OpenDocument(),
+            ) { uri ->
+                if (uri == null) {
+                    clearImportSavesRequest(appId)
+                    return@rememberLauncherForActivityResult
+                }
+
+                uiScope.launch {
+                    try {
+                        importSaves(context, libraryItem, uri)
+                    } finally {
+                        clearImportSavesRequest(appId)
+                    }
+                }
+            }
+
+        LaunchedEffect(importSavesRequested) {
+            if (importSavesRequested) {
+                importSavesLauncher.launch(
+                    arrayOf(
+                        "application/zip",
+                        "application/x-zip-compressed",
+                        "application/octet-stream",
+                    ),
                 )
             }
         }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -77,6 +77,7 @@ import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.ui.screen.library.GameMigrationDialog
 import app.gamenative.ui.component.dialog.state.GameManagerDialogState
 import app.gamenative.ui.util.SnackbarManager
+import app.gamenative.ui.util.SteamSaveTransfer
 import app.gamenative.utils.ContainerUtils.getContainer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -645,6 +646,62 @@ class SteamAppScreen : BaseAppScreen() {
             AppOptionMenuType.ResetToDefaults,
             onClick = { showResetConfirmDialog = true },
         )
+    }
+
+    override fun supportsSaveTransfer(libraryItem: LibraryItem): Boolean {
+        return libraryItem.gameSource == app.gamenative.data.GameSource.STEAM
+    }
+
+    private suspend fun activateSaveTransferContainer(context: Context, appId: String): Throwable? {
+        return try {
+            withContext(Dispatchers.IO) {
+                val containerManager = ContainerManager(context)
+                val container = ContainerUtils.getOrCreateContainer(context, appId)
+                containerManager.activateContainer(container)
+            }
+            null
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Timber.e(t, "Failed to activate save transfer container for $appId")
+            t
+        }
+    }
+
+    override suspend fun exportSaves(
+        context: Context,
+        libraryItem: LibraryItem,
+        uri: Uri,
+    ): Boolean {
+        val activationError = activateSaveTransferContainer(context, libraryItem.appId)
+        if (activationError != null) {
+            SnackbarManager.show(
+                context.getString(
+                    R.string.steam_save_export_failed,
+                    activationError.message ?: "Unknown error",
+                ),
+            )
+            return false
+        }
+        return SteamSaveTransfer.exportSaves(context, libraryItem.gameId, uri)
+    }
+
+    override suspend fun importSaves(
+        context: Context,
+        libraryItem: LibraryItem,
+        uri: Uri,
+    ): Boolean {
+        val activationError = activateSaveTransferContainer(context, libraryItem.appId)
+        if (activationError != null) {
+            SnackbarManager.show(
+                context.getString(
+                    R.string.steam_save_import_failed,
+                    activationError.message ?: "Unknown error",
+                ),
+            )
+            return false
+        }
+        return SteamSaveTransfer.importSaves(context, libraryItem.gameId, uri)
     }
 
     @Composable

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/GameOptionsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/GameOptionsPanel.kt
@@ -341,6 +341,8 @@ private fun getIconForOption(type: AppOptionMenuType): ImageVector {
         AppOptionMenuType.TestGraphics -> Icons.Default.Build
         AppOptionMenuType.ImportConfig -> Icons.Default.ArrowDownward
         AppOptionMenuType.ExportConfig -> Icons.Default.ArrowUpward
+        AppOptionMenuType.ImportSaves -> Icons.Default.ArrowDownward
+        AppOptionMenuType.ExportSaves -> Icons.Default.ArrowUpward
         AppOptionMenuType.ManageGameContent -> Icons.Default.Apps
         AppOptionMenuType.ManageWorkshop -> Icons.Default.Build
         AppOptionMenuType.ChangeBranch -> Icons.AutoMirrored.Filled.CallSplit
@@ -378,6 +380,8 @@ private fun groupOptions(options: List<AppMenuOption>): Map<OptionCategory, List
             AppOptionMenuType.UseKnownConfig,
             AppOptionMenuType.ImportConfig,
             AppOptionMenuType.ExportConfig,
+            AppOptionMenuType.ImportSaves,
+            AppOptionMenuType.ExportSaves,
             -> containerSettings.add(option)
 
             // Cloud Saves

--- a/app/src/main/java/app/gamenative/ui/util/SteamSaveTransfer.kt
+++ b/app/src/main/java/app/gamenative/ui/util/SteamSaveTransfer.kt
@@ -1,0 +1,346 @@
+package app.gamenative.ui.util
+
+import android.content.Context
+import android.net.Uri
+import app.gamenative.R
+import app.gamenative.data.SaveFilePattern
+import app.gamenative.enums.PathType
+import app.gamenative.service.SteamService
+import app.gamenative.utils.FileUtils
+import java.io.IOException
+import java.nio.channels.Channels
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardOpenOption
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createDirectories
+import kotlin.io.path.inputStream
+import kotlin.io.path.pathString
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+
+object SteamSaveTransfer {
+    private const val ARCHIVE_VERSION = 5
+    private const val MANIFEST_ENTRY = "manifest.json"
+    private const val FILES_PREFIX = "files/"
+    private val json = Json {
+        prettyPrint = true
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+        explicitNulls = false
+    }
+
+    @Serializable
+    private data class SaveArchiveManifest(
+        val version: Int = ARCHIVE_VERSION,
+        val steamAppId: Int,
+        val gameName: String,
+        val exportedAt: Long,
+        val roots: List<SaveRoot>,
+    )
+
+    @Serializable
+    private data class SaveRoot(
+        val rootId: String,
+        val path: String,
+    )
+
+    private data class ResolvedSaveRoot(
+        val rootId: String,
+        val absolutePath: Path,
+        val files: List<Path>,
+    )
+
+    suspend fun exportSaves(
+        context: Context,
+        steamAppId: Int,
+        uri: Uri,
+    ): Boolean {
+        return try {
+            val app = SteamService.getAppInfoOf(steamAppId)
+                ?: throw IOException("Steam app not found")
+            val prefixToPath = makePrefixToPath(context, steamAppId)
+            val roots = withContext(Dispatchers.IO) { resolveExportRoots(app, prefixToPath) }
+
+            if (roots.isEmpty()) {
+                SnackbarManager.show(context.getString(R.string.steam_save_export_no_saves_found))
+                return false
+            }
+
+            withContext(Dispatchers.IO) {
+                context.contentResolver.openOutputStream(uri)?.use { outputStream ->
+                    ZipOutputStream(outputStream.buffered()).use { zip ->
+                        val manifestRoots = roots.map { SaveRoot(rootId = it.rootId, path = it.absolutePath.pathString) }
+                        val manifest = SaveArchiveManifest(
+                            steamAppId = steamAppId,
+                            gameName = app.name,
+                            exportedAt = System.currentTimeMillis(),
+                            roots = manifestRoots,
+                        )
+
+                        zip.putNextEntry(ZipEntry(MANIFEST_ENTRY))
+                        zip.write(json.encodeToString(SaveArchiveManifest.serializer(), manifest).toByteArray())
+                        zip.closeEntry()
+
+                        roots.forEach { root ->
+                            root.files.forEach { file ->
+                                if (!Files.isRegularFile(file)) return@forEach
+                                val relativePath = normalizeRelativePath(root.absolutePath.relativize(file).toString())
+                                zip.putNextEntry(ZipEntry("$FILES_PREFIX${root.rootId}/$relativePath"))
+                                file.inputStream().use { it.copyTo(zip) }
+                                zip.closeEntry()
+                            }
+                        }
+                    }
+                } ?: throw IOException("Unable to open destination")
+            }
+
+            SnackbarManager.show(context.getString(R.string.steam_save_export_success))
+            true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to export Steam saves for appId=$steamAppId")
+            SnackbarManager.show(context.getString(R.string.steam_save_export_failed, e.message ?: "Unknown error"))
+            false
+        }
+    }
+
+    suspend fun importSaves(
+        context: Context,
+        steamAppId: Int,
+        uri: Uri,
+    ): Boolean {
+        return try {
+            val app = SteamService.getAppInfoOf(steamAppId)
+                ?: throw IOException("Steam app not found")
+            val archiveManifest = withContext(Dispatchers.IO) { readArchiveManifest(context, uri) }
+            if (archiveManifest.steamAppId != steamAppId) {
+                throw IOException("Archive is for Steam app ${archiveManifest.steamAppId}, expected $steamAppId")
+            }
+            if (archiveManifest.roots.isEmpty()) {
+                throw IOException("Archive does not declare any save roots")
+            }
+
+            val prefixToPath = makePrefixToPath(context, steamAppId)
+            val rootMap = withContext(Dispatchers.IO) {
+                resolveImportRoots(app, archiveManifest.roots, prefixToPath)
+            }
+
+            var importedFileCount = 0
+            withContext(Dispatchers.IO) {
+                context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                    ZipInputStream(inputStream.buffered()).use { zip ->
+                        while (true) {
+                            val entry = zip.nextEntry ?: break
+                            try {
+                                if (entry.isDirectory || entry.name == MANIFEST_ENTRY || !entry.name.startsWith(FILES_PREFIX)) {
+                                    continue
+                                }
+                                if (writeArchiveEntry(zip, entry.name, rootMap)) {
+                                    importedFileCount += 1
+                                }
+                            } finally {
+                                zip.closeEntry()
+                            }
+                        }
+                    }
+                } ?: throw IOException("Unable to open archive")
+            }
+
+            if (importedFileCount == 0) {
+                throw IOException("No save files found in archive")
+            }
+
+            SnackbarManager.show(context.getString(R.string.steam_save_import_success))
+            true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to import Steam saves for appId=$steamAppId")
+            SnackbarManager.show(context.getString(R.string.steam_save_import_failed, e.message ?: "Unknown error"))
+            false
+        }
+    }
+
+    // -- Root resolution -------------------------------------------------------
+
+    /**
+     * Mirrors the file discovery logic in `SteamAutoCloud.getLocalUserFilesAsPrefixMap`:
+     * 1. Walk UFS saveFilePatterns (GameInstall, WinMyDocuments, WinAppData*, etc.)
+     * 2. Always scan SteamUserData recursively
+     *
+     * Returns only roots that have at least one file.
+     */
+    private fun resolveExportRoots(
+        app: app.gamenative.data.SteamApp,
+        prefixToPath: (String) -> String,
+    ): List<ResolvedSaveRoot> {
+        val accountId = SteamService.userSteamId?.accountID?.toLong()
+            ?: throw IOException("Steam not logged in")
+        val result = mutableListOf<ResolvedSaveRoot>()
+
+        // 1) UFS patterns (skip SteamUserData — handled below)
+        val savePatterns = app.ufs.saveFilePatterns.filter { it.root.isWindows }
+        savePatterns
+            .filter { it.root != PathType.SteamUserData }
+            .forEach { pattern ->
+                val basePath = Paths.get(prefixToPath(pattern.root.name), pattern.substitutedPath)
+                val files = findPatternFiles(basePath, pattern)
+                if (files.isNotEmpty()) {
+                    result += ResolvedSaveRoot(
+                        rootId = patternRootId(pattern),
+                        absolutePath = basePath,
+                        files = files,
+                    )
+                }
+            }
+
+        // 2) SteamUserData — always scanned recursively (matches SteamAutoCloud behavior)
+        val userDataPath = Paths.get(prefixToPath(PathType.SteamUserData.name))
+        val userDataFiles = findPatternFiles(userDataPath, SaveFilePattern(root = PathType.SteamUserData, path = "", pattern = "*", recursive = 5))
+        if (userDataFiles.isNotEmpty()) {
+            result += ResolvedSaveRoot(
+                rootId = PathType.SteamUserData.name.lowercase(),
+                absolutePath = userDataPath,
+                files = userDataFiles,
+            )
+        }
+
+        return result
+    }
+
+    /**
+     * For import: resolve each manifest root back to an absolute path.
+     * Matches by rootId against known UFS patterns + SteamUserData.
+     */
+    private fun resolveImportRoots(
+        app: app.gamenative.data.SteamApp,
+        manifestRoots: List<SaveRoot>,
+        prefixToPath: (String) -> String,
+    ): Map<String, Path> {
+        val accountId = SteamService.userSteamId?.accountID?.toLong()
+            ?: throw IOException("Steam not logged in")
+
+        val knownRoots = mutableMapOf<String, Path>()
+
+        // Build lookup from UFS patterns
+        app.ufs.saveFilePatterns
+            .filter { it.root.isWindows }
+            .filter { it.root != PathType.SteamUserData }
+            .forEach { pattern ->
+                val id = patternRootId(pattern)
+                knownRoots[id] = Paths.get(prefixToPath(pattern.root.name), pattern.substitutedPath)
+            }
+
+        // SteamUserData
+        knownRoots[PathType.SteamUserData.name.lowercase()] = Paths.get(prefixToPath(PathType.SteamUserData.name))
+
+        // Resolve manifest roots against known roots, fall back to stored path
+        return manifestRoots.associate { mr ->
+            mr.rootId to (knownRoots[mr.rootId] ?: Paths.get(mr.path))
+        }
+    }
+
+    private fun findPatternFiles(basePath: Path, pattern: SaveFilePattern): List<Path> {
+        if (!Files.exists(basePath)) return emptyList()
+        val depth = if (pattern.recursive > 0) pattern.recursive else 5
+        return FileUtils.findFilesRecursive(
+            rootPath = basePath,
+            pattern = pattern.pattern,
+            maxDepth = depth,
+        )
+            .filter { Files.isRegularFile(it) }
+            .toList()
+    }
+
+    private fun patternRootId(pattern: SaveFilePattern): String {
+        val root = pattern.root.name.lowercase()
+        val normalizedPath = pattern.path
+            .replace('\\', '/')
+            .ifBlank { "root" }
+            .lowercase()
+        return "$root/$normalizedPath"
+    }
+
+    // -- Archive I/O -----------------------------------------------------------
+
+    private fun readArchiveManifest(context: Context, uri: Uri): SaveArchiveManifest {
+        context.contentResolver.openInputStream(uri)?.use { inputStream ->
+            ZipInputStream(inputStream.buffered()).use { zip ->
+                while (true) {
+                    val entry = zip.nextEntry ?: break
+                    try {
+                        if (!entry.isDirectory && entry.name == MANIFEST_ENTRY) {
+                            return json.decodeFromString(
+                                SaveArchiveManifest.serializer(),
+                                zip.readBytes().decodeToString(),
+                            )
+                        }
+                    } finally {
+                        zip.closeEntry()
+                    }
+                }
+            }
+        } ?: throw IOException("Unable to open archive")
+
+        throw IOException("Missing save archive manifest")
+    }
+
+    private fun writeArchiveEntry(
+        zip: ZipInputStream,
+        entryName: String,
+        rootMap: Map<String, Path>,
+    ): Boolean {
+        val relativeEntry = entryName.removePrefix(FILES_PREFIX).replace('\\', '/')
+        val slashIndex = relativeEntry.indexOf('/')
+        if (slashIndex <= 0) return false
+
+        val rootId = relativeEntry.substring(0, slashIndex)
+        val relativePath = normalizeRelativePath(relativeEntry.substring(slashIndex + 1))
+        if (relativePath.isBlank()) return false
+
+        val destinationRoot = rootMap[rootId]
+            ?: throw IOException("Archive save root not available: $rootId")
+        val normalizedRoot = destinationRoot.normalize()
+        val destination = normalizedRoot.resolve(relativePath).normalize()
+        if (!destination.startsWith(normalizedRoot)) {
+            throw IOException("Archive entry escapes save root: $entryName")
+        }
+
+        destination.parent?.createDirectories()
+        if (Files.isSymbolicLink(destination)) {
+            throw IOException("Archive entry is a symlink: $entryName")
+        }
+
+        Files.newByteChannel(
+            destination,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING,
+            StandardOpenOption.WRITE,
+            LinkOption.NOFOLLOW_LINKS,
+        ).use { channel ->
+            Channels.newOutputStream(channel).use { output ->
+                zip.copyTo(output)
+            }
+        }
+        return true
+    }
+
+    // -- Helpers ---------------------------------------------------------------
+
+    private fun makePrefixToPath(context: Context, appId: Int): (String) -> String = { prefix ->
+        PathType.from(prefix).toAbsPath(context, appId, SteamService.userSteamId!!.accountID)
+    }
+
+    private fun normalizeRelativePath(value: String): String =
+        value.replace('\\', '/').trimStart('/').trim()
+}

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1251,4 +1251,9 @@
     <string name="review_overwhelmingly_negative">Overvældende negativ</string>
     <string name="settings_interface_show_recommendations_title">Vis spilanbefalinger</string>
     <string name="settings_interface_show_recommendations_subtitle">Vis udvalgte indie-spil i dit bibliotek. At holde dette aktiveret hjælper med at støtte indie-udviklere og GameNative.</string>
+     <string name="steam_save_export_success">Gemte filer eksporteret</string>
+     <string name="steam_save_export_no_saves_found">Ingen gemte filer fundet</string>
+     <string name="steam_save_export_failed">Kunne ikke eksportere gemte filer: %s</string>
+     <string name="steam_save_import_success">Gemte filer importeret</string>
+     <string name="steam_save_import_failed">Kunne ikke importere gemte filer: %s</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1321,4 +1321,9 @@
     <string name="review_overwhelmingly_negative">Überwältigend negativ</string>
     <string name="settings_interface_show_recommendations_title">Spielempfehlungen anzeigen</string>
     <string name="settings_interface_show_recommendations_subtitle">Zeigt kuratierte Indie-Spiele in deiner Bibliothek. Aktiviert lassen unterstützt Indie-Entwickler und GameNative.</string>
+     <string name="steam_save_export_success">Spielstände exportiert</string>
+     <string name="steam_save_export_no_saves_found">Keine Spielstände gefunden</string>
+     <string name="steam_save_export_failed">Spielstände konnten nicht exportiert werden: %s</string>
+     <string name="steam_save_import_success">Spielstände importiert</string>
+     <string name="steam_save_import_failed">Spielstände konnten nicht importiert werden: %s</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1387,4 +1387,9 @@
     <string name="review_overwhelmingly_negative">Abrumadoramente negativo</string>
     <string name="settings_interface_show_recommendations_title">Mostrar recomendaciones de juegos</string>
     <string name="settings_interface_show_recommendations_subtitle">Muestra juegos indie seleccionados en tu biblioteca. Mantenerlo activado ayuda a apoyar a los desarrolladores indie y a GameNative.</string>
+     <string name="steam_save_export_success">Partidas guardadas exportadas</string>
+     <string name="steam_save_export_no_saves_found">No se encontraron partidas guardadas</string>
+     <string name="steam_save_export_failed">Error al exportar partidas: %s</string>
+     <string name="steam_save_import_success">Partidas guardadas importadas</string>
+     <string name="steam_save_import_failed">Error al importar partidas: %s</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1381,4 +1381,9 @@
     <string name="review_overwhelmingly_negative">Extrêmement négatif</string>
     <string name="settings_interface_show_recommendations_title">Afficher les recommandations de jeux</string>
     <string name="settings_interface_show_recommendations_subtitle">Affiche des jeux indés sélectionnés dans votre bibliothèque. Garder cette option activée aide à soutenir les développeurs indés et GameNative.</string>
+     <string name="steam_save_export_success">Sauvegardes exportées</string>
+     <string name="steam_save_export_no_saves_found">Aucune sauvegarde trouvée</string>
+     <string name="steam_save_export_failed">Échec de l\'exportation des sauvegardes : %s</string>
+     <string name="steam_save_import_success">Sauvegardes importées</string>
+     <string name="steam_save_import_failed">Échec de l\'importation des sauvegardes : %s</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1377,4 +1377,9 @@
     <string name="review_overwhelmingly_negative">Estremamente negativo</string>
     <string name="settings_interface_show_recommendations_title">Mostra consigli di gioco</string>
     <string name="settings_interface_show_recommendations_subtitle">Mostra giochi indie selezionati nella tua libreria. Mantenere attiva questa opzione aiuta a sostenere gli sviluppatori indie e GameNative.</string>
+     <string name="steam_save_export_success">Salvataggi esportati</string>
+     <string name="steam_save_export_no_saves_found">Nessun salvataggio trovato</string>
+     <string name="steam_save_export_failed">Esportazione salvataggi fallita: %s</string>
+     <string name="steam_save_import_success">Salvataggi importati</string>
+     <string name="steam_save_import_failed">Importazione salvataggi fallita: %s</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1385,4 +1385,9 @@
     <string name="review_overwhelmingly_negative">압도적으로 부정적</string>
     <string name="settings_interface_show_recommendations_title">게임 추천 표시</string>
     <string name="settings_interface_show_recommendations_subtitle">라이브러리에 엄선된 인디 게임을 표시합니다. 이 기능을 켜두면 인디 개발자와 GameNative를 지원하는 데 도움이 됩니다.</string>
+     <string name="steam_save_export_success">세이브 데이터 내보내기 완료</string>
+     <string name="steam_save_export_no_saves_found">세이브 파일을 찾을 수 없음</string>
+     <string name="steam_save_export_failed">세이브 데이터 내보내기 실패: %s</string>
+     <string name="steam_save_import_success">세이브 데이터 가져오기 완료</string>
+     <string name="steam_save_import_failed">세이브 데이터 가져오기 실패: %s</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1384,4 +1384,9 @@
     <string name="review_overwhelmingly_negative">Przytłaczająco negatywne</string>
     <string name="settings_interface_show_recommendations_title">Pokaż rekomendacje gier</string>
     <string name="settings_interface_show_recommendations_subtitle">Wyświetla wyselekcjonowane gry indie w twojej bibliotece. Pozostawienie tego włączonego wspiera niezależnych deweloperów i GameNative.</string>
+     <string name="steam_save_export_success">Zapisy wyeksportowane</string>
+     <string name="steam_save_export_no_saves_found">Nie znaleziono plików zapisów</string>
+     <string name="steam_save_export_failed">Nie udało się wyeksportować zapisów: %s</string>
+     <string name="steam_save_import_success">Zapisy zaimportowane</string>
+     <string name="steam_save_import_failed">Nie udało się zaimportować zapisów: %s</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1251,4 +1251,9 @@
     <string name="review_overwhelmingly_negative">Extremamente negativo</string>
     <string name="settings_interface_show_recommendations_title">Mostrar recomendações de jogos</string>
     <string name="settings_interface_show_recommendations_subtitle">Mostra jogos indie selecionados na sua biblioteca. Manter ativado ajuda a apoiar desenvolvedores indie e o GameNative.</string>
+     <string name="steam_save_export_success">Saves exportados</string>
+     <string name="steam_save_export_no_saves_found">Nenhum save encontrado</string>
+     <string name="steam_save_export_failed">Falha ao exportar saves: %s</string>
+     <string name="steam_save_import_success">Saves importados</string>
+     <string name="steam_save_import_failed">Falha ao importar saves: %s</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1386,4 +1386,9 @@
     <string name="review_overwhelmingly_negative">Copleșitor de negativ</string>
     <string name="settings_interface_show_recommendations_title">Afișează recomandări de jocuri</string>
     <string name="settings_interface_show_recommendations_subtitle">Afișează jocuri indie selectate în biblioteca ta. Păstrând această opțiune activată, sprijini dezvoltatorii indie și GameNative.</string>
+     <string name="steam_save_export_success">Salvari exportate</string>
+     <string name="steam_save_export_no_saves_found">Nu s-au găsit fișiere de salvare</string>
+     <string name="steam_save_export_failed">Exportul salvărilor a eșuat: %s</string>
+     <string name="steam_save_import_success">Salvari importate</string>
+     <string name="steam_save_import_failed">Importul salvărilor a eșuat: %s</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1314,4 +1314,9 @@ https://gamenative.app
     <string name="review_overwhelmingly_negative">Крайне отрицательные</string>
     <string name="settings_interface_show_recommendations_title">Показывать рекомендации игр</string>
     <string name="settings_interface_show_recommendations_subtitle">Показывает подобранные инди-игры в вашей библиотеке. Оставляя это включённым, вы поддерживаете инди-разработчиков и GameNative.</string>
+     <string name="steam_save_export_success">Сохранения экспортированы</string>
+     <string name="steam_save_export_no_saves_found">Сохранения не найдены</string>
+     <string name="steam_save_export_failed">Не удалось экспортировать сохранения: %s</string>
+     <string name="steam_save_import_success">Сохранения импортированы</string>
+     <string name="steam_save_import_failed">Не удалось импортировать сохранения: %s</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1380,4 +1380,9 @@
     <string name="review_overwhelmingly_negative">Надзвичайно негативні</string>
     <string name="settings_interface_show_recommendations_title">Показувати рекомендації ігор</string>
     <string name="settings_interface_show_recommendations_subtitle">Показує підібрані інді-ігри у вашій бібліотеці. Залишаючи це увімкненим, ви підтримуєте інді-розробників та GameNative.</string>
+     <string name="steam_save_export_success">Збереження експортовано</string>
+     <string name="steam_save_export_no_saves_found">Збереження не знайдено</string>
+     <string name="steam_save_export_failed">Не вдалося експортувати збереження: %s</string>
+     <string name="steam_save_import_success">Збереження імпортовано</string>
+     <string name="steam_save_import_failed">Не вдалося імпортувати збереження: %s</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1374,4 +1374,9 @@
     <string name="review_overwhelmingly_negative">差评如潮</string>
     <string name="settings_interface_show_recommendations_title">显示游戏推荐</string>
     <string name="settings_interface_show_recommendations_subtitle">在游戏库中显示精选独立游戏。保持开启有助于支持独立开发者和 GameNative。</string>
+     <string name="steam_save_export_success">存档已导出</string>
+     <string name="steam_save_export_no_saves_found">未找到存档文件</string>
+     <string name="steam_save_export_failed">导出存档失败：%s</string>
+     <string name="steam_save_import_success">存档已导入</string>
+     <string name="steam_save_import_failed">导入存档失败：%s</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1377,4 +1377,9 @@
     <string name="review_overwhelmingly_negative">壓倒性負評</string>
     <string name="settings_interface_show_recommendations_title">顯示遊戲推薦</string>
     <string name="settings_interface_show_recommendations_subtitle">在遊戲庫中顯示精選獨立遊戲。保持開啟有助於支持獨立開發者和 GameNative。</string>
+     <string name="steam_save_export_success">存檔已匯出</string>
+     <string name="steam_save_export_no_saves_found">未找到存檔檔案</string>
+     <string name="steam_save_export_failed">匯出存檔失敗：%s</string>
+     <string name="steam_save_import_success">存檔已匯入</string>
+     <string name="steam_save_import_failed">匯入存檔失敗：%s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1157,6 +1157,11 @@
     <string name="best_config_missing_content">%s missing</string>
     <string name="import_config">Import config</string>
     <string name="export_config">Export config</string>
+    <string name="steam_save_export_success">Saves exported</string>
+    <string name="steam_save_export_no_saves_found">No save files found</string>
+    <string name="steam_save_export_failed">Failed to export saves: %s</string>
+    <string name="steam_save_import_success">Saves imported</string>
+    <string name="steam_save_import_failed">Failed to import saves: %s</string>
     <string name="library_app_type">App Type</string>
     <string name="library_app_status">App Status</string>
     <string name="library_layout">Layout</string>


### PR DESCRIPTION
## Description
WIP

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] I have attached a recording of the change.
- [ ] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Steam save import/export for Steam games with multi-root discovery, letting users back up and restore saves as a zip with a manifest. Adds options to the game menu and uses system file pickers, with clear success/error messages.

- **New Features**
  - Added “Import saves” and “Export saves” options for Steam titles in the options menu, with new icons.
  - Implemented `SteamSaveTransfer` to scan UFS roots (GameInstall, WinMyDocuments, WinAppData*, etc.) and always recurse SteamUserData; exports/imports via a zip + `manifest.json`.
  - Secure import: blocks path traversal and symlinks; writes only within resolved roots.
  - Uses Android document pickers (Create/Open) and snackbars for feedback; auto-activates the per-game container before transfer.
  - Localized success/failure strings added across all supported languages.

<sup>Written for commit 7a8d8a53663d0bf8a31c5338b4d9a5a64e778004. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

