### PR TITLE
Move Touchscreen Mode toggle to in-game sidebar

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -42,9 +42,11 @@ import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Gamepad
 import androidx.compose.material.icons.filled.Keyboard
 import androidx.compose.material.icons.filled.QueryStats
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.TouchApp
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -71,6 +73,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -91,6 +94,7 @@ object QuickMenuAction {
     const val EDIT_CONTROLS = 4
     const val EDIT_PHYSICAL_CONTROLLER = 5
     const val PERFORMANCE_HUD = 6
+    const val TOUCHSCREEN_MODE = 7
 }
 
 private object QuickMenuTab {
@@ -220,6 +224,8 @@ fun QuickMenu(
     performanceHudConfig: PerformanceHudConfig = PerformanceHudConfig(),
     onPerformanceHudConfigChanged: (PerformanceHudConfig) -> Unit = {},
     hasPhysicalController: Boolean = false,
+    isTouchscreenModeActive: Boolean = false,
+    onTouchGestureSettingsClick: () -> Unit = {},
     activeToggleIds: Set<Int> = emptySet(),
     modifier: Modifier = Modifier,
 ) {
@@ -263,6 +269,14 @@ fun QuickMenu(
                 icon = Icons.Default.Edit,
                 labelResId = R.string.edit_controls,
                 accentColor = PluviaTheme.colors.accentSuccess,
+            )
+        )
+        add(
+            QuickMenuItem(
+                id = QuickMenuAction.TOUCHSCREEN_MODE,
+                icon = Icons.Default.Fingerprint,
+                labelResId = R.string.touchscreen_mode,
+                accentColor = PluviaTheme.colors.accentPurple,
             )
         )
     }
@@ -510,6 +524,10 @@ fun QuickMenu(
                                                         }
                                                     },
                                                     focusRequester = if (index == 0) controllerItemFocusRequester else null,
+                                                    secondaryIcon = if (item.id == QuickMenuAction.TOUCHSCREEN_MODE && isTouchscreenModeActive)
+                                                        Icons.Default.Settings else null,
+                                                    onSecondaryClick = if (item.id == QuickMenuAction.TOUCHSCREEN_MODE && isTouchscreenModeActive)
+                                                        onTouchGestureSettingsClick else null,
                                                 )
                                             }
                                         }
@@ -1491,6 +1509,8 @@ private fun QuickMenuItemRow(
     isActive: Boolean = false,
     onClick: () -> Unit,
     focusRequester: FocusRequester? = null,
+    secondaryIcon: ImageVector? = null,
+    onSecondaryClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -1604,6 +1624,24 @@ private fun QuickMenuItemRow(
             },
             modifier = Modifier.weight(1f),
         )
+
+        if (secondaryIcon != null && onSecondaryClick != null) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                    .clickable(role = Role.Button, onClick = onSecondaryClick),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = secondaryIcon,
+                    contentDescription = stringResource(R.string.gesture_settings_title),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ControllerTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ControllerTab.kt
@@ -1,33 +1,19 @@
 package app.gamenative.ui.component.dialog
 
-import androidx.compose.foundation.layout.Row
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.stringResource
 import app.gamenative.R
-import app.gamenative.data.TouchGestureConfig
 import app.gamenative.ui.component.settings.SettingsListDropdown
 import app.gamenative.ui.theme.settingsTileColors
 import app.gamenative.ui.theme.settingsTileColorsAlt
 import com.alorma.compose.settings.ui.SettingsGroup
 import com.alorma.compose.settings.ui.SettingsSwitch
-import com.alorma.compose.settings.ui.SettingsMenuLink
 import com.winlator.container.Container
 
 @Composable
 fun ControllerTabContent(state: ContainerConfigState, default: Boolean) {
     val config = state.config.value
-    var showGestureDialog by remember { mutableStateOf(false) }
 
     SettingsGroup() {
         if (!default) {
@@ -71,26 +57,6 @@ fun ControllerTabContent(state: ContainerConfigState, default: Boolean) {
             state = config.disableMouseInput,
             onCheckedChange = { state.config.value = config.copy(disableMouseInput = it) },
         )
-        SettingsMenuLink(
-            colors = settingsTileColorsAlt(),
-            title = { Text(text = stringResource(R.string.touchscreen_mode)) },
-            subtitle = { Text(text = stringResource(R.string.touchscreen_mode_description)) },
-            onClick = { state.config.value = config.copy(touchscreenMode = !config.touchscreenMode) },
-            action = {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconButton(onClick = { showGestureDialog = true }) {
-                        Icon(
-                            imageVector = Icons.Default.Settings,
-                            contentDescription = stringResource(R.string.gesture_settings),
-                        )
-                    }
-                    Switch(
-                        checked = config.touchscreenMode,
-                        onCheckedChange = { state.config.value = config.copy(touchscreenMode = it) },
-                    )
-                }
-            },
-        )
         SettingsSwitch(
             colors = settingsTileColorsAlt(),
             title = { Text(text = stringResource(R.string.shooter_mode_toggle)) },
@@ -122,23 +88,6 @@ fun ControllerTabContent(state: ContainerConfigState, default: Boolean) {
             subtitle = { Text(text = stringResource(R.string.external_display_swap_subtitle)) },
             state = config.externalDisplaySwap,
             onCheckedChange = { state.config.value = config.copy(externalDisplaySwap = it) },
-        )
-    }
-
-    // Gesture settings full-screen dialog
-    if (showGestureDialog) {
-        val gestureConfig = remember(config.gestureConfig) {
-            TouchGestureConfig.fromJson(config.gestureConfig)
-        }
-        TouchGestureSettingsDialog(
-            gestureConfig = gestureConfig,
-            onDismiss = { showGestureDialog = false },
-            onSave = { updatedGesture ->
-                // Read the latest config to avoid overwriting concurrent changes
-                val latest = state.config.value
-                state.config.value = latest.copy(gestureConfig = updatedGesture.toJson())
-                showGestureDialog = false
-            },
         )
     }
 }

--- a/app/src/main/java/app/gamenative/ui/component/dialog/TouchGestureSettingsDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/TouchGestureSettingsDialog.kt
@@ -6,11 +6,13 @@ import androidx.compose.foundation.text.KeyboardOptions
 import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -52,20 +54,31 @@ fun TouchGestureSettingsDialog(
 
     Dialog(
         onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false,
+        ),
     ) {
         Scaffold(
+            modifier = Modifier.fillMaxSize(),
             topBar = {
-                TopAppBar(
-                    title = { Text(stringResource(R.string.gesture_settings_title)) },
+                CenterAlignedTopAppBar(
+                    title = {
+                        Text(
+                            text = stringResource(R.string.gesture_settings_title),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    },
                     navigationIcon = {
                         IconButton(onClick = onDismiss) {
-                            Icon(Icons.Default.Close, contentDescription = "Close")
+                            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.close))
                         }
                     },
                     actions = {
-                        TextButton(onClick = { onSave(config) }) {
-                            Text(stringResource(android.R.string.ok))
+                        IconButton(onClick = { onSave(config) }) {
+                            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.save))
                         }
                     },
                 )
@@ -75,145 +88,137 @@ fun TouchGestureSettingsDialog(
                 modifier = Modifier
                     .padding(padding)
                     .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 8.dp),
+                    .verticalScroll(rememberScrollState()),
             ) {
                 // ── 1. Tap (fixed: Left Click) ──────────────────────────
-                OutlinedCard(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-                    SettingsSwitch(
-                        colors = settingsTileColorsAlt(),
-                        title = { Text(stringResource(R.string.gesture_tap)) },
-                        subtitle = { Text(stringResource(R.string.gesture_tap_subtitle)) },
-                        state = config.tapEnabled,
-                        onCheckedChange = { config = config.copy(tapEnabled = it) },
-                    )
-                }
+                SettingsSwitch(
+                    colors = settingsTileColorsAlt(),
+                    title = { Text(stringResource(R.string.gesture_tap)) },
+                    subtitle = { Text(stringResource(R.string.gesture_tap_subtitle)) },
+                    state = config.tapEnabled,
+                    onCheckedChange = { config = config.copy(tapEnabled = it) },
+                )
+
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 
                 // ── 2. Drag (fixed: Drag Left Click) ────────────────────
-                OutlinedCard(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-                    SettingsSwitch(
-                        colors = settingsTileColorsAlt(),
-                        title = { Text(stringResource(R.string.gesture_drag)) },
-                        subtitle = { Text(stringResource(R.string.gesture_drag_subtitle)) },
-                        state = config.dragEnabled,
-                        onCheckedChange = { config = config.copy(dragEnabled = it) },
-                    )
-                }
+                SettingsSwitch(
+                    colors = settingsTileColorsAlt(),
+                    title = { Text(stringResource(R.string.gesture_drag)) },
+                    subtitle = { Text(stringResource(R.string.gesture_drag_subtitle)) },
+                    state = config.dragEnabled,
+                    onCheckedChange = { config = config.copy(dragEnabled = it) },
+                )
+
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 
                 // ── 3. Long Press (customisable action + delay) ──────────
-                OutlinedCard(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-                    SettingsSwitch(
-                        colors = settingsTileColorsAlt(),
-                        title = { Text(stringResource(R.string.gesture_long_press)) },
-                        subtitle = { Text(mouseActionLabel(config.longPressAction)) },
-                        state = config.longPressEnabled,
-                        onCheckedChange = { config = config.copy(longPressEnabled = it) },
+                SettingsSwitch(
+                    colors = settingsTileColorsAlt(),
+                    title = { Text(stringResource(R.string.gesture_long_press)) },
+                    subtitle = { Text(mouseActionLabel(config.longPressAction)) },
+                    state = config.longPressEnabled,
+                    onCheckedChange = { config = config.copy(longPressEnabled = it) },
+                )
+                if (config.longPressEnabled) {
+                    SettingsListDropdown(
+                        colors = settingsTileColors(),
+                        title = { Text(stringResource(R.string.gesture_action_label)) },
+                        value = COMMON_MOUSE_ACTIONS.indexOf(config.longPressAction).coerceAtLeast(0),
+                        items = COMMON_MOUSE_ACTIONS.map { mouseActionLabel(it) },
+                        onItemSelected = { index ->
+                            config = config.copy(longPressAction = COMMON_MOUSE_ACTIONS[index])
+                        },
                     )
-                    if (config.longPressEnabled) {
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                        SettingsListDropdown(
-                            colors = settingsTileColors(),
-                            title = { Text(stringResource(R.string.gesture_action_label)) },
-                            value = COMMON_MOUSE_ACTIONS.indexOf(config.longPressAction).coerceAtLeast(0),
-                            items = COMMON_MOUSE_ACTIONS.map { mouseActionLabel(it) },
-                            onItemSelected = { index ->
-                                config = config.copy(longPressAction = COMMON_MOUSE_ACTIONS[index])
-                            },
-                        )
-                        DelayTextField(
-                            label = stringResource(R.string.gesture_long_press_delay),
-                            value = config.longPressDelay,
-                            onValueChange = { config = config.copy(longPressDelay = it) },
-                        )
-                    }
+                    DelayTextField(
+                        label = stringResource(R.string.gesture_long_press_delay),
+                        value = config.longPressDelay,
+                        onValueChange = { config = config.copy(longPressDelay = it) },
+                    )
                 }
+
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 
                 // ── 4. Double-Tap (fixed action, customisable delay) ─────
-                OutlinedCard(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-                    SettingsSwitch(
-                        colors = settingsTileColorsAlt(),
-                        title = { Text(stringResource(R.string.gesture_double_tap)) },
-                        subtitle = { Text(stringResource(R.string.gesture_double_tap_subtitle)) },
-                        state = config.doubleTapEnabled,
-                        onCheckedChange = { config = config.copy(doubleTapEnabled = it) },
+                SettingsSwitch(
+                    colors = settingsTileColorsAlt(),
+                    title = { Text(stringResource(R.string.gesture_double_tap)) },
+                    subtitle = { Text(stringResource(R.string.gesture_double_tap_subtitle)) },
+                    state = config.doubleTapEnabled,
+                    onCheckedChange = { config = config.copy(doubleTapEnabled = it) },
+                )
+                if (config.doubleTapEnabled) {
+                    DelayTextField(
+                        label = stringResource(R.string.gesture_double_tap_delay),
+                        value = config.doubleTapDelay,
+                        onValueChange = { config = config.copy(doubleTapDelay = it) },
                     )
-                    if (config.doubleTapEnabled) {
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                        DelayTextField(
-                            label = stringResource(R.string.gesture_double_tap_delay),
-                            value = config.doubleTapDelay,
-                            onValueChange = { config = config.copy(doubleTapDelay = it) },
-                        )
-                    }
                 }
+
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 
                 // ── 5. Two-Finger Drag (customisable action) ─────────────
-                OutlinedCard(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-                    SettingsSwitch(
-                        colors = settingsTileColorsAlt(),
-                        title = { Text(stringResource(R.string.gesture_two_finger_drag)) },
-                        subtitle = { Text(panActionLabel(config.twoFingerDragAction)) },
-                        state = config.twoFingerDragEnabled,
-                        onCheckedChange = { config = config.copy(twoFingerDragEnabled = it) },
+                SettingsSwitch(
+                    colors = settingsTileColorsAlt(),
+                    title = { Text(stringResource(R.string.gesture_two_finger_drag)) },
+                    subtitle = { Text(panActionLabel(config.twoFingerDragAction)) },
+                    state = config.twoFingerDragEnabled,
+                    onCheckedChange = { config = config.copy(twoFingerDragEnabled = it) },
+                )
+                if (config.twoFingerDragEnabled) {
+                    SettingsListDropdown(
+                        colors = settingsTileColors(),
+                        title = { Text(stringResource(R.string.gesture_action_label)) },
+                        value = PAN_ACTIONS.indexOf(config.twoFingerDragAction).coerceAtLeast(0),
+                        items = PAN_ACTIONS.map { panActionLabel(it) },
+                        onItemSelected = { index ->
+                            config = config.copy(twoFingerDragAction = PAN_ACTIONS[index])
+                        },
                     )
-                    if (config.twoFingerDragEnabled) {
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                        SettingsListDropdown(
-                            colors = settingsTileColors(),
-                            title = { Text(stringResource(R.string.gesture_action_label)) },
-                            value = PAN_ACTIONS.indexOf(config.twoFingerDragAction).coerceAtLeast(0),
-                            items = PAN_ACTIONS.map { panActionLabel(it) },
-                            onItemSelected = { index ->
-                                config = config.copy(twoFingerDragAction = PAN_ACTIONS[index])
-                            },
-                        )
-                    }
                 }
+
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 
                 // ── 6. Pinch In/Out (customisable action) ────────────────
-                OutlinedCard(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-                    SettingsSwitch(
-                        colors = settingsTileColorsAlt(),
-                        title = { Text(stringResource(R.string.gesture_pinch)) },
-                        subtitle = { Text(zoomActionLabel(config.pinchAction)) },
-                        state = config.pinchEnabled,
-                        onCheckedChange = { config = config.copy(pinchEnabled = it) },
+                SettingsSwitch(
+                    colors = settingsTileColorsAlt(),
+                    title = { Text(stringResource(R.string.gesture_pinch)) },
+                    subtitle = { Text(zoomActionLabel(config.pinchAction)) },
+                    state = config.pinchEnabled,
+                    onCheckedChange = { config = config.copy(pinchEnabled = it) },
+                )
+                if (config.pinchEnabled) {
+                    SettingsListDropdown(
+                        colors = settingsTileColors(),
+                        title = { Text(stringResource(R.string.gesture_action_label)) },
+                        value = ZOOM_ACTIONS.indexOf(config.pinchAction).coerceAtLeast(0),
+                        items = ZOOM_ACTIONS.map { zoomActionLabel(it) },
+                        onItemSelected = { index ->
+                            config = config.copy(pinchAction = ZOOM_ACTIONS[index])
+                        },
                     )
-                    if (config.pinchEnabled) {
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                        SettingsListDropdown(
-                            colors = settingsTileColors(),
-                            title = { Text(stringResource(R.string.gesture_action_label)) },
-                            value = ZOOM_ACTIONS.indexOf(config.pinchAction).coerceAtLeast(0),
-                            items = ZOOM_ACTIONS.map { zoomActionLabel(it) },
-                            onItemSelected = { index ->
-                                config = config.copy(pinchAction = ZOOM_ACTIONS[index])
-                            },
-                        )
-                    }
                 }
 
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+
                 // ── 7. Two-Finger Tap (customisable action) ──────────────
-                OutlinedCard(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-                    SettingsSwitch(
-                        colors = settingsTileColorsAlt(),
-                        title = { Text(stringResource(R.string.gesture_two_finger_tap)) },
-                        subtitle = { Text(mouseActionLabel(config.twoFingerTapAction)) },
-                        state = config.twoFingerTapEnabled,
-                        onCheckedChange = { config = config.copy(twoFingerTapEnabled = it) },
+                SettingsSwitch(
+                    colors = settingsTileColorsAlt(),
+                    title = { Text(stringResource(R.string.gesture_two_finger_tap)) },
+                    subtitle = { Text(mouseActionLabel(config.twoFingerTapAction)) },
+                    state = config.twoFingerTapEnabled,
+                    onCheckedChange = { config = config.copy(twoFingerTapEnabled = it) },
+                )
+                if (config.twoFingerTapEnabled) {
+                    SettingsListDropdown(
+                        colors = settingsTileColors(),
+                        title = { Text(stringResource(R.string.gesture_action_label)) },
+                        value = COMMON_MOUSE_ACTIONS.indexOf(config.twoFingerTapAction).coerceAtLeast(0),
+                        items = COMMON_MOUSE_ACTIONS.map { mouseActionLabel(it) },
+                        onItemSelected = { index ->
+                            config = config.copy(twoFingerTapAction = COMMON_MOUSE_ACTIONS[index])
+                        },
                     )
-                    if (config.twoFingerTapEnabled) {
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                        SettingsListDropdown(
-                            colors = settingsTileColors(),
-                            title = { Text(stringResource(R.string.gesture_action_label)) },
-                            value = COMMON_MOUSE_ACTIONS.indexOf(config.twoFingerTapAction).coerceAtLeast(0),
-                            items = COMMON_MOUSE_ACTIONS.map { mouseActionLabel(it) },
-                            onItemSelected = { index ->
-                                config = config.copy(twoFingerTapAction = COMMON_MOUSE_ACTIONS[index])
-                            },
-                        )
-                    }
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -370,6 +370,11 @@ fun XServerScreen(
     var showElementEditor by remember { mutableStateOf(false) }
     var elementToEdit by remember { mutableStateOf<com.winlator.inputcontrols.ControlElement?>(null) }
     var showPhysicalControllerDialog by remember { mutableStateOf(false) }
+    var showTouchGestureDialog by remember { mutableStateOf(false) }
+    var isTouchscreenModeActive by remember { mutableStateOf(container.isTouchscreenMode) }
+    var currentGestureConfig by remember {
+        mutableStateOf(app.gamenative.data.TouchGestureConfig.fromJson(container.getGestureConfig()))
+    }
     var keyboardRequestedFromOverlay by remember { mutableStateOf(false) }
     var showQuickMenu by remember { mutableStateOf(false) }
     var hasPhysicalController by remember { mutableStateOf(false) }
@@ -916,6 +921,55 @@ fun XServerScreen(
                     }
                 }
                 true
+            }
+
+            QuickMenuAction.TOUCHSCREEN_MODE -> {
+                val newMode = !container.isTouchscreenMode
+                container.setTouchscreenMode(newMode)
+                container.saveData()
+                isTouchscreenModeActive = newMode
+
+                // Notify TouchpadView of the mode change
+                PluviaApp.touchpadView?.setTouchscreenMode(newMode)
+
+                if (newMode) {
+                    // Apply gesture config when enabling
+                    PluviaApp.touchpadView?.setGestureConfig(currentGestureConfig)
+
+                    // Hide on-screen controls (mirrors startup priority logic)
+                    if (areControlsVisible) {
+                        hideInputControls()
+                        areControlsVisible = false
+                    }
+
+                    // Hide cursor in touchscreen mode
+                    xServerView?.renderer?.setCursorVisible(false)
+                } else {
+                    // Restore cursor if mouse input is allowed
+                    if (!container.isDisableMouseInput) {
+                        xServerView?.renderer?.setCursorVisible(true)
+                    }
+
+                    // Re-evaluate whether to show on-screen controls
+                    // (same logic as scanForExternalDevices startup path)
+                    if (!hasPhysicalController && !hasPhysicalKeyboard &&
+                        !hasPhysicalMouse && !hasInternalTouchpad) {
+                        val manager = PluviaApp.inputControlsManager
+                        val profiles = manager?.getProfiles(false) ?: listOf()
+                        if (profiles.isNotEmpty() && !areControlsVisible) {
+                            val profileIdStr = container.getExtra("profileId", "0")
+                            val profileId = profileIdStr.toIntOrNull() ?: 0
+                            val targetProfile = if (profileId != 0) {
+                                manager?.getProfile(profileId)
+                            } else {
+                                null
+                            } ?: manager?.getProfile(0) ?: profiles.getOrNull(2) ?: profiles.first()
+                            showInputControls(targetProfile, xServerView!!.getxServer().winHandler, container)
+                            areControlsVisible = true
+                        }
+                    }
+                }
+                false
             }
 
             QuickMenuAction.EDIT_PHYSICAL_CONTROLLER -> {
@@ -2026,8 +2080,11 @@ fun XServerScreen(
             performanceHudConfig = performanceHudConfig,
             onPerformanceHudConfigChanged = ::applyPerformanceHudConfig,
             hasPhysicalController = hasPhysicalController,
+            isTouchscreenModeActive = isTouchscreenModeActive,
+            onTouchGestureSettingsClick = { showTouchGestureDialog = true },
             activeToggleIds = buildSet {
                 if (areControlsVisible) add(QuickMenuAction.INPUT_CONTROLS)
+                if (isTouchscreenModeActive) add(QuickMenuAction.TOUCHSCREEN_MODE)
             },
         )
 
@@ -2076,6 +2133,21 @@ fun XServerScreen(
                 showElementEditor = false
                 // Keep edit mode active so user can edit other elements
             }
+        )
+    }
+
+    // Touch Gesture Settings Dialog
+    if (showTouchGestureDialog) {
+        app.gamenative.ui.component.dialog.TouchGestureSettingsDialog(
+            gestureConfig = currentGestureConfig,
+            onDismiss = { showTouchGestureDialog = false },
+            onSave = { newConfig ->
+                currentGestureConfig = newConfig
+                container.setGestureConfig(newConfig.toJson())
+                container.saveData()
+                PluviaApp.touchpadView?.setGestureConfig(newConfig)
+                showTouchGestureDialog = false
+            },
         )
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -723,14 +723,12 @@
     <string name="directinput_mapper_type">DirectInput Mapper Type</string>
     <string name="disable_mouse_input">Disable Mouse Input</string>
     <string name="touchscreen_mode">Touchscreen Mode</string>
-    <string name="touchscreen_mode_description">For visual novels and RTS games</string>
     <string name="shooter_mode_toggle">Shooter Mode</string>
     <string name="shooter_mode_toggle_description">Auto-replace stick elements with dynamic joysticks</string>
     <string name="shooter_mode_on">Enable Mouse</string>
     <string name="shooter_mode_off">Enable Sticks</string>
 
     <!-- Gesture Settings Dialog -->
-    <string name="gesture_settings">Gesture Settings</string>
     <string name="gesture_settings_title">Touch Gesture Settings</string>
     <string name="gesture_tap">Tap</string>
     <string name="gesture_tap_subtitle">Left Click</string>


### PR DESCRIPTION
## Description
Moved Touchscreen Mode toggle from Edit Container > Controller section to the in-game sidebar, right below the existing `Edit On-screen Controller` line.

## Recording


https://github.com/user-attachments/assets/bc961c79-03d1-4d71-88a3-f134f5e45c70



## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Touchscreen mode is now accessible via the quick menu with dedicated gesture configuration settings, allowing seamless switching between input methods.

* **UI/UX Improvements**
  * Gesture settings dialog has been redesigned with improved layout, enhanced visual hierarchy, and clearer controls for better usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->