### PR TITLE
Input bug fix - input dlls not being correctly extracted

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -52,6 +52,11 @@ object PrefManager {
     private lateinit var dataStore: DataStore<Preferences>
 
     fun init(context: Context) {
+        // Pre-create the datastore directory so DataStore doesn't throw FileNotFoundException
+        // (ENOENT) on first launch before the directory exists — DataStore 1.1.x bug on
+        // some Android 13 devices where the missing-file path isn't handled gracefully.
+        runCatching { context.applicationContext.filesDir.resolve("datastore").mkdirs() }
+
         dataStore = context.datastore
 
         // Note: Should remove after a few release versions. we've moved to encrypted values.
@@ -120,7 +125,15 @@ object PrefManager {
 
     @Suppress("SameParameterValue")
     private fun <T> getPref(key: Preferences.Key<T>, defaultValue: T): T = runBlocking {
-        dataStore.data.first()[key] ?: defaultValue
+        try {
+            dataStore.data.first()[key] ?: defaultValue
+        } catch (e: Exception) {
+            // DataStore 1.1.x bug: on some Android 13 devices a missing preferences file
+            // propagates as FileNotFoundException instead of returning emptyPreferences().
+            // Return the default so the app doesn't crash on a fresh install.
+            Timber.w(e, "PrefManager: failed to read pref '${key.name}', returning default")
+            defaultValue
+        }
     }
 
     @Suppress("SameParameterValue")

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3685,8 +3685,8 @@ private fun extractArm64ecInputDLLs(context: Context, container: Container) {
     val wineVersion: String? = container.getWineVersion()
     Log.d("XServerDisplayActivity", "arm64ec Input DLL Extraction Verification: Container Wine version: " + wineVersion)
 
-    // Check if the wineVersion string is not null and contains "arm64ec"
-    if (wineVersion != null && wineVersion.contains("proton-9.0-arm64ec")) {
+    // Check if the wineVersion string is not null and contains "arm64ec" (matches any proton-X.Y-arm64ec)
+    if (wineVersion != null && wineVersion.contains("arm64ec")) {
         val wineFolder: File = File(imageFs.getWinePath() + "/lib/wine/")
         Log.d("XServerDisplayActivity", "Wine version contains arm64ec. Extracting input dlls to " + wineFolder.getPath())
         val success: Boolean = TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, context.assets, inputAsset, wineFolder)
@@ -3704,10 +3704,17 @@ private fun extractx86_64InputDlls(context: Context, container: Container) {
     val imageFs = ImageFs.find(context)
     val wineVersion: String? = container.getWineVersion()
     Log.d("XServerDisplayActivity", "x86_64 Input DLL Extraction Verification: Container Wine version: " + wineVersion)
-    if ("proton-9.0-x86_64" == wineVersion) {
+    // Match any x86_64 wine/proton version (not just proton-9.0-x86_64)
+    if (wineVersion != null && wineVersion.contains("x86_64")) {
         val wineFolder: File = File(imageFs.getWinePath() + "/lib/wine/")
-        Log.d("XServerDisplayActivity", "Extracting input dlls to " + wineFolder.getPath())
-    } else Log.d("XServerDisplayActivity", "Wine version is not proton-9.0-x86_64, skipping input dlls extraction")
+        Log.d("XServerDisplayActivity", "Wine version contains x86_64. Extracting input dlls to " + wineFolder.getPath())
+        val success: Boolean = TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, context.assets, inputAsset, wineFolder)
+        if (!success) {
+            Log.d("XServerDisplayActivity", "Failed to extract x86_64 input dlls")
+        }
+    } else {
+        Log.d("XServerDisplayActivity", "Wine version is not x86_64, skipping input dlls extraction.")
+    }
 }
 
 private fun setupWineSystemFiles(

--- a/app/src/main/java/com/winlator/PrefManager.kt
+++ b/app/src/main/java/com/winlator/PrefManager.kt
@@ -38,6 +38,9 @@ object PrefManager {
     @JvmStatic
     fun init(context: Context) {
         if (dataStore == null) {
+            // Pre-create the datastore directory so DataStore doesn't throw FileNotFoundException
+            // (ENOENT) on first launch — DataStore 1.1.x bug on some Android 13 devices.
+            runCatching { context.applicationContext.filesDir.resolve("datastore").mkdirs() }
             dataStore = context.datastore
         }
     }
@@ -66,7 +69,14 @@ object PrefManager {
     }
 
     private fun <T> getPref(key: Preferences.Key<T>, defaultValue: T): T = runBlocking {
-        dataStore!!.data.first()[key] ?: defaultValue
+        try {
+            dataStore!!.data.first()[key] ?: defaultValue
+        } catch (e: Exception) {
+            // DataStore 1.1.x bug: missing file can propagate as FileNotFoundException
+            // instead of returning emptyPreferences() on some Android 13 devices.
+            Timber.w(e, "WinlatorPrefManager: failed to read pref '${key.name}', returning default")
+            defaultValue
+        }
     }
 
     private fun <T> setPref(key: Preferences.Key<T>, value: T): CompletableFuture<Unit> {


### PR DESCRIPTION
Fixes Input devices (gamepad, mouse, keyboard) not working inside Wine when using any arm64ec build newer than proton-9.0. 
bug fix: launch crash fix on android 13

## Description
Bug 1 — extractArm64ecInputDLLs checks for the hardcoded string "proton-9.0-arm64ec", so it never fires for proton-10.0-arm64ec. Input DLLs are never injected for proton-10.

Bug 2 — extractx86_64InputDlls checks the version but never calls TarCompressorUtils.extract — it would not fire and extract

Bug 3 - Added quick Bug fix for app crash on fresh install: Pre-create the datastore directory so DataStore doesn't throw FileNotFoundException
        (ENOENT) on first launch — DataStore 1.1.x bug on some Android 13 devices. it crashes as you try to open the first time, quickly, right as the app finished installing, happens only at that moment.

## Recording
No recording for this one

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed app crashes on first launch on certain Android devices due to missing preference storage directory
  * Improved preference data reading with fallback to default values when errors occur
  * Enhanced DLL extraction compatibility across different processor architectures and container configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->