### PR TITLE
Fix/steam achievement timestamp fix

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2858,7 +2858,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             cachedAchievements = result.achievements
             cachedAchievementsAppId = appId
 
-            // Create AchievementFile for each GSE save directory so that they can be unlocked by Goldberg
+            // Create AchievementFile for each GSE save directory so that they can be tracked by goldberg
             generator.writeGseAchievementFiles(result, getGseSaveDirs(instance!!, appId))
 
             val nameToBlockBit = result.nameToBlockBit

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2853,10 +2853,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             val userStats = instance?._steamUserStats!!.getUserStats(appId, steamUser.steamID!!).await()
             val schemaArray = userStats.schema.toByteArray()
             val generator = StatsAchievementsGenerator()
-
-            val parsed = generator.parseSchema(schemaArray)
-            val result = generator.applyEarnedState(parsed, userStats.achievementBlocks ?: emptyList())
-            generator.writeConfigFiles(result, configDirectory)
+            val result = generator.generateStatsAchievements(schemaArray, configDirectory, userStats.achievementBlocks ?: emptyList())
 
             cachedAchievements = result.achievements
             cachedAchievementsAppId = appId

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2858,6 +2858,9 @@ class SteamService : Service(), IChallengeUrlChanged {
             cachedAchievements = result.achievements
             cachedAchievementsAppId = appId
 
+            // Create AchievementFile for each GSE save directory so that they can be unlocked by Goldberg
+            generator.writeGseAchievementFiles(result, getGseSaveDirs(instance!!, appId))
+
             val nameToBlockBit = result.nameToBlockBit
             Timber.d("nameToBlockBit size=${nameToBlockBit.size} for appId=$appId")
             if (nameToBlockBit.isNotEmpty()) {

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2853,7 +2853,11 @@ class SteamService : Service(), IChallengeUrlChanged {
             val userStats = instance?._steamUserStats!!.getUserStats(appId, steamUser.steamID!!).await()
             val schemaArray = userStats.schema.toByteArray()
             val generator = StatsAchievementsGenerator()
-            val result = generator.generateStatsAchievements(schemaArray, configDirectory)
+
+            val parsed = generator.parseSchema(schemaArray)
+            val result = generator.applyEarnedState(parsed, userStats.achievementBlocks ?: emptyList())
+            generator.writeConfigFiles(result, configDirectory)
+
             cachedAchievements = result.achievements
             cachedAchievementsAppId = appId
 

--- a/app/src/main/java/app/gamenative/statsgen/StatsAchievementsGenerator.kt
+++ b/app/src/main/java/app/gamenative/statsgen/StatsAchievementsGenerator.kt
@@ -1,6 +1,7 @@
 package app.gamenative.statsgen
 
 import java.io.File
+import timber.log.Timber
 
 class StatsAchievementsGenerator {
     private val vdfParser = VdfParser()
@@ -192,6 +193,10 @@ class StatsAchievementsGenerator {
                 outputAch["progress"] = ach.progress
             }
 
+            if(ach.unlocked == true){ 
+                Timber.tag("ach").i("Achievement ${ach.name} is unlocked: ${ach.unlocked}, unlockTimestamp: ${ach.unlockTimestamp}, formattedUnlockTime: ${ach.formattedUnlockTime}")
+            }
+
             ach.unlocked?.let { outputAch["earned"] = it }
             ach.unlockTimestamp?.let { outputAch["earned_time"] = it }
             ach.formattedUnlockTime?.let { outputAch["formattedUnlockTime"] = it }
@@ -257,7 +262,7 @@ class StatsAchievementsGenerator {
 
             val orderedKeys = listOf(
                 "hidden", "displayName", "description", "icon", "icon_gray", "name",
-                "unlocked", "unlockTimestamp", "formattedUnlockTime",
+                "earned", "earned_time", "formattedUnlockTime",
             )
 
             for ((index, ach) in outputAchievements.withIndex()) {
@@ -290,10 +295,10 @@ class StatsAchievementsGenerator {
                                     jsonBuilder.append("\"$escapedText\"")
                                 }
                             }
-                            "hidden", "unlockTimestamp" -> {
+                            "hidden", "earned_time" -> {
                                 jsonBuilder.append("    \"$key\": $value")
                             }
-                            "unlocked" -> {
+                            "earned" -> {
                                 jsonBuilder.append("    \"$key\": ${value.toString().lowercase()}")
                             }
                             else -> {

--- a/app/src/main/java/app/gamenative/statsgen/StatsAchievementsGenerator.kt
+++ b/app/src/main/java/app/gamenative/statsgen/StatsAchievementsGenerator.kt
@@ -1,5 +1,6 @@
 package app.gamenative.statsgen
 
+import `in`.dragonbra.javasteam.steam.handlers.steamuserstats.AchievementBlocks
 import java.io.File
 import timber.log.Timber
 
@@ -158,6 +159,37 @@ class StatsAchievementsGenerator {
             copyDefaultLockedImg = achievementsOut.any { it.iconGray.isNullOrEmpty() },
             nameToBlockBit = nameToBlockBit,
         )
+    }
+
+    /**
+     * Merges earned state from the raw [achievementBlocks] (from [UserStatsCallback.achievementBlocks])
+     * into the parsed [result] using the [ProcessingResult.nameToBlockBit] map produced by [parseSchema].
+     *
+     * Each achievement's (blockId, bitIndex) is looked up in the raw blocks to retrieve its
+     * individual unlock timestamp, avoiding the bitIndex=0 bug present in getExpandedAchievements().
+     */
+    fun applyEarnedState(
+        result: ProcessingResult,
+        achievementBlocks: List<AchievementBlocks>,
+    ): ProcessingResult {
+        if (achievementBlocks.isEmpty()) return result
+
+        // blockId -> ordered list of unlock timestamps (one per bit, 0 = locked)
+        val blockUnlockTimes: Map<Int, List<Int>> = achievementBlocks.associate { block ->
+            block.achievementId to block.unlockTime
+        }
+
+        val enriched = result.achievements.map { ach ->
+            val (blockId, bitIndex) = result.nameToBlockBit[ach.name] ?: return@map ach
+            val unlockTimes = blockUnlockTimes[blockId] ?: return@map ach.copy(unlocked = false)
+            val timestamp = unlockTimes.getOrElse(bitIndex) { 0 }
+            if (timestamp != 0) {
+                ach.copy(unlocked = true, unlockTimestamp = timestamp)
+            } else {
+                ach.copy(unlocked = false)
+            }
+        }
+        return result.copy(achievements = enriched)
     }
 
     fun writeConfigFiles(result: ProcessingResult, configDirectory: String) {

--- a/app/src/main/java/app/gamenative/statsgen/StatsAchievementsGenerator.kt
+++ b/app/src/main/java/app/gamenative/statsgen/StatsAchievementsGenerator.kt
@@ -1,7 +1,5 @@
 package app.gamenative.statsgen
 
-import org.json.JSONArray
-import org.json.JSONObject
 import java.io.File
 
 class StatsAchievementsGenerator {
@@ -22,13 +20,13 @@ class StatsAchievementsGenerator {
         return sb.toString()
     }
 
-    fun generateStatsAchievements(schema: ByteArray, configDirectory: String): ProcessingResult {
+    fun parseSchema(schema: ByteArray): ProcessingResult {
         val parsedSchema = vdfParser.binaryLoads(schema)
         val achievementsOut = mutableListOf<Achievement>()
         val statsOut = mutableListOf<Stat>()
         val nameToBlockBit = mutableMapOf<String, Pair<Int, Int>>()
 
-        for ((appId, appData) in parsedSchema) {
+        for ((_, appData) in parsedSchema) {
             if (appData !is Map<*, *>) continue
             val sch = appData as Map<String, Any>
             val statInfo = sch["stats"] as? Map<String, Any> ?: continue
@@ -99,17 +97,18 @@ class StatsAchievementsGenerator {
                             achievementBuilder["progress"] = ach["progress"] as Any
                         }
 
-                        val achievement = Achievement(
-                            name = achievementBuilder["name"]?.toString() ?: "",
-                            displayName = achievementBuilder["displayName"] as? Map<String, String>,
-                            description = achievementBuilder["description"] as? Map<String, String>,
-                            hidden = (achievementBuilder["hidden"] as? Number)?.toInt() ?: 0,
-                            icon = achievementBuilder["icon"]?.toString(),
-                            iconGray = achievementBuilder["icon_gray"]?.toString(),
-                            icongray = achievementBuilder["icongray"]?.toString(),
-                            progress = achievementBuilder["progress"] as? Map<String, Any>
+                        achievementsOut.add(
+                            Achievement(
+                                name = achievementBuilder["name"]?.toString() ?: "",
+                                displayName = achievementBuilder["displayName"] as? Map<String, String>,
+                                description = achievementBuilder["description"] as? Map<String, String>,
+                                hidden = (achievementBuilder["hidden"] as? Number)?.toInt() ?: 0,
+                                icon = achievementBuilder["icon"]?.toString(),
+                                iconGray = achievementBuilder["icon_gray"]?.toString(),
+                                icongray = achievementBuilder["icongray"]?.toString(),
+                                progress = achievementBuilder["progress"] as? Map<String, Any>,
+                            )
                         )
-                        achievementsOut.add(achievement)
                     }
                 } else {
                     val statBuilder = mutableMapOf<String, Any>()
@@ -137,24 +136,33 @@ class StatsAchievementsGenerator {
                         statBuilder["default"] = stat["default"] as Any
                     }
 
-                    val statObj = Stat(
-                        id = statBuilder["id"]?.toString() ?: "",
-                        name = statBuilder["name"]?.toString() ?: "",
-                        type = statBuilder["type"]?.toString() ?: "int",
-                        default = statBuilder["default"]?.toString() ?: "0",
-                        global = statBuilder["global"]?.toString() ?: "0",
-                        min = statBuilder["min"]?.toString()
+                    statsOut.add(
+                        Stat(
+                            id = statBuilder["id"]?.toString() ?: "",
+                            name = statBuilder["name"]?.toString() ?: "",
+                            type = statBuilder["type"]?.toString() ?: "int",
+                            default = statBuilder["default"]?.toString() ?: "0",
+                            global = statBuilder["global"]?.toString() ?: "0",
+                            min = statBuilder["min"]?.toString(),
+                        )
                     )
-                    statsOut.add(statObj)
                 }
             }
         }
 
-        var copyDefaultUnlockedImg = false
-        var copyDefaultLockedImg = false
+        return ProcessingResult(
+            achievements = achievementsOut,
+            stats = statsOut,
+            copyDefaultUnlockedImg = achievementsOut.any { it.icon.isNullOrEmpty() },
+            copyDefaultLockedImg = achievementsOut.any { it.iconGray.isNullOrEmpty() },
+            nameToBlockBit = nameToBlockBit,
+        )
+    }
+
+    fun writeConfigFiles(result: ProcessingResult, configDirectory: String) {
         val outputAchievements = mutableListOf<Map<String, Any>>()
 
-        for (ach in achievementsOut) {
+        for (ach in result.achievements) {
             val outputAch = mutableMapOf<String, Any>()
             outputAch["name"] = ach.name
             outputAch["displayName"] = ach.displayName ?: emptyMap<String, String>()
@@ -166,7 +174,6 @@ class StatsAchievementsGenerator {
                 outputAch["icon"] = "img/$icon"
             } else {
                 outputAch["icon"] = "img/steam_default_icon_unlocked.jpg"
-                copyDefaultUnlockedImg = true
             }
 
             val iconGray = ach.iconGray
@@ -174,7 +181,6 @@ class StatsAchievementsGenerator {
                 outputAch["icon_gray"] = "img/$iconGray"
             } else {
                 outputAch["icon_gray"] = "img/steam_default_icon_locked.jpg"
-                copyDefaultLockedImg = true
             }
 
             val icongray = ach.icongray
@@ -186,15 +192,15 @@ class StatsAchievementsGenerator {
                 outputAch["progress"] = ach.progress
             }
 
-            ach.unlocked?.let { outputAch["unlocked"] = it }
-            ach.unlockTimestamp?.let { outputAch["unlockTimestamp"] = it }
+            ach.unlocked?.let { outputAch["earned"] = it }
+            ach.unlockTimestamp?.let { outputAch["earned_time"] = it }
             ach.formattedUnlockTime?.let { outputAch["formattedUnlockTime"] = it }
 
             outputAchievements.add(outputAch)
         }
 
         val outputStats = mutableListOf<Map<String, Any>>()
-        for (stat in statsOut) {
+        for (stat in result.stats) {
             val outputStat = mutableMapOf<String, Any>()
             outputStat["id"] = stat.id
             outputStat["name"] = stat.name
@@ -251,7 +257,7 @@ class StatsAchievementsGenerator {
 
             val orderedKeys = listOf(
                 "hidden", "displayName", "description", "icon", "icon_gray", "name",
-                "unlocked", "unlockTimestamp", "formattedUnlockTime"
+                "unlocked", "unlockTimestamp", "formattedUnlockTime",
             )
 
             for ((index, ach) in outputAchievements.withIndex()) {
@@ -320,7 +326,6 @@ class StatsAchievementsGenerator {
                 if (index > 0) jsonBuilder.append(",\n")
                 jsonBuilder.append("  {\n")
 
-                // Define the desired order of properties
                 val orderedKeys = listOf("id", "default", "global", "name", "type")
                 val statMap = stat.toMap()
 
@@ -337,13 +342,11 @@ class StatsAchievementsGenerator {
             jsonBuilder.append("\n]")
             statsFile.writeText(jsonBuilder.toString(), Charsets.UTF_8)
         }
+    }
 
-        return ProcessingResult(
-            achievements = achievementsOut,
-            stats = statsOut,
-            copyDefaultUnlockedImg = copyDefaultUnlockedImg,
-            copyDefaultLockedImg = copyDefaultLockedImg,
-            nameToBlockBit = nameToBlockBit,
-        )
+    fun generateStatsAchievements(schema: ByteArray, configDirectory: String): ProcessingResult {
+        val result = parseSchema(schema)
+        writeConfigFiles(result, configDirectory)
+        return result
     }
 }

--- a/app/src/main/java/app/gamenative/statsgen/StatsAchievementsGenerator.kt
+++ b/app/src/main/java/app/gamenative/statsgen/StatsAchievementsGenerator.kt
@@ -225,10 +225,6 @@ class StatsAchievementsGenerator {
                 outputAch["progress"] = ach.progress
             }
 
-            if(ach.unlocked == true){ 
-                Timber.tag("ach").i("Achievement ${ach.name} is unlocked: ${ach.unlocked}, unlockTimestamp: ${ach.unlockTimestamp}, formattedUnlockTime: ${ach.formattedUnlockTime}")
-            }
-
             ach.unlocked?.let { outputAch["earned"] = it }
             ach.unlockTimestamp?.let { outputAch["earned_time"] = it }
             ach.formattedUnlockTime?.let { outputAch["formattedUnlockTime"] = it }

--- a/app/src/main/java/app/gamenative/statsgen/StatsAchievementsGenerator.kt
+++ b/app/src/main/java/app/gamenative/statsgen/StatsAchievementsGenerator.kt
@@ -381,6 +381,42 @@ class StatsAchievementsGenerator {
         }
     }
 
+    /**
+     * Merges earned state from [result] into each directory in [gseSaveDirs] as a
+     * Goldberg-compatible achievements.json. Existing files are merged so that
+     * locally-earned achievements are never downgraded (earned: true → false).
+     */
+    fun writeGseAchievementFiles(result: ProcessingResult, gseSaveDirs: List<File>) {
+        for (gseDir in gseSaveDirs) {
+            try {
+                if (!gseDir.exists()) gseDir.mkdirs()
+                val achFile = File(gseDir, "achievements.json")
+                val existing = if (achFile.exists()) {
+                    try {
+                        org.json.JSONObject(achFile.readText(Charsets.UTF_8))
+                    } catch (e: Exception) {
+                        Timber.w(e, "Failed to parse existing GSE achievements.json in ${gseDir.absolutePath}, starting fresh")
+                        org.json.JSONObject()
+                    }
+                } else {
+                    org.json.JSONObject()
+                }
+                for (ach in result.achievements) {
+                    val entry = existing.optJSONObject(ach.name) ?: org.json.JSONObject()
+                    if (!entry.optBoolean("earned", false)) {
+                        entry.put("earned", ach.unlocked == true)
+                        entry.put("earned_time", ach.unlockTimestamp?.toLong() ?: 0L)
+                    }
+                    existing.put(ach.name, entry)
+                }
+                achFile.writeText(existing.toString(2), Charsets.UTF_8)
+                Timber.tag("GenerateAchievements").d("Wrote GSE save achievements.json to ${gseDir.absolutePath}")
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to write GSE save achievements.json to ${gseDir.absolutePath}")
+            }
+        }
+    }
+
     fun generateStatsAchievements(schema: ByteArray, configDirectory: String, achievementBlocks: List<AchievementBlocks>): ProcessingResult {
         val parsedSchema = parseSchema(schema)
         val result = applyEarnedState(parsedSchema, achievementBlocks)

--- a/app/src/main/java/app/gamenative/statsgen/StatsAchievementsGenerator.kt
+++ b/app/src/main/java/app/gamenative/statsgen/StatsAchievementsGenerator.kt
@@ -381,8 +381,9 @@ class StatsAchievementsGenerator {
         }
     }
 
-    fun generateStatsAchievements(schema: ByteArray, configDirectory: String): ProcessingResult {
-        val result = parseSchema(schema)
+    fun generateStatsAchievements(schema: ByteArray, configDirectory: String, achievementBlocks: List<AchievementBlocks>): ProcessingResult {
+        val parsedSchema = parseSchema(schema)
+        val result = applyEarnedState(parsedSchema, achievementBlocks)
         writeConfigFiles(result, configDirectory)
         return result
     }


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

This PR fixes 3 bugs in the achievement generator code.

1. It was not supplying the achievements.json with the correct fields. It required "earned" and "earned_time" for the unlock and unlock time respectively.

2. We were not getting timestamps due to the fact that the schema for achievements & stats did not provide this. To fix this, I needed to create a new function called "applyEarnedState" which applies the earned state based on the bitIndex match with the raw achievementBlocks from userStatsCallback.

3. Goldberg requires us to put an achievements.json in the GSE save locations and populate them based on the above 2 fixes.

This now fixes the issue where games would re-trigger achievements on launch, such as Brotato.

Happy for feedback. The big one I'm sure could do with some critique is the file output code.

**Out of Scope:**
- In a follow-up branch I will refactor Javasteam "getExpandedAchievements" to give back the correct achievement Ids and timestamps, since it looks like there's a bug there.

## Recording
<!-- Attach a short recording/GIF showing the change -->

Achievement Fix Video:
https://github.com/user-attachments/assets/dccfc456-ddbf-421e-960b-e26a31c54f06


## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Steam achievement earned state and per‑achievement timestamps, and writes Goldberg-compatible achievements files so games don’t re-trigger achievements.

- **Bug Fixes**
  - Output now uses "earned" (bool) and "earned_time" (unix); per‑achievement times come from `AchievementBlocks` via `applyEarnedState`, avoiding the expanded‑achievements bug.
  - `SteamService` passes `userStats.achievementBlocks` into generation and writes a Goldberg `achievements.json` to each GSE save dir; existing files are merged so earned progress isn’t downgraded.

<sup>Written for commit 7346f83e51b680857456c0bcbb103d91301ee158. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Achievement generation now uses per-user unlock data to produce accurate earned states and timestamps and writes Goldberg-compatible achievement files into user save directories.
* **Bug Fixes**
  * Merging with existing saved achievement files preserves previously earned entries and avoids overwriting user progress; improved logging and error handling during file updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->