### PR TITLE
fix: use stored installPath in GOGManager.deleteGame to prevent uninstall failures

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
@@ -470,36 +470,36 @@ class GOGManager @Inject constructor(
         return withContext(Dispatchers.IO) {
             try {
                 val gameId = libraryItem.gameId.toString()
-                val installPath = getGameInstallPath(gameId, libraryItem.name)
-                val installDir = File(installPath)
-                val hadInstallArtifacts = installDir.exists() || MarkerUtils.hasPartialInstall(installPath)
-                val wasInstalled = MarkerUtils.hasMarker(installPath, Marker.DOWNLOAD_COMPLETE_MARKER)
 
-                // Delete the manifest file
+                val game = getGameFromDbById(gameId)
+                val storedPath = game?.installPath?.takeIf { it.isNotBlank() }
+                val computedPath = getGameInstallPath(gameId, libraryItem.name)
+                val pathsToClean = listOfNotNull(storedPath, computedPath).distinct()
+
                 val manifestPath = File(context.filesDir, "manifests/$gameId")
                 if (manifestPath.exists()) {
                     manifestPath.delete()
                     Timber.i("Deleted manifest file for game $gameId")
                 }
 
-                // Delete game files
-                if (installDir.exists()) {
-                    val success = installDir.deleteRecursively()
-                    if (success) {
-                        Timber.i("Successfully deleted game directory: $installPath")
+                val failedPaths = mutableListOf<String>()
+                for (path in pathsToClean) {
+                    val dir = File(path)
+                    if (dir.exists()) {
+                        if (dir.deleteRecursively()) {
+                            Timber.i("Successfully deleted game directory: $path")
+                        } else {
+                            Timber.w("Failed to delete some game files at $path")
+                            failedPaths.add(path)
+                        }
                     } else {
-                        Timber.w("Failed to delete some game files")
-                        return@withContext Result.failure(Exception("Failed to fully delete at $installPath"))
+                        Timber.w("GOG game directory doesn't exist: $path")
                     }
-                } else {
-                    Timber.w("GOG game directory doesn't exist: $installPath")
+                    MarkerUtils.removeMarker(path, Marker.DOWNLOAD_COMPLETE_MARKER)
+                    MarkerUtils.removeMarker(path, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
                 }
 
-                MarkerUtils.removeMarker(installPath, Marker.DOWNLOAD_COMPLETE_MARKER)
-                MarkerUtils.removeMarker(installPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
-
-                val game = getGameFromDbById(gameId)
-                if (game != null && (wasInstalled || hadInstallArtifacts)) {
+                if (game != null) {
                     val updatedGame = game.copy(isInstalled = false, installPath = "")
                     gogGameDao.update(updatedGame)
                     Timber.d("Updated database: game marked as not installed")
@@ -513,6 +513,10 @@ class GOGManager @Inject constructor(
                 app.gamenative.PluviaApp.events.emitJava(
                     app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged(libraryItem.gameId),
                 )
+
+                if (failedPaths.isNotEmpty()) {
+                    return@withContext Result.failure(Exception("Failed to fully delete at: ${failedPaths.joinToString()}"))
+                }
 
                 Result.success(Unit)
             } catch (e: Exception) {
@@ -1246,6 +1250,7 @@ class GOGManager @Inject constructor(
         val game = runBlocking { getGameFromDbById(gameId.toString()) }
 
         if (game != null) {
+            if (game.installPath.isNotBlank()) return game.installPath
             return GOGConstants.getGameInstallPath(game.title)
         }
 


### PR DESCRIPTION
## Description
`deleteGame` was computing the install path from the current storage preference instead of reading it from the DB. If storage settings changed since install, the computed path would be wrong.

Fix: collect both the DB-stored path and the computed path, deduplicate, and attempt deletion at each. DB is always marked uninstalled regardless of whether files were found.

- Common case (no storage change): paths are identical, `distinct()` reduces to one operation, no behavior change
- Storage changed since install: both locations get cleaned, no orphans
- DB always cleared: game can never get stuck as installed

mirrors existing epic and amazon primary and fallback. GoG was odd one out.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More thorough cleanup of all candidate install directories during game removal.
  * Prioritize stored install path when resolving locations and remove duplicate targets.
  * Ensure download markers are cleared for each candidate path.
  * Always update install status in the database when a record exists.
  * Aggregate deletion failures and report overall failure if any path could not be removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->