### PR TITLE
Added ability to use USB as external storage

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
@@ -1,8 +1,10 @@
 package app.gamenative.ui.screen.settings
 
 import android.content.res.Configuration
+import android.os.Build
 import android.os.Environment
 import android.os.storage.StorageManager
+import java.io.File
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -446,18 +448,37 @@ fun SettingsGroupInterface(
         val ctx = LocalContext.current
         val sm = ctx.getSystemService(StorageManager::class.java)
 
-        // All writable volumes: primary first, then every SD / USB
+        // All writable non-primary volumes (SD / USB).
+        // Uses getExternalFilesDirs first, and falls back to enumerating StorageManager
+        // volumes on devices where getExternalFilesDirs misses removable media (e.g. USB).
         val dirs = remember {
-            ctx.getExternalFilesDirs(null)
-                .filterNotNull()
-                .filter { Environment.getExternalStorageState(it) == Environment.MEDIA_MOUNTED }
-                .filter { sm.getStorageVolume(it)?.isPrimary != true }
+            val seen = mutableSetOf<String>()
+            val result = mutableListOf<File>()
+
+            fun tryAdd(dir: File?) {
+                if (dir == null) return
+                if (Environment.getExternalStorageState(dir) != Environment.MEDIA_MOUNTED) return
+                if (sm?.getStorageVolume(dir)?.isPrimary == true) return
+                if (seen.add(dir.absolutePath)) result += dir
+            }
+
+            ctx.getExternalFilesDirs(null)?.forEach { tryAdd(it) }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                sm?.storageVolumes?.forEach { volume ->
+                    if (volume.isPrimary) return@forEach
+                    val volDir = volume.directory ?: return@forEach
+                    tryAdd(File(volDir, "Android/data/${ctx.packageName}/files"))
+                }
+            }
+
+            result
         }
 
         // Labels the user sees
         val labels = remember(dirs) {
             dirs.map { dir ->
-                sm.getStorageVolume(dir)?.getDescription(ctx) ?: dir.name
+                sm?.getStorageVolume(dir)?.getDescription(ctx) ?: dir.name
             }
         }
         var useExternalStorage by rememberSaveable { mutableStateOf(PrefManager.useExternalStorage) }


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes external storage selection so USB drives now appear and can be used in Settings. Improves detection of removable storage across devices.

- **Bug Fixes**
  - Detects mounted non-primary volumes (SD/USB) via `getExternalFilesDirs()`, with a fallback to `StorageManager.storageVolumes` on Android 11+.
  - Builds app-scoped paths (`.../Android/data/<package>/files`) for write access on each volume.
  - Deduplicates paths and skips primary storage; only includes `MEDIA_MOUNTED` volumes.
  - Uses safe volume labels from `StorageManager.getStorageVolume(dir)?.getDescription(ctx)`.

<sup>Written for commit 9eb9980a06acc3b106723fef62adf90a26e8269c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved external storage volume discovery to support removable media such as SD cards and USB drives.
  * Enhanced compatibility for accessing external storage volumes on Android R and newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->