### PR TITLE
fix(workshop): force standard Steam UGC path for Tale of Immortal

### DIFF
--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -2229,7 +2229,7 @@ object WorkshopManager {
         // Starbound has mods/ (HIGH confidence) but workshop items use a
         // _metadata format that doesn't work when symlinked into mods/.
         // Force ISteamUGC path regardless of detection.
-        val forceStandardAppIds = setOf(211820) // Starbound
+        val forceStandardAppIds = setOf(211820,1468810) // Starbound,TaleofImmortal
 
         // When the game's binary contains ISteamUGC / GetItemInstallInfo
         // strings AND there's a HIGH-confidence mod directory, the game


### PR DESCRIPTION
- Add AppID 1468810 (Tale of Immortal) to `forceStandardAppIds` to ensure workshop items are handled via the standard ISteamUGC path.

## Description
Tale of Immortal (鬼谷八荒, AppID 1468810) is a Unity game that contains a `Mods/` directory in its install folder. The current heuristic in `willUseFilesystemMods` treats this as a filesystem-managed mod game, which causes `mods.json` to be cleared and `ISteamUGC::GetNumSubscribedItems()` to return 0. However, the game's built-in mod management page relies on the ISteamUGC API to discover workshop items — it does not scan the `Mods/` directory for workshop content.

Adding AppID 1468810 to `forceStandardAppIds` forces the Standard (ISteamUGC) path, ensuring `mods.json` is populated correctly. This branch also sets `stdSeenWithHighDir = true` which prevents Phase 6 from creating filesystem symlinks into `Mods/` and triggers cleanup of any stale symlinks from previous launches.

This is the same pattern already used by Starbound (AppID 211820), which has a similar issue where its `mods/` directory exists but workshop items don't work when symlinked into it.

## Recording

https://github.com/user-attachments/assets/e583564a-fe3e-4691-8fa1-8caff066e03f



## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior [approval)](url)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force the standard Steam UGC path for Tale of Immortal (AppID 1468810) so workshop items are detected and managed correctly. This prevents `mods.json` from being cleared and stops creating symlinks into `Mods/`.

- **Bug Fixes**
  - Added `1468810` to `forceStandardAppIds` in `WorkshopManager`, following the Starbound approach.

<sup>Written for commit c417337be24e7f9b4322e2b9b13926690e026bd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mod symlink handling for additional game versions, expanding compatibility with Starbound configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->