### PR TITLE
added new turnip drivers to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,24 @@
   "items": {
     "driver": [
       {
+        "id": "A8XX MR v25.1",
+        "name": "a8xx-gen8-V25.1",
+        "url": "https://downloads.gamenative.app/drivers/a8xx-gen8-V25.1.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "Turnip v26.2.0 R1",
+        "name": "Turnip_v26.2.0_R1",
+        "url": "https://downloads.gamenative.app/drivers/Turnip_v26.2.0_R1.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "Turnip Gen8 V28",
+        "name": "Turnip_Gen8_V28",
+        "url": "https://downloads.gamenative.app/drivers/Turnip_Gen8_V28.zip",
+        "variant": "bionic"
+      },
+      {
         "id": "Turnip_Gen8_V23",
         "name": "Turnip_Gen8_V23",
         "url": "https://downloads.gamenative.app/drivers/Turnip_Gen8_V23.zip",


### PR DESCRIPTION
## Description
Added new turnip drivers to manifest.json so that people can use them. These fix dx12 issues in UE5 games on adreno incl 8xx devices

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added three new driver versions: A8XX MR v25.1, Turnip v26.2.0 R1, and Turnip Gen8 V28. Each includes bionic variant support, expanding driver availability for improved system compatibility and performance options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added three new Turnip drivers to `manifest.json` so users can install them from the app. Improves DX12 stability in UE5 on Adreno 8xx devices.

- **New Features**
  - Added `A8XX MR v25.1` (bionic)
  - Added `Turnip v26.2.0 R1` (bionic)
  - Added `Turnip Gen8 V28` (bionic)

<sup>Written for commit 74a8f546946c5f4e3c702db6702622ab4026b596. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

