### PR TITLE
feat: sync cloud saves immediately after install

### DIFF
--- a/app/src/main/java/app/gamenative/data/DownloadInfo.kt
+++ b/app/src/main/java/app/gamenative/data/DownloadInfo.kt
@@ -33,6 +33,7 @@ data class DownloadInfo(
     private var hasEmaSpeed: Boolean = false
     private var isActive: Boolean = true
     private val statusMessage = MutableStateFlow<String?>(null)
+    private val postInstallSyncing = MutableStateFlow(false)
 
     fun cancel() {
         cancel("Cancelled by user")
@@ -47,6 +48,7 @@ data class DownloadInfo(
         persistProgressSnapshot()
         // Mark as inactive and clear speed tracking so a future resume
         // does not use stale samples.
+        setPostInstallSyncing(false)
         setActive(false)
         resetSpeedTracking()
         downloadJob?.cancel(CancellationException(message))
@@ -139,6 +141,14 @@ data class DownloadInfo(
     }
 
     fun getStatusMessageFlow(): StateFlow<String?> = statusMessage
+
+    fun setPostInstallSyncing(syncing: Boolean) {
+        postInstallSyncing.value = syncing
+    }
+
+    fun isPostInstallSyncing(): Boolean = postInstallSyncing.value
+
+    fun getPostInstallSyncingFlow(): StateFlow<Boolean> = postInstallSyncing
 
     private fun addSpeedSample(timestampMs: Long) {
         speedSamples.add(SpeedSample(timestampMs, bytesDownloaded))

--- a/app/src/main/java/app/gamenative/data/DownloadInfo.kt
+++ b/app/src/main/java/app/gamenative/data/DownloadInfo.kt
@@ -148,8 +148,6 @@ data class DownloadInfo(
 
     fun isPostInstallSyncing(): Boolean = postInstallSyncing.value
 
-    fun getPostInstallSyncingFlow(): StateFlow<Boolean> = postInstallSyncing
-
     private fun addSpeedSample(timestampMs: Long) {
         speedSamples.add(SpeedSample(timestampMs, bytesDownloaded))
         trimOldSamples(timestampMs)

--- a/app/src/main/java/app/gamenative/data/DownloadInfo.kt
+++ b/app/src/main/java/app/gamenative/data/DownloadInfo.kt
@@ -48,8 +48,8 @@ data class DownloadInfo(
         persistProgressSnapshot()
         // Mark as inactive and clear speed tracking so a future resume
         // does not use stale samples.
-        setPostInstallSyncing(false)
         setActive(false)
+        setPostInstallSyncing(false)
         resetSpeedTracking()
         downloadJob?.cancel(CancellationException(message))
     }

--- a/app/src/main/java/app/gamenative/data/DownloadInfo.kt
+++ b/app/src/main/java/app/gamenative/data/DownloadInfo.kt
@@ -148,6 +148,8 @@ data class DownloadInfo(
 
     fun isPostInstallSyncing(): Boolean = postInstallSyncing.value
 
+    fun getPostInstallSyncingFlow(): StateFlow<Boolean> = postInstallSyncing
+
     private fun addSpeedSample(timestampMs: Long) {
         speedSamples.add(SpeedSample(timestampMs, bytesDownloaded))
         trimOldSamples(timestampMs)

--- a/app/src/main/java/app/gamenative/enums/PathType.kt
+++ b/app/src/main/java/app/gamenative/enums/PathType.kt
@@ -85,6 +85,55 @@ enum class PathType {
         return if (!path.endsWith("/")) "$path/" else path
     }
 
+    /**
+     * Container-aware variant of [toAbsPath]. Resolves paths against the container's own wine
+     * prefix directory rather than the shared `home/xuser` symlink, so this is safe to call
+     * concurrently with any other game session — no container activation required.
+     */
+    fun toAbsPath(context: Context, appId: Int, accountId: Long, container: Container): String {
+        val containerRoot = container.rootDir.absolutePath
+        val path = when (this) {
+            GameInstall -> SteamService.getAppDirPath(appId)
+            SteamUserData -> Paths.get(
+                containerRoot, ".wine",
+                "drive_c/Program Files (x86)/Steam/userdata/$accountId/$appId/remote",
+            ).toString()
+            WinMyDocuments -> Paths.get(
+                containerRoot, ".wine",
+                "drive_c/users/", ImageFs.USER, "Documents/",
+            ).toString()
+            WinAppDataLocal -> Paths.get(
+                containerRoot, ".wine",
+                "drive_c/users/", ImageFs.USER, "AppData/Local/",
+            ).toString()
+            WinAppDataLocalLow -> Paths.get(
+                containerRoot, ".wine",
+                "drive_c/users/", ImageFs.USER, "AppData/LocalLow/",
+            ).toString()
+            WinAppDataRoaming -> Paths.get(
+                containerRoot, ".wine",
+                "drive_c/users/", ImageFs.USER, "AppData/Roaming/",
+            ).toString()
+            WinSavedGames -> Paths.get(
+                containerRoot, ".wine",
+                "drive_c/users/", ImageFs.USER, "Saved Games/",
+            ).toString()
+            WinProgramData -> Paths.get(
+                containerRoot, ".wine",
+                "drive_c/ProgramData/",
+            ).toString()
+            Root -> Paths.get(
+                containerRoot, ".wine",
+                "drive_c/users/", ImageFs.USER, "",
+            ).toString()
+            else -> {
+                Timber.e("Did not recognize or unsupported path type $this")
+                SteamService.getAppDirPath(appId)
+            }
+        }
+        return if (!path.endsWith("/")) "$path/" else path
+    }
+
     val isWindows: Boolean
         get() = when (this) {
             GameInstall,

--- a/app/src/main/java/app/gamenative/enums/PathType.kt
+++ b/app/src/main/java/app/gamenative/enums/PathType.kt
@@ -85,55 +85,6 @@ enum class PathType {
         return if (!path.endsWith("/")) "$path/" else path
     }
 
-    /**
-     * Container-aware variant of [toAbsPath]. Resolves paths against the container's own wine
-     * prefix directory rather than the shared `home/xuser` symlink, so this is safe to call
-     * concurrently with any other game session — no container activation required.
-     */
-    fun toAbsPath(context: Context, appId: Int, accountId: Long, container: Container): String {
-        val containerRoot = container.rootDir.absolutePath
-        val path = when (this) {
-            GameInstall -> SteamService.getAppDirPath(appId)
-            SteamUserData -> Paths.get(
-                containerRoot, ".wine",
-                "drive_c/Program Files (x86)/Steam/userdata/$accountId/$appId/remote",
-            ).toString()
-            WinMyDocuments -> Paths.get(
-                containerRoot, ".wine",
-                "drive_c/users/", ImageFs.USER, "Documents/",
-            ).toString()
-            WinAppDataLocal -> Paths.get(
-                containerRoot, ".wine",
-                "drive_c/users/", ImageFs.USER, "AppData/Local/",
-            ).toString()
-            WinAppDataLocalLow -> Paths.get(
-                containerRoot, ".wine",
-                "drive_c/users/", ImageFs.USER, "AppData/LocalLow/",
-            ).toString()
-            WinAppDataRoaming -> Paths.get(
-                containerRoot, ".wine",
-                "drive_c/users/", ImageFs.USER, "AppData/Roaming/",
-            ).toString()
-            WinSavedGames -> Paths.get(
-                containerRoot, ".wine",
-                "drive_c/users/", ImageFs.USER, "Saved Games/",
-            ).toString()
-            WinProgramData -> Paths.get(
-                containerRoot, ".wine",
-                "drive_c/ProgramData/",
-            ).toString()
-            Root -> Paths.get(
-                containerRoot, ".wine",
-                "drive_c/users/", ImageFs.USER, "",
-            ).toString()
-            else -> {
-                Timber.e("Did not recognize or unsupported path type $this")
-                SteamService.getAppDirPath(appId)
-            }
-        }
-        return if (!path.endsWith("/")) "$path/" else path
-    }
-
     val isWindows: Boolean
         get() = when (this) {
             GameInstall,

--- a/app/src/main/java/app/gamenative/events/AndroidEvent.kt
+++ b/app/src/main/java/app/gamenative/events/AndroidEvent.kt
@@ -21,6 +21,7 @@ interface AndroidEvent<T> : Event<T> {
     data class SetBootingSplashText(val text: String) : AndroidEvent<Unit>
     data class DownloadPausedDueToConnectivity(val appId: Int) : AndroidEvent<Unit>
     data class DownloadStatusChanged(val appId: Int, val isDownloading: Boolean) : AndroidEvent<Unit>
+    data class PostInstallSyncStatusChanged(val appId: Int, val isSyncing: Boolean) : AndroidEvent<Unit>
     data class LibraryInstallStatusChanged(val appId: Int) : AndroidEvent<Unit>
     data class CustomGameImagesFetched(val appId: String) : AndroidEvent<Unit>
     data object RecommendationToggleChanged : AndroidEvent<Unit>

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1949,8 +1949,9 @@ class SteamService : Service(), IChallengeUrlChanged {
                             completeAppDownload(di, dlcAppId, dlcDepotIds, emptyList(), appDirPath, branch)
                         }
 
-                        // Remove the job here
+                        // Remove the job here — Play button becomes visible after this
                         removeDownloadJob(appId)
+                        PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(appId))
 
                         // Remove the downloading app info
                         runBlocking {
@@ -2034,26 +2035,27 @@ class SteamService : Service(), IChallengeUrlChanged {
                 // clean up DB record BEFORE notifying UI to avoid stale "Resume" button
                 instance?.downloadingAppInfoDao?.deleteApp(downloadInfo.gameId)
 
-                PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(downloadInfo.gameId))
-
-                // Trigger a cloud save download so saves are ready before first launch.
+                // Download cloud saves so they're ready before first launch.
+                // Uses the container's own path directly — no activation of the shared xuser
+                // symlink needed, so this is safe to run concurrently with any other game session.
                 instance?.let { svc ->
                     val appId = downloadInfo.gameId
                     val steamId = userSteamId
                     if (steamId != null && !ContainerUtils.isLocalSavesOnly(svc.applicationContext, "STEAM_$appId")) {
-                        svc.scope.launch {
-                            // Must activate the container before resolving save paths / downloading save files.
+                        downloadInfo.updateStatusMessage("Syncing saves...")
+                        PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(downloadInfo.gameId))
+                        try {
                             val container = ContainerUtils.getOrCreateContainer(svc.applicationContext, "STEAM_$appId")
-                            ContainerManager(svc.applicationContext).activateContainer(container)
-
                             val prefixToPath: (String) -> String = { prefix ->
-                                PathType.from(prefix).toAbsPath(svc.applicationContext, appId, steamId.accountID)
+                                PathType.from(prefix).toAbsPath(svc.applicationContext, appId, steamId.accountID, container)
                             }
                             forceSyncUserFiles(
                                 appId = appId,
                                 prefixToPath = prefixToPath,
                                 preferredSave = SaveLocation.Remote,
                             ).await()
+                        } catch (e: Exception) {
+                            Timber.e(e, "[PostInstallSync] Cloud save sync failed for app $appId")
                         }
                     }
                 }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2074,7 +2074,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                         try {
                             val container = ContainerUtils.getOrCreateContainer(svc.applicationContext, containerId)
                             val prefixToPath: (String) -> String = { prefix ->
-                                PathType.from(prefix).toAbsPath(appId, steamId.accountID, container)
+                                PathType.from(prefix).toAbsPath(container, appId, steamId.accountID)
                             }
                             val postSyncInfo = forceSyncUserFiles(
                                 appId = appId,

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2005,7 +2005,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             selectedDlcAppIds: List<Int>,
             appDirPath: String,
             branch: String = "public",
-            parentScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
+            parentScope: CoroutineScope,
         ) {
             Timber.i("Item $downloadingAppId download completed, saving database")
 
@@ -2061,7 +2061,6 @@ class SteamService : Service(), IChallengeUrlChanged {
                     if (steamId != null && !ContainerUtils.isLocalSavesOnly(svc.applicationContext, "STEAM_$appId")) {
                         downloadInfo.updateStatusMessage("Syncing saves...")
                         PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(appId, true))
-                        PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(downloadInfo.gameId))
                         try {
                             val container = ContainerUtils.getOrCreateContainer(svc.applicationContext, "STEAM_$appId")
                             val prefixToPath: (String) -> String = { prefix ->
@@ -2073,6 +2072,8 @@ class SteamService : Service(), IChallengeUrlChanged {
                                 preferredSave = SaveLocation.Remote,
                                 parentScope = parentScope,
                             ).await()
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             Timber.e(e, "[PostInstallSync] Cloud save sync failed for app $appId")
                         } finally {

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1939,14 +1939,30 @@ class SteamService : Service(), IChallengeUrlChanged {
                         // Complete app download
                         if (mainAppDepots.isNotEmpty()) {
                             val mainAppDepotIds = mainAppDepots.keys.sorted()
-                            completeAppDownload(di, appId, mainAppDepotIds, mainAppDlcIds, appDirPath, branch)
+                            completeAppDownload(
+                                downloadInfo = di,
+                                downloadingAppId = appId,
+                                entitledDepotIds = mainAppDepotIds,
+                                selectedDlcAppIds = mainAppDlcIds,
+                                appDirPath = appDirPath,
+                                branch = branch,
+                                parentScope = this,
+                            )
                         }
 
                         // Complete dlc app download
                         calculatedDlcAppIds.forEach { dlcAppId ->
                             val dlcDepots = selectedDepots.filter { it.value.dlcAppId == dlcAppId }
                             val dlcDepotIds = dlcDepots.keys.sorted()
-                            completeAppDownload(di, dlcAppId, dlcDepotIds, emptyList(), appDirPath, branch)
+                            completeAppDownload(
+                                downloadInfo = di,
+                                downloadingAppId = dlcAppId,
+                                entitledDepotIds = dlcDepotIds,
+                                selectedDlcAppIds = emptyList(),
+                                appDirPath = appDirPath,
+                                branch = branch,
+                                parentScope = this,
+                            )
                         }
 
                         // Remove the job here — Play button becomes visible after this
@@ -1989,6 +2005,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             selectedDlcAppIds: List<Int>,
             appDirPath: String,
             branch: String = "public",
+            parentScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
         ) {
             Timber.i("Item $downloadingAppId download completed, saving database")
 
@@ -2043,6 +2060,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                     val steamId = userSteamId
                     if (steamId != null && !ContainerUtils.isLocalSavesOnly(svc.applicationContext, "STEAM_$appId")) {
                         downloadInfo.updateStatusMessage("Syncing saves...")
+                        PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(appId, true))
                         PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(downloadInfo.gameId))
                         try {
                             val container = ContainerUtils.getOrCreateContainer(svc.applicationContext, "STEAM_$appId")
@@ -2053,9 +2071,12 @@ class SteamService : Service(), IChallengeUrlChanged {
                                 appId = appId,
                                 prefixToPath = prefixToPath,
                                 preferredSave = SaveLocation.Remote,
+                                parentScope = parentScope,
                             ).await()
                         } catch (e: Exception) {
                             Timber.e(e, "[PostInstallSync] Cloud save sync failed for app $appId")
+                        } finally {
+                            PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(appId, false))
                         }
                     }
                 }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -23,6 +23,7 @@ import app.gamenative.data.DownloadInfo
 import app.gamenative.data.Emoticon
 import app.gamenative.data.EncryptedAppTicket
 import app.gamenative.data.GameProcessInfo
+import app.gamenative.data.GameSource
 import app.gamenative.data.LaunchInfo
 import app.gamenative.data.OwnedGames
 import app.gamenative.data.PostSyncInfo
@@ -1970,9 +1971,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                         PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(appId))
 
                         // Remove the downloading app info
-                        runBlocking {
-                            instance?.downloadingAppInfoDao?.deleteApp(appId)
-                        }
+                        instance?.downloadingAppInfoDao?.deleteApp(appId)
                     } catch (e: Exception) {
                         Timber.e(e, "Download failed for app $appId")
                         di.persistProgressSnapshot()
@@ -1998,6 +1997,8 @@ class SteamService : Service(), IChallengeUrlChanged {
             return info
         }
 
+        // parentScope is intentionally the download job's own CoroutineScope: cancelling the
+        // download (e.g. user taps Cancel) also cancels the post-install cloud save sync.
         private suspend fun completeAppDownload(
             downloadInfo: DownloadInfo,
             downloadingAppId: Int,
@@ -2058,12 +2059,13 @@ class SteamService : Service(), IChallengeUrlChanged {
                 instance?.let { svc ->
                     val appId = downloadInfo.gameId
                     val steamId = userSteamId
-                    if (steamId != null && !ContainerUtils.isLocalSavesOnly(svc.applicationContext, "STEAM_$appId")) {
+                    val containerId = "${GameSource.STEAM.name}_$appId"
+                    if (steamId != null && !ContainerUtils.isLocalSavesOnly(svc.applicationContext, containerId)) {
                         downloadInfo.setPostInstallSyncing(true)
                         downloadInfo.updateStatusMessage("Syncing saves...")
                         PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(appId, true))
                         try {
-                            val container = ContainerUtils.getOrCreateContainer(svc.applicationContext, "STEAM_$appId")
+                            val container = ContainerUtils.getOrCreateContainer(svc.applicationContext, containerId)
                             val prefixToPath: (String) -> String = { prefix ->
                                 PathType.from(prefix).toAbsPath(appId, steamId.accountID, container)
                             }
@@ -2264,8 +2266,9 @@ class SteamService : Service(), IChallengeUrlChanged {
                 return@async PostSyncInfo(SyncResult.InProgress)
             }
 
+            val context = instance?.applicationContext ?: return@async PostSyncInfo(SyncResult.UnknownFail)
             // Migrate GSE Saves to Steam userdata
-            SteamUtils.migrateGSESavesToSteamUserdata(instance?.applicationContext!!, appId)
+            SteamUtils.migrateGSESavesToSteamUserdata(context, appId)
 
             try {
                 var syncResult = PostSyncInfo(SyncResult.UnknownFail)
@@ -2355,8 +2358,9 @@ class SteamService : Service(), IChallengeUrlChanged {
                 return@async PostSyncInfo(SyncResult.InProgress)
             }
 
+            val context = instance?.applicationContext ?: return@async PostSyncInfo(SyncResult.UnknownFail)
             // Migrate GSE Saves to Steam userdata
-            SteamUtils.migrateGSESavesToSteamUserdata(instance?.applicationContext!!, appId)
+            SteamUtils.migrateGSESavesToSteamUserdata(context, appId)
 
             try {
                 var syncResult = PostSyncInfo(SyncResult.UnknownFail)

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -43,6 +43,7 @@ import app.gamenative.enums.LoginResult
 import app.gamenative.enums.Marker
 import app.gamenative.enums.OS
 import app.gamenative.enums.OSArch
+import app.gamenative.enums.PathType
 import app.gamenative.enums.SaveLocation
 import app.gamenative.enums.SyncResult
 import app.gamenative.events.AndroidEvent
@@ -2034,6 +2035,28 @@ class SteamService : Service(), IChallengeUrlChanged {
                 instance?.downloadingAppInfoDao?.deleteApp(downloadInfo.gameId)
 
                 PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(downloadInfo.gameId))
+
+                // Trigger a cloud save download so saves are ready before first launch.
+                instance?.let { svc ->
+                    val appId = downloadInfo.gameId
+                    val steamId = userSteamId
+                    if (steamId != null && !ContainerUtils.isLocalSavesOnly(svc.applicationContext, "STEAM_$appId")) {
+                        svc.scope.launch {
+                            // Must activate the container before resolving save paths / downloading save files.
+                            val container = ContainerUtils.getOrCreateContainer(svc.applicationContext, "STEAM_$appId")
+                            ContainerManager(svc.applicationContext).activateContainer(container)
+
+                            val prefixToPath: (String) -> String = { prefix ->
+                                PathType.from(prefix).toAbsPath(svc.applicationContext, appId, steamId.accountID)
+                            }
+                            forceSyncUserFiles(
+                                appId = appId,
+                                prefixToPath = prefixToPath,
+                                preferredSave = SaveLocation.Remote,
+                            ).await()
+                        }
+                    }
+                }
 
                 // Clear persisted bytes file on successful completion
                 downloadInfo.clearPersistedBytesDownloaded(appDirPath)

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2059,6 +2059,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                     val appId = downloadInfo.gameId
                     val steamId = userSteamId
                     if (steamId != null && !ContainerUtils.isLocalSavesOnly(svc.applicationContext, "STEAM_$appId")) {
+                        downloadInfo.setPostInstallSyncing(true)
                         downloadInfo.updateStatusMessage("Syncing saves...")
                         PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(appId, true))
                         try {
@@ -2077,6 +2078,8 @@ class SteamService : Service(), IChallengeUrlChanged {
                         } catch (e: Exception) {
                             Timber.e(e, "[PostInstallSync] Cloud save sync failed for app $appId")
                         } finally {
+                            downloadInfo.setPostInstallSyncing(false)
+                            downloadInfo.updateStatusMessage(null)
                             PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(appId, false))
                         }
                     }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1972,6 +1972,9 @@ class SteamService : Service(), IChallengeUrlChanged {
 
                         // Remove the downloading app info
                         instance?.downloadingAppInfoDao?.deleteApp(appId)
+                    } catch (e: CancellationException) {
+                        Timber.d(e, "Download canceled for app $appId")
+                        throw e
                     } catch (e: Exception) {
                         Timber.e(e, "Download failed for app $appId")
                         di.persistProgressSnapshot()
@@ -2266,11 +2269,11 @@ class SteamService : Service(), IChallengeUrlChanged {
                 return@async PostSyncInfo(SyncResult.InProgress)
             }
 
-            val context = instance?.applicationContext ?: return@async PostSyncInfo(SyncResult.UnknownFail)
-            // Migrate GSE Saves to Steam userdata
-            SteamUtils.migrateGSESavesToSteamUserdata(context, appId)
-
             try {
+                val context = instance?.applicationContext ?: return@async PostSyncInfo(SyncResult.UnknownFail)
+                // Migrate GSE Saves to Steam userdata
+                SteamUtils.migrateGSESavesToSteamUserdata(context, appId)
+
                 var syncResult = PostSyncInfo(SyncResult.UnknownFail)
 
                 val maxAttempts = 3
@@ -2358,11 +2361,11 @@ class SteamService : Service(), IChallengeUrlChanged {
                 return@async PostSyncInfo(SyncResult.InProgress)
             }
 
-            val context = instance?.applicationContext ?: return@async PostSyncInfo(SyncResult.UnknownFail)
-            // Migrate GSE Saves to Steam userdata
-            SteamUtils.migrateGSESavesToSteamUserdata(context, appId)
-
             try {
+                val context = instance?.applicationContext ?: return@async PostSyncInfo(SyncResult.UnknownFail)
+                // Migrate GSE Saves to Steam userdata
+                SteamUtils.migrateGSESavesToSteamUserdata(context, appId)
+
                 var syncResult = PostSyncInfo(SyncResult.UnknownFail)
 
                 val maxAttempts = 3

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2076,12 +2076,15 @@ class SteamService : Service(), IChallengeUrlChanged {
                             val prefixToPath: (String) -> String = { prefix ->
                                 PathType.from(prefix).toAbsPath(appId, steamId.accountID, container)
                             }
-                            forceSyncUserFiles(
+                            val postSyncInfo = forceSyncUserFiles(
                                 appId = appId,
                                 prefixToPath = prefixToPath,
                                 preferredSave = SaveLocation.Remote,
                                 parentScope = parentScope,
                             ).await()
+                            if (postSyncInfo.syncResult !in setOf(SyncResult.Success, SyncResult.UpToDate)) {
+                                Timber.w("[PostInstallSync] Cloud save sync finished with ${postSyncInfo.syncResult} for app $appId")
+                            }
                         } catch (e: CancellationException) {
                             throw e
                         } catch (e: Exception) {

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2047,7 +2047,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                         try {
                             val container = ContainerUtils.getOrCreateContainer(svc.applicationContext, "STEAM_$appId")
                             val prefixToPath: (String) -> String = { prefix ->
-                                PathType.from(prefix).toAbsPath(svc.applicationContext, appId, steamId.accountID, container)
+                                PathType.from(prefix).toAbsPath(appId, steamId.accountID, container)
                             }
                             forceSyncUserFiles(
                                 appId = appId,

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2056,6 +2056,10 @@ class SteamService : Service(), IChallengeUrlChanged {
                 // clean up DB record BEFORE notifying UI to avoid stale "Resume" button
                 instance?.downloadingAppInfoDao?.deleteApp(downloadInfo.gameId)
 
+                // Clear persisted bytes now — depot install is committed. Post-install sync is
+                // best-effort and may be cancelled, so this must not be deferred past the sync block.
+                downloadInfo.clearPersistedBytesDownloaded(appDirPath)
+
                 // Download cloud saves so they're ready before first launch.
                 // Uses the container's own path directly — no activation of the shared xuser
                 // symlink needed, so this is safe to run concurrently with any other game session.
@@ -2089,9 +2093,6 @@ class SteamService : Service(), IChallengeUrlChanged {
                         }
                     }
                 }
-
-                // Clear persisted bytes file on successful completion
-                downloadInfo.clearPersistedBytesDownloaded(appDirPath)
             }
         }
 

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -441,21 +441,28 @@ class EpicService : Service() {
 
                     if (result.isSuccess) {
                         Timber.i("[Download] Completed successfully for game $gameId")
-                        downloadInfo.setProgress(1.0f)
-                        downloadInfo.setActive(false)
-
                         SnackbarManager.show("Download completed successfully!")
 
-                        // Trigger a cloud save download so saves are ready before first launch.
-                        if (game.cloudSaveEnabled && !ContainerUtils.isLocalSavesOnly(context, "EPIC_$gameId")) {
-                            instance.scope.launch {
+                        // Download cloud saves so they're ready before first launch.
+                        // Status message keeps isDownloading() true so Play stays hidden during sync.
+                        val epicAppId = "EPIC_$gameId"
+                        if (game.cloudSaveEnabled && !ContainerUtils.isLocalSavesOnly(context, epicAppId)) {
+                            downloadInfo.updateStatusMessage("Syncing saves...")
+                            try {
                                 EpicCloudSavesManager.syncCloudSaves(
                                     context = context,
                                     appId = gameId,
                                     preferredAction = "download",
                                 )
+                            } catch (e: Exception) {
+                                Timber.e(e, "[PostInstallSync] Cloud save sync failed for game $gameId")
                             }
+                            downloadInfo.updateStatusMessage(null)
                         }
+
+                        downloadInfo.setProgress(1.0f)
+                        downloadInfo.setActive(false)
+                        instance.activeDownloads.remove(appId)
                     } else {
                         val error = result.exceptionOrNull()
                         Timber.e(error, "[Download] Failed for game $gameId")

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -445,6 +445,17 @@ class EpicService : Service() {
                         downloadInfo.setActive(false)
 
                         SnackbarManager.show("Download completed successfully!")
+
+                        // Trigger a cloud save download so saves are ready before first launch.
+                        if (game.cloudSaveEnabled && !ContainerUtils.isLocalSavesOnly(context, "EPIC_$gameId")) {
+                            instance.scope.launch {
+                                EpicCloudSavesManager.syncCloudSaves(
+                                    context = context,
+                                    appId = gameId,
+                                    preferredAction = "download",
+                                )
+                            }
+                        }
                     } else {
                         val error = result.exceptionOrNull()
                         Timber.e(error, "[Download] Failed for game $gameId")

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -447,6 +447,9 @@ class EpicService : Service() {
                         // Status message keeps isDownloading() true so Play stays hidden during sync.
                         val epicAppId = "EPIC_$gameId"
                         if (game.cloudSaveEnabled && !ContainerUtils.isLocalSavesOnly(context, epicAppId)) {
+                            downloadInfo.setPostInstallSyncing(true)
+                            downloadInfo.setActive(true)
+                            PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(gameId, true))
                             downloadInfo.updateStatusMessage("Syncing saves...")
                             try {
                                 EpicCloudSavesManager.syncCloudSaves(
@@ -454,10 +457,15 @@ class EpicService : Service() {
                                     appId = gameId,
                                     preferredAction = "download",
                                 )
+                            } catch (e: CancellationException) {
+                                throw e
                             } catch (e: Exception) {
                                 Timber.e(e, "[PostInstallSync] Cloud save sync failed for game $gameId")
+                            } finally {
+                                downloadInfo.setPostInstallSyncing(false)
+                                downloadInfo.updateStatusMessage(null)
+                                PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(gameId, false))
                             }
-                            downloadInfo.updateStatusMessage(null)
                         }
 
                         downloadInfo.setProgress(1.0f)
@@ -471,8 +479,14 @@ class EpicService : Service() {
 
                         SnackbarManager.show("Download failed: ${error?.message ?: "Unknown error"}")
                     }
+                } catch (e: CancellationException) {
+                    downloadInfo.setPostInstallSyncing(false)
+                    downloadInfo.updateStatusMessage(null)
+                    throw e
                 } catch (e: Exception) {
                     Timber.e(e, "[Download] Exception for game $gameId")
+                    downloadInfo.setPostInstallSyncing(false)
+                    downloadInfo.updateStatusMessage(null)
                     downloadInfo.setProgress(-1.0f)
                     downloadInfo.setActive(false)
 

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -441,7 +441,6 @@ class EpicService : Service() {
 
                     if (result.isSuccess) {
                         Timber.i("[Download] Completed successfully for game $gameId")
-                        SnackbarManager.show("Download completed successfully!")
 
                         // Download cloud saves so they're ready before first launch.
                         // Status message keeps isDownloading() true so Play stays hidden during sync.
@@ -467,6 +466,7 @@ class EpicService : Service() {
                             }
                         }
 
+                        SnackbarManager.show("Download completed successfully!")
                         downloadInfo.setProgress(1.0f)
                         downloadInfo.setActive(false)
                     } else {
@@ -480,11 +480,13 @@ class EpicService : Service() {
                 } catch (e: CancellationException) {
                     downloadInfo.setPostInstallSyncing(false)
                     downloadInfo.updateStatusMessage(null)
+                    PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(gameId, false))
                     throw e
                 } catch (e: Exception) {
                     Timber.e(e, "[Download] Exception for game $gameId")
                     downloadInfo.setPostInstallSyncing(false)
                     downloadInfo.updateStatusMessage(null)
+                    PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(gameId, false))
                     downloadInfo.setProgress(-1.0f)
                     downloadInfo.setActive(false)
 

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -448,7 +448,6 @@ class EpicService : Service() {
                         val epicAppId = "EPIC_$gameId"
                         if (game.cloudSaveEnabled && !ContainerUtils.isLocalSavesOnly(context, epicAppId)) {
                             downloadInfo.setPostInstallSyncing(true)
-                            downloadInfo.setActive(true)
                             PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(gameId, true))
                             downloadInfo.updateStatusMessage("Syncing saves...")
                             try {
@@ -470,7 +469,6 @@ class EpicService : Service() {
 
                         downloadInfo.setProgress(1.0f)
                         downloadInfo.setActive(false)
-                        instance.activeDownloads.remove(appId)
                     } else {
                         val error = result.exceptionOrNull()
                         Timber.e(error, "[Download] Failed for game $gameId")

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -375,6 +375,18 @@ class GOGService : Service() {
                         downloadInfo.setActive(false)
 
                         SnackbarManager.show("Download completed successfully!")
+
+                        // Trigger a cloud save download so saves are ready before first launch,
+                        // but only when this title actually exposes cloud save locations.
+                        val appId = "GOG_$gameId"
+                        instance.scope.launch {
+                            val game = instance.gogManager.getGameFromDbById(gameId) ?: return@launch
+                            val locations = instance.gogManager.getSaveDirectoryPath(context, appId, game.title)
+                            val supportsCloudSaves = !locations.isNullOrEmpty()
+                            if (supportsCloudSaves && !ContainerUtils.isLocalSavesOnly(context, appId)) {
+                                syncCloudSaves(context, appId, preferredAction = "download")
+                            }
+                        }
                     }
                 } catch (e: Exception) {
                     Timber.e(e, "[Download] Exception for game $gameId")

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -376,23 +376,29 @@ class GOGService : Service() {
                         // Status message keeps isDownloading() true so Play stays hidden during sync.
                         val appId = "GOG_$gameId"
                         val numericGameId = gameId.toIntOrNull()
-                        val gogGame = instance.gogManager.getGameFromDbById(gameId)
-                        val locations = if (gogGame != null) instance.gogManager.getSaveDirectoryPath(context, appId, gogGame.title) else null
-                        if (numericGameId != null && !locations.isNullOrEmpty() && !ContainerUtils.isLocalSavesOnly(context, appId)) {
-                            downloadInfo.setPostInstallSyncing(true)
-                            PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(numericGameId, true))
-                            downloadInfo.updateStatusMessage("Syncing saves...")
-                            try {
-                                syncCloudSaves(context, appId, preferredAction = "download")
-                            } catch (e: CancellationException) {
-                                throw e
-                            } catch (e: Exception) {
-                                Timber.e(e, "[PostInstallSync] Cloud save sync failed for game $gameId")
-                            } finally {
-                                downloadInfo.setPostInstallSyncing(false)
-                                downloadInfo.updateStatusMessage(null)
-                                PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(numericGameId, false))
+                        try {
+                            val gogGame = instance.gogManager.getGameFromDbById(gameId)
+                            val locations = if (gogGame != null) instance.gogManager.getSaveDirectoryPath(context, appId, gogGame.title) else null
+                            if (numericGameId != null && !locations.isNullOrEmpty() && !ContainerUtils.isLocalSavesOnly(context, appId)) {
+                                downloadInfo.setPostInstallSyncing(true)
+                                PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(numericGameId, true))
+                                downloadInfo.updateStatusMessage("Syncing saves...")
+                                try {
+                                    syncCloudSaves(context, appId, preferredAction = "download")
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (e: Exception) {
+                                    Timber.e(e, "[PostInstallSync] Cloud save sync failed for game $gameId")
+                                } finally {
+                                    downloadInfo.setPostInstallSyncing(false)
+                                    downloadInfo.updateStatusMessage(null)
+                                    PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(numericGameId, false))
+                                }
                             }
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            Timber.e(e, "[PostInstallSync] Cloud save sync failed for game $gameId")
                         }
 
                         SnackbarManager.show("Download completed successfully!")

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -380,10 +380,10 @@ class GOGService : Service() {
                             val gogGame = instance.gogManager.getGameFromDbById(gameId)
                             val locations = if (gogGame != null) instance.gogManager.getSaveDirectoryPath(context, appId, gogGame.title) else null
                             if (numericGameId != null && !locations.isNullOrEmpty() && !ContainerUtils.isLocalSavesOnly(context, appId)) {
-                                downloadInfo.setPostInstallSyncing(true)
-                                PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(numericGameId, true))
-                                downloadInfo.updateStatusMessage("Syncing saves...")
                                 try {
+                                    downloadInfo.setPostInstallSyncing(true)
+                                    PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(numericGameId, true))
+                                    downloadInfo.updateStatusMessage("Syncing saves...")
                                     syncCloudSaves(context, appId, preferredAction = "download")
                                 } catch (e: CancellationException) {
                                     throw e

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -380,7 +380,6 @@ class GOGService : Service() {
                         val locations = if (gogGame != null) instance.gogManager.getSaveDirectoryPath(context, appId, gogGame.title) else null
                         if (!locations.isNullOrEmpty() && !ContainerUtils.isLocalSavesOnly(context, appId)) {
                             downloadInfo.setPostInstallSyncing(true)
-                            downloadInfo.setActive(true)
                             PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(gameId.toIntOrNull() ?: 0, true))
                             downloadInfo.updateStatusMessage("Syncing saves...")
                             try {
@@ -398,7 +397,6 @@ class GOGService : Service() {
 
                         downloadInfo.setProgress(1.0f)
                         downloadInfo.setActive(false)
-                        instance.activeDownloads.remove(gameId)
                     }
                 } catch (e: CancellationException) {
                     downloadInfo.setPostInstallSyncing(false)

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -371,22 +371,26 @@ class GOGService : Service() {
                         SnackbarManager.show("Download failed: ${error?.message ?: "Unknown error"}")
                     } else {
                         Timber.i("[Download] Completed successfully for game $gameId")
-                        downloadInfo.setProgress(1.0f)
-                        downloadInfo.setActive(false)
-
                         SnackbarManager.show("Download completed successfully!")
 
-                        // Trigger a cloud save download so saves are ready before first launch,
-                        // but only when this title actually exposes cloud save locations.
+                        // Download cloud saves so they're ready before first launch.
+                        // Status message keeps isDownloading() true so Play stays hidden during sync.
                         val appId = "GOG_$gameId"
-                        instance.scope.launch {
-                            val game = instance.gogManager.getGameFromDbById(gameId) ?: return@launch
-                            val locations = instance.gogManager.getSaveDirectoryPath(context, appId, game.title)
-                            val supportsCloudSaves = !locations.isNullOrEmpty()
-                            if (supportsCloudSaves && !ContainerUtils.isLocalSavesOnly(context, appId)) {
+                        val gogGame = instance.gogManager.getGameFromDbById(gameId)
+                        val locations = if (gogGame != null) instance.gogManager.getSaveDirectoryPath(context, appId, gogGame.title) else null
+                        if (!locations.isNullOrEmpty() && !ContainerUtils.isLocalSavesOnly(context, appId)) {
+                            downloadInfo.updateStatusMessage("Syncing saves...")
+                            try {
                                 syncCloudSaves(context, appId, preferredAction = "download")
+                            } catch (e: Exception) {
+                                Timber.e(e, "[PostInstallSync] Cloud save sync failed for game $gameId")
                             }
+                            downloadInfo.updateStatusMessage(null)
                         }
+
+                        downloadInfo.setProgress(1.0f)
+                        downloadInfo.setActive(false)
+                        instance.activeDownloads.remove(gameId)
                     }
                 } catch (e: Exception) {
                     Timber.e(e, "[Download] Exception for game $gameId")

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -376,11 +376,12 @@ class GOGService : Service() {
                         // Download cloud saves so they're ready before first launch.
                         // Status message keeps isDownloading() true so Play stays hidden during sync.
                         val appId = "GOG_$gameId"
+                        val numericGameId = gameId.toIntOrNull()
                         val gogGame = instance.gogManager.getGameFromDbById(gameId)
                         val locations = if (gogGame != null) instance.gogManager.getSaveDirectoryPath(context, appId, gogGame.title) else null
-                        if (!locations.isNullOrEmpty() && !ContainerUtils.isLocalSavesOnly(context, appId)) {
+                        if (numericGameId != null && !locations.isNullOrEmpty() && !ContainerUtils.isLocalSavesOnly(context, appId)) {
                             downloadInfo.setPostInstallSyncing(true)
-                            PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(gameId.toIntOrNull() ?: 0, true))
+                            PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(numericGameId, true))
                             downloadInfo.updateStatusMessage("Syncing saves...")
                             try {
                                 syncCloudSaves(context, appId, preferredAction = "download")
@@ -391,7 +392,7 @@ class GOGService : Service() {
                             } finally {
                                 downloadInfo.setPostInstallSyncing(false)
                                 downloadInfo.updateStatusMessage(null)
-                                PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(gameId.toIntOrNull() ?: 0, false))
+                                PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(numericGameId, false))
                             }
                         }
 

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -371,7 +371,6 @@ class GOGService : Service() {
                         SnackbarManager.show("Download failed: ${error?.message ?: "Unknown error"}")
                     } else {
                         Timber.i("[Download] Completed successfully for game $gameId")
-                        SnackbarManager.show("Download completed successfully!")
 
                         // Download cloud saves so they're ready before first launch.
                         // Status message keeps isDownloading() true so Play stays hidden during sync.
@@ -396,17 +395,20 @@ class GOGService : Service() {
                             }
                         }
 
+                        SnackbarManager.show("Download completed successfully!")
                         downloadInfo.setProgress(1.0f)
                         downloadInfo.setActive(false)
                     }
                 } catch (e: CancellationException) {
                     downloadInfo.setPostInstallSyncing(false)
                     downloadInfo.updateStatusMessage(null)
+                    PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(gameId.toIntOrNull() ?: -1, false))
                     throw e
                 } catch (e: Exception) {
                     Timber.e(e, "[Download] Exception for game $gameId")
                     downloadInfo.setPostInstallSyncing(false)
                     downloadInfo.updateStatusMessage(null)
+                    PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(gameId.toIntOrNull() ?: -1, false))
                     downloadInfo.setProgress(-1.0f)
                     downloadInfo.setActive(false)
 
@@ -586,6 +588,8 @@ class GOGService : Service() {
                                 Timber.tag("GOG").e("[Cloud Saves] Failed to sync save location '${location.name}' for game $gameId (timestamp: $newTimestamp)")
                                 allSucceeded = false
                             }
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             Timber.tag("GOG").e(e, "[Cloud Saves] Exception syncing save location '${location.name}' for game $gameId")
                             allSucceeded = false
@@ -604,6 +608,8 @@ class GOGService : Service() {
                     getInstance()?.gogManager?.endSync(appId)
                     Timber.tag("GOG").d("[Cloud Saves] Sync completed and lock released for $appId")
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Timber.tag("GOG").e(e, "[Cloud Saves] Failed to sync cloud saves for App ID: $appId")
                 return@withContext false

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -379,21 +379,35 @@ class GOGService : Service() {
                         val gogGame = instance.gogManager.getGameFromDbById(gameId)
                         val locations = if (gogGame != null) instance.gogManager.getSaveDirectoryPath(context, appId, gogGame.title) else null
                         if (!locations.isNullOrEmpty() && !ContainerUtils.isLocalSavesOnly(context, appId)) {
+                            downloadInfo.setPostInstallSyncing(true)
+                            downloadInfo.setActive(true)
+                            PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(gameId.toIntOrNull() ?: 0, true))
                             downloadInfo.updateStatusMessage("Syncing saves...")
                             try {
                                 syncCloudSaves(context, appId, preferredAction = "download")
+                            } catch (e: CancellationException) {
+                                throw e
                             } catch (e: Exception) {
                                 Timber.e(e, "[PostInstallSync] Cloud save sync failed for game $gameId")
+                            } finally {
+                                downloadInfo.setPostInstallSyncing(false)
+                                downloadInfo.updateStatusMessage(null)
+                                PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(gameId.toIntOrNull() ?: 0, false))
                             }
-                            downloadInfo.updateStatusMessage(null)
                         }
 
                         downloadInfo.setProgress(1.0f)
                         downloadInfo.setActive(false)
                         instance.activeDownloads.remove(gameId)
                     }
+                } catch (e: CancellationException) {
+                    downloadInfo.setPostInstallSyncing(false)
+                    downloadInfo.updateStatusMessage(null)
+                    throw e
                 } catch (e: Exception) {
                     Timber.e(e, "[Download] Exception for game $gameId")
+                    downloadInfo.setPostInstallSyncing(false)
+                    downloadInfo.updateStatusMessage(null)
                     downloadInfo.setProgress(-1.0f)
                     downloadInfo.setActive(false)
 

--- a/app/src/main/java/app/gamenative/ui/model/DownloadsViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/DownloadsViewModel.kt
@@ -63,10 +63,12 @@ class DownloadsViewModel @Inject constructor(
         val info: DownloadInfo,
         val progressListener: (Float) -> Unit,
         val statusJob: Job,
+        val syncingJob: Job,
     ) {
         fun dispose() {
             info.removeProgressListener(progressListener)
             statusJob.cancel()
+            syncingJob.cancel()
         }
     }
 
@@ -420,10 +422,17 @@ class DownloadsViewModel @Inject constructor(
                 }
             }
 
+            val syncingJob = viewModelScope.launch(Dispatchers.Default) {
+                binding.info.getPostInstallSyncingFlow().collect {
+                    updateObservedDownloadItem(binding)
+                }
+            }
+
             observedDownloads[key] = ObservedDownload(
                 info = binding.info,
                 progressListener = progressListener,
                 statusJob = statusJob,
+                syncingJob = syncingJob,
             )
         }
     }

--- a/app/src/main/java/app/gamenative/ui/model/DownloadsViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/DownloadsViewModel.kt
@@ -98,9 +98,14 @@ class DownloadsViewModel @Inject constructor(
         scheduleRefreshDownloads()
     }
 
+    private val onPostInstallSyncStatusChanged: (AndroidEvent.PostInstallSyncStatusChanged) -> Unit = {
+        scheduleRefreshDownloads()
+    }
+
     init {
         PluviaApp.events.on<AndroidEvent.DownloadStatusChanged, Unit>(onDownloadStatusChanged)
         PluviaApp.events.on<AndroidEvent.LibraryInstallStatusChanged, Unit>(onLibraryInstallStatusChanged)
+        PluviaApp.events.on<AndroidEvent.PostInstallSyncStatusChanged, Unit>(onPostInstallSyncStatusChanged)
 
         viewModelScope.launch(Dispatchers.IO) {
             refreshRequests.collect {
@@ -114,6 +119,7 @@ class DownloadsViewModel @Inject constructor(
     override fun onCleared() {
         PluviaApp.events.off<AndroidEvent.DownloadStatusChanged, Unit>(onDownloadStatusChanged)
         PluviaApp.events.off<AndroidEvent.LibraryInstallStatusChanged, Unit>(onLibraryInstallStatusChanged)
+        PluviaApp.events.off<AndroidEvent.PostInstallSyncStatusChanged, Unit>(onPostInstallSyncStatusChanged)
         clearObservedDownloads()
         super.onCleared()
     }
@@ -279,9 +285,10 @@ class DownloadsViewModel @Inject constructor(
         val key = downloadKey(gameSource, appId)
         val rawProgress = info.getProgress()
         val statusMessage = normalizeStatusMessage(info.getStatusMessageFlow().value)
+        val isRunning = info.isActive() || info.isPostInstallSyncing()
         val status = when {
             rawProgress < 0f || statusMessage?.startsWith("Failed", ignoreCase = true) == true -> DownloadItemStatus.FAILED
-            info.isActive() -> DownloadItemStatus.DOWNLOADING
+            isRunning -> DownloadItemStatus.DOWNLOADING
             else -> DownloadItemStatus.PAUSED
         }
 

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -576,7 +576,7 @@ internal fun AppScreenContent(
             val secondsPart = totalSeconds % 60
             "${minutesLeft}m ${secondsPart}s left"
         } else if (isDownloading && downloadProgress >= 1f) {
-            "Unpacking..."
+            downloadStatusMessage?.takeUnless { it.isBlank() } ?: "Unpacking..."
         } else if (downloadProgress in 0f..1f && downloadProgress < 1f) {
             downloadStatusMessage?.takeUnless { it.isBlank() } ?: ""
         } else {

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
@@ -303,8 +303,8 @@ class EpicAppScreen : BaseAppScreen() {
 
     override fun isDownloading(context: Context, libraryItem: LibraryItem): Boolean {
         val downloadInfo = EpicService.getDownloadInfo(libraryItem.gameId) ?: return false
-        val isSyncing = downloadInfo.getStatusMessageFlow().value != null
-        return isSyncing || (downloadInfo.getProgress() ?: 0f) < 1f
+        val progress = downloadInfo.getProgress() ?: 0f
+        return downloadInfo.isPostInstallSyncing() || (downloadInfo.isActive() && progress < 1f)
     }
 
     override fun getDownloadProgress(context: Context, libraryItem: LibraryItem): Float {
@@ -709,6 +709,16 @@ class EpicAppScreen : BaseAppScreen() {
         app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
         disposables +=
             { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener) }
+
+        val postInstallSyncListener: (app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged) -> Unit = { event ->
+            if (event.appId == libraryItem.gameId) {
+                Timber.tag(TAG).d("[OBSERVE] PostInstallSyncStatusChanged for ${libraryItem.appId}, isSyncing=${event.isSyncing}")
+                onStateChanged()
+            }
+        }
+        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener)
+        disposables +=
+            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener) }
 
         // Return cleanup function
         return {

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
@@ -17,9 +17,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import app.gamenative.PluviaApp
 import app.gamenative.R
-import app.gamenative.events.AndroidEvent
 import app.gamenative.data.EpicGame
 import app.gamenative.data.LibraryItem
 import app.gamenative.service.DownloadService
@@ -128,7 +126,7 @@ class EpicAppScreen : BaseAppScreen() {
 
         // Listen for install status changes to refresh game data
         DisposableEffect(gameId) {
-            val installListener: (AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
+            val installListener: (app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
                 if (event.appId == gameId) {
                     Timber.tag(TAG).d("Install status changed, refreshing game data for $gameId")
                     val game = EpicService.getEpicGameOf(gameId)
@@ -138,9 +136,9 @@ class EpicAppScreen : BaseAppScreen() {
                     }
                 }
             }
-            PluviaApp.events.on<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
+            app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
             onDispose {
-                PluviaApp.events.off<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
+                app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
             }
         }
 
@@ -654,7 +652,7 @@ class EpicAppScreen : BaseAppScreen() {
         }
 
         // Listen for download status changes
-        val downloadStatusListener: (AndroidEvent.DownloadStatusChanged) -> Unit = { event ->
+        val downloadStatusListener: (app.gamenative.events.AndroidEvent.DownloadStatusChanged) -> Unit = { event ->
             Timber.tag(TAG).d("[OBSERVE] DownloadStatusChanged event received: event.appId=${event.appId}, libraryItem.gameId=${libraryItem.gameId}, match=${event.appId == libraryItem.gameId}")
             if (event.appId == libraryItem.gameId) {
                 Timber.tag(TAG).d("[OBSERVE] Download status changed for ${libraryItem.gameId}, isDownloading=${event.isDownloading}")
@@ -696,31 +694,31 @@ class EpicAppScreen : BaseAppScreen() {
                 onStateChanged()
             }
         }
-        PluviaApp.events.on<AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener)
+        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener)
         disposables +=
-            { PluviaApp.events.off<AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener) }
+            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener) }
 
         // Listen for install status changes
-        val installListener: (AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
+        val installListener: (app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
             Timber.tag(TAG).d("[OBSERVE] LibraryInstallStatusChanged event received: event.appId=${event.appId}, libraryItem.appId=${libraryItem.appId}, match=${event.appId == libraryItem.gameId}")
             if (event.appId == libraryItem.gameId) {
                 Timber.tag(TAG).d("[OBSERVE] Install status changed for ${libraryItem.appId}, calling onStateChanged()")
                 onStateChanged()
             }
         }
-        PluviaApp.events.on<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
+        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
         disposables +=
-            { PluviaApp.events.off<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener) }
+            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener) }
 
-        val postInstallSyncListener: (AndroidEvent.PostInstallSyncStatusChanged) -> Unit = { event ->
+        val postInstallSyncListener: (app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged) -> Unit = { event ->
             if (event.appId == libraryItem.gameId) {
                 Timber.tag(TAG).d("[OBSERVE] PostInstallSyncStatusChanged for ${libraryItem.appId}, isSyncing=${event.isSyncing}")
                 onStateChanged()
             }
         }
-        PluviaApp.events.on<AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener)
+        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener)
         disposables +=
-            { PluviaApp.events.off<AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener) }
+            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener) }
 
         // Return cleanup function
         return {
@@ -804,8 +802,8 @@ class EpicAppScreen : BaseAppScreen() {
                             DownloadService.invalidateCache()
                             withContext(Dispatchers.Main) {
                                 BaseAppScreen.hideInstallDialog(appId)
-                                PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(gameId, false))
-                                PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(gameId))
+                                app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.DownloadStatusChanged(gameId, false))
+                                app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged(gameId))
                             }
                         }
                     }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
@@ -17,7 +17,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import app.gamenative.PluviaApp
 import app.gamenative.R
+import app.gamenative.events.AndroidEvent
 import app.gamenative.data.EpicGame
 import app.gamenative.data.LibraryItem
 import app.gamenative.service.DownloadService
@@ -126,7 +128,7 @@ class EpicAppScreen : BaseAppScreen() {
 
         // Listen for install status changes to refresh game data
         DisposableEffect(gameId) {
-            val installListener: (app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
+            val installListener: (AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
                 if (event.appId == gameId) {
                     Timber.tag(TAG).d("Install status changed, refreshing game data for $gameId")
                     val game = EpicService.getEpicGameOf(gameId)
@@ -136,9 +138,9 @@ class EpicAppScreen : BaseAppScreen() {
                     }
                 }
             }
-            app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
+            PluviaApp.events.on<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
             onDispose {
-                app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
+                PluviaApp.events.off<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
             }
         }
 
@@ -652,7 +654,7 @@ class EpicAppScreen : BaseAppScreen() {
         }
 
         // Listen for download status changes
-        val downloadStatusListener: (app.gamenative.events.AndroidEvent.DownloadStatusChanged) -> Unit = { event ->
+        val downloadStatusListener: (AndroidEvent.DownloadStatusChanged) -> Unit = { event ->
             Timber.tag(TAG).d("[OBSERVE] DownloadStatusChanged event received: event.appId=${event.appId}, libraryItem.gameId=${libraryItem.gameId}, match=${event.appId == libraryItem.gameId}")
             if (event.appId == libraryItem.gameId) {
                 Timber.tag(TAG).d("[OBSERVE] Download status changed for ${libraryItem.gameId}, isDownloading=${event.isDownloading}")
@@ -694,31 +696,31 @@ class EpicAppScreen : BaseAppScreen() {
                 onStateChanged()
             }
         }
-        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener)
+        PluviaApp.events.on<AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener)
         disposables +=
-            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener) }
+            { PluviaApp.events.off<AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener) }
 
         // Listen for install status changes
-        val installListener: (app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
+        val installListener: (AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
             Timber.tag(TAG).d("[OBSERVE] LibraryInstallStatusChanged event received: event.appId=${event.appId}, libraryItem.appId=${libraryItem.appId}, match=${event.appId == libraryItem.gameId}")
             if (event.appId == libraryItem.gameId) {
                 Timber.tag(TAG).d("[OBSERVE] Install status changed for ${libraryItem.appId}, calling onStateChanged()")
                 onStateChanged()
             }
         }
-        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
+        PluviaApp.events.on<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
         disposables +=
-            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener) }
+            { PluviaApp.events.off<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener) }
 
-        val postInstallSyncListener: (app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged) -> Unit = { event ->
+        val postInstallSyncListener: (AndroidEvent.PostInstallSyncStatusChanged) -> Unit = { event ->
             if (event.appId == libraryItem.gameId) {
                 Timber.tag(TAG).d("[OBSERVE] PostInstallSyncStatusChanged for ${libraryItem.appId}, isSyncing=${event.isSyncing}")
                 onStateChanged()
             }
         }
-        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener)
+        PluviaApp.events.on<AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener)
         disposables +=
-            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener) }
+            { PluviaApp.events.off<AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener) }
 
         // Return cleanup function
         return {
@@ -802,8 +804,8 @@ class EpicAppScreen : BaseAppScreen() {
                             DownloadService.invalidateCache()
                             withContext(Dispatchers.Main) {
                                 BaseAppScreen.hideInstallDialog(appId)
-                                app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.DownloadStatusChanged(gameId, false))
-                                app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged(gameId))
+                                PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(gameId, false))
+                                PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(gameId))
                             }
                         }
                     }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
@@ -302,9 +302,9 @@ class EpicAppScreen : BaseAppScreen() {
     }
 
     override fun isDownloading(context: Context, libraryItem: LibraryItem): Boolean {
-        val downloadInfo = EpicService.getDownloadInfo(libraryItem.gameId)
-        val isDownloading = downloadInfo != null && (downloadInfo.getProgress() ?: 0f) < 1f
-        return isDownloading
+        val downloadInfo = EpicService.getDownloadInfo(libraryItem.gameId) ?: return false
+        val isSyncing = downloadInfo.getStatusMessageFlow().value != null
+        return isSyncing || (downloadInfo.getProgress() ?: 0f) < 1f
     }
 
     override fun getDownloadProgress(context: Context, libraryItem: LibraryItem): Float {

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -233,10 +233,11 @@ class GOGAppScreen : BaseAppScreen() {
     override fun isDownloading(context: Context, libraryItem: LibraryItem): Boolean {
         Timber.tag(TAG).d("isDownloading: checking appId=${libraryItem.appId}")
         val downloadInfo = GOGService.getDownloadInfo(libraryItem.gameId.toString()) ?: return false
-        val isSyncing = downloadInfo.getStatusMessageFlow().value != null
         val progress = downloadInfo.getProgress() ?: 0f
-        val downloading = isSyncing || (downloadInfo.isActive() && progress < 1f)
-        Timber.tag(TAG).d("isDownloading: appId=${libraryItem.appId}, isSyncing=$isSyncing, active=${downloadInfo.isActive()}, progress=$progress, result=$downloading")
+        val downloading = downloadInfo.isPostInstallSyncing() || (downloadInfo.isActive() && progress < 1f)
+        Timber.tag(TAG).d(
+            "isDownloading: appId=${libraryItem.appId}, postInstallSyncing=${downloadInfo.isPostInstallSyncing()}, active=${downloadInfo.isActive()}, progress=$progress, result=$downloading",
+        )
         return downloading
     }
 
@@ -615,6 +616,16 @@ class GOGAppScreen : BaseAppScreen() {
         app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
         disposables +=
             { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener) }
+
+        val postInstallSyncListener: (app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged) -> Unit = { event ->
+            if (event.appId == libraryItem.gameId) {
+                Timber.tag(TAG).d("[OBSERVE] PostInstallSyncStatusChanged for ${libraryItem.appId}, isSyncing=${event.isSyncing}")
+                onStateChanged()
+            }
+        }
+        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener)
+        disposables +=
+            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener) }
 
         // Return cleanup function
         return {

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -14,7 +14,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import app.gamenative.PluviaApp
 import app.gamenative.R
+import app.gamenative.events.AndroidEvent
 import app.gamenative.data.GOGGame
 import app.gamenative.data.LibraryItem
 import app.gamenative.enums.Marker
@@ -135,13 +137,13 @@ class GOGAppScreen : BaseAppScreen() {
 
         // Listen for install status changes to refresh game data
         LaunchedEffect(gameId) {
-            val installListener: (app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
+            val installListener: (AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
                 if (event.appId == libraryItem.gameId) {
                     Timber.tag(TAG).d("Install status changed, refreshing game data for $gameId")
                     refreshTrigger++
                 }
             }
-            app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
+            PluviaApp.events.on<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
         }
 
         var gogGame by remember(gameId, refreshTrigger) { mutableStateOf<GOGGame?>(null) }
@@ -561,7 +563,7 @@ class GOGAppScreen : BaseAppScreen() {
         var currentProgressListener: ((Float) -> Unit)? = null
 
         // Listen for download status changes
-        val downloadStatusListener: (app.gamenative.events.AndroidEvent.DownloadStatusChanged) -> Unit = { event ->
+        val downloadStatusListener: (AndroidEvent.DownloadStatusChanged) -> Unit = { event ->
             Timber.tag(TAG).d("[OBSERVE] DownloadStatusChanged event received: event.appId=${event.appId}, libraryItem.gameId=${libraryItem.gameId}, match=${event.appId == libraryItem.gameId}")
             if (event.appId == libraryItem.gameId) {
                 Timber.tag(TAG).d("[OBSERVE] Download status changed for ${libraryItem.appId}, isDownloading=${event.isDownloading}")
@@ -601,31 +603,31 @@ class GOGAppScreen : BaseAppScreen() {
                 onStateChanged()
             }
         }
-        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener)
+        PluviaApp.events.on<AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener)
         disposables +=
-            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener) }
+            { PluviaApp.events.off<AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener) }
 
         // Listen for install status changes
-        val installListener: (app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
+        val installListener: (AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
             Timber.tag(TAG).d("[OBSERVE] LibraryInstallStatusChanged event received: event.appId=${event.appId}, libraryItem.gameId=${libraryItem.gameId}, match=${event.appId == libraryItem.gameId}")
             if (event.appId == libraryItem.gameId) {
                 Timber.tag(TAG).d("[OBSERVE] Install status changed for ${libraryItem.appId}, calling onStateChanged()")
                 onStateChanged()
             }
         }
-        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
+        PluviaApp.events.on<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
         disposables +=
-            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener) }
+            { PluviaApp.events.off<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener) }
 
-        val postInstallSyncListener: (app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged) -> Unit = { event ->
+        val postInstallSyncListener: (AndroidEvent.PostInstallSyncStatusChanged) -> Unit = { event ->
             if (event.appId == libraryItem.gameId) {
                 Timber.tag(TAG).d("[OBSERVE] PostInstallSyncStatusChanged for ${libraryItem.appId}, isSyncing=${event.isSyncing}")
                 onStateChanged()
             }
         }
-        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener)
+        PluviaApp.events.on<AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener)
         disposables +=
-            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener) }
+            { PluviaApp.events.off<AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener) }
 
         // Return cleanup function
         return {

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -232,13 +232,11 @@ class GOGAppScreen : BaseAppScreen() {
 
     override fun isDownloading(context: Context, libraryItem: LibraryItem): Boolean {
         Timber.tag(TAG).d("isDownloading: checking appId=${libraryItem.appId}")
-        // Check if there's an active download for this GOG game
-        // GOGService expects numeric gameId
-        val downloadInfo = GOGService.getDownloadInfo(libraryItem.gameId.toString())
-        val progress = downloadInfo?.getProgress() ?: 0f
-        val isActive = downloadInfo?.isActive() ?: false
-        val downloading = downloadInfo != null && isActive && progress < 1f
-        Timber.tag(TAG).d("isDownloading: appId=${libraryItem.appId}, hasDownloadInfo=${downloadInfo != null}, active=$isActive, progress=$progress, result=$downloading")
+        val downloadInfo = GOGService.getDownloadInfo(libraryItem.gameId.toString()) ?: return false
+        val isSyncing = downloadInfo.getStatusMessageFlow().value != null
+        val progress = downloadInfo.getProgress() ?: 0f
+        val downloading = isSyncing || (downloadInfo.isActive() && progress < 1f)
+        Timber.tag(TAG).d("isDownloading: appId=${libraryItem.appId}, isSyncing=$isSyncing, active=${downloadInfo.isActive()}, progress=$progress, result=$downloading")
         return downloading
     }
 

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -14,9 +14,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import app.gamenative.PluviaApp
 import app.gamenative.R
-import app.gamenative.events.AndroidEvent
 import app.gamenative.data.GOGGame
 import app.gamenative.data.LibraryItem
 import app.gamenative.enums.Marker
@@ -137,13 +135,13 @@ class GOGAppScreen : BaseAppScreen() {
 
         // Listen for install status changes to refresh game data
         LaunchedEffect(gameId) {
-            val installListener: (AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
+            val installListener: (app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
                 if (event.appId == libraryItem.gameId) {
                     Timber.tag(TAG).d("Install status changed, refreshing game data for $gameId")
                     refreshTrigger++
                 }
             }
-            PluviaApp.events.on<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
+            app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
         }
 
         var gogGame by remember(gameId, refreshTrigger) { mutableStateOf<GOGGame?>(null) }
@@ -563,7 +561,7 @@ class GOGAppScreen : BaseAppScreen() {
         var currentProgressListener: ((Float) -> Unit)? = null
 
         // Listen for download status changes
-        val downloadStatusListener: (AndroidEvent.DownloadStatusChanged) -> Unit = { event ->
+        val downloadStatusListener: (app.gamenative.events.AndroidEvent.DownloadStatusChanged) -> Unit = { event ->
             Timber.tag(TAG).d("[OBSERVE] DownloadStatusChanged event received: event.appId=${event.appId}, libraryItem.gameId=${libraryItem.gameId}, match=${event.appId == libraryItem.gameId}")
             if (event.appId == libraryItem.gameId) {
                 Timber.tag(TAG).d("[OBSERVE] Download status changed for ${libraryItem.appId}, isDownloading=${event.isDownloading}")
@@ -603,31 +601,31 @@ class GOGAppScreen : BaseAppScreen() {
                 onStateChanged()
             }
         }
-        PluviaApp.events.on<AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener)
+        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener)
         disposables +=
-            { PluviaApp.events.off<AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener) }
+            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.DownloadStatusChanged, Unit>(downloadStatusListener) }
 
         // Listen for install status changes
-        val installListener: (AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
+        val installListener: (app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
             Timber.tag(TAG).d("[OBSERVE] LibraryInstallStatusChanged event received: event.appId=${event.appId}, libraryItem.gameId=${libraryItem.gameId}, match=${event.appId == libraryItem.gameId}")
             if (event.appId == libraryItem.gameId) {
                 Timber.tag(TAG).d("[OBSERVE] Install status changed for ${libraryItem.appId}, calling onStateChanged()")
                 onStateChanged()
             }
         }
-        PluviaApp.events.on<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
+        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener)
         disposables +=
-            { PluviaApp.events.off<AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener) }
+            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged, Unit>(installListener) }
 
-        val postInstallSyncListener: (AndroidEvent.PostInstallSyncStatusChanged) -> Unit = { event ->
+        val postInstallSyncListener: (app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged) -> Unit = { event ->
             if (event.appId == libraryItem.gameId) {
                 Timber.tag(TAG).d("[OBSERVE] PostInstallSyncStatusChanged for ${libraryItem.appId}, isSyncing=${event.isSyncing}")
                 onStateChanged()
             }
         }
-        PluviaApp.events.on<AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener)
+        app.gamenative.PluviaApp.events.on<app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener)
         disposables +=
-            { PluviaApp.events.off<AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener) }
+            { app.gamenative.PluviaApp.events.off<app.gamenative.events.AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener) }
 
         // Return cleanup function
         return {

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -423,6 +423,14 @@ class SteamAppScreen : BaseAppScreen() {
         PluviaApp.events.on<AndroidEvent.DownloadPausedDueToConnectivity, Unit>(connectivityListener)
         disposables += { PluviaApp.events.off<AndroidEvent.DownloadPausedDueToConnectivity, Unit>(connectivityListener) }
 
+        val postInstallSyncListener: (AndroidEvent.PostInstallSyncStatusChanged) -> Unit = { event ->
+            if (event.appId == appId) {
+                onStateChanged()
+            }
+        }
+        PluviaApp.events.on<AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener)
+        disposables += { PluviaApp.events.off<AndroidEvent.PostInstallSyncStatusChanged, Unit>(postInstallSyncListener) }
+
         return {
             progressDisposer?.invoke()
             disposables.forEach { it() }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -362,8 +362,9 @@ class SteamAppScreen : BaseAppScreen() {
     }
 
     override fun isDownloading(context: Context, libraryItem: LibraryItem): Boolean {
-        // download job is removed on completion, so non-null means actively downloading
-        return SteamService.getAppDownloadInfo(libraryItem.gameId) != null
+        val downloadInfo = SteamService.getAppDownloadInfo(libraryItem.gameId) ?: return false
+        val progress = downloadInfo.getProgress() ?: 0f
+        return downloadInfo.isPostInstallSyncing() || (downloadInfo.isActive() && progress < 1f)
     }
 
     override fun getDownloadProgress(context: Context, libraryItem: LibraryItem): Float {

--- a/app/src/test/java/app/gamenative/data/DownloadInfoTest.kt
+++ b/app/src/test/java/app/gamenative/data/DownloadInfoTest.kt
@@ -19,7 +19,6 @@ class DownloadInfoTest {
         info.setPostInstallSyncing(true)
 
         assertTrue(info.isPostInstallSyncing())
-        assertTrue(info.getPostInstallSyncingFlow().value)
     }
 
     @Test
@@ -34,7 +33,6 @@ class DownloadInfoTest {
         info.cancel()
 
         assertFalse(info.isPostInstallSyncing())
-        assertFalse(info.getPostInstallSyncingFlow().value)
         assertFalse(info.isActive())
     }
 }

--- a/app/src/test/java/app/gamenative/data/DownloadInfoTest.kt
+++ b/app/src/test/java/app/gamenative/data/DownloadInfoTest.kt
@@ -1,0 +1,40 @@
+package app.gamenative.data
+
+import java.util.concurrent.CopyOnWriteArrayList
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DownloadInfoTest {
+    @Test
+    fun `post install sync state is tracked independently`() {
+        val info = DownloadInfo(
+            jobCount = 1,
+            gameId = 123,
+            downloadingAppIds = CopyOnWriteArrayList(),
+        )
+
+        assertFalse(info.isPostInstallSyncing())
+
+        info.setPostInstallSyncing(true)
+
+        assertTrue(info.isPostInstallSyncing())
+        assertTrue(info.getPostInstallSyncingFlow().value)
+    }
+
+    @Test
+    fun `cancel clears post install sync state`() {
+        val info = DownloadInfo(
+            jobCount = 1,
+            gameId = 123,
+            downloadingAppIds = CopyOnWriteArrayList(),
+        )
+
+        info.setPostInstallSyncing(true)
+        info.cancel()
+
+        assertFalse(info.isPostInstallSyncing())
+        assertFalse(info.getPostInstallSyncingFlow().value)
+        assertFalse(info.isActive())
+    }
+}


### PR DESCRIPTION
## Description
When a game finishes installing, GameNative now immediately syncs cloud saves down from Steam, Epic, and GOG before the Play button appears. This means a user can install a game, go offline, and expect their saves to be ready — matching the behaviour of the native Steam client.

The sync runs inside the existing download flow (after depot extraction for Steam, after the download job for Epic/GOG). The Play button stays hidden until the sync completes, and a "Syncing saves..." status message is shown in the download card. If the sync fails, it is logged and the game proceeds normally — it is non-blocking for the install itself.

Extracted from https://github.com/utkarshdalal/GameNative/pull/1094.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional post‑install cloud-save sync after downloads; UI shows "Syncing saves..." and keeps items active until sync finishes. Added observable post‑install syncing state and events so UI stays in sync.
  * Improved path resolution to support container-aware saved-game locations.

* **Bug Fixes**
  * More robust cancellation/error handling to reliably clear post‑install sync state and status; safer handling when app context is unavailable.

* **Tests**
  * Added tests for post‑install sync state tracking and path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->