### PR TITLE
fix: repair steam save export

### DIFF
--- a/app/src/main/java/app/gamenative/ui/util/SteamSaveTransfer.kt
+++ b/app/src/main/java/app/gamenative/ui/util/SteamSaveTransfer.kt
@@ -2,11 +2,13 @@ package app.gamenative.ui.util
 
 import android.content.Context
 import android.net.Uri
+import app.gamenative.PrefManager
 import app.gamenative.R
 import app.gamenative.data.SaveFilePattern
 import app.gamenative.enums.PathType
 import app.gamenative.service.SteamService
 import app.gamenative.utils.FileUtils
+import com.winlator.xenvironment.ImageFs
 import java.io.IOException
 import java.nio.channels.Channels
 import java.nio.file.Files
@@ -14,6 +16,7 @@ import java.nio.file.LinkOption
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
+import java.util.stream.Collectors
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
@@ -182,10 +185,8 @@ object SteamSaveTransfer {
      */
     private fun resolveExportRoots(
         app: app.gamenative.data.SteamApp,
-        prefixToPath: (String) -> String,
+        prefixToPath: (String) -> String?,
     ): List<ResolvedSaveRoot> {
-        val accountId = SteamService.userSteamId?.accountID?.toLong()
-            ?: throw IOException("Steam not logged in")
         val result = mutableListOf<ResolvedSaveRoot>()
 
         // 1) UFS patterns (skip SteamUserData — handled below)
@@ -193,7 +194,8 @@ object SteamSaveTransfer {
         savePatterns
             .filter { it.root != PathType.SteamUserData }
             .forEach { pattern ->
-                val basePath = Paths.get(prefixToPath(pattern.root.name), pattern.substitutedPath)
+                val rootPath = prefixToPath(pattern.root.name) ?: return@forEach
+                val basePath = Paths.get(rootPath, pattern.substitutedPath)
                 val files = findPatternFiles(basePath, pattern)
                 if (files.isNotEmpty()) {
                     result += ResolvedSaveRoot(
@@ -205,14 +207,19 @@ object SteamSaveTransfer {
             }
 
         // 2) SteamUserData — always scanned recursively (matches SteamAutoCloud behavior)
-        val userDataPath = Paths.get(prefixToPath(PathType.SteamUserData.name))
-        val userDataFiles = findPatternFiles(userDataPath, SaveFilePattern(root = PathType.SteamUserData, path = "", pattern = "*", recursive = 5))
-        if (userDataFiles.isNotEmpty()) {
-            result += ResolvedSaveRoot(
-                rootId = PathType.SteamUserData.name.lowercase(),
-                absolutePath = userDataPath,
-                files = userDataFiles,
+        prefixToPath(PathType.SteamUserData.name)?.let { userDataRoot ->
+            val userDataPath = Paths.get(userDataRoot)
+            val userDataFiles = findPatternFiles(
+                userDataPath,
+                SaveFilePattern(root = PathType.SteamUserData, path = "", pattern = "*", recursive = 5),
             )
+            if (userDataFiles.isNotEmpty()) {
+                result += ResolvedSaveRoot(
+                    rootId = PathType.SteamUserData.name.lowercase(),
+                    absolutePath = userDataPath,
+                    files = userDataFiles,
+                )
+            }
         }
 
         return result
@@ -225,11 +232,8 @@ object SteamSaveTransfer {
     private fun resolveImportRoots(
         app: app.gamenative.data.SteamApp,
         manifestRoots: List<SaveRoot>,
-        prefixToPath: (String) -> String,
+        prefixToPath: (String) -> String?,
     ): Map<String, Path> {
-        val accountId = SteamService.userSteamId?.accountID?.toLong()
-            ?: throw IOException("Steam not logged in")
-
         val knownRoots = mutableMapOf<String, Path>()
 
         // Build lookup from UFS patterns
@@ -237,12 +241,15 @@ object SteamSaveTransfer {
             .filter { it.root.isWindows }
             .filter { it.root != PathType.SteamUserData }
             .forEach { pattern ->
+                val rootPath = prefixToPath(pattern.root.name) ?: return@forEach
                 val id = patternRootId(pattern)
-                knownRoots[id] = Paths.get(prefixToPath(pattern.root.name), pattern.substitutedPath)
+                knownRoots[id] = Paths.get(rootPath, pattern.substitutedPath)
             }
 
         // SteamUserData
-        knownRoots[PathType.SteamUserData.name.lowercase()] = Paths.get(prefixToPath(PathType.SteamUserData.name))
+        prefixToPath(PathType.SteamUserData.name)?.let { userDataRoot ->
+            knownRoots[PathType.SteamUserData.name.lowercase()] = Paths.get(userDataRoot)
+        }
 
         // Resolve manifest roots against known roots, fall back to stored path
         return manifestRoots.associate { mr ->
@@ -259,7 +266,7 @@ object SteamSaveTransfer {
             maxDepth = depth,
         )
             .filter { Files.isRegularFile(it) }
-            .toList()
+            .collect(Collectors.toList())
     }
 
     private fun patternRootId(pattern: SaveFilePattern): String {
@@ -337,8 +344,53 @@ object SteamSaveTransfer {
 
     // -- Helpers ---------------------------------------------------------------
 
-    private fun makePrefixToPath(context: Context, appId: Int): (String) -> String = { prefix ->
-        PathType.from(prefix).toAbsPath(context, appId, SteamService.userSteamId!!.accountID)
+    private fun makePrefixToPath(context: Context, appId: Int): (String) -> String? = { prefix ->
+        resolveRootBasePath(context, appId, PathType.from(prefix))?.pathString
+    }
+
+    private fun resolveRootBasePath(
+        context: Context,
+        appId: Int,
+        rootType: PathType,
+    ): Path? {
+        val accountId = when (rootType) {
+            PathType.SteamUserData -> resolveSteamAccountId(context, appId) ?: return null
+            else -> 0L
+        }
+        return Paths.get(rootType.toAbsPath(context, appId, accountId))
+    }
+
+    private fun resolveSteamAccountId(context: Context, appId: Int): Long? {
+        SteamService.userSteamId?.accountID?.toLong()?.let { return it }
+        PrefManager.steamUserAccountId.takeIf { it != 0 }?.toLong()?.let { return it }
+
+        val userdataRoot = Paths.get(
+            ImageFs.find(context).rootDir.absolutePath,
+            ImageFs.WINEPREFIX,
+            "/drive_c/Program Files (x86)/Steam/userdata",
+        )
+        if (!Files.isDirectory(userdataRoot)) return null
+
+        val matchingAccountIds = Files.list(userdataRoot).use { children ->
+            children
+                .filter { Files.isDirectory(it) }
+                .map { it.fileName.toString() }
+                .filter { candidate -> candidate.all(Char::isDigit) }
+                .filter { candidate ->
+                    val appRoot = userdataRoot.resolve(candidate).resolve(appId.toString())
+                    Files.isDirectory(appRoot)
+                }
+                .sorted()
+                .collect(Collectors.toList())
+        }
+
+        if (matchingAccountIds.size > 1) {
+            Timber.w(
+                "Multiple Steam userdata accounts found for appId=$appId; using ${matchingAccountIds.first()} for save transfer",
+            )
+        }
+
+        return matchingAccountIds.firstOrNull()?.toLongOrNull()
     }
 
     private fun normalizeRelativePath(value: String): String =

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -1405,10 +1405,12 @@ object SteamUtils {
 
     fun getSteamId64(): Long? {
         return SteamService.userSteamId?.convertToUInt64()?.toLong()
+            ?: PrefManager.steamUserSteamId64.takeIf { it != 0L }
     }
 
     fun getSteam3AccountId(): Long? {
         return SteamService.userSteamId?.accountID?.toLong()
+            ?: PrefManager.steamUserAccountId.takeIf { it != 0 }?.toLong()
     }
 
     /**


### PR DESCRIPTION
## Description
two save export issues checking the import/export work from #966.

export could crash during file discovery because of `Stream.toList()`, which left the SAF-created zip behind as a 0 B file. Games with Steam ID placeholders in their save paths could also miss saves when the live Steam session info was missing even though the saved account info was already on disk.

This switches the stream collection to an Android-safe collector and falls back to the stored Steam IDs / resolved roots when building save paths, so export can actually find the files and write the archive.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [x] Compatibility improvements
- [ ] Performance / stability improvement
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Steam save export on Android by preventing a discovery crash and finding saves when no active Steam session exists. Exports now produce valid archives and include userdata for affected games.

- **Bug Fixes**
  - Replaced `Stream.toList()` with `Collectors.toList()` to stop Android crashes and 0 B ZIPs.
  - Added fallback Steam account ID resolution via `PrefManager` and on-disk `userdata` scan; export/import works without a live Steam login.
  - Made root path mapping nullable and skipped missing roots; `SteamUserData` is scanned recursively only when the root exists.
  - Updated `SteamUtils.getSteamId64` and `getSteam3AccountId` to return stored IDs when `SteamService` is unavailable.

<sup>Written for commit 0a2afc839cfb101c5631dc5f066209bcecefa78a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Steam save transfer reliability by gracefully handling cases where Steam service data is unavailable, falling back to previously saved Steam account information
  * Enhanced root path resolution to conditionally skip inaccessible paths instead of failing when Steam credentials are missing, improving robustness when Steam isn't logged in

<!-- end of auto-generated comment: release notes by coderabbit.ai -->