### PR TITLE
feat: move Disable Mouse Input to in-game Quick Menu overlay

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -48,6 +48,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Gamepad
 import androidx.compose.material.icons.filled.Keyboard
+import androidx.compose.material.icons.filled.Mouse
 import androidx.compose.material.icons.filled.QueryStats
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.TouchApp
@@ -252,9 +253,9 @@ fun QuickMenu(
         add(
             QuickMenuItem(
                 id = QuickMenuAction.DISABLE_MOUSE,
-                icon = Icons.Default.TouchApp,
+                icon = Icons.Filled.Mouse,
                 labelResId = R.string.disable_mouse_input,
-                accentColor = PluviaTheme.colors.accentPurple,
+                accentColor = PluviaTheme.colors.accentPink,
             )
         )
         add(

--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -101,6 +101,7 @@ object QuickMenuAction {
     const val EDIT_PHYSICAL_CONTROLLER = 5
     const val PERFORMANCE_HUD = 6
     const val TOUCHSCREEN_MODE = 7
+    const val DISABLE_MOUSE = 8
 }
 
 private object QuickMenuTab {
@@ -248,6 +249,14 @@ fun QuickMenu(
     )
 
     val controllerItems = buildList {
+        add(
+            QuickMenuItem(
+                id = QuickMenuAction.DISABLE_MOUSE,
+                icon = Icons.Default.TouchApp,
+                labelResId = R.string.disable_mouse_input,
+                accentColor = PluviaTheme.colors.accentPurple,
+            )
+        )
         add(
             QuickMenuItem(
                 id = QuickMenuAction.KEYBOARD,

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ControllerTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ControllerTab.kt
@@ -53,12 +53,6 @@ fun ControllerTabContent(state: ContainerConfigState, default: Boolean) {
         )
         SettingsSwitch(
             colors = settingsTileColorsAlt(),
-            title = { Text(text = stringResource(R.string.disable_mouse_input)) },
-            state = config.disableMouseInput,
-            onCheckedChange = { state.config.value = config.copy(disableMouseInput = it) },
-        )
-        SettingsSwitch(
-            colors = settingsTileColorsAlt(),
             title = { Text(text = stringResource(R.string.shooter_mode_toggle)) },
             subtitle = { Text(text = stringResource(R.string.shooter_mode_toggle_description)) },
             state = config.shooterMode,

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -402,6 +402,7 @@ fun XServerScreen(
     }
     var isKeyboardVisible = false
     var areControlsVisible by remember { mutableStateOf(false) }
+    var isDisableMouseInput by remember { mutableStateOf(container.isDisableMouseInput) }
     var isEditMode by remember { mutableStateOf(false) }
     var gameRoot by remember { mutableStateOf<View?>(null) }
     var windowModificationListener by remember { mutableStateOf<WindowManager.OnWindowModificationListener?>(null) }
@@ -918,6 +919,16 @@ fun XServerScreen(
                     }
                 }
                 areControlsVisible = !areControlsVisible
+                true
+            }
+
+            QuickMenuAction.DISABLE_MOUSE -> {
+                val newValue = !isDisableMouseInput
+                isDisableMouseInput = newValue
+                container.setDisableMouseInput(newValue)
+                container.saveData()
+                PluviaApp.touchpadView?.setTouchscreenMouseDisabled(newValue)
+                xServerView?.renderer?.setCursorVisible(!newValue)
                 true
             }
 
@@ -2163,6 +2174,7 @@ fun XServerScreen(
             activeToggleIds = buildSet {
                 if (areControlsVisible) add(QuickMenuAction.INPUT_CONTROLS)
                 if (isTouchscreenModeActive) add(QuickMenuAction.TOUCHSCREEN_MODE)
+                if (isDisableMouseInput) add(QuickMenuAction.DISABLE_MOUSE)
             },
         )
 

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -402,7 +402,7 @@ fun XServerScreen(
     }
     var isKeyboardVisible = false
     var areControlsVisible by remember { mutableStateOf(false) }
-    var isDisableMouseInput by remember { mutableStateOf(container.isDisableMouseInput) }
+    var isDisableMouseInput by remember(container.id) { mutableStateOf(container.isDisableMouseInput) }
     var isEditMode by remember { mutableStateOf(false) }
     var gameRoot by remember { mutableStateOf<View?>(null) }
     var windowModificationListener by remember { mutableStateOf<WindowManager.OnWindowModificationListener?>(null) }
@@ -928,7 +928,6 @@ fun XServerScreen(
                 container.setDisableMouseInput(newValue)
                 container.saveData()
                 PluviaApp.touchpadView?.setTouchscreenMouseDisabled(newValue)
-                xServerView?.renderer?.setCursorVisible(!newValue)
                 true
             }
 

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -928,6 +928,11 @@ fun XServerScreen(
                 container.setDisableMouseInput(newValue)
                 container.saveData()
                 PluviaApp.touchpadView?.setTouchscreenMouseDisabled(newValue)
+                if (!newValue && !container.isTouchscreenMode) {
+                    xServerView?.renderer?.setCursorVisible(true)
+                } else if (newValue) {
+                    xServerView?.renderer?.setCursorVisible(false)
+                }
                 true
             }
 


### PR DESCRIPTION
## Description

Moves the **Disable Mouse Input** toggle from the container settings Controller tab into the in-game Quick Menu overlay, allowing players to toggle it during gameplay without leaving the game.

The setting already existed as a persisted container property (`disableMouseInput`). This change surfaces it in the overlay and removes it from settings, where it was awkward to access mid-game.

## Recording

https://github.com/user-attachments/assets/df8f20cf-b785-482f-b138-457207d74c16



## Type of Change
- [x] Other (requires prior approval) — discussed and approved by lead dev in #code-changes

## Checklist
- [x] I have discussed this change in #code-changes and it has been green-lighted.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.
- [x] I have attached a recording of the change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the Disable Mouse Input setting into the in-game Quick Menu so players can toggle it during gameplay. State persists to the container, touchpad behavior updates instantly, and the cursor updates on toggle without overriding a physical mouse.

- New Features
  - Quick Menu toggle for Disable Mouse Input with mouse icon and pink accent; shows active state and persists via container config.
  - Assigned action ID 8 to avoid conflict with `TOUCHSCREEN_MODE`.

- Bug Fixes
  - Keyed `isDisableMouseInput` to `container.id` to prevent stale state when switching containers.
  - Cursor visibility respects the toggle: shows on re-enable unless Touchscreen Mode is on, hides when disabled, without forcing state when a hardware mouse may be present.

<sup>Written for commit 81bb2e2d9f76933415fb2af34853f42fb4350649. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1267?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a quick-menu toggle to disable or enable mouse input with persistent saving of the chosen state.

* **UI/UX Changes**
  * Removed the disable-mouse-input switch from controller preferences and relocated it to the quick menu for faster access.
  * Cursor visibility and touch behavior now update immediately to reflect the current mouse input setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->