### PR TITLE
fix: open storage/download game details fullscreen

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/downloads/DownloadsScreen.kt
@@ -160,81 +160,75 @@ fun HomeDownloadsScreen(
         clearSelectedLibraryItem()
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .statusBarsPadding()
-            .displayCutoutPadding(),
-    ) {
-        DownloadsHeader(
-            title = stringResource(selectedSection.titleResId),
-            onBack = {
-                if (selectedLibraryItem != null) {
-                    clearSelectedLibraryItem()
-                } else {
-                    onBack()
+    if (selectedLibraryItem != null) {
+        LibraryDetailPane(
+            libraryItem = selectedLibraryItem,
+            onBack = ::clearSelectedLibraryItem,
+            onClickPlay = { useBoxArt ->
+                selectedLibraryItem?.let { libraryItem ->
+                    onClickPlay(libraryItem.appId, useBoxArt)
                 }
             },
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            onTestGraphics = {
+                selectedLibraryItem?.let { libraryItem ->
+                    onTestGraphics(libraryItem.appId)
+                }
+            },
         )
-
-        val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
-
-        if (isPortrait && selectedLibraryItem == null) {
-            // Portrait: horizontal tab row above the content
-            DownloadsTabRow(
-                sections = sections,
-                selectedSection = selectedSection,
-                onSectionSelected = { selectedSectionIndex = it.ordinal },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-            )
-        }
-
-        Row(
+    } else {
+        Column(
             modifier = Modifier
-                .weight(1f)
-                .padding(horizontal = 16.dp, vertical = if (isPortrait) 0.dp else 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .statusBarsPadding()
+                .displayCutoutPadding(),
         ) {
-            if (!isPortrait && selectedLibraryItem == null) {
-                DownloadsSidebar(
+            DownloadsHeader(
+                title = stringResource(selectedSection.titleResId),
+                onBack = onBack,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            )
+
+            val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
+
+            if (isPortrait) {
+                // Portrait: horizontal tab row above the content
+                DownloadsTabRow(
                     sections = sections,
                     selectedSection = selectedSection,
                     onSectionSelected = { selectedSectionIndex = it.ordinal },
                     modifier = Modifier
-                        .width(96.dp)
-                        .fillMaxHeight(),
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
                 )
             }
 
-            Surface(
+            Row(
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxHeight(),
-                shape = RoundedCornerShape(24.dp),
-                color = PluviaTheme.colors.surfacePanel.copy(alpha = 0.94f),
-                tonalElevation = 2.dp,
-                shadowElevation = 12.dp,
+                    .padding(horizontal = 16.dp, vertical = if (isPortrait) 0.dp else 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                if (selectedLibraryItem != null) {
-                    LibraryDetailPane(
-                        libraryItem = selectedLibraryItem,
-                        onBack = ::clearSelectedLibraryItem,
-                        onClickPlay = { useBoxArt ->
-                            selectedLibraryItem?.let { libraryItem ->
-                                onClickPlay(libraryItem.appId, useBoxArt)
-                            }
-                        },
-                        onTestGraphics = {
-                            selectedLibraryItem?.let { libraryItem ->
-                                onTestGraphics(libraryItem.appId)
-                            }
-                        },
+                if (!isPortrait) {
+                    DownloadsSidebar(
+                        sections = sections,
+                        selectedSection = selectedSection,
+                        onSectionSelected = { selectedSectionIndex = it.ordinal },
+                        modifier = Modifier
+                            .width(96.dp)
+                            .fillMaxHeight(),
                     )
-                } else {
+                }
+
+                Surface(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight(),
+                    shape = RoundedCornerShape(24.dp),
+                    color = PluviaTheme.colors.surfacePanel.copy(alpha = 0.94f),
+                    tonalElevation = 2.dp,
+                    shadowElevation = 12.dp,
+                ) {
                     when (selectedSection) {
                         DownloadsSection.Downloads -> DownloadsContent(
                             state = state,


### PR DESCRIPTION
## Description
Currently, when going into game page from downloads or storage tabs, the appLandingPage is nested incorrectly

<img width="620" height="353" alt="Screenshot 2026-04-21 at 6 29 21 PM" src="https://github.com/user-attachments/assets/1c8b70de-1e33-4acb-8609-a7f258cfe185" />

this corrects the layout so the game details screen is fullscreen like when selected from launcher

## Recording


https://github.com/user-attachments/assets/b81c16b0-f810-4b05-8432-3a019ff84cab



## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved responsive layout handling for the Downloads screen, with enhanced portrait and landscape orientation support.
  * Refined navigation flow and back button behavior for streamlined user interaction when selecting library items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->