### PR TITLE
Added some changes for rockstar launcher

### DIFF
--- a/app/src/main/java/com/winlator/core/WineUtils.java
+++ b/app/src/main/java/com/winlator/core/WineUtils.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.util.Log;
 
 import com.winlator.container.Container;
+import com.winlator.fexcore.FEXCoreManager;
 import com.winlator.xenvironment.ImageFs;
 
 import org.json.JSONArray;
@@ -170,6 +171,11 @@ public abstract class WineUtils {
             for (String name : xinputLibs) registryEditor.setStringValue(dllOverridesKey, name, "builtin,native");
             if (wineInfo.isArm64EC()) for (String name : opengLibs) registryEditor.setStringValue(dllOverridesKey, name, "native,builtin");
 
+            // Force Rockstar Social Club helper onto Wine's builtin D3D stack
+            final String socialClubDllOverridesKey = "Software\\Wine\\AppDefaults\\SocialClubHelper.exe\\DllOverrides";
+            final String[] socialClubBuiltinLibs = {"dxgi", "d3d9", "d3d10", "d3d10_1", "d3d10core", "d3d11"};
+            for (String name : socialClubBuiltinLibs) registryEditor.setStringValue(socialClubDllOverridesKey, name, "builtin");
+
             registryEditor.removeKey("Software\\Winlator\\WFM\\ContextMenu\\7-Zip");
             registryEditor.setStringValue("Software\\Winlator\\WFM\\ContextMenu\\7-Zip", "Open Archive", "Z:\\opt\\apps\\7-Zip\\7zFM.exe \"%FILE%\"");
             registryEditor.setStringValue("Software\\Winlator\\WFM\\ContextMenu\\7-Zip", "Extract Here", "Z:\\opt\\apps\\7-Zip\\7zG.exe x \"%FILE%\" -r -o\"%DIR%\" -y");
@@ -188,6 +194,11 @@ public abstract class WineUtils {
         for (String dlname : dlnames) {
             FileUtils.copy(new File(wineSysWoW64Dir, dlname), new File(win64 ? containerSysWoW64Dir : containerSystem32Dir, dlname));
             if (win64) FileUtils.copy(new File(wineSystem32Dir, dlname), new File(containerSystem32Dir, dlname));
+        }
+
+        // FEX AppConfig presets only apply when running Arm64X (arm64ec) Wine under FEX
+        if (wineInfo.isArm64EC()) {
+            FEXCoreManager.ensureAppConfigOverrides(context);
         }
     }
 


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `SocialClubHelper.exe` to use Wine’s builtin D3D stack and enable FEX AppConfig presets on Arm64EC to improve Rockstar Games Launcher compatibility. Adds DLL overrides for dxgi/d3d9/d3d10/d3d10_1/d3d10core/d3d11 and calls `com.winlator.fexcore.FEXCoreManager.ensureAppConfigOverrides` when running Arm64EC.

<sup>Written for commit be81c67a41bdd2b7ad05caa6fa30e78f9d022360. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced graphics library configuration to improve rendering compatibility and performance for applications requiring Direct3D functionality.
  * Expanded system configuration support to improve platform compatibility on ARM-based processor architectures.
  * Refined application-specific graphics settings for better system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->