### PR TITLE
fix: allow Steam intent launches when disconnected

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -3475,7 +3475,7 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         var isAutoLoggingIn = false
 
-        if (PrefManager.username.isNotEmpty() && PrefManager.refreshToken.isNotEmpty()) {
+        if (SteamUtils.hasStoredCredentials()) {
             isAutoLoggingIn = true
 
             login(

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -345,7 +345,7 @@ fun PluviaMain(
         trackGameLaunched(resolvedAppId)
         viewModel.setLaunchedAppId(resolvedAppId)
         viewModel.setBootToContainer(false)
-        CoroutineScope(Dispatchers.IO).launch {
+        scope.launch(Dispatchers.IO) {
             val gameSource = ContainerUtils.extractGameSourceFromContainerId(resolvedAppId)
             val isOffline = when {
                 gameSource != GameSource.STEAM -> false
@@ -358,6 +358,8 @@ fun PluviaMain(
                     !SteamUtils.awaitSteamLogin()
                 }
             }
+            // sync viewModel — dialog retries + replaceSteamApi read isOffline.value
+            viewModel.setOffline(isOffline)
             preLaunchApp(
                 context = context,
                 appId = resolvedAppId,

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -63,13 +63,11 @@ import app.gamenative.enums.PathType
 import app.gamenative.enums.SaveLocation
 import app.gamenative.enums.SyncResult
 import app.gamenative.events.AndroidEvent
-import app.gamenative.events.SteamEvent
 import app.gamenative.service.SteamService
 import app.gamenative.service.amazon.AmazonService
 import com.posthog.PostHog
 import app.gamenative.ui.component.AchievementOverlay
 import app.gamenative.ui.component.ConnectionStatusBanner
-import app.gamenative.ui.component.TIMEOUT_SHOW_OFFLINE_OPTION_SECONDS
 import app.gamenative.service.epic.EpicService
 import app.gamenative.service.gog.GOGService
 import app.gamenative.ui.component.dialog.ContainerConfigDialog
@@ -127,44 +125,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 
 private const val PENDING_LAUNCH_TIMEOUT_MS = 10_000L
 
-// fall back at the same moment the banner would offer "Continue Offline".
-private const val STEAM_LOGIN_AWAIT_MS: Long = TIMEOUT_SHOW_OFFLINE_OPTION_SECONDS * 1000L
-
 /** Used to suspend preLaunchApp while the user decides on large workshop updates. */
 private var workshopUpdateDeferred: CompletableDeferred<Boolean>? = null
-
-// disconnect listener ignores non-terminal events on purpose: SteamService.reconnect()
-// emits Disconnected(isTerminal=false) before each retry, and a wifi blip mid-login should
-// resolve via the eventual LogonEnded(Success), not bail the wait.
-private suspend fun awaitSteamLogin(timeoutMs: Long = STEAM_LOGIN_AWAIT_MS): Boolean {
-    val deferred = CompletableDeferred<Boolean>()
-    val onLogon: (SteamEvent.LogonEnded) -> Unit = { e ->
-        when (e.loginResult) {
-            LoginResult.Success -> deferred.complete(true)
-            LoginResult.Failed -> deferred.complete(false)
-            else -> Unit
-        }
-    }
-    val onDisconnect: (SteamEvent.Disconnected) -> Unit = { e ->
-        if (e.isTerminal) deferred.complete(false)
-    }
-    PluviaApp.events.on<SteamEvent.LogonEnded, Unit>(onLogon)
-    PluviaApp.events.on<SteamEvent.Disconnected, Unit>(onDisconnect)
-    try {
-        // register-then-check: a flag check before registration would race events
-        // fired in the gap.
-        if (SteamService.isLoggedIn) return true
-        return withTimeoutOrNull(timeoutMs) { deferred.await() } ?: false
-    } finally {
-        PluviaApp.events.off<SteamEvent.LogonEnded, Unit>(onLogon)
-        PluviaApp.events.off<SteamEvent.Disconnected, Unit>(onDisconnect)
-    }
-}
 
 private fun NavHostController.navigateFromLoginIfNeeded(
     targetRoute: String,
@@ -372,6 +338,40 @@ fun PluviaMain(
         }
     }
 
+    // shared intent-launch path. resolves isOffline at the call site because intent launches can
+    // arrive pre-login (cold-boot via stored creds) and downstream cloud-sync needs a settled answer.
+    val launchIntentApp: (resolvedAppId: String, hasTemporaryOverride: Boolean) -> Unit = { resolvedAppId, hasTemporaryOverride ->
+        MainActivity.wasLaunchedViaExternalIntent = true
+        trackGameLaunched(resolvedAppId)
+        viewModel.setLaunchedAppId(resolvedAppId)
+        viewModel.setBootToContainer(false)
+        CoroutineScope(Dispatchers.IO).launch {
+            val gameSource = ContainerUtils.extractGameSourceFromContainerId(resolvedAppId)
+            val isOffline = when {
+                gameSource != GameSource.STEAM -> false
+                SteamService.isLoggedIn -> false
+                !NetworkMonitor.hasInternet.value -> true
+                else -> {
+                    viewModel.setLoadingDialogVisible(true)
+                    viewModel.setLoadingDialogMessage(context.getString(R.string.connecting_to_steam))
+                    viewModel.setLoadingDialogProgress(-1f)
+                    !SteamUtils.awaitSteamLogin()
+                }
+            }
+            preLaunchApp(
+                context = context,
+                appId = resolvedAppId,
+                useTemporaryOverride = hasTemporaryOverride,
+                setLoadingDialogVisible = viewModel::setLoadingDialogVisible,
+                setLoadingProgress = viewModel::setLoadingDialogProgress,
+                setLoadingMessage = viewModel::setLoadingDialogMessage,
+                setMessageDialogState = setMessageDialogState,
+                onSuccess = viewModel::launchApp,
+                isOffline = isOffline,
+            )
+        }
+    }
+
     // process pending launch request from cold start (event bus has no replay)
     LaunchedEffect(Unit) {
         MainActivity.consumePendingLaunchRequest()?.let { launchRequest ->
@@ -392,20 +392,7 @@ fun PluviaMain(
                             context, launchRequest.appId, launchRequest.containerConfig,
                         )
                     }
-                    MainActivity.wasLaunchedViaExternalIntent = true
-                    trackGameLaunched(resolution.finalAppId)
-                    viewModel.setLaunchedAppId(resolution.finalAppId)
-                    viewModel.setBootToContainer(false)
-                    preLaunchApp(
-                        context = context,
-                        appId = resolution.finalAppId,
-                        useTemporaryOverride = launchRequest.containerConfig != null,
-                        setLoadingDialogVisible = viewModel::setLoadingDialogVisible,
-                        setLoadingProgress = viewModel::setLoadingDialogProgress,
-                        setLoadingMessage = viewModel::setLoadingDialogMessage,
-                        setMessageDialogState = setMessageDialogState,
-                        onSuccess = viewModel::launchApp,
-                    )
+                    launchIntentApp(resolution.finalAppId, launchRequest.containerConfig != null)
                 }
 
                 is GameResolutionResult.NotFound -> {
@@ -467,21 +454,8 @@ fun PluviaMain(
                             popUpTo(navController.graph.startDestinationId) { saveState = false }
                         }
                     }
-                    MainActivity.wasLaunchedViaExternalIntent = true
                     // finalAppId — track what actually launched (may differ from launchRequest.appId after resolution)
-                    trackGameLaunched(resolution.finalAppId)
-                    viewModel.setLaunchedAppId(resolution.finalAppId)
-                    viewModel.setBootToContainer(false)
-                    preLaunchApp(
-                        context = context,
-                        appId = resolution.finalAppId,
-                        useTemporaryOverride = launchRequest.containerConfig != null,
-                        setLoadingDialogVisible = viewModel::setLoadingDialogVisible,
-                        setLoadingProgress = viewModel::setLoadingDialogProgress,
-                        setLoadingMessage = viewModel::setLoadingDialogMessage,
-                        setMessageDialogState = setMessageDialogState,
-                        onSuccess = viewModel::launchApp,
-                    )
+                    launchIntentApp(resolution.finalAppId, launchRequest.containerConfig != null)
                 }
             }
         }
@@ -514,20 +488,9 @@ fun PluviaMain(
                     when (val resolution = resolveGameAppId(context, event.appId)) {
                         is GameResolutionResult.Success -> {
                             Timber.i("[PluviaMain]: Using appId: ${resolution.finalAppId} (original: ${event.appId}, isSteamInstalled: ${resolution.isSteamInstalled}, isCustomGame: ${resolution.isCustomGame})")
-
-                            MainActivity.wasLaunchedViaExternalIntent = true
-                            trackGameLaunched(resolution.finalAppId)
-                            viewModel.setLaunchedAppId(resolution.finalAppId)
-                            viewModel.setBootToContainer(false)
-                            preLaunchApp(
-                                context = context,
-                                appId = resolution.finalAppId,
-                                useTemporaryOverride = IntentLaunchManager.hasTemporaryOverride(resolution.finalAppId),
-                                setLoadingDialogVisible = viewModel::setLoadingDialogVisible,
-                                setLoadingProgress = viewModel::setLoadingDialogProgress,
-                                setLoadingMessage = viewModel::setLoadingDialogMessage,
-                                setMessageDialogState = setMessageDialogState,
-                                onSuccess = viewModel::launchApp,
+                            launchIntentApp(
+                                resolution.finalAppId,
+                                IntentLaunchManager.hasTemporaryOverride(resolution.finalAppId),
                             )
                         }
 
@@ -1612,22 +1575,6 @@ fun preLaunchApp(
             return@launch
         }
 
-        // resolve real offline state for this launch. caller-supplied isOffline=true is honored
-        // (user explicitly went offline). otherwise, when Steam isn't logged in yet, wait briefly
-        // so cold-start cloud sync can run; wait fast-fails on a terminal disconnect so wifi-off
-        // doesn't ride out the full timeout.
-        val effectiveIsOffline = when {
-            isOffline -> true
-            gameSource != GameSource.STEAM -> false
-            SteamService.isLoggedIn -> false
-            !NetworkMonitor.hasInternet.value -> true
-            else -> {
-                setLoadingMessage(context.getString(R.string.connecting_to_steam))
-                setLoadingProgress(-1f)
-                !awaitSteamLogin()
-            }
-        }
-
         // When "Open container" is used we boot to desktop/file manager only — skip executable check
         if (!bootToContainer) {
             // Verify we have a launch executable for all platforms before proceeding (fail fast, avoid black screen)
@@ -1811,7 +1758,7 @@ fun preLaunchApp(
         if(isSteamGame) {
             try {
                 val currentPlaying = SteamService.getSelfCurrentlyPlayingAppId()
-                if (!effectiveIsOffline && currentPlaying != null && currentPlaying != gameId) {
+                if (!isOffline && currentPlaying != null && currentPlaying != gameId) {
                     val otherGameName = SteamService.getAppInfoOf(currentPlaying)?.name ?: "another game"
                     setLoadingDialogVisible(false)
                     setMessageDialogState(
@@ -1935,7 +1882,7 @@ fun preLaunchApp(
             try {
                 // Skip workshop sync if Steam isn't fully connected yet
                 // (can happen if the user taps Play immediately after opening the app).
-                if (effectiveIsOffline || !SteamService.isConnected || !SteamService.isLoggedIn) {
+                if (isOffline || !SteamService.isConnected || !SteamService.isLoggedIn) {
                     Timber.tag("Workshop").w(
                         "Steam not connected/logged in or offline, skipping workshop sync for appId=$gameId"
                     )
@@ -2078,7 +2025,7 @@ fun preLaunchApp(
             ignorePendingOperations = ignorePendingOperations,
             preferredSave = preferredSave,
             parentScope = this,
-            isOffline = effectiveIsOffline,
+            isOffline = isOffline,
             onProgress = { message, progress ->
                 setLoadingMessage(message)
                 setLoadingProgress(if (progress < 0) -1f else progress)

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -52,6 +52,7 @@ import androidx.navigation.navDeepLink
 import app.gamenative.BuildConfig
 import app.gamenative.Constants
 import app.gamenative.MainActivity
+import app.gamenative.NetworkMonitor
 import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
 import app.gamenative.R
@@ -62,11 +63,13 @@ import app.gamenative.enums.PathType
 import app.gamenative.enums.SaveLocation
 import app.gamenative.enums.SyncResult
 import app.gamenative.events.AndroidEvent
+import app.gamenative.events.SteamEvent
 import app.gamenative.service.SteamService
 import app.gamenative.service.amazon.AmazonService
 import com.posthog.PostHog
 import app.gamenative.ui.component.AchievementOverlay
 import app.gamenative.ui.component.ConnectionStatusBanner
+import app.gamenative.ui.component.TIMEOUT_SHOW_OFFLINE_OPTION_SECONDS
 import app.gamenative.service.epic.EpicService
 import app.gamenative.service.gog.GOGService
 import app.gamenative.ui.component.dialog.ContainerConfigDialog
@@ -95,6 +98,7 @@ import app.gamenative.utils.CustomGameScanner
 import app.gamenative.utils.ManifestInstaller
 import app.gamenative.utils.GameFeedbackUtils
 import app.gamenative.utils.IntentLaunchManager
+import app.gamenative.utils.SteamUtils
 import app.gamenative.utils.UpdateChecker
 import app.gamenative.utils.UpdateInfo
 import app.gamenative.utils.UpdateInstaller
@@ -123,12 +127,44 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 
 private const val PENDING_LAUNCH_TIMEOUT_MS = 10_000L
 
+// fall back at the same moment the banner would offer "Continue Offline".
+private const val STEAM_LOGIN_AWAIT_MS: Long = TIMEOUT_SHOW_OFFLINE_OPTION_SECONDS * 1000L
+
 /** Used to suspend preLaunchApp while the user decides on large workshop updates. */
 private var workshopUpdateDeferred: CompletableDeferred<Boolean>? = null
+
+// disconnect listener ignores non-terminal events on purpose: SteamService.reconnect()
+// emits Disconnected(isTerminal=false) before each retry, and a wifi blip mid-login should
+// resolve via the eventual LogonEnded(Success), not bail the wait.
+private suspend fun awaitSteamLogin(timeoutMs: Long = STEAM_LOGIN_AWAIT_MS): Boolean {
+    val deferred = CompletableDeferred<Boolean>()
+    val onLogon: (SteamEvent.LogonEnded) -> Unit = { e ->
+        when (e.loginResult) {
+            LoginResult.Success -> deferred.complete(true)
+            LoginResult.Failed -> deferred.complete(false)
+            else -> Unit
+        }
+    }
+    val onDisconnect: (SteamEvent.Disconnected) -> Unit = { e ->
+        if (e.isTerminal) deferred.complete(false)
+    }
+    PluviaApp.events.on<SteamEvent.LogonEnded, Unit>(onLogon)
+    PluviaApp.events.on<SteamEvent.Disconnected, Unit>(onDisconnect)
+    try {
+        // register-then-check: a flag check before registration would race events
+        // fired in the gap.
+        if (SteamService.isLoggedIn) return true
+        return withTimeoutOrNull(timeoutMs) { deferred.await() } ?: false
+    } finally {
+        PluviaApp.events.off<SteamEvent.LogonEnded, Unit>(onLogon)
+        PluviaApp.events.off<SteamEvent.Disconnected, Unit>(onDisconnect)
+    }
+}
 
 private fun NavHostController.navigateFromLoginIfNeeded(
     targetRoute: String,
@@ -214,7 +250,12 @@ private fun resolveGameAppId(context: Context, appId: String): GameResolutionRes
 private fun needsDeferLaunch(context: Context, appId: String): Boolean {
     val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
     return when (gameSource) {
-        GameSource.STEAM -> !SteamService.isLoggedIn
+        GameSource.STEAM -> {
+            if (SteamService.isLoggedIn) return false
+            // isLoggedIn is network-gated (requires LoggedOnCallback). allow offline launch when
+            // saved creds + local container exist — Steam can reconnect in background.
+            !(SteamUtils.hasStoredCredentials() && ContainerUtils.hasContainer(context, appId))
+        }
         GameSource.GOG -> !GOGService.isRunning
         GameSource.EPIC -> !EpicService.isRunning
         GameSource.AMAZON -> !AmazonService.isRunning
@@ -1234,7 +1275,7 @@ fun PluviaMain(
 
             // Connection status banner (overlay) - dismissible so users can access navigation
             if (state.currentScreen != PluviaScreen.LoginUser && !connectionBannerDismissed && initialConnectDone && !state.isSteamConnected &&
-                PrefManager.refreshToken.isNotEmpty() && PrefManager.username.isNotEmpty()) {
+                SteamUtils.hasStoredCredentials()) {
                 Box(modifier = Modifier.zIndex(5f)) {
                     ConnectionStatusBanner(
                         connectionState = state.connectionState,
@@ -1258,7 +1299,7 @@ fun PluviaMain(
                 when {
                     SteamService.isLoggedIn -> PluviaScreen.Home.route + "?offline=false"
                     // skip login screen if any service has stored credentials
-                    (PrefManager.username.isNotEmpty() && PrefManager.refreshToken.isNotEmpty()) ||
+                    SteamUtils.hasStoredCredentials() ||
                         GOGService.hasStoredCredentials(context) ||
                         EpicService.hasStoredCredentials(context) ||
                         AmazonService.hasStoredCredentials(context) ->
@@ -1302,8 +1343,7 @@ fun PluviaMain(
                     // Show update/crash/support dialogs when Home is first displayed
                     // Skip when offline with Steam credentials (avoid flash when Steam reconnects)
                     LaunchedEffect(Unit) {
-                        val hasSteamCredentials = PrefManager.refreshToken.isNotEmpty() && PrefManager.username.isNotEmpty()
-                        val shouldShowDialogs = !isOffline || !hasSteamCredentials
+                        val shouldShowDialogs = !isOffline || !SteamUtils.hasStoredCredentials()
 
                         if (shouldShowDialogs && !state.annoyingDialogShown && PluviaApp.xEnvironment == null && !SteamService.keepAlive && !MainActivity.wasLaunchedViaExternalIntent) {
                             val currentUpdateInfo = updateInfo
@@ -1572,6 +1612,22 @@ fun preLaunchApp(
             return@launch
         }
 
+        // resolve real offline state for this launch. caller-supplied isOffline=true is honored
+        // (user explicitly went offline). otherwise, when Steam isn't logged in yet, wait briefly
+        // so cold-start cloud sync can run; wait fast-fails on a terminal disconnect so wifi-off
+        // doesn't ride out the full timeout.
+        val effectiveIsOffline = when {
+            isOffline -> true
+            gameSource != GameSource.STEAM -> false
+            SteamService.isLoggedIn -> false
+            !NetworkMonitor.hasInternet.value -> true
+            else -> {
+                setLoadingMessage(context.getString(R.string.connecting_to_steam))
+                setLoadingProgress(-1f)
+                !awaitSteamLogin()
+            }
+        }
+
         // When "Open container" is used we boot to desktop/file manager only — skip executable check
         if (!bootToContainer) {
             // Verify we have a launch executable for all platforms before proceeding (fail fast, avoid black screen)
@@ -1755,7 +1811,7 @@ fun preLaunchApp(
         if(isSteamGame) {
             try {
                 val currentPlaying = SteamService.getSelfCurrentlyPlayingAppId()
-                if (!isOffline && currentPlaying != null && currentPlaying != gameId) {
+                if (!effectiveIsOffline && currentPlaying != null && currentPlaying != gameId) {
                     val otherGameName = SteamService.getAppInfoOf(currentPlaying)?.name ?: "another game"
                     setLoadingDialogVisible(false)
                     setMessageDialogState(
@@ -1879,7 +1935,7 @@ fun preLaunchApp(
             try {
                 // Skip workshop sync if Steam isn't fully connected yet
                 // (can happen if the user taps Play immediately after opening the app).
-                if (isOffline || !SteamService.isConnected || !SteamService.isLoggedIn) {
+                if (effectiveIsOffline || !SteamService.isConnected || !SteamService.isLoggedIn) {
                     Timber.tag("Workshop").w(
                         "Steam not connected/logged in or offline, skipping workshop sync for appId=$gameId"
                     )
@@ -2022,7 +2078,7 @@ fun preLaunchApp(
             ignorePendingOperations = ignorePendingOperations,
             preferredSave = preferredSave,
             parentScope = this,
-            isOffline = isOffline,
+            isOffline = effectiveIsOffline,
             onProgress = { message, progress ->
                 setLoadingMessage(message)
                 setLoadingProgress(if (progress < 0) -1f else progress)

--- a/app/src/main/java/app/gamenative/ui/component/ConnectionStatusBanner.kt
+++ b/app/src/main/java/app/gamenative/ui/component/ConnectionStatusBanner.kt
@@ -46,8 +46,7 @@ import app.gamenative.R
 import app.gamenative.ui.enums.ConnectionState
 import app.gamenative.ui.theme.PluviaTheme
 
-// Threshold past which the UX (and any autonomous wait, e.g. preLaunchApp) treats
-// a still-CONNECTING Steam session as "slow enough to fall back to offline."
+// shared with SteamUtils.awaitSteamLogin so banner UI and intent-launch await fall back to offline together.
 const val TIMEOUT_SHOW_OFFLINE_OPTION_SECONDS = 5
 
 @Composable

--- a/app/src/main/java/app/gamenative/ui/component/ConnectionStatusBanner.kt
+++ b/app/src/main/java/app/gamenative/ui/component/ConnectionStatusBanner.kt
@@ -46,7 +46,9 @@ import app.gamenative.R
 import app.gamenative.ui.enums.ConnectionState
 import app.gamenative.ui.theme.PluviaTheme
 
-private const val TIMEOUT_SHOW_OFFLINE_OPTION_SECONDS = 5
+// Threshold past which the UX (and any autonomous wait, e.g. preLaunchApp) treats
+// a still-CONNECTING Steam session as "slow enough to fall back to offline."
+const val TIMEOUT_SHOW_OFFLINE_OPTION_SECONDS = 5
 
 @Composable
 fun ConnectionStatusBanner(

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -106,6 +106,7 @@ import app.gamenative.service.epic.EpicService
 import app.gamenative.service.gog.GOGService
 import app.gamenative.utils.CustomGameScanner
 import app.gamenative.utils.PlatformOAuthHandlers
+import app.gamenative.utils.SteamUtils
 import kotlinx.coroutines.launch
 import android.os.SystemClock
 
@@ -860,10 +861,9 @@ private fun LibraryScreenContent(
         if (selectedAppId == null) {
             // Use Box to allow content to scroll behind the tab bar
             Box(modifier = Modifier.fillMaxSize()) {
-                val hasSteamCredentials = PrefManager.refreshToken.isNotEmpty() && PrefManager.username.isNotEmpty()
                 // When on Steam/GOG/Epic/Amazon tab and not logged in, or LOCAL tab with no custom games, show splash
                 val showEmptyStateSplash = when (state.currentTab) {
-                    LibraryTab.STEAM -> !hasSteamCredentials && !state.isLoading
+                    LibraryTab.STEAM -> !SteamUtils.hasStoredCredentials() && !state.isLoading
                     LibraryTab.GOG -> !GOGService.hasStoredCredentials(context)
                     LibraryTab.EPIC -> !EpicService.hasStoredCredentials(context)
                     LibraryTab.AMAZON -> !AmazonService.hasStoredCredentials(context)

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -3,23 +3,29 @@ package app.gamenative.utils
 import android.annotation.SuppressLint
 import android.content.Context
 import android.provider.Settings
+import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
 import app.gamenative.data.DepotInfo
 import app.gamenative.data.LaunchInfo
 import app.gamenative.data.ManifestInfo
 import app.gamenative.data.SteamApp
+import app.gamenative.enums.LoginResult
 import app.gamenative.enums.Marker
 import app.gamenative.enums.SpecialGameSaveMapping
+import app.gamenative.events.SteamEvent
 import app.gamenative.service.SteamService
 import app.gamenative.service.SteamService.Companion.getAppDirName
 import app.gamenative.service.SteamService.Companion.getAppInfoOf
+import app.gamenative.ui.component.TIMEOUT_SHOW_OFFLINE_OPTION_SECONDS
 import com.winlator.container.Container
 import com.winlator.core.TarCompressorUtils
 import com.winlator.core.WineRegistryEditor
 import com.winlator.xenvironment.ImageFs
 import `in`.dragonbra.javasteam.types.KeyValue
 import `in`.dragonbra.javasteam.util.HardwareUtils
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -49,6 +55,37 @@ object SteamUtils {
      */
     fun hasStoredCredentials(): Boolean =
         PrefManager.username.isNotEmpty() && PrefManager.refreshToken.isNotEmpty()
+
+    // fall back at the same moment the banner would offer "Continue Offline".
+    const val STEAM_LOGIN_AWAIT_MS: Long = TIMEOUT_SHOW_OFFLINE_OPTION_SECONDS * 1000L
+
+    // disconnect listener ignores non-terminal events on purpose: SteamService.reconnect()
+    // emits Disconnected(isTerminal=false) before each retry, and a wifi blip mid-login should
+    // resolve via the eventual LogonEnded(Success), not bail the wait.
+    suspend fun awaitSteamLogin(timeoutMs: Long = STEAM_LOGIN_AWAIT_MS): Boolean {
+        val deferred = CompletableDeferred<Boolean>()
+        val onLogon: (SteamEvent.LogonEnded) -> Unit = { e ->
+            when (e.loginResult) {
+                LoginResult.Success -> deferred.complete(true)
+                LoginResult.Failed -> deferred.complete(false)
+                else -> Unit
+            }
+        }
+        val onDisconnect: (SteamEvent.Disconnected) -> Unit = { e ->
+            if (e.isTerminal) deferred.complete(false)
+        }
+        PluviaApp.events.on<SteamEvent.LogonEnded, Unit>(onLogon)
+        PluviaApp.events.on<SteamEvent.Disconnected, Unit>(onDisconnect)
+        try {
+            // register-then-check: a flag check before registration would race events
+            // fired in the gap.
+            if (SteamService.isLoggedIn) return true
+            return withTimeoutOrNull(timeoutMs) { deferred.await() } ?: false
+        } finally {
+            PluviaApp.events.off<SteamEvent.LogonEnded, Unit>(onLogon)
+            PluviaApp.events.off<SteamEvent.Disconnected, Unit>(onDisconnect)
+        }
+    }
 
     fun getDownloadBytes(manifest: ManifestInfo?): Long {
         if (manifest == null) return 0L

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -442,8 +442,12 @@ object SteamUtils {
     }
 
     fun autoLoginUserChanges(imageFs: ImageFs) {
+        // userSteamId is null on offline launch — fall back to persisted ID, else writer puts "null" in vdf
+        val steamId64 = SteamService.userSteamId?.convertToUInt64()?.toString()
+            ?: PrefManager.steamUserSteamId64.takeIf { it != 0L }?.toString()
+            ?: "0"
         val vdfFileText = SteamService.getLoginUsersVdfOauth(
-            steamId64 = SteamService.userSteamId?.convertToUInt64().toString(),
+            steamId64 = steamId64,
             account = PrefManager.username,
             refreshToken = PrefManager.refreshToken,
             accessToken = PrefManager.accessToken,      // may be blank

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -43,6 +43,13 @@ import kotlin.io.path.setLastModifiedTime
 
 object SteamUtils {
 
+    /**
+     * True when a stored Steam session exists (offline-launch gate).
+     * Matches GOG/Epic/Amazon AuthManager.hasStoredCredentials convention.
+     */
+    fun hasStoredCredentials(): Boolean =
+        PrefManager.username.isNotEmpty() && PrefManager.refreshToken.isNotEmpty()
+
     fun getDownloadBytes(manifest: ManifestInfo?): Long {
         if (manifest == null) return 0L
         return if (manifest.download > 0L) manifest.download else manifest.size

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -211,7 +211,8 @@ object SteamUtils {
         val backupPaths = mutableSetOf<String>()
         val imageFs = ImageFs.find(context)
         autoLoginUserChanges(imageFs)
-        setupLightweightSteamConfig(imageFs, SteamService.userSteamId?.toString())
+        // userdata is keyed by Steam3 accountID (matches restoreSteamApi). userSteamId is null on offline.
+        setupLightweightSteamConfig(imageFs, getSteam3AccountId()?.toString())
 
         val rootPath = Paths.get(appDirPath)
         // Get ticket once for all DLLs
@@ -1475,8 +1476,9 @@ object SteamUtils {
         val mapping = SpecialGameSaveMapping.registry.find { it.appId == steamAppId } ?: return
 
         try {
-            val accountId = SteamService.userSteamId?.accountID?.toLong() ?: 0L
-            val steamId64 = SteamService.userSteamId?.convertToUInt64()?.toString() ?: "0"
+            // safe accessors fall back to PrefManager — match siblings (SteamAutoCloud, SaveFilePattern)
+            val accountId = getSteam3AccountId() ?: 0L
+            val steamId64 = getSteamId64()?.toString() ?: "0"
             val steam3AccountId = accountId.toString()
 
             val basePath = mapping.pathType.toAbsPath(container, steamAppId, accountId)


### PR DESCRIPTION
## Description

Cold-boot intent launches (e.g., Steam shortcut for appid 2824580) fail when
offline. The prior "no need to check offline mode" fix relied on
`SteamService.isLoggedIn`, but that flag is network-gated — `steamID` only
becomes valid after `LoggedOnCallback`, which never fires without a Steam
connection. Result: `needsDeferLaunch` defers forever; when reconnect retries
exhaust, the terminal disconnect consumes the pending request with an
`intent_launch_steam_login_failed` snackbar.

This PR proceeds with the launch when we have saved Steam credentials + a
local container for the appid. Steam still reconnects in the background; the
existing `LogonEnded`/`ServiceReady` handlers remain untouched.

GOG/Epic/Amazon aren't affected — their `isRunning` getter is purely local
(`instance != null`), so the existing defer logic handles cold boot correctly
for those stores regardless of connectivity.

Split into 2 commits for review:
- `refactor: extract SteamUtils.hasStoredCredentials()` — no behavior change,
  replaces 4 inline `username.isNotEmpty() && refreshToken.isNotEmpty()`
  duplicates. Matches `hasStoredCredentials(context)` convention used by
  GOG/Epic/Amazon AuthManagers.
- `fix: allow Steam intent launches when disconnected` — the actual fix.

## Recording

https://github.com/user-attachments/assets/64d1b521-4090-4a03-b3bc-ef9b11de9ef0

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Steam app intent launches while offline or on flaky networks when saved Steam credentials and a local container exist. Offline resolution now applies only to intent launches, with a 5s Steam login wait aligned with the connection banner and fast-fail on terminal disconnect.

- **Bug Fixes**
  - Allow Steam intent launches when `SteamService.isLoggedIn` is false but `SteamUtils.hasStoredCredentials()` and `ContainerUtils.hasContainer()` are true; `launchIntentApp` resolves `isOffline` (no internet or 5s `SteamUtils.awaitSteamLogin()` with terminal-disconnect fast-fail) and passes it to `preLaunchApp`.
  - Persist and reuse Steam IDs when offline: write `loginusers.vdf` with stored `steamId64`, and use stored Steam3 account ID for config/save-path mapping to avoid null IDs.
  - UI respects stored credentials across the connection banner, initial routing, Library splash, and update/crash/support dialogs to avoid unnecessary prompts while offline.

- **Refactors**
  - Added `SteamUtils.hasStoredCredentials()` and `SteamUtils.awaitSteamLogin()`; share timeout via `TIMEOUT_SHOW_OFFLINE_OPTION_SECONDS` so intent-launch waits match the banner.
  - Consolidated intent handling into `launchIntentApp`; `preLaunchApp` now uses caller-provided `isOffline`.
  - Replaced direct `PrefManager` checks with `SteamUtils.hasStoredCredentials()` across `SteamService`, `PluviaMain`, and `LibraryScreen`.

<sup>Written for commit d2dcf37c69c3f446360e92494f688fddf23c572f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized launch handling that better respects stored Steam credentials and local launch state.
  * Launch now waits for Steam login (bounded timeout) when online before offering an offline fallback.

* **Bug Fixes / UX**
  * Connection banner timeout and launch wait are coordinated to avoid premature offline fallbacks.
  * Home, library, and dialogs suppress unnecessary offline prompts when stored Steam credentials exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->