### PR TITLE
fix: resolve cloud save path for Danganronpa 2 (app 413420)

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -131,6 +131,7 @@ object SteamAutoCloud {
                 val cloudKey = "%${p.uploadRoot.name}%${p.uploadPath}"
                     .replace("{64BitSteamID}", SteamUtils.getSteamId64().toString())
                     .replace("{Steam3AccountID}", SteamUtils.getSteam3AccountId().toString())
+                    .trimEnd('/')  // keep consistent with the trimEnd done at lookup time
                 cloudKey to Paths.get(prefixToPath(p.root.name), p.substitutedPath).pathString
             }
 
@@ -205,10 +206,17 @@ object SteamAutoCloud {
             val gameInstallPrefix = "%${PathType.GameInstall.name}%"
             if (file.filename.startsWith(gameInstallPrefix)) {
                 // Steam API sometimes returns prefix="" and filename="%GameInstall%save0.dat" instead of splitting correctly.
-                return@getFullFilePath Paths.get(
-                    prefixToPath(PathType.GameInstall.name),
-                    file.filename.removePrefix(gameInstallPrefix)
-                )
+                // Strip the embedded prefix (and any leading slash) to get the bare filename.
+                val stripped = file.filename.removePrefix(gameInstallPrefix).trimStart('/')
+                // If a Windows rootoverride remaps GameInstall → another directory (e.g.
+                // Danganronpa 2: WinMyDocuments/My Games/Danganronpa2/), download there instead
+                // of the raw game-install folder so the game can find its saves.
+                val remapped = cloudPrefixToLocalPath[gameInstallPrefix]
+                return@getFullFilePath if (remapped != null) {
+                    Paths.get(remapped, stripped)
+                } else {
+                    Paths.get(prefixToPath(PathType.GameInstall.name), stripped)
+                }
             }
 
             val convertedPrefixes = convertPrefixes(fileList)

--- a/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
@@ -25,7 +25,7 @@ import `in`.dragonbra.javasteam.types.KeyValue
 import java.util.Date
 import timber.log.Timber
 
-const val CURRENT_UFS_PARSE_VERSION = 2
+const val CURRENT_UFS_PARSE_VERSION = 3
 
 /**
  * Extension functions relating to [KeyValue] as the receiver type.
@@ -187,10 +187,11 @@ fun KeyValue.generateSteamApp(): SteamApp {
                     if (platforms.isNotEmpty() && "windows" !in platforms) return@mapNotNull null
 
                     val originalRoot = PathType.from(saveFile["root"].value)
-                    // Treat "." as empty: it means "root of this path type" with no subdirectory.
-                    // Keeping the literal dot causes addpath joins to produce "MyGame/." and
-                    // uploadPath = "." which breaks cloud key lookups in SteamAutoCloud.
-                    val originalPath = saveFile["path"].value.orEmpty().let { if (it == ".") "" else it }
+                    // Treat "." and "/" as empty: both mean "root of this path type" with no
+                    // subdirectory. Keeping the literal value causes addpath joins to produce
+                    // "MyGame/." or "MyGame/" and stores uploadPath = "." or "/" which breaks
+                    // cloud key lookups in SteamAutoCloud (e.g. Danganronpa 2 uses path="/").
+                    val originalPath = saveFile["path"].value.orEmpty().let { if (it == "." || it == "/") "" else it }
                     val rootRemap = rootOverrides.find { it.fromRoot == originalRoot }
 
                     SaveFilePattern(

--- a/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
+++ b/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
@@ -1062,6 +1062,119 @@ class SteamAutoCloudTest {
         }
     }
 
+    /**
+     * Danganronpa 2 sends cloud files with the GameInstall placeholder embedded in the filename
+     * (e.g. filename="%GameInstall%savedata.vfs", pathPrefixes=[]) because its PICS UFS entry has
+     * path="/". A Windows rootoverride maps GameInstall → WinMyDocuments + My Games/Danganronpa2/.
+     * The downloaded file must land in the WinMyDocuments subdirectory, NOT the game install dir.
+     */
+    @Test
+    fun downloadWithEmbeddedGameInstallPrefixUsesRootoverrideLocalPath() = runBlocking {
+        saveFilesDir.listFiles()?.forEach { it.delete() }
+        runBlocking {
+            db.appChangeNumbersDao().deleteByAppId(steamAppId)
+            db.appFileChangeListsDao().deleteByAppId(steamAppId)
+            db.appChangeNumbersDao().insert(app.gamenative.data.ChangeNumbers(steamAppId, 0))
+            db.appFileChangeListsDao().insert(steamAppId, emptyList())
+        }
+
+        val docsRoot = File(tempDir, "Documents")
+        val gameInstallRoot = File(tempDir, "GameInstall")
+        val expectedSaveDir = File(docsRoot, "My Games/Danganronpa2")
+        docsRoot.mkdirs()
+        gameInstallRoot.mkdirs()
+        expectedSaveDir.mkdirs()
+
+        // Danganronpa 2 SaveFilePattern after KeyValueUtils fix: "/" path normalised to ""
+        val saveFilePatterns = listOf(
+            SaveFilePattern(
+                root = PathType.WinMyDocuments,
+                path = "My Games/Danganronpa2",
+                pattern = "savedata.vfs",
+                uploadRoot = PathType.GameInstall,
+                uploadPath = "",
+            ),
+        )
+        val danganApp = db.steamAppDao().findApp(steamAppId)!!
+            .copy(ufs = UFS(saveFilePatterns = saveFilePatterns))
+
+        val fileContent = "save file content".toByteArray()
+        val fileHash = CryptoHelper.shaHash(fileContent)
+
+        // Steam sends filename with embedded %GameInstall% prefix (no separate pathPrefixes entry)
+        val mockFile = mock<AppFileInfo>()
+        whenever(mockFile.filename).thenReturn("%GameInstall%savedata.vfs")
+        whenever(mockFile.shaFile).thenReturn(fileHash)
+        whenever(mockFile.pathPrefixIndex).thenReturn(0)
+        whenever(mockFile.timestamp).thenReturn(Date())
+        whenever(mockFile.rawFileSize).thenReturn(fileContent.size)
+
+        val cloudChangeNumber = 5L
+        val mockAppFileChangeList = mock<AppFileChangeList>()
+        whenever(mockAppFileChangeList.currentChangeNumber).thenReturn(cloudChangeNumber)
+        whenever(mockAppFileChangeList.isOnlyDelta).thenReturn(false)
+        whenever(mockAppFileChangeList.appBuildIDHwm).thenReturn(0)
+        whenever(mockAppFileChangeList.pathPrefixes).thenReturn(listOf())
+        whenever(mockAppFileChangeList.machineNames).thenReturn(listOf())
+        whenever(mockAppFileChangeList.files).thenReturn(listOf(mockFile))
+
+        every { mockSteamCloud.getAppFileListChange(any(), any(), any()) } returns
+            CompletableFuture.completedFuture(mockAppFileChangeList)
+
+        val downloadInfo = mock<FileDownloadInfo>()
+        whenever(downloadInfo.urlHost).thenReturn("test.example.com")
+        whenever(downloadInfo.urlPath).thenReturn("/download/savedata.vfs")
+        whenever(downloadInfo.useHttps).thenReturn(true)
+        whenever(downloadInfo.requestHeaders).thenReturn(emptyList())
+        whenever(downloadInfo.fileSize).thenReturn(fileContent.size)
+        whenever(downloadInfo.rawFileSize).thenReturn(fileContent.size)
+
+        every { mockSteamCloud.clientFileDownload(any(), any()) } returns
+            CompletableFuture.completedFuture(downloadInfo)
+        every { mockSteamCloud.clientFileDownload(any(), any(), any(), any(), any()) } returns
+            CompletableFuture.completedFuture(downloadInfo)
+
+        val mockHttpClient = mock<OkHttpClient>()
+        every { Net.httpForParallelDownloads(any()) } returns mockHttpClient
+        val call = mock<Call>()
+        whenever(call.execute()).thenReturn(
+            Response.Builder()
+                .request(okhttp3.Request.Builder().url("https://test.example.com/download/savedata.vfs").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(fileContent.toResponseBody(null))
+                .build(),
+        )
+        whenever(mockHttpClient.newCall(any())).thenReturn(call)
+
+        val prefixToPath: (String) -> String = { prefix ->
+            when (prefix) {
+                "WinMyDocuments" -> docsRoot.absolutePath
+                "GameInstall" -> gameInstallRoot.absolutePath
+                "SteamUserData" -> File(tempDir, "userdata").absolutePath
+                else -> tempDir.absolutePath
+            }
+        }
+
+        val result = SteamAutoCloud.syncUserFiles(
+            appInfo = danganApp,
+            clientId = clientId,
+            steamInstance = mockSteamService,
+            steamCloud = mockSteamCloud,
+            preferredSave = SaveLocation.None,
+            prefixToPath = prefixToPath,
+        ).await()
+
+        assertNotNull("Result should not be null", result)
+        assertEquals("Should download 1 file", 1, result!!.filesDownloaded)
+
+        // File must land in WinMyDocuments/My Games/Danganronpa2/, NOT the game install dir
+        val expectedFile = File(expectedSaveDir, "savedata.vfs")
+        assertTrue("savedata.vfs must be in WinMyDocuments/My Games/Danganronpa2/, not game install dir: ${expectedFile.absolutePath}", expectedFile.exists())
+        assertFalse("savedata.vfs must NOT be in game install dir", File(gameInstallRoot, "savedata.vfs").exists())
+    }
+
     @Test
     fun testNoPrefixUpload() = runBlocking {
         val testApp = db.steamAppDao().findApp(steamAppId)!!

--- a/app/src/test/java/app/gamenative/utils/KeyValueUtilsTest.kt
+++ b/app/src/test/java/app/gamenative/utils/KeyValueUtilsTest.kt
@@ -785,6 +785,95 @@ class KeyValueUtilsTest {
         assertEquals("", patterns[0].uploadPath)
     }
 
+    /**
+     * Danganronpa 2: Goodbye Despair (App ID 413420) has savefiles with `path: /` (a lone
+     * forward-slash) and a Windows rootoverride mapping gameinstall → WinMyDocuments with
+     * addpath="My Games/Danganronpa2/". The "/" is semantically identical to "" (root of this
+     * path type) and must be normalised to empty so that:
+     *   1. The computed local path is "My Games/Danganronpa2" (no spurious trailing slash that
+     *      would break file-system lookups).
+     *   2. uploadPath is "" (not "/"), keeping the cloud key as "%GameInstall%" instead of
+     *      "%GameInstall%/" which would cause a lookup miss in cloudPrefixToLocalPath.
+     */
+    @Test
+    fun danganronpa2SlashPathWithWindowsRootOverrideIsNormalizedToEmpty() {
+        val kvString = """
+            "appinfo"
+            {
+                "appid"     "413420"
+                "ufs"
+                {
+                    "quota"         "1000000000"
+                    "maxnumfiles"   "5"
+                    "savefiles"
+                    {
+                        "0"
+                        {
+                            "root"      "gameinstall"
+                            "path"      "/"
+                            "pattern"   "savedata.vfs"
+                        }
+                        "1"
+                        {
+                            "root"      "gameinstall"
+                            "path"      "/"
+                            "pattern"   "savedata_jp.vfs"
+                        }
+                        "2"
+                        {
+                            "root"      "gameinstall"
+                            "path"      "/"
+                            "pattern"   "savedata_ch.vfs"
+                        }
+                    }
+                    "rootoverrides"
+                    {
+                        "0"
+                        {
+                            "root"          "gameinstall"
+                            "os"            "Windows"
+                            "oscompare"     "="
+                            "useinstead"    "WinMyDocuments"
+                            "addpath"       "My Games/Danganronpa2/"
+                        }
+                        "1"
+                        {
+                            "root"          "gameinstall"
+                            "os"            "MacOS"
+                            "oscompare"     "="
+                            "useinstead"    "MacAppSupport"
+                            "addpath"       "Danganronpa2"
+                        }
+                        "2"
+                        {
+                            "root"          "gameinstall"
+                            "os"            "Linux"
+                            "oscompare"     "="
+                            "useinstead"    "LinuxXdgDataHome"
+                            "addpath"       "/Danganronpa2Save"
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+        val kv = KeyValue.loadFromString(kvString)!!
+        val steamApp = kv.generateSteamApp()
+
+        val patterns = steamApp.ufs.saveFilePatterns
+        assertEquals(3, patterns.size)
+
+        // All three patterns share the same resolved root and path
+        patterns.forEach { p ->
+            assertEquals(PathType.WinMyDocuments, p.root)
+            assertEquals("My Games/Danganronpa2", p.path)  // no trailing slash
+            assertEquals(PathType.GameInstall, p.uploadRoot)
+            assertEquals("", p.uploadPath)  // "/" normalised to "" → cloud key has no trailing slash
+        }
+        assertEquals("savedata.vfs", patterns[0].pattern)
+        assertEquals("savedata_jp.vfs", patterns[1].pattern)
+        assertEquals("savedata_ch.vfs", patterns[2].pattern)
+    }
+
     @Test
     fun generateSteamAppStampsCurrentUfsParseVersion() {
         val kvString = """

--- a/keyvalues/Danganronpa 2 Goodbye Despair.txt
+++ b/keyvalues/Danganronpa 2 Goodbye Despair.txt
@@ -1,0 +1,51 @@
+413420: Danganronpa 2: Goodbye Despair
+	appinfo
+		appid: 413420
+		common
+			name: Danganronpa 2: Goodbye Despair
+			type: Game
+			oslist: windows
+		config
+			contenttype: 3
+			installdir: Danganronpa2
+			launch
+				0
+					executable: Danganronpa2.exe
+					type: default
+					config
+						oslist: windows
+		ufs
+			quota: 1000000000
+			maxnumfiles: 5
+			savefiles
+				0
+					root: gameinstall
+					path: /
+					pattern: savedata.vfs
+				1
+					root: gameinstall
+					path: /
+					pattern: savedata_jp.vfs
+				2
+					root: gameinstall
+					path: /
+					pattern: savedata_ch.vfs
+			rootoverrides
+				0
+					root: gameinstall
+					os: Windows
+					oscompare: =
+					useinstead: WinMyDocuments
+					addpath: My Games/Danganronpa2/
+				1
+					root: gameinstall
+					os: MacOS
+					oscompare: =
+					useinstead: MacAppSupport
+					addpath: Danganronpa2
+				2
+					root: gameinstall
+					os: Linux
+					oscompare: =
+					useinstead: LinuxXdgDataHome
+					addpath: /Danganronpa2Save


### PR DESCRIPTION


## Description
Danganronpa 2 stores saves in WinMyDocuments/My Games/Danganronpa2/ via a Windows rootoverride, but GameNative was placing downloaded cloud saves in the game install directory instead, so the game never found them.

Two bugs fixed:

1. KeyValueUtils: treat PICS path '/' as empty (same as '.') A lone forward-slash means 'root of this path type' with no subdir. Keeping the literal '/' caused uploadPath='/' which put a trailing slash on the cloudPrefixToLocalPath map key ('%GameInstall%/') while the lookup trimmed it ('%GameInstall%'), causing a miss. With the fix, uploadPath='' and path='My Games/Danganronpa2' (no trailing slash). Also bumps CURRENT_UFS_PARSE_VERSION 2->3 to force cache refresh.

2. SteamAutoCloud getFullFilePath: consult cloudPrefixToLocalPath when Steam embeds the placeholder in the filename (prefix=[], filename='%GameInstall%savedata.vfs'). The previous early-return hardcoded the destination as the game install dir, bypassing all rootoverride remapping. Now checks cloudPrefixToLocalPath['%GameInstall%'] first so the file lands in WinMyDocuments/My Games/Danganronpa2/.

Also adds .trimEnd('/') to cloudKey construction in cloudPrefixToLocalPath so map keys are always slash-free (matching the existing lookup behaviour).

Tests added:
- KeyValueUtilsTest: danganronpa2SlashPathWithWindowsRootOverrideIsNormalizedToEmpty
- SteamAutoCloudTest: downloadWithEmbeddedGameInstallPrefixUsesRootoverrideLocalPath
- keyvalues/Danganronpa 2 Goodbye Despair.txt: PICS reference documentation


## Type of Change
- [X] Bug fix
- [ ] Performance / stability improvement
- [X] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cloud save downloads for Danganronpa 2 (app 413420) by resolving saves to WinMyDocuments/My Games/Danganronpa2/ instead of the game install folder. Handles Steam files with embedded `%GameInstall%` and normalizes PICS `path: /` so lookups work.

- **Bug Fixes**
  - Normalize PICS `path: "/"` the same as `"."`, preventing trailing-slash cloud keys; bump `CURRENT_UFS_PARSE_VERSION` to 3 to refresh cached parses.
  - In `SteamAutoCloud.getFullFilePath`, remap filenames that embed `%GameInstall%` using the rootoverride path before falling back to the install dir.
  - Trim trailing `/` when constructing cloud keys to keep map keys consistent.
  - Added tests for path normalization and remapped downloads, plus a PICS reference file for app 413420.

<sup>Written for commit a76b397bf70fd22d59c7cd010a3d3fe1c16db1fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cloud save support for Danganronpa 2: Goodbye Despair with proper directory mapping.

* **Bug Fixes**
  * Fixed cloud save path normalization to prevent lookup failures when saves contain special path patterns.
  * Improved handling of save file directory mappings across platforms.

* **Tests**
  * Added tests validating cloud save behavior with directory overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->