### PR TITLE
Made layouts for appscreen and libraryscreen cutout/notch aware

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -23,13 +23,20 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.rememberScrollState
@@ -739,12 +746,23 @@ internal fun AppScreenContent(
                         ),
                 )
 
-                // Back button (top left)
+                // Back button (top left).
+                // The hero image is intentionally drawn full-bleed through the status bar
+                // and any display cutout (notch / hole-punch / side cutout). The button
+                // itself, however, has to stay tappable, so it's pushed inwards by whichever
+                // is larger of the status bar inset or the cutout inset on each affected
+                // edge before the visual 16dp padding is applied.
                 ActionIconButton(
                     icon = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = stringResource(R.string.back),
                     onClick = onBack,
-                    modifier = Modifier.padding(16.dp),
+                    modifier = Modifier
+                        .windowInsetsPadding(
+                            WindowInsets.statusBars
+                                .union(WindowInsets.displayCutout)
+                                .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+                        )
+                        .padding(16.dp),
                 )
 
                 // Bottom overlay with title and action bar

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -15,11 +15,16 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -459,17 +464,25 @@ private fun LibraryScreenContent(
     }
 
 
-    // Apply top padding differently for list vs game detail pages.
-    // On the game page we want to hide the top padding when the status bar is hidden.
-    val safePaddingModifier = if (selectedLibraryItem != null) {
-        // Detail (game) page: use actual status bar height when status bar is visible,
-        // or 0.dp when status bar is hidden
-        val topPadding = if (PrefManager.hideStatusBarWhenNotInGame) {
-            0.dp
-        } else {
-            WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
-        }
-        Modifier.padding(top = topPadding)
+    // Padding for the library *list* view (tab bar, grid, search bar) so content
+    // never draws behind the display cutout. The window now opts in to
+    // LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES via Theme.Pluvia, so:
+    //   * Status bar visible (portrait):   statusBars insets already cover the top notch.
+    //   * Status bar hidden (portrait):    statusBars insets are 0; displayCutout supplies
+    //                                       the notch height so content isn't behind the notch.
+    //   * Landscape (cutout on a side):    statusBars is top-only; displayCutout supplies
+    //                                       the side inset so the tab bar isn't clipped.
+    // Bottom is intentionally excluded so scroll content can reach the bottom edge.
+    //
+    // The detail (game) page deliberately does NOT use this — the hero image is meant
+    // to bleed through the cutout, so AppScreenContent insets only the elements that
+    // need to stay tappable (e.g. the back button) instead.
+    val safePaddingModifier = if (selectedLibraryItem == null) {
+        Modifier.windowInsetsPadding(
+            WindowInsets.statusBars
+                .union(WindowInsets.displayCutout)
+                .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+        )
     } else {
         Modifier
     }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -5,5 +5,6 @@
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 </resources>


### PR DESCRIPTION
## Description
made the UI aware of notches

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Library and App screens notch/cutout aware so content and controls don’t sit under the status bar or camera hole. Hero images remain full-bleed; interactive elements get safe padding.

- **Bug Fixes**
  - Opted into display cutouts with `shortEdges` in `themes.xml`.
  - Library list views now use `statusBars.union(displayCutout)` with top + horizontal insets to avoid overlap (including landscape side cutouts).
  - App screen back button uses `windowInsetsPadding` for safe taps; hero image intentionally ignores insets.

<sup>Written for commit 82f73608d4728bee757653cf6c9b7282a0318600. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of phone notches and display cutouts for better layout compatibility.
  * Fixed back button positioning to remain tappable while allowing content to render full-bleed in notched areas.

* **UI/UX**
  * Enhanced padding logic on library screens to properly account for screen insets on both list and detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->