### PR TITLE
fix: add game fix for Danganronpa 2 (STEAM 413420)

### DIFF
--- a/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
@@ -36,6 +36,7 @@ object GameFixesRegistry {
         STEAM_Fix_22380,
         STEAM_Fix_22490,
         STEAM_Fix_413150,
+        STEAM_Fix_413420,
         STEAM_Fix_752580,
         STEAM_Fix_1637320,
         STEAM_Fix_2868840,

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_413420.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_413420.kt
@@ -1,0 +1,122 @@
+package app.gamenative.gamefixes
+
+import android.content.Context
+import app.gamenative.data.GameSource
+import com.winlator.container.Container
+import com.winlator.core.TarCompressorUtils
+import com.winlator.core.WineRegistryEditor
+import timber.log.Timber
+import java.io.File
+
+/**
+ * Danganronpa 2: Goodbye Despair (Steam App ID 413420)
+ *
+ * After launching another game and returning to DR2, the game crashes on any scene with
+ * shader compilation. The symptom is E5017 ("Flatten 'if' conditionals branches") logged
+ * by vkd3d-shader, causing a hard crash shortly after the title screen.
+ *
+ * Root cause: applyGeneralPatches() runs when the app or image version changes. It resets
+ * user.reg from the container template (removing all DLL overrides) and replaces all common
+ * DLLs — including d3dx9_43 — with Proton stubs. The wincomponent re-extraction that would
+ * normally restore the real Microsoft DLLs is then skipped because the wincomponents setting
+ * has not changed. The game is permanently broken until a full container reset.
+ *
+ * Why the Proton stubs fail: all Proton-bundled DLLs are Wine-compiled "builtin" PE files.
+ * Wine identifies them as builtin via PE metadata, so they load as builtin even when the
+ * DLL override says "native,builtin". Wine's builtin d3dx9_43 routes HLSL shader compilation
+ * through d3dcompiler_47 (vkd3d-shader), which does not support the [flatten] attribute →
+ * E5017.
+ *
+ * Fix: DR2 requires the real Microsoft d3dx9_43 and d3dcompiler_43 DLLs from the direct3d
+ * wincomponent (wincomponents/direct3d.tzst). The real MS d3dx9_43 loads as native and
+ * compiles shaders internally via d3dcompiler_43 (also native MS DLL), bypassing vkd3d
+ * entirely. Two steps are applied every launch:
+ * 1. If d3dx9_43=native,builtin is absent from user.reg (a reliable signal that
+ *    applyGeneralPatches() has reset both the registry and the DLLs), re-extract
+ *    wincomponents/direct3d.tzst to restore the full real MS DLL set.
+ * 2. Always write "native,builtin" overrides for d3dx9_43 and d3dcompiler_43 to user.reg
+ *    so they survive any future user.reg reset.
+ */
+val STEAM_Fix_413420: KeyedGameFix = object : KeyedGameFix {
+    override val gameSource = GameSource.STEAM
+    override val gameId = "413420"
+
+    override fun apply(
+        context: Context,
+        gameId: String,
+        installPath: String,
+        installPathWindows: String,
+        container: Container,
+    ): Boolean {
+        return try {
+            ensureNativeDirectXDlls(context, container)
+            true
+        } catch (e: Exception) {
+            Timber.tag("GameFixes").e(e, "Failed to apply fixes for Danganronpa 2")
+            false
+        }
+    }
+
+    /**
+     * Restores real Microsoft DirectX DLLs and ensures they load as native.
+     *
+     * When applyGeneralPatches() resets the container, it clears user.reg and replaces
+     * DLLs with Proton stubs in one coupled operation. Checking for d3dx9_43=native,builtin
+     * in user.reg is therefore a reliable signal for both resets: if the override is absent,
+     * wincomponents/direct3d.tzst is re-extracted to restore the real MS DLL set. Registry
+     * overrides are then written (or re-written) every launch regardless.
+     */
+    private fun ensureNativeDirectXDlls(context: Context, container: Container) {
+        val userRegFile = File(container.getRootDir(), ".wine/user.reg")
+        val needsExtraction = if (!userRegFile.exists()) {
+            true
+        } else {
+            WineRegistryEditor(userRegFile).use { editor ->
+                editor.getStringValue("Software\\Wine\\DllOverrides", "d3dx9_43", null) == null
+            }
+        }
+
+        if (needsExtraction) {
+            val windowsDir = File(container.getRootDir(), ".wine/drive_c/windows")
+            val extracted = TarCompressorUtils.extract(
+                TarCompressorUtils.Type.ZSTD, context.assets,
+                "wincomponents/direct3d.tzst", windowsDir
+            )
+            if (extracted) {
+                Timber.tag("GameFixes").i("Extracted direct3d.tzst: d3dx9_43 override was absent (user.reg was reset)")
+            } else {
+                Timber.tag("GameFixes").w("Failed to extract direct3d.tzst; game may crash")
+            }
+        }
+
+        setNativeOverrides(container)
+    }
+
+    /**
+     * Writes "native,builtin" overrides for d3dx9_43 and d3dcompiler_43 to user.reg.
+     *
+     * Without these overrides, Wine loads Proton stubs as builtin (even if real MS DLLs
+     * are present) and routes shader compilation through vkd3d → E5017. Overrides are
+     * written to HKCU\Software\Wine\DllOverrides (user.reg) every launch because
+     * applyGeneralPatches() may reset user.reg at any time. HKLM overrides are ignored
+     * by Wine.
+     */
+    private fun setNativeOverrides(container: Container) {
+        val userRegFile = File(container.getRootDir(), ".wine/user.reg")
+        if (!userRegFile.exists()) {
+            Timber.tag("GameFixes").w("user.reg not found, cannot set DLL overrides")
+            return
+        }
+        try {
+            WineRegistryEditor(userRegFile).use { editor ->
+                editor.setCreateKeyIfNotExist(true)
+                val key = "Software\\Wine\\DllOverrides"
+                editor.setStringValue(key, "d3dx9_43", "native,builtin")
+                editor.setStringValue(key, "d3dcompiler_43", "native,builtin")
+            }
+            Timber.tag("GameFixes").i("Set d3dx9_43, d3dcompiler_43=native,builtin in user.reg")
+        } catch (e: Exception) {
+            Timber.tag("GameFixes").e(e, "Failed to set DLL overrides in user.reg")
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_413420.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_413420.kt
@@ -1,12 +1,6 @@
 package app.gamenative.gamefixes
 
-import android.content.Context
 import app.gamenative.data.GameSource
-import com.winlator.container.Container
-import com.winlator.core.TarCompressorUtils
-import com.winlator.core.WineRegistryEditor
-import timber.log.Timber
-import java.io.File
 
 /**
  * Danganronpa 2: Goodbye Despair (Steam App ID 413420)
@@ -15,108 +9,17 @@ import java.io.File
  * shader compilation. The symptom is E5017 ("Flatten 'if' conditionals branches") logged
  * by vkd3d-shader, causing a hard crash shortly after the title screen.
  *
- * Root cause: applyGeneralPatches() runs when the app or image version changes. It resets
- * user.reg from the container template (removing all DLL overrides) and replaces all common
- * DLLs — including d3dx9_43 — with Proton stubs. The wincomponent re-extraction that would
- * normally restore the real Microsoft DLLs is then skipped because the wincomponents setting
- * has not changed. The game is permanently broken until a full container reset.
+ * Root cause: Wine's builtin d3dx9_43 (from Proton) routes HLSL shader compilation through
+ * vkd3d-shader, which does not support the [flatten] attribute → E5017 crash.
  *
- * Why the Proton stubs fail: all Proton-bundled DLLs are Wine-compiled "builtin" PE files.
- * Wine identifies them as builtin via PE metadata, so they load as builtin even when the
- * DLL override says "native,builtin". Wine's builtin d3dx9_43 routes HLSL shader compilation
- * through d3dcompiler_47 (vkd3d-shader), which does not support the [flatten] attribute →
- * E5017.
- *
- * Fix: DR2 requires the real Microsoft d3dx9_43 and d3dcompiler_43 DLLs from the direct3d
- * wincomponent (wincomponents/direct3d.tzst). The real MS d3dx9_43 loads as native and
- * compiles shaders internally via d3dcompiler_43 (also native MS DLL), bypassing vkd3d
- * entirely. Two steps are applied every launch:
- * 1. If d3dx9_43=native,builtin is absent from user.reg (a reliable signal that
- *    applyGeneralPatches() has reset both the registry and the DLLs), re-extract
- *    wincomponents/direct3d.tzst to restore the full real MS DLL set.
- * 2. Always write "native,builtin" overrides for d3dx9_43 and d3dcompiler_43 to user.reg
- *    so they survive any future user.reg reset.
+ * Fix: Set WINEDLLOVERRIDES to ensure d3dx9_43 and d3dcompiler_43 load as native,builtin.
+ * This forces Wine to use the real Microsoft DirectX DLLs (when present) instead of Proton
+ * stubs, allowing shaders to compile internally and bypass vkd3d entirely.
  */
-val STEAM_Fix_413420: KeyedGameFix = object : KeyedGameFix {
-    override val gameSource = GameSource.STEAM
-    override val gameId = "413420"
-
-    override fun apply(
-        context: Context,
-        gameId: String,
-        installPath: String,
-        installPathWindows: String,
-        container: Container,
-    ): Boolean {
-        return try {
-            ensureNativeDirectXDlls(context, container)
-            true
-        } catch (e: Exception) {
-            Timber.tag("GameFixes").e(e, "Failed to apply fixes for Danganronpa 2")
-            false
-        }
-    }
-
-    /**
-     * Restores real Microsoft DirectX DLLs and ensures they load as native.
-     *
-     * When applyGeneralPatches() resets the container, it clears user.reg and replaces
-     * DLLs with Proton stubs in one coupled operation. Checking for d3dx9_43=native,builtin
-     * in user.reg is therefore a reliable signal for both resets: if the override is absent,
-     * wincomponents/direct3d.tzst is re-extracted to restore the real MS DLL set. Registry
-     * overrides are then written (or re-written) every launch regardless.
-     */
-    private fun ensureNativeDirectXDlls(context: Context, container: Container) {
-        val userRegFile = File(container.getRootDir(), ".wine/user.reg")
-        val needsExtraction = if (!userRegFile.exists()) {
-            true
-        } else {
-            WineRegistryEditor(userRegFile).use { editor ->
-                editor.getStringValue("Software\\Wine\\DllOverrides", "d3dx9_43", null) == null
-            }
-        }
-
-        if (needsExtraction) {
-            val windowsDir = File(container.getRootDir(), ".wine/drive_c/windows")
-            val extracted = TarCompressorUtils.extract(
-                TarCompressorUtils.Type.ZSTD, context.assets,
-                "wincomponents/direct3d.tzst", windowsDir
-            )
-            if (extracted) {
-                Timber.tag("GameFixes").i("Extracted direct3d.tzst: d3dx9_43 override was absent (user.reg was reset)")
-            } else {
-                Timber.tag("GameFixes").w("Failed to extract direct3d.tzst; game may crash")
-            }
-        }
-
-        setNativeOverrides(container)
-    }
-
-    /**
-     * Writes "native,builtin" overrides for d3dx9_43 and d3dcompiler_43 to user.reg.
-     *
-     * Without these overrides, Wine loads Proton stubs as builtin (even if real MS DLLs
-     * are present) and routes shader compilation through vkd3d → E5017. Overrides are
-     * written to HKCU\Software\Wine\DllOverrides (user.reg) every launch because
-     * applyGeneralPatches() may reset user.reg at any time. HKLM overrides are ignored
-     * by Wine.
-     */
-    private fun setNativeOverrides(container: Container) {
-        val userRegFile = File(container.getRootDir(), ".wine/user.reg")
-        if (!userRegFile.exists()) {
-            Timber.tag("GameFixes").w("user.reg not found, cannot set DLL overrides")
-            return
-        }
-        try {
-            WineRegistryEditor(userRegFile).use { editor ->
-                editor.setCreateKeyIfNotExist(true)
-                val key = "Software\\Wine\\DllOverrides"
-                editor.setStringValue(key, "d3dx9_43", "native,builtin")
-                editor.setStringValue(key, "d3dcompiler_43", "native,builtin")
-            }
-            Timber.tag("GameFixes").i("Set d3dx9_43, d3dcompiler_43=native,builtin in user.reg")
-        } catch (e: Exception) {
-            Timber.tag("GameFixes").e(e, "Failed to set DLL overrides in user.reg")
-        }
-    }
-}
+val STEAM_Fix_413420: KeyedGameFix = KeyedWineEnvVarFix(
+    gameSource = GameSource.STEAM,
+    gameId = "413420",
+    envVarsToSet = mapOf(
+        "WINEDLLOVERRIDES" to "d3dx9_43=native,builtin d3dcompiler_43=native,builtin",
+    ),
+)


### PR DESCRIPTION
## Description

Fixes Danganronpa 2 (Steam 413420) crashing with E5017 ("Flatten 'if' conditionals branches") when launched after playing another game.

**Root cause:** `applyGeneralPatches()` runs when the app or image version changes. It resets `user.reg` from the container template (removing all DLL overrides) and replaces all common DLLs — including `d3dx9_43` — with Proton stubs via `deleteCommonDlls()` + `extractCommonDlls()`. The wincomponent re-extraction that would normally restore the real Microsoft DLLs is then skipped because the `wincomponents` setting has not changed. This leaves `d3dx9_43` as a Wine-builtin PE stub that routes HLSL shader compilation through `d3dcompiler_47` (vkd3d-shader), which does not support the `[flatten]` attribute → E5017 crash.

**Why Proton stubs fail:** All Proton-bundled DLLs are Wine-compiled "builtin" PE files. Wine identifies them as builtin via PE metadata and loads them as builtin even when the DLL override says `native,builtin`. Wine's builtin `d3dx9_43` routes through vkd3d → E5017.

**Fix:** Detect when `applyGeneralPatches()` has reset the registry (by checking if `d3dx9_43=native,builtin` is absent from user.reg), then re-extract `wincomponents/direct3d.tzst` to restore the real Microsoft DLL set. This DLL set loads as native and compiles shaders internally, bypassing vkd3d entirely. Also ensure registry overrides are written every launch so they survive any future user.reg reset.

Tested on device: DR2 launches successfully after another game is launched in the same session (previously crashed with E5017).

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality / game compatibility).
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Danganronpa 2 (Steam 413420) crashing with E5017 after launching another game by forcing native DirectX 9 DLLs via `WINEDLLOVERRIDES` on every launch.

- **Bug Fixes**
  - Add per-game fix that sets `WINEDLLOVERRIDES` to `d3dx9_43=native,builtin d3dcompiler_43=native,builtin` to bypass `vkd3d-shader` and avoid the `[flatten]` crash.
  - Register `STEAM_413420` in `GameFixesRegistry` so the override applies each launch.

<sup>Written for commit e49d819fd69228808454f857de15c217e75e32eb. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1301?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a dedicated fix for Danganronpa 2 on Steam that resolves DirectX-related crashes and compatibility issues. The fix applies automatically at launch, configuring the necessary graphics runtime handling to improve stability and prevent manual workarounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->