### PR TITLE
fix(ui): make quick menu navigation rail scrollable to fix landscape clipping

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -398,11 +398,13 @@ fun QuickMenu(
                             modifier = Modifier
                                 .width(64.dp)
                                 .fillMaxHeight()
-                                .verticalScroll(navRailScrollState)
                                 .focusGroup(),
                             horizontalAlignment = Alignment.CenterHorizontally,
                         ) {
                             Column(
+                                modifier = Modifier
+                                    .weight(1f, fill = false)
+                                    .verticalScroll(navRailScrollState),
                                 verticalArrangement = Arrangement.spacedBy(8.dp),
                                 horizontalAlignment = Alignment.CenterHorizontally,
                             ) {

--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -311,6 +311,7 @@ fun QuickMenu(
     val effectsItemFocusRequester = remember { FocusRequester() }
     val controllerItemFocusRequester = remember { FocusRequester() }
     val toolsItemFocusRequester = remember { FocusRequester() }
+    val navRailScrollState = rememberScrollState()
 
     BackHandler(enabled = isVisible) {
         onDismiss()
@@ -397,6 +398,7 @@ fun QuickMenu(
                             modifier = Modifier
                                 .width(64.dp)
                                 .fillMaxHeight()
+                                .verticalScroll(navRailScrollState)
                                 .focusGroup(),
                             horizontalAlignment = Alignment.CenterHorizontally,
                         ) {


### PR DESCRIPTION
## Description
Added a `verticalScroll` modifier to the Navigation Rail (the left sidebar) within the `QuickMenu` component. 

In landscape mode, vertical screen real estate is extremely limited. Recent additions, such as "Task Manager" items and extra tab buttons, caused the total height of the sidebar content to exceed the physical screen height. 

Since the original `Column` container was not scrollable, the **"Exit Game"** button at the bottom was clipped (hidden) and became completely unreachable for users in landscape orientation. This change ensures that all navigation and functional items remain accessible via scrolling, regardless of the screen's aspect ratio or orientation.

## Recording

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation rail now supports vertical scrolling, allowing tab/action buttons to be scrolled when there are more items than fit in the rail. This ensures all navigation options remain accessible in constrained layouts and improves usability when many items are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Quick Menu navigation rail scrollable in landscape and keeps the Exit Game button pinned at the bottom. Fixes clipping on short screens and restores access to all items.

- **Bug Fixes**
  - Made the content column scrollable with `verticalScroll(rememberScrollState())` and `weight(1f, fill = false)` so overflow scrolls while bottom actions stay fixed.

<sup>Written for commit a40821240249fddcf3ef9b367e6f329b162616dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

