### PR TITLE
fix: eliminate global symlink dependency in PathType.toAbsPath

### DIFF
--- a/app/src/main/java/app/gamenative/enums/PathType.kt
+++ b/app/src/main/java/app/gamenative/enums/PathType.kt
@@ -2,6 +2,7 @@ package app.gamenative.enums
 
 import android.content.Context
 import app.gamenative.service.SteamService
+import com.winlator.container.Container
 import com.winlator.xenvironment.ImageFs
 import java.nio.file.Paths
 import timber.log.Timber
@@ -26,62 +27,53 @@ enum class PathType {
 
     /**
      * Turns a path type to a full path through the android system to the expected directory in
-     * the wine prefix or the steam common app dir. Make sure to run
-     * [com.winlator.container.ContainerManager.activateContainer] on the proper
-     * [com.winlator.container.Container] beforehand.
+     * the wine prefix or the steam common app dir.
      */
-    fun toAbsPath(context: Context, appId: Int, accountId: Long): String {
+    fun toAbsPath(container: Container, appId: Int, accountId: Long): String {
+        val root = container.rootDir.absolutePath
         val path = when (this) {
             GameInstall -> SteamService.getAppDirPath(appId)
             SteamUserData -> Paths.get(
-                ImageFs.find(context).rootDir.absolutePath,
-                ImageFs.WINEPREFIX,
-                "/drive_c/Program Files (x86)/Steam/userdata/$accountId/$appId/remote",
+                root,
+                ".wine/drive_c/Program Files (x86)/Steam/userdata/$accountId/$appId/remote",
             ).toString()
             WinMyDocuments -> Paths.get(
-                ImageFs.find(context).rootDir.absolutePath,
-                ImageFs.WINEPREFIX,
-                "/drive_c/users/",
+                root,
+                ".wine/drive_c/users",
                 ImageFs.USER,
                 "Documents/",
             ).toString()
             WinAppDataLocal -> Paths.get(
-                ImageFs.find(context).rootDir.absolutePath,
-                ImageFs.WINEPREFIX,
-                "/drive_c/users/",
+                root,
+                ".wine/drive_c/users",
                 ImageFs.USER,
                 "AppData/Local/",
             ).toString()
             WinAppDataLocalLow -> Paths.get(
-                ImageFs.find(context).rootDir.absolutePath,
-                ImageFs.WINEPREFIX,
-                "/drive_c/users/",
+                root,
+                ".wine/drive_c/users",
                 ImageFs.USER,
                 "AppData/LocalLow/",
             ).toString()
             WinAppDataRoaming -> Paths.get(
-                ImageFs.find(context).rootDir.absolutePath,
-                ImageFs.WINEPREFIX,
-                "/drive_c/users/",
+                root,
+                ".wine/drive_c/users",
                 ImageFs.USER,
                 "AppData/Roaming/",
             ).toString()
             WinSavedGames -> Paths.get(
-                ImageFs.find(context).rootDir.absolutePath,
-                ImageFs.WINEPREFIX,
-                "/drive_c/users/",
+                root,
+                ".wine/drive_c/users",
                 ImageFs.USER,
                 "Saved Games/",
             ).toString()
             WinProgramData -> Paths.get(
-                ImageFs.find(context).rootDir.absolutePath,
-                ImageFs.WINEPREFIX,
-                "/drive_c/ProgramData/",
+                root,
+                ".wine/drive_c/ProgramData/",
             ).toString()
             Root -> Paths.get(
-                ImageFs.find(context).rootDir.absolutePath,
-                ImageFs.WINEPREFIX,
-                "/drive_c/users/",
+                root,
+                ".wine/drive_c/users",
                 ImageFs.USER,
                 "",
             ).toString()

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1841,7 +1841,7 @@ fun preLaunchApp(
 
         // For Steam games, sync save files and check no pending remote operations are running
         val prefixToPath: (String) -> String = { prefix ->
-            PathType.from(prefix).toAbsPath(context, gameId, SteamService.userSteamId!!.accountID)
+            PathType.from(prefix).toAbsPath(container, gameId, SteamService.userSteamId!!.accountID)
         }
 
         // Workshop mod sync: check for updates and download if needed

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 @HiltViewModel
@@ -586,8 +587,11 @@ class MainViewModel @Inject constructor(
 
         if (gameSource == GameSource.STEAM) {
             try {
+                val container = withContext(Dispatchers.IO) {
+                    ContainerUtils.getOrCreateContainer(context, appId)
+                }
                 SteamService.closeApp(context, gameId, isOffline.value) { prefix ->
-                    PathType.from(prefix).toAbsPath(context, gameId, SteamService.userSteamId!!.accountID)
+                    PathType.from(prefix).toAbsPath(container, gameId, SteamService.userSteamId!!.accountID)
                 }.await()
             } catch (e: CancellationException) {
                 throw e

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -588,7 +588,7 @@ class MainViewModel @Inject constructor(
         if (gameSource == GameSource.STEAM) {
             try {
                 val container = withContext(Dispatchers.IO) {
-                    ContainerUtils.getOrCreateContainer(context, appId)
+                    ContainerUtils.getContainer(context, appId)
                 }
                 SteamService.closeApp(context, gameId, isOffline.value) { prefix ->
                     PathType.from(prefix).toAbsPath(container, gameId, SteamService.userSteamId!!.accountID)

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -653,39 +653,13 @@ class SteamAppScreen : BaseAppScreen() {
         return libraryItem.gameSource == app.gamenative.data.GameSource.STEAM
     }
 
-    private suspend fun activateSaveTransferContainer(context: Context, appId: String): Result<Container> {
-        return try {
-            val container = withContext(Dispatchers.IO) {
-                val containerManager = ContainerManager(context)
-                val container = ContainerUtils.getOrCreateContainer(context, appId)
-                containerManager.activateContainer(container)
-                container
-            }
-            Result.success(container)
-        } catch (e: kotlinx.coroutines.CancellationException) {
-            throw e
-        } catch (t: Throwable) {
-            Timber.e(t, "Failed to activate save transfer container for $appId")
-            Result.failure(t)
-        }
-    }
-
     override suspend fun exportSaves(
         context: Context,
         libraryItem: LibraryItem,
         uri: Uri,
     ): Boolean {
-        val containerResult = activateSaveTransferContainer(context, libraryItem.appId)
-        if (containerResult.isFailure) {
-            SnackbarManager.show(
-                context.getString(
-                    R.string.steam_save_export_failed,
-                    containerResult.exceptionOrNull()?.message ?: "Unknown error",
-                ),
-            )
-            return false
-        }
-        return SteamSaveTransfer.exportSaves(context, containerResult.getOrThrow(), libraryItem.gameId, uri)
+        val container = withContext(Dispatchers.IO) { ContainerUtils.getOrCreateContainer(context, libraryItem.appId) }
+        return SteamSaveTransfer.exportSaves(context, container, libraryItem.gameId, uri)
     }
 
     override suspend fun importSaves(
@@ -693,17 +667,8 @@ class SteamAppScreen : BaseAppScreen() {
         libraryItem: LibraryItem,
         uri: Uri,
     ): Boolean {
-        val containerResult = activateSaveTransferContainer(context, libraryItem.appId)
-        if (containerResult.isFailure) {
-            SnackbarManager.show(
-                context.getString(
-                    R.string.steam_save_import_failed,
-                    containerResult.exceptionOrNull()?.message ?: "Unknown error",
-                ),
-            )
-            return false
-        }
-        return SteamSaveTransfer.importSaves(context, containerResult.getOrThrow(), libraryItem.gameId, uri)
+        val container = withContext(Dispatchers.IO) { ContainerUtils.getOrCreateContainer(context, libraryItem.appId) }
+        return SteamSaveTransfer.importSaves(context, container, libraryItem.gameId, uri)
     }
 
     @Composable
@@ -828,9 +793,7 @@ class SteamAppScreen : BaseAppScreen() {
                             return@launch
                         }
 
-                        val containerManager = ContainerManager(context)
                         val container = ContainerUtils.getOrCreateContainer(context, appId)
-                        containerManager.activateContainer(container)
 
                         val prefixToPath: (String) -> String = { prefix ->
                             PathType.from(prefix).toAbsPath(container, gameId, steamId.accountID)

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -61,6 +61,7 @@ import app.gamenative.workshop.WorkshopManager
 import app.gamenative.NetworkMonitor
 import com.google.android.play.core.splitcompat.SplitCompat
 import com.posthog.PostHog
+import com.winlator.container.Container
 import com.winlator.container.ContainerData
 import com.winlator.container.ContainerManager
 import com.winlator.fexcore.FEXCoreManager
@@ -652,19 +653,20 @@ class SteamAppScreen : BaseAppScreen() {
         return libraryItem.gameSource == app.gamenative.data.GameSource.STEAM
     }
 
-    private suspend fun activateSaveTransferContainer(context: Context, appId: String): Throwable? {
+    private suspend fun activateSaveTransferContainer(context: Context, appId: String): Result<Container> {
         return try {
-            withContext(Dispatchers.IO) {
+            val container = withContext(Dispatchers.IO) {
                 val containerManager = ContainerManager(context)
                 val container = ContainerUtils.getOrCreateContainer(context, appId)
                 containerManager.activateContainer(container)
+                container
             }
-            null
+            Result.success(container)
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (t: Throwable) {
             Timber.e(t, "Failed to activate save transfer container for $appId")
-            t
+            Result.failure(t)
         }
     }
 
@@ -673,17 +675,17 @@ class SteamAppScreen : BaseAppScreen() {
         libraryItem: LibraryItem,
         uri: Uri,
     ): Boolean {
-        val activationError = activateSaveTransferContainer(context, libraryItem.appId)
-        if (activationError != null) {
+        val containerResult = activateSaveTransferContainer(context, libraryItem.appId)
+        if (containerResult.isFailure) {
             SnackbarManager.show(
                 context.getString(
                     R.string.steam_save_export_failed,
-                    activationError.message ?: "Unknown error",
+                    containerResult.exceptionOrNull()?.message ?: "Unknown error",
                 ),
             )
             return false
         }
-        return SteamSaveTransfer.exportSaves(context, libraryItem.gameId, uri)
+        return SteamSaveTransfer.exportSaves(context, containerResult.getOrThrow(), libraryItem.gameId, uri)
     }
 
     override suspend fun importSaves(
@@ -691,17 +693,17 @@ class SteamAppScreen : BaseAppScreen() {
         libraryItem: LibraryItem,
         uri: Uri,
     ): Boolean {
-        val activationError = activateSaveTransferContainer(context, libraryItem.appId)
-        if (activationError != null) {
+        val containerResult = activateSaveTransferContainer(context, libraryItem.appId)
+        if (containerResult.isFailure) {
             SnackbarManager.show(
                 context.getString(
                     R.string.steam_save_import_failed,
-                    activationError.message ?: "Unknown error",
+                    containerResult.exceptionOrNull()?.message ?: "Unknown error",
                 ),
             )
             return false
         }
-        return SteamSaveTransfer.importSaves(context, libraryItem.gameId, uri)
+        return SteamSaveTransfer.importSaves(context, containerResult.getOrThrow(), libraryItem.gameId, uri)
     }
 
     @Composable
@@ -831,7 +833,7 @@ class SteamAppScreen : BaseAppScreen() {
                         containerManager.activateContainer(container)
 
                         val prefixToPath: (String) -> String = { prefix ->
-                            PathType.from(prefix).toAbsPath(context, gameId, steamId.accountID)
+                            PathType.from(prefix).toAbsPath(container, gameId, steamId.accountID)
                         }
                         val syncResult = SteamService.forceSyncUserFiles(
                             appId = gameId,
@@ -1128,7 +1130,7 @@ class SteamAppScreen : BaseAppScreen() {
                                     val steamId = SteamService.userSteamId
                                     if (steamId != null) {
                                         val prefixToPath: (String) -> String = { prefix ->
-                                            PathType.from(prefix).toAbsPath(context, gameId, steamId.accountID)
+                                            PathType.from(prefix).toAbsPath(container, gameId, steamId.accountID)
                                         }
                                         SteamService.forceSyncUserFiles(
                                             appId = gameId,

--- a/app/src/main/java/app/gamenative/ui/util/SteamSaveTransfer.kt
+++ b/app/src/main/java/app/gamenative/ui/util/SteamSaveTransfer.kt
@@ -8,7 +8,7 @@ import app.gamenative.data.SaveFilePattern
 import app.gamenative.enums.PathType
 import app.gamenative.service.SteamService
 import app.gamenative.utils.FileUtils
-import com.winlator.xenvironment.ImageFs
+import com.winlator.container.Container
 import java.io.IOException
 import java.nio.channels.Channels
 import java.nio.file.Files
@@ -64,13 +64,14 @@ object SteamSaveTransfer {
 
     suspend fun exportSaves(
         context: Context,
+        container: Container,
         steamAppId: Int,
         uri: Uri,
     ): Boolean {
         return try {
             val app = SteamService.getAppInfoOf(steamAppId)
                 ?: throw IOException("Steam app not found")
-            val prefixToPath = makePrefixToPath(context, steamAppId)
+            val prefixToPath = makePrefixToPath(container, steamAppId)
             val roots = withContext(Dispatchers.IO) { resolveExportRoots(app, prefixToPath) }
 
             if (roots.isEmpty()) {
@@ -119,6 +120,7 @@ object SteamSaveTransfer {
 
     suspend fun importSaves(
         context: Context,
+        container: Container,
         steamAppId: Int,
         uri: Uri,
     ): Boolean {
@@ -133,7 +135,7 @@ object SteamSaveTransfer {
                 throw IOException("Archive does not declare any save roots")
             }
 
-            val prefixToPath = makePrefixToPath(context, steamAppId)
+            val prefixToPath = makePrefixToPath(container, steamAppId)
             val rootMap = withContext(Dispatchers.IO) {
                 resolveImportRoots(app, archiveManifest.roots, prefixToPath)
             }
@@ -344,30 +346,29 @@ object SteamSaveTransfer {
 
     // -- Helpers ---------------------------------------------------------------
 
-    private fun makePrefixToPath(context: Context, appId: Int): (String) -> String? = { prefix ->
-        resolveRootBasePath(context, appId, PathType.from(prefix))?.pathString
+    private fun makePrefixToPath(container: Container, appId: Int): (String) -> String? = { prefix ->
+        resolveRootBasePath(container, appId, PathType.from(prefix))?.pathString
     }
 
     private fun resolveRootBasePath(
-        context: Context,
+        container: Container,
         appId: Int,
         rootType: PathType,
     ): Path? {
         val accountId = when (rootType) {
-            PathType.SteamUserData -> resolveSteamAccountId(context, appId) ?: return null
+            PathType.SteamUserData -> resolveSteamAccountId(container, appId) ?: return null
             else -> 0L
         }
-        return Paths.get(rootType.toAbsPath(context, appId, accountId))
+        return Paths.get(rootType.toAbsPath(container, appId, accountId))
     }
 
-    private fun resolveSteamAccountId(context: Context, appId: Int): Long? {
+    private fun resolveSteamAccountId(container: Container, appId: Int): Long? {
         SteamService.userSteamId?.accountID?.toLong()?.let { return it }
         PrefManager.steamUserAccountId.takeIf { it != 0 }?.toLong()?.let { return it }
 
         val userdataRoot = Paths.get(
-            ImageFs.find(context).rootDir.absolutePath,
-            ImageFs.WINEPREFIX,
-            "/drive_c/Program Files (x86)/Steam/userdata",
+            container.rootDir.absolutePath,
+            ".wine/drive_c/Program Files (x86)/Steam/userdata",
         )
         if (!Files.isDirectory(userdataRoot)) return null
 

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -228,7 +228,8 @@ object SteamUtils {
         createAppManifest(context, steamAppId)
 
         // Game-specific Handling
-        ensureSaveLocationsForGames(context, steamAppId)
+        val container = ContainerUtils.getOrCreateContainer(context, appId)
+        ensureSaveLocationsForGames(context, steamAppId, container)
 
         // Generate achievements.json
         generateAchievementsFile(rootPath.resolve("steam_settings"), appId)
@@ -277,7 +278,7 @@ object SteamUtils {
         generateAchievementsFile(path, appId)
 
         // Game-specific Handling
-        ensureSaveLocationsForGames(context, steamAppId)
+        ensureSaveLocationsForGames(context, steamAppId, container)
 
         MarkerUtils.addMarker(appDirPath, Marker.STEAM_COLDCLIENT_USED)
     }
@@ -759,7 +760,7 @@ object SteamUtils {
         createAppManifest(context, steamAppId)
 
         // Game-specific Handling
-        ensureSaveLocationsForGames(context, steamAppId)
+        ensureSaveLocationsForGames(context, steamAppId, container)
 
         MarkerUtils.addMarker(appDirPath, Marker.STEAM_DLL_RESTORED)
     }
@@ -1422,7 +1423,7 @@ object SteamUtils {
      * - {64BitSteamID} - Replaced with the user's 64-bit Steam ID
      * - {Steam3AccountID} - Replaced with the user's Steam3 account ID
      */
-    fun ensureSaveLocationsForGames(context: Context, steamAppId: Int) {
+    fun ensureSaveLocationsForGames(context: Context, steamAppId: Int, container: Container) {
         val mapping = SpecialGameSaveMapping.registry.find { it.appId == steamAppId } ?: return
 
         try {
@@ -1430,7 +1431,7 @@ object SteamUtils {
             val steamId64 = SteamService.userSteamId?.convertToUInt64()?.toString() ?: "0"
             val steam3AccountId = accountId.toString()
 
-            val basePath = mapping.pathType.toAbsPath(context, steamAppId, accountId)
+            val basePath = mapping.pathType.toAbsPath(container, steamAppId, accountId)
 
             // Substitute placeholders in paths
             val sourceRelativePath = mapping.sourceRelativePath

--- a/app/src/test/java/app/gamenative/enums/PathTypeTest.kt
+++ b/app/src/test/java/app/gamenative/enums/PathTypeTest.kt
@@ -1,0 +1,123 @@
+package app.gamenative.enums
+
+import com.winlator.container.Container
+import com.winlator.xenvironment.ImageFs
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PathTypeTest {
+
+    private val containerRoot = "/data/test/container"
+    private val container = Container("test-id").apply { setRootDir(File(containerRoot)) }
+    private val appId = 220
+    private val accountId = 76561198025127569L
+
+    @Test
+    fun `SteamUserData resolves to Steam userdata remote directory`() {
+        assertEquals(
+            "$containerRoot/.wine/drive_c/Program Files (x86)/Steam/userdata/$accountId/$appId/remote/",
+            PathType.SteamUserData.toAbsPath(container, appId, accountId),
+        )
+    }
+
+    @Test
+    fun `WinMyDocuments resolves to Documents folder in wine prefix`() {
+        assertEquals(
+            "$containerRoot/.wine/drive_c/users/${ImageFs.USER}/Documents/",
+            PathType.WinMyDocuments.toAbsPath(container, appId, accountId),
+        )
+    }
+
+    @Test
+    fun `WinAppDataLocal resolves to AppData Local in wine prefix`() {
+        assertEquals(
+            "$containerRoot/.wine/drive_c/users/${ImageFs.USER}/AppData/Local/",
+            PathType.WinAppDataLocal.toAbsPath(container, appId, accountId),
+        )
+    }
+
+    @Test
+    fun `WinAppDataLocalLow resolves to AppData LocalLow in wine prefix`() {
+        assertEquals(
+            "$containerRoot/.wine/drive_c/users/${ImageFs.USER}/AppData/LocalLow/",
+            PathType.WinAppDataLocalLow.toAbsPath(container, appId, accountId),
+        )
+    }
+
+    @Test
+    fun `WinAppDataRoaming resolves to AppData Roaming in wine prefix`() {
+        assertEquals(
+            "$containerRoot/.wine/drive_c/users/${ImageFs.USER}/AppData/Roaming/",
+            PathType.WinAppDataRoaming.toAbsPath(container, appId, accountId),
+        )
+    }
+
+    @Test
+    fun `WinSavedGames resolves to Saved Games folder in wine prefix`() {
+        assertEquals(
+            "$containerRoot/.wine/drive_c/users/${ImageFs.USER}/Saved Games/",
+            PathType.WinSavedGames.toAbsPath(container, appId, accountId),
+        )
+    }
+
+    @Test
+    fun `WinProgramData resolves to ProgramData in wine prefix`() {
+        assertEquals(
+            "$containerRoot/.wine/drive_c/ProgramData/",
+            PathType.WinProgramData.toAbsPath(container, appId, accountId),
+        )
+    }
+
+    @Test
+    fun `Root resolves to user home in wine prefix`() {
+        assertEquals(
+            "$containerRoot/.wine/drive_c/users/${ImageFs.USER}/",
+            PathType.Root.toAbsPath(container, appId, accountId),
+        )
+    }
+
+    @Test
+    fun `paths are rooted in the container not a global shared directory`() {
+        val otherRoot = "/data/test/other-container"
+        val otherContainer = Container("other-id").apply { setRootDir(File(otherRoot)) }
+        val path1 = PathType.WinAppDataRoaming.toAbsPath(container, appId, accountId)
+        val path2 = PathType.WinAppDataRoaming.toAbsPath(otherContainer, appId, accountId)
+        assertTrue(path1.startsWith(containerRoot))
+        assertTrue(path2.startsWith(otherRoot))
+        assertNotEquals(path1, path2)
+    }
+
+    @Test
+    fun `isWindows is true for Windows path types`() {
+        listOf(
+            PathType.GameInstall,
+            PathType.SteamUserData,
+            PathType.WinMyDocuments,
+            PathType.WinAppDataLocal,
+            PathType.WinAppDataLocalLow,
+            PathType.WinAppDataRoaming,
+            PathType.WinSavedGames,
+            PathType.WinProgramData,
+            PathType.Root,
+        ).forEach { assertTrue("${it.name} should be isWindows", it.isWindows) }
+    }
+
+    @Test
+    fun `isWindows is false for non-Windows path types`() {
+        listOf(
+            PathType.LinuxHome,
+            PathType.LinuxXdgDataHome,
+            PathType.LinuxXdgConfigHome,
+            PathType.MacHome,
+            PathType.MacAppSupport,
+            PathType.None,
+        ).forEach { assertFalse("${it.name} should not be isWindows", it.isWindows) }
+    }
+}


### PR DESCRIPTION
## Description

`PathType.toAbsPath(context, appId, accountId)` resolved paths through the global `xuser` symlink managed by `ContainerManager.activateContainer`. This creates a race condition that can silently corrupt cloud saves — no crash, no error, just the wrong bytes in the wrong place.

Consider a user who exits **Game A** and immediately launches **Game B** before the cloud save upload for Game A has finished:

1. User exits Game A → `SteamAutoCloud` begins uploading saves, resolving file paths through `xuser` → correctly points at Game A's container
2. Before the upload finishes, user launches Game B → `activateContainer(gameB)` shifts `xuser` to Game B's container
3. The still-running upload for Game A resolves any remaining file paths through `xuser` → **Game B's container**
4. `SteamAutoCloud` reads those files and uploads them to **Game A's Steam Cloud slot**

Result: Game A's cloud saves get overwritten with files from Game B's Wine prefix. The upload reports success. Neither the user nor the app sees any error. The same corruption runs in reverse for a background download.

This PR replaces the context-based signature with `toAbsPath(container, appId, accountId)`, which builds paths directly from `container.rootDir` — the same pattern already used by `toAbsPathForGOG`. The old signature is removed.

This is a prerequisite for #1264 (Steam cloud save status / background sync). That PR downloads saves in the background while the user may be playing a different game, making the two-container-active scenario a certainty rather than a race.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Path resolution now computes filesystem locations relative to the active game container root.
  * Save export/import and cloud-sync flows use container-rooted paths and avoid activating containers implicitly.
  * Container lookup and path computation moved off the main thread to reduce UI blocking.

* **Tests**
  * Added tests validating container-specific path resolution across multiple container roots and Windows-style layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->