### PR TITLE
fix: show actionable dialog when Steam session is taken by another device

### DIFF
--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -234,6 +234,7 @@ class PluviaApp : SplitCompatApplication() {
             touchpadView = null
             achievementWatcher = null
             SteamService.keepAlive = false
+            SteamService.clearPlayingConflict()
             clearActiveSuspendState()
         }
 

--- a/app/src/main/java/app/gamenative/events/SteamEvent.kt
+++ b/app/src/main/java/app/gamenative/events/SteamEvent.kt
@@ -16,6 +16,7 @@ sealed interface SteamEvent<T> : Event<T> {
 
     // data object AppInfoReceived : SteamEvent<Unit>
     data object ForceCloseApp : SteamEvent<Unit>
+    data object PlayingBlocked : SteamEvent<Unit>
     data class Disconnected(val isTerminal: Boolean = false) : SteamEvent<Unit>
     data object RemotelyDisconnected : SteamEvent<Unit>
 }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -282,6 +282,7 @@ class SteamService : Service(), IChallengeUrlChanged {
 
     private val _isPlayingBlocked = MutableStateFlow(false)
     val isPlayingBlocked = _isPlayingBlocked.asStateFlow()
+    private val _isHandlingConflict = java.util.concurrent.atomic.AtomicBoolean(false)
 
     // Cache in-memory the local persona state.
     private val _localPersona = MutableStateFlow(
@@ -416,6 +417,14 @@ class SteamService : Service(), IChallengeUrlChanged {
             get() = instance?.steamClient?.steamID?.isValid == true
         var isWaitingForQRAuth: Boolean = false
             private set
+
+        val isPlayingBlocked: kotlinx.coroutines.flow.StateFlow<Boolean>
+            get() = instance?._isPlayingBlocked ?: MutableStateFlow(false)
+
+        fun clearPlayingConflict() {
+            instance?._isPlayingBlocked?.value = false
+            instance?._isHandlingConflict?.set(false)
+        }
 
         private val serverListPath: String
             get() = Paths.get(DownloadService.baseCacheDirPath, "server_list.bin").pathString
@@ -3526,10 +3535,17 @@ class SteamService : Service(), IChallengeUrlChanged {
         } else if (callback.result == EResult.LoggedInElsewhere) {
             // received when a client runs an app and wants to forcibly close another
             // client running an app
-            val event = SteamEvent.ForceCloseApp
-            PluviaApp.events.emit(event)
-
-            reconnect()
+            if (PluviaApp.xEnvironment != null) {
+                if (!_isHandlingConflict.getAndSet(true)) {
+                    _isPlayingBlocked.value = true
+                    PluviaApp.events.emit(SteamEvent.PlayingBlocked)
+                }
+                reconnect()
+            } else {
+                val event = SteamEvent.ForceCloseApp
+                PluviaApp.events.emit(event)
+                reconnect()
+            }
         } else {
             reconnect()
         }
@@ -3538,6 +3554,9 @@ class SteamService : Service(), IChallengeUrlChanged {
     private fun onPlayingSessionState(callback: PlayingSessionStateCallback) {
         Timber.d("onPlayingSessionState called with isPlayingBlocked = " + callback.isPlayingBlocked)
         _isPlayingBlocked.value = callback.isPlayingBlocked
+        if (callback.isPlayingBlocked) {
+            PluviaApp.events.emit(SteamEvent.PlayingBlocked)
+        }
     }
 
     @OptIn(ExperimentalStdlibApi::class)

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -3336,8 +3336,10 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         isConnected = false
 
-        val event = SteamEvent.Disconnected(isTerminal = false)
-        PluviaApp.events.emit(event)
+        if (!_isHandlingConflict.get()) {
+            val event = SteamEvent.Disconnected(isTerminal = false)
+            PluviaApp.events.emit(event)
+        }
 
         steamClient!!.disconnect()
     }
@@ -3378,8 +3380,10 @@ class SteamService : Service(), IChallengeUrlChanged {
 
             Timber.w("Attempting to reconnect (retry $retryAttempt) after ${backoffMs}ms")
 
-            val event = SteamEvent.RemotelyDisconnected
-            PluviaApp.events.emit(event)
+            if (!_isHandlingConflict.get()) {
+                val event = SteamEvent.RemotelyDisconnected
+                PluviaApp.events.emit(event)
+            }
 
             reconnectJob = scope.launch {
                 delay(backoffMs)

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -3556,7 +3556,7 @@ class SteamService : Service(), IChallengeUrlChanged {
     private fun onPlayingSessionState(callback: PlayingSessionStateCallback) {
         Timber.d("onPlayingSessionState called with isPlayingBlocked = " + callback.isPlayingBlocked)
         _isPlayingBlocked.value = callback.isPlayingBlocked
-        if (callback.isPlayingBlocked) {
+        if (callback.isPlayingBlocked && _isHandlingConflict.compareAndSet(false, true)) {
             val event = SteamEvent.PlayingBlocked
             PluviaApp.events.emit(event)
         }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -282,7 +282,7 @@ class SteamService : Service(), IChallengeUrlChanged {
 
     private val _isPlayingBlocked = MutableStateFlow(false)
     val isPlayingBlocked = _isPlayingBlocked.asStateFlow()
-    private val _isHandlingConflict = java.util.concurrent.atomic.AtomicBoolean(false)
+    private val _isHandlingConflict = AtomicBoolean(false)
 
     // Cache in-memory the local persona state.
     private val _localPersona = MutableStateFlow(
@@ -417,9 +417,6 @@ class SteamService : Service(), IChallengeUrlChanged {
             get() = instance?.steamClient?.steamID?.isValid == true
         var isWaitingForQRAuth: Boolean = false
             private set
-
-        val isPlayingBlocked: kotlinx.coroutines.flow.StateFlow<Boolean>
-            get() = instance?._isPlayingBlocked ?: MutableStateFlow(false)
 
         fun clearPlayingConflict() {
             instance?._isPlayingBlocked?.value = false
@@ -3542,7 +3539,8 @@ class SteamService : Service(), IChallengeUrlChanged {
             if (PluviaApp.xEnvironment != null) {
                 if (!_isHandlingConflict.getAndSet(true)) {
                     _isPlayingBlocked.value = true
-                    PluviaApp.events.emit(SteamEvent.PlayingBlocked)
+                    val event = SteamEvent.PlayingBlocked
+                    PluviaApp.events.emit(event)
                 }
                 reconnect()
             } else {
@@ -3559,7 +3557,8 @@ class SteamService : Service(), IChallengeUrlChanged {
         Timber.d("onPlayingSessionState called with isPlayingBlocked = " + callback.isPlayingBlocked)
         _isPlayingBlocked.value = callback.isPlayingBlocked
         if (callback.isPlayingBlocked) {
-            PluviaApp.events.emit(SteamEvent.PlayingBlocked)
+            val event = SteamEvent.PlayingBlocked
+            PluviaApp.events.emit(event)
         }
     }
 

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import app.gamenative.MainActivity
@@ -300,6 +301,7 @@ fun XServerScreen(
     Timber.i("Starting up XServerScreen")
     val context = LocalContext.current
     val view = LocalView.current
+    val scope = rememberCoroutineScope()
     val imm = remember(context) {
         context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
     }
@@ -411,6 +413,7 @@ fun XServerScreen(
     var showElementEditor by remember { mutableStateOf(false) }
     var elementToEdit by remember { mutableStateOf<com.winlator.inputcontrols.ControlElement?>(null) }
     var showPhysicalControllerDialog by remember { mutableStateOf(false) }
+    var showPlayingBlockedDialog by remember { mutableStateOf(false) }
     var showTouchGestureDialog by remember { mutableStateOf(false) }
     var isTouchscreenModeActive by remember { mutableStateOf(container.isTouchscreenMode) }
     var currentGestureConfig by remember {
@@ -1301,6 +1304,10 @@ fun XServerScreen(
             Timber.i("onForceCloseApp")
             exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
         }
+        val onPlayingBlocked: (SteamEvent.PlayingBlocked) -> Unit = {
+            Timber.i("onPlayingBlocked")
+            showPlayingBlockedDialog = true
+        }
         val debugCallback = Callback<String> { outputLine ->
             Timber.i(outputLine ?: "")
         }
@@ -1310,6 +1317,7 @@ fun XServerScreen(
         PluviaApp.events.on<AndroidEvent.MotionEvent, Boolean>(onMotionEvent)
         PluviaApp.events.on<AndroidEvent.GuestProgramTerminated, Unit>(onGuestProgramTerminated)
         PluviaApp.events.on<SteamEvent.ForceCloseApp, Unit>(onForceCloseApp)
+        PluviaApp.events.on<SteamEvent.PlayingBlocked, Unit>(onPlayingBlocked)
         ProcessHelper.addDebugCallback(debugCallback)
 
         onDispose {
@@ -1318,6 +1326,7 @@ fun XServerScreen(
             PluviaApp.events.off<AndroidEvent.MotionEvent, Boolean>(onMotionEvent)
             PluviaApp.events.off<AndroidEvent.GuestProgramTerminated, Unit>(onGuestProgramTerminated)
             PluviaApp.events.off<SteamEvent.ForceCloseApp, Unit>(onForceCloseApp)
+            PluviaApp.events.off<SteamEvent.PlayingBlocked, Unit>(onPlayingBlocked)
             ProcessHelper.removeDebugCallback(debugCallback)
         }
     }
@@ -2333,6 +2342,32 @@ fun XServerScreen(
                 }
             }
         }
+    }
+
+    if (showPlayingBlockedDialog) {
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = {},
+            title = { Text(text = stringResource(R.string.main_app_running_title)) },
+            text = { Text(text = stringResource(R.string.main_app_running_message, context.getString(R.string.main_another_device))) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showPlayingBlockedDialog = false
+                    scope.launch {
+                        app.gamenative.service.SteamService.kickPlayingSession(onlyGame = true)
+                    }
+                }) {
+                    Text(text = stringResource(R.string.main_play_anyway))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showPlayingBlockedDialog = false
+                    exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+                }) {
+                    Text(text = stringResource(R.string.cancel))
+                }
+            },
+        )
     }
 
     // var ranSetup by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2262,9 +2262,9 @@ fun XServerScreen(
             confirmButton = {
                 TextButton(onClick = {
                     showPlayingBlockedDialog = false
+                    SteamService.clearPlayingConflict()
                     scope.launch {
                         SteamService.kickPlayingSession(onlyGame = true)
-                        SteamService.clearPlayingConflict()
                     }
                 }) {
                     Text(text = stringResource(R.string.main_play_anyway))

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2254,6 +2254,32 @@ fun XServerScreen(
         )
     }
 
+    if (showPlayingBlockedDialog) {
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = {},
+            title = { Text(text = stringResource(R.string.main_app_running_title)) },
+            text = { Text(text = stringResource(R.string.main_app_running_message, context.getString(R.string.main_app_running_unknown_game))) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showPlayingBlockedDialog = false
+                    scope.launch {
+                        SteamService.kickPlayingSession(onlyGame = true)
+                    }
+                }) {
+                    Text(text = stringResource(R.string.main_play_anyway))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showPlayingBlockedDialog = false
+                    exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+                }) {
+                    Text(text = stringResource(R.string.cancel))
+                }
+            },
+        )
+    }
+
     // Physical Controller Config Dialog
     if (showPhysicalControllerDialog) {
         // Get profile from container settings, not from InputControlsView
@@ -2342,32 +2368,6 @@ fun XServerScreen(
                 }
             }
         }
-    }
-
-    if (showPlayingBlockedDialog) {
-        androidx.compose.material3.AlertDialog(
-            onDismissRequest = {},
-            title = { Text(text = stringResource(R.string.main_app_running_title)) },
-            text = { Text(text = stringResource(R.string.main_app_running_message, context.getString(R.string.main_another_device))) },
-            confirmButton = {
-                TextButton(onClick = {
-                    showPlayingBlockedDialog = false
-                    scope.launch {
-                        app.gamenative.service.SteamService.kickPlayingSession(onlyGame = true)
-                    }
-                }) {
-                    Text(text = stringResource(R.string.main_play_anyway))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = {
-                    showPlayingBlockedDialog = false
-                    exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
-                }) {
-                    Text(text = stringResource(R.string.cancel))
-                }
-            },
-        )
     }
 
     // var ranSetup by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2273,7 +2273,7 @@ fun XServerScreen(
             dismissButton = {
                 TextButton(onClick = {
                     showPlayingBlockedDialog = false
-                    exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+                    exit(xServerView?.getxServer()?.winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
                 }) {
                     Text(text = stringResource(R.string.cancel))
                 }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -413,7 +413,7 @@ fun XServerScreen(
     var showElementEditor by remember { mutableStateOf(false) }
     var elementToEdit by remember { mutableStateOf<com.winlator.inputcontrols.ControlElement?>(null) }
     var showPhysicalControllerDialog by remember { mutableStateOf(false) }
-    var showPlayingBlockedDialog by remember { mutableStateOf(false) }
+    var showPlayingBlockedDialog by rememberSaveable { mutableStateOf(false) }
     var showTouchGestureDialog by remember { mutableStateOf(false) }
     var isTouchscreenModeActive by remember { mutableStateOf(container.isTouchscreenMode) }
     var currentGestureConfig by remember {

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2264,6 +2264,7 @@ fun XServerScreen(
                     showPlayingBlockedDialog = false
                     scope.launch {
                         SteamService.kickPlayingSession(onlyGame = true)
+                        SteamService.clearPlayingConflict()
                     }
                 }) {
                     Text(text = stringResource(R.string.main_play_anyway))

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -844,6 +844,7 @@
     <string name="main_app_running_message">Du er logget ind på en anden enhed og spiller allerede %s. \nDu kan stadig spille dette spil, men det vil afbryde den anden session fra Steam.</string>
     <string name="main_app_running_other_device">Du er logget ind på en anden enhed (%1$s) og spiller allerede %2$s (%3$s), og den gemfil er ikke i skyen endnu. \nDu kan stadig spille dette spil, men det vil afbryde den anden session fra Steam og kan skabe en gemfilkonflikt når sessionsframgangen synkroniseres</string>
     <string name="main_play_anyway">Spil alligevel</string>
+    <string name="main_app_running_unknown_game">et spil</string>
 
     <!-- TODO: Manual review - PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Gemfilkonflikt</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -970,6 +970,7 @@
     <string name="main_app_running_message">Du bist auf einem anderen Gerät bereits mit %s angemeldet. Du kannst trotzdem spielen, aber das beendet die andere Steam-Sitzung.</string>
     <string name="main_app_running_other_device">Du bist auf einem anderen Gerät (%1$s) mit %2$s (%3$s) angemeldet, und dieser Spielstand wurde noch nicht in der Cloud gespeichert. Du kannst trotzdem spielen, doch wird dadurch die andere Sitzung getrennt und es kann zu Speicherstandskonflikten kommen, wenn die andere Sitzung synchronisiert wird.</string>
     <string name="main_play_anyway">Trotzdem starten</string>
+    <string name="main_app_running_unknown_game">ein Spiel</string>
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Speicherstandkonflikt</string>
     <string name="main_save_conflict_message">Es wurden ein neuer lokaler und ein neuer Cloud-Spielstand gefunden. Welchen möchtest du behalten?\n\nLokal:\n\t%1$s\nCloud:\n\t%2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1034,6 +1034,7 @@
     <string name="main_app_running_message">Has iniciado sesión en otro dispositivo que ya está jugando a %s.\nAún puedes jugar a este juego, pero eso desconectará la otra sesión de Steam.</string>
     <string name="main_app_running_other_device">Has iniciado sesión en otro dispositivo (%1$s) que ya está jugando a %2$s (%3$s), y ese archivo de guardado aún no está en la nube.\nAún puedes jugar a este juego, pero eso desconectará la otra sesión de Steam y podría crear un conflicto de guardado cuando se sincronice el progreso de esa sesión.</string>
     <string name="main_play_anyway">Jugar de todos modos</string>
+    <string name="main_app_running_unknown_game">un juego</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Conflicto de guardado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1018,6 +1018,7 @@
     <string name="main_app_running_message">Vous êtes connecté sur un autre appareil jouant déjà à %s. \nVous pouvez toujours jouer à ce jeu, mais cela déconnectera l\'autre session de Steam.</string>
     <string name="main_app_running_other_device">Vous êtes connecté sur un autre appareil (%1$s) jouant déjà à %2$s (%3$s), et cette sauvegarde n\'est pas encore dans le cloud. \nVous pouvez toujours jouer à ce jeu, mais cela déconnectera l\'autre session de Steam et peut créer un conflit de sauvegarde lorsque la progression de cette session sera synchronisée</string>
     <string name="main_play_anyway">Jouer quand même</string>
+    <string name="main_app_running_unknown_game">un jeu</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Conflit de sauvegarde</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1014,6 +1014,7 @@
     <string name="main_app_running_message">Sei connesso su un altro dispositivo che sta già giocando a %s. \nPuoi comunque giocare a questo gioco, ma ciò disconnetterà l\'altra sessione da Steam.</string>
     <string name="main_app_running_other_device">Sei connesso su un altro dispositivo (%1$s) che sta già giocando a %2$s (%3$s), e quel salvataggio non è ancora nel cloud. \nPuoi comunque giocare a questo gioco, ma ciò disconnetterà l\'altra sessione da Steam e potrebbe creare un conflitto di salvataggio quando il progresso di quella sessione verrà sincronizzato</string>
     <string name="main_play_anyway">Gioca comunque</string>
+    <string name="main_app_running_unknown_game">un gioco</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Conflitto Salvataggio</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1032,6 +1032,7 @@
     <string name="main_app_running_message">다른 장치에서 이미 %s을(를) 플레이 중입니다. \n이 게임을 플레이할 수 있지만 다른 세션의 Steam 연결이 끊어집니다.</string>
     <string name="main_app_running_other_device">다른 장치(%1$s)에서 이미 %2$s(%3$s)을(를) 플레이 중이며, 해당 저장 파일이 아직 클라우드에 없습니다. \n이 게임을 플레이할 수 있지만 다른 세션의 Steam 연결이 끊어지고 해당 세션의 진행 상황이 동기화될 때 저장 충돌이 발생할 수 있습니다</string>
     <string name="main_play_anyway">어쨌든 플레이</string>
+    <string name="main_app_running_unknown_game">게임</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">저장 충돌</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1031,6 +1031,7 @@
     <string name="main_app_running_message">Jesteś zalogowany na innym urządzeniu grając w %s. \nMożesz kontynuować grę, ale to rozłączy drugą sesję ze Steam.</string>
     <string name="main_app_running_other_device">Jesteś zalogowany na innym urządzeniu (%1$s) grając w %2$s (%3$s), a zapis nie jest jeszcze w chmurze. \nMożesz kontynuować grę, ale to rozłączy drugą sesję ze Steam i może stworzyć konflikt zapisu, gdy postęp tamtej sesji zostanie zsynchronizowany.</string>
     <string name="main_play_anyway">Graj mimo to</string>
+    <string name="main_app_running_unknown_game">grę</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Konflikt zapisu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -844,6 +844,7 @@
     <string name="main_app_running_message">Você já está logado em outro dispositivo jogando %s. \nVocê ainda pode jogar este jogo, mas isso desconectará a outra sessão do Steam.</string>
     <string name="main_app_running_other_device">Você já está logado em outro dispositivo (%1$s) jogando %2$s (%3$s), e esse save ainda não está na nuvem. \nVocê ainda pode jogar este jogo, mas isso desconectará a outra sessão do Steam e pode criar um conflito de save quando o progresso da sessão for sincronizado</string>
     <string name="main_play_anyway">Jogar mesmo assim</string>
+    <string name="main_app_running_unknown_game">um jogo</string>
 
     <!-- TODO: Revisão manual - PluviaMain: Conflitos de save -->
     <string name="main_save_conflict_title">Conflito de save</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1022,6 +1022,7 @@
 	<string name="main_app_running_message">Ești autentificat pe un alt dispozitiv care deja rulează %s.\nPoți juca în continuare, dar asta va deconecta cealaltă sesiune din Steam.</string>
 	<string name="main_app_running_other_device">Ești autentificat pe un alt dispozitiv (%1$s) care rulează deja %2$s (%3$s), iar salvarea nu este încă în cloud.\nPoți juca în continuare, dar asta va deconecta cealaltă sesiune și poate crea conflicte de salvare când progresul este sincronizat.</string>
 	<string name="main_play_anyway">Joacă oricum</string>
+	<string name="main_app_running_unknown_game">un joc</string>
 
 	<!-- PluviaMain: Save Conflicts -->
 	<string name="main_save_conflict_title">Conflict de salvare</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -675,6 +675,7 @@ Ubuntu RootFs - releases.ubuntu.com/focal</string>
 Вы всё ещё можете играть в эту игру, но это может создать конфликт, когда ваш предыдущий прогресс успешно загрузится.</string>
     <string name="main_pending_upload_title">Ожидание загрузки</string>
     <string name="main_play_anyway">Играть в любом случае</string>
+    <string name="main_app_running_unknown_game">игру</string>
     <string name="main_recent_crash_message">Приносим извинения!
 Было бы хорошо узнать о недавней проблеме, которая у вас была.
 Вы можете просмотреть и экспортировать самый последний журнал сбоев в настройках приложения и приложить его как Github проблему в репозитории проекта.

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1017,6 +1017,7 @@
     <string name="main_app_running_message">Ви авторизовані на іншому пристрої, де граєте у %s. Ви все одно можете грати в цю гру, але це завершить інший сеанс у Steam.</string>
     <string name="main_app_running_other_device">Ви авторизовані на іншому пристрої (%1$s), де граєте у %2$s (%3$s), і прогрес цієї гри ще не синхронізовано з хмарою. \nВи все одно можете грати в цю гру, але це завершить інший сеанс у Steam і може створити конфлікт збережень, коли прогрес того сеансу синхронізуватиметься</string>
     <string name="main_play_anyway">Все одно грати</string>
+    <string name="main_app_running_unknown_game">гру</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Конфлікт збережень</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1011,6 +1011,7 @@
     <string name="main_app_running_message">您已在另一台设备登录并正在游玩 %s。\n您仍可继续游玩此游戏，但此操作将导致 Steam 断开另一设备的连接。</string>
     <string name="main_app_running_other_device">您已在另一台设备（%1$s）上登录并正在游玩 %2$s（%3$s），该存档尚未同步至云端。\n您仍可继续游玩此游戏，但此操作将使另一设备的 Steam 连接中断，且当该设备的进度同步时可能产生存档冲突。</string>
     <string name="main_play_anyway">仍要继续</string>
+    <string name="main_app_running_unknown_game">游戏</string>
 
     <!-- 主界面：存档冲突 -->
     <string name="main_save_conflict_title">存档冲突</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1014,6 +1014,7 @@
     <string name="main_app_running_message">您已在另一台裝置登入並正在遊玩 %s。\n您仍可繼續遊玩此遊戲，但此操作將導致 Steam 斷開另一裝置的連線。</string>
     <string name="main_app_running_other_device">您已在另一台裝置 (%1$s) 上登入並正在遊玩 %2$s (%3$s)，該存檔尚未同步至雲端。\n您仍可繼續遊玩此遊戲，但此操作將使另一裝置的 Steam 連線中斷，且當該裝置的進度同步時可能產生存檔衝突。</string>
     <string name="main_play_anyway">仍要繼續</string>
+    <string name="main_app_running_unknown_game">遊戲</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">存檔衝突</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1065,6 +1065,7 @@
     <string name="main_app_running_message">You are logged in on another device already playing %s. \nYou can still play this game, but that will disconnect the other session from Steam.</string>
     <string name="main_app_running_other_device">You are logged in on another device (%1$s) already playing %2$s (%3$s), and that save is not yet in the cloud. \nYou can still play this game, but that will disconnect the other session from Steam and may create a save conflict when that session progress is synced</string>
     <string name="main_play_anyway">Play anyway</string>
+    <string name="main_another_device">another device</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Save Conflict</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1065,7 +1065,7 @@
     <string name="main_app_running_message">You are logged in on another device already playing %s. \nYou can still play this game, but that will disconnect the other session from Steam.</string>
     <string name="main_app_running_other_device">You are logged in on another device (%1$s) already playing %2$s (%3$s), and that save is not yet in the cloud. \nYou can still play this game, but that will disconnect the other session from Steam and may create a save conflict when that session progress is synced</string>
     <string name="main_play_anyway">Play anyway</string>
-    <string name="main_app_running_unknown_game">another device</string>
+    <string name="main_app_running_unknown_game">a game</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Save Conflict</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1065,7 +1065,7 @@
     <string name="main_app_running_message">You are logged in on another device already playing %s. \nYou can still play this game, but that will disconnect the other session from Steam.</string>
     <string name="main_app_running_other_device">You are logged in on another device (%1$s) already playing %2$s (%3$s), and that save is not yet in the cloud. \nYou can still play this game, but that will disconnect the other session from Steam and may create a save conflict when that session progress is synced</string>
     <string name="main_play_anyway">Play anyway</string>
-    <string name="main_another_device">another device</string>
+    <string name="main_app_running_unknown_game">another device</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Save Conflict</string>


### PR DESCRIPTION
## Problem

When a PC starts a Steam game while a game is already running in Wine on the device, Steam sends `EResult.LoggedInElsewhere` inside `LoggedOffCallback`. The previous code treated this the same as any other logoff — it emitted `ForceCloseApp` and silently killed the game with no feedback to the user.

https://github.com/user-attachments/assets/0dbe8ceb-64e6-45e8-ba8c-316e5e055e96

**Root cause confirmed via logcat:** `PlayingSessionStateCallback` was assumed to fire in this scenario, but it never does. `LoggedInElsewhere` inside `LoggedOffCallback` is the only signal Steam sends.

## Changes

https://github.com/user-attachments/assets/a31124f0-59d1-44f6-b4f0-4ff3198286df

**`SteamEvent.kt`** — adds `PlayingBlocked` event to signal the conflict to the UI layer.

**`SteamService.kt`**
- `onLoggedOff`: when `LoggedInElsewhere` arrives and a game is running (`xEnvironment != null`), show the conflict dialog instead of force-closing. When no game is running, the existing `ForceCloseApp` behaviour is preserved.
- `_isHandlingConflict` (`AtomicBoolean`): prevents the dialog being shown multiple times if `LoggedInElsewhere` fires repeatedly during reconnect attempts.
- `clearPlayingConflict()`: resets conflict state on game exit.
- `reconnect()` / `onDisconnected()`: suppress `Disconnected`/`RemotelyDisconnected` events while a conflict is being handled, so the reconnect cycle doesn't flash a "Disconnected from Steam" banner behind the dialog.
- `onPlayingSessionState`: safety net — also emits `PlayingBlocked` if `PlayingSessionStateCallback` fires with `isPlayingBlocked=true` while in-game.

**`PluviaApp.kt`** — calls `SteamService.clearPlayingConflict()` in `shutdownEnvironment()` to reset state when the game exits.

**`XServerScreen.kt`** — registers a listener for `SteamEvent.PlayingBlocked` and shows an `AlertDialog` with:
- **Play Anyway** — calls `kickPlayingSession(onlyGame=true)` to stop the PC's game session
- **Cancel** — exits the local game cleanly

`onDismissRequest` is intentionally empty — the user must make an explicit choice.

**`strings.xml`** — adds `main_app_running_unknown_game` ("another device"), used as the fallback game name in the dialog message when the conflicting game title cannot be determined.

## Note

Behaviour varies slightly depending on the conflicting device (PC, Steam Deck, Mac). This has been tested across all three and is improved in each case, but given the variance in how Steam signals session conflicts across platforms, further edge cases may exist.

## Test plan
- [x] Launch a game on PC, then launch a game on device — pre-launch "App Running" dialog appears (existing behaviour, unaffected)
- [x] Launch a game on device, then start a game on PC — in-game "App Running" dialog appears without a "Disconnected from Steam" banner
- [x] Press **Cancel** — game exits cleanly
- [x] Press **Play Anyway** — PC game session is kicked, device continues playing
- [x] Normal game exit with no conflict — no regression to shutdown flow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show an actionable “App Running” dialog when Steam logs the user off because another device started a game, instead of silently closing the local game. The dialog persists across Activity recreation and hides the disconnect banner; users can kick the remote session or exit.

- **Bug Fixes**
  - Handle `EResult.LoggedInElsewhere` in `SteamService.onLoggedOff`: if a game is running, emit `PlayingBlocked` (not `ForceCloseApp`); otherwise keep existing behavior.
  - Show an `AlertDialog` in `XServerScreen` on `PlayingBlocked` with “Play anyway” (call `SteamService.clearPlayingConflict()` then `SteamService.kickPlayingSession(onlyGame=true)`) and “Cancel” (clean exit); persist with `rememberSaveable` and safe-call `xServerView`.
  - Add `_isHandlingConflict` to prevent duplicate dialogs; suppress `Disconnected`/`RemotelyDisconnected` while handling; reset via `SteamService.clearPlayingConflict()` on shutdown and before kicking.
  - Also emit `PlayingBlocked` when `PlayingSessionStateCallback.isPlayingBlocked` is true; add `main_app_running_unknown_game` fallback and translations across locales.

<sup>Written for commit b9083cf285fadcb4836f9fa8f1c17df6ea7fe47f. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1306?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects when a game session is blocked by another device and notifies the app.
  * Shows a conflict-resolution dialog to stop the remote session or exit the current session.
  * Adds a fallback label when the remote game name is unknown.

* **Bug Fixes**
  * Improved cleanup/reset of Steam-related session/conflict state during app shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->