### PR TITLE
fix: keep exit button visible on ultrawide phones by making tab rail scrollable

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -410,7 +410,11 @@ fun QuickMenu(
                                 .focusGroup(),
                             horizontalAlignment = Alignment.CenterHorizontally,
                         ) {
+                            val tabScrollState = rememberScrollState()
                             Column(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .verticalScroll(tabScrollState),
                                 verticalArrangement = Arrangement.spacedBy(8.dp),
                                 horizontalAlignment = Alignment.CenterHorizontally,
                             ) {
@@ -451,8 +455,6 @@ fun QuickMenu(
                                     focusRequester = toolsTabFocusRequester,
                                 )
                             }
-
-                            Spacer(modifier = Modifier.weight(1f))
 
                             Box(
                                 modifier = Modifier


### PR DESCRIPTION
## Description
On ultrawide landscape phones the red exit button in the Quick Menu rail was getting clipped off-screen. The task manager PR added a 4th tab to the rail, and on short-height displays the `Spacer(weight(1f))` collapsed to zero, pushing the exit button out of view. Fixed by giving the tab buttons column `weight(1f) + verticalScroll` so the rail scrolls when needed and the exit button stays pinned at the bottom.

## Recording
<!-- Attach screen recording here -->

before:
<img width="3168" height="1440" alt="Screenshot_2026-04-27-12-16-52-42_9dffa109e6ad2ca95f3480b66a4336ca" src="https://github.com/user-attachments/assets/8e1409f6-31b3-49a8-aa03-33af0076df28" />

per https://discord.com/channels/1378308569287622737/1498360195892514906

this PR:

https://github.com/user-attachments/assets/423c9919-6d2e-4a43-a517-0a31c2f5df85


added a bunch of extra tabs to demo the solution here, as I dont have an ultra wide device to directly compare


## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Left sidebar tab rail now scrolls correctly and better manages vertical space so navigation tabs remain accessible on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->