### PR TITLE
fix: join prealloc job

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -942,7 +942,7 @@ class GOGDownloadManager @Inject constructor(
             downloadInfo.setActive(true)
 
             // Start downloads by launching a separate coroutine to emit chunks
-            scope.launch {
+            val preallocJob: Job = scope.launch {
                 if (!downloadInfo.isActive()) {
                     Timber.tag("GOG").w("Download cancelled by user")
                     return@launch
@@ -981,6 +981,8 @@ class GOGDownloadManager @Inject constructor(
                     }
                 }
             }
+
+            preallocJob.join()
 
             // Wait for all pending chunks to complete processing
             var lastPendingChunks = pendingChunks.get()


### PR DESCRIPTION
## Description
Race condition in `downloadAndAssembleChunks` was causing `GOGDownloadManagerTest.gen2_download_includes_game_and_support_files` to fail intermittently in CI.

## Recording

## Type of Change
- [x] Bug fix

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the pre-allocation stage completes before chunk processing begins, improving download reliability and reducing risk of incomplete or stalled downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->