### PR TITLE
fix: use consistent purple accent color for all quick menu items

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -255,7 +255,7 @@ fun QuickMenu(
                 id = QuickMenuAction.DISABLE_MOUSE,
                 icon = Icons.Filled.Mouse,
                 labelResId = R.string.disable_mouse_input,
-                accentColor = PluviaTheme.colors.accentPink,
+                accentColor = PluviaTheme.colors.accentPurple,
             )
         )
         add(
@@ -263,7 +263,7 @@ fun QuickMenu(
                 id = QuickMenuAction.KEYBOARD,
                 icon = Icons.Default.Keyboard,
                 labelResId = R.string.keyboard,
-                accentColor = PluviaTheme.colors.accentCyan,
+                accentColor = PluviaTheme.colors.accentPurple,
             )
         )
         add(
@@ -280,7 +280,7 @@ fun QuickMenu(
                     id = QuickMenuAction.EDIT_PHYSICAL_CONTROLLER,
                     icon = Icons.Default.Gamepad,
                     labelResId = R.string.edit_physical_controller,
-                    accentColor = PluviaTheme.colors.accentWarning,
+                    accentColor = PluviaTheme.colors.accentPurple,
                 )
             )
         }
@@ -289,7 +289,7 @@ fun QuickMenu(
                 id = QuickMenuAction.EDIT_CONTROLS,
                 icon = Icons.Default.Edit,
                 labelResId = R.string.edit_controls,
-                accentColor = PluviaTheme.colors.accentSuccess,
+                accentColor = PluviaTheme.colors.accentPurple,
             )
         )
         add(


### PR DESCRIPTION
## Description

All quick menu items except Exit Game were using different accent colors (cyan, pink, warning orange, success green). This changes them all to the standard purple used across the rest of the menu, so the active/focus highlight is consistent throughout.

Exit Game retains `accentDanger` (red) as it is a destructive action.

## Recording
https://github.com/user-attachments/assets/8adfb942-886f-4b59-9dea-1336224c3647
## Type of Change
- [x] Bug fix

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies quick menu item accents to the standard purple for consistent focus/active highlights. Exit Game stays red (`accentDanger`) since it's destructive.

- **Bug Fixes**
  - `DISABLE_MOUSE`: `accentPink` → `accentPurple`
  - `KEYBOARD`: `accentCyan` → `accentPurple`
  - `EDIT_PHYSICAL_CONTROLLER`: `accentWarning` → `accentPurple`
  - `EDIT_CONTROLS`: `accentSuccess` → `accentPurple`

<sup>Written for commit bf85f3b154004cbf4adb1c0781f758f032c3dd35. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1311?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated quick menu accent colors for a more consistent visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->