### PR TITLE
fix: clear persona state and hide status picker on sign out

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2680,6 +2680,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             val username = PrefManager.username
 
             clearUserData(clearCloudSyncState = clearCloudSyncState)
+            instance?._localPersona?.value = SteamFriend()
 
             val event = SteamEvent.LoggedOut(username)
             PluviaApp.events.emit(event)

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/SystemMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/SystemMenu.kt
@@ -283,10 +283,16 @@ fun SystemMenu(
             selectedStatus = event.persona.state
         }
 
+        val onLoggedOut: (SteamEvent.LoggedOut) -> Unit = {
+            persona = SteamFriend()
+        }
+
         PluviaApp.events.on<SteamEvent.PersonaStateReceived, Unit>(onPersonaStateReceived)
+        PluviaApp.events.on<SteamEvent.LoggedOut, Unit>(onLoggedOut)
 
         onDispose {
             PluviaApp.events.off<SteamEvent.PersonaStateReceived, Unit>(onPersonaStateReceived)
+            PluviaApp.events.off<SteamEvent.LoggedOut, Unit>(onLoggedOut)
         }
     }
 
@@ -430,7 +436,7 @@ fun SystemMenu(
                                     selected = isProfileFocused,
                                     interactionSource = profileInteractionSource,
                                     indication = null,
-                                    onClick = { if (!isOffline) showStatusPicker = !showStatusPicker },
+                                    onClick = { if (!isOffline && SteamService.isLoggedIn) showStatusPicker = !showStatusPicker },
                                 )
                                 .padding(12.dp),
                             verticalAlignment = Alignment.CenterVertically,
@@ -491,7 +497,7 @@ fun SystemMenu(
                             }
 
                             // Dropdown indicator (only when online)
-                            if (!isOffline) {
+                            if (!isOffline && SteamService.isLoggedIn) {
                                 Icon(
                                     imageVector = if (showStatusPicker) {
                                         Icons.Default.KeyboardArrowUp

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/SystemMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/SystemMenu.kt
@@ -285,6 +285,7 @@ fun SystemMenu(
 
         val onLoggedOut: (SteamEvent.LoggedOut) -> Unit = {
             persona = SteamFriend()
+            showStatusPicker = false
         }
 
         PluviaApp.events.on<SteamEvent.PersonaStateReceived, Unit>(onPersonaStateReceived)


### PR DESCRIPTION
## Description

When signing out of Steam via the system menu, the games list cleared correctly but the profile picture, account name, online status, and status picker dropdown remained visible with the previous user's data.

<img width="1920" height="1080" alt="Screenshot_20260513-001933" src="https://github.com/user-attachments/assets/8fff41d1-668d-4cb9-9fbb-e6b00c389d1e" />

(This is the view after I've signed out)


**Root cause:** `SystemMenu` seeds `persona` state once on composition from `SteamService.localPersona` and updates it via `PersonaStateReceived` events, but had no handler for `SteamEvent.LoggedOut` to clear it. Additionally, `_localPersona` in `SteamService` is an in-memory `StateFlow` not reset on logout, so if `SystemMenu` re-enters composition (e.g. after a game session), `LaunchedEffect(Unit)` would re-read the stale persona.

**Changes:**

- `SteamService.kt` - reset `_localPersona` to `SteamFriend()` in `performLogOffDuties`, so the in-memory state matches the cleared preferences
- `SystemMenu.kt` - add `SteamEvent.LoggedOut` handler to set `persona = SteamFriend()` (blank name, offline state, no avatar), matching the appearance when skipping login
- `SystemMenu.kt` - gate the status picker click handler and dropdown arrow on `SteamService.isLoggedIn`, consistent with the existing pattern at line 613

## Recording
https://github.com/user-attachments/assets/5fe5ece0-37c5-49fa-b606-8617d86ebec2
## Type of Change
- [x] Bug fix

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clear persona UI and close/hide the status picker on sign out so the System Menu doesn’t show the previous user’s avatar, name, or status. The menu now reflects the logged-out state immediately and after recomposition.

- **Bug Fixes**
  - Reset `_localPersona` to `SteamFriend()` on logout in `SteamService`.
  - Handle `SteamEvent.LoggedOut` in `SystemMenu` to set `persona = SteamFriend()` and `showStatusPicker = false`.
  - Gate status picker click and chevron by `SteamService.isLoggedIn` so they’re hidden when logged out.

<sup>Written for commit 5330ac13eec9f9078f7f30d2577c1041ba202b36. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1312?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logout now fully clears cached profile/persona state to prevent stale info after signing out.
  * Profile controls (status picker and online indicator) are disabled and hidden appropriately when not signed in.
  * UI now listens for logout events so visible profile and status UI stay synchronized with authentication state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->