### PR TITLE
fix(workshop): skip ZIP extraction for games that read archives directly

### DIFF
--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -68,6 +68,15 @@ object WorkshopManager {
     private var workshopTypesPatched = false
 
     /**
+     * Games whose own mod system reads .zip files directly from workshop
+     * item directories. Our extractZipMods skips these to avoid deleting
+     * the archive before the game can process it.
+     */
+    private val SKIP_ZIP_EXTRACTION_APP_IDS = setOf(
+        1942280, // Brotato
+    )
+
+    /**
      * Fetches the list of subscribed Workshop items for the given app.
      *
      * Uses the `PublishedFile.GetUserFiles` service RPC with `type=mysubscriptions`
@@ -501,9 +510,17 @@ object WorkshopManager {
      *
      * A `.zip_extracted` marker file prevents re-extraction on subsequent runs.
      * Preview images (`preview.jpg`/`preview.png`) are preserved.
+     *
+     * Games in [SKIP_ZIP_EXTRACTION_APP_IDS] are skipped — they read .zip
+     * files directly from workshop item directories.
      */
     fun extractZipMods(workshopContentDir: File) {
         if (!workshopContentDir.exists()) return
+        val appId = workshopContentDir.name.toIntOrNull()
+        if (appId != null && appId in SKIP_ZIP_EXTRACTION_APP_IDS) {
+            Timber.tag(TAG).d("Skipping ZIP extraction for appId $appId (game reads .zip directly)")
+            return
+        }
         var extractedCount = 0
 
         workshopContentDir.listFiles()?.forEach { itemDir ->


### PR DESCRIPTION
- Add `SKIP_ZIP_EXTRACTION_APP_IDS` set with Brotato (app ID 1942280)
- Early return in `extractZipMods()` when the current app ID is in the skip set
- Log debug message when skipping extraction for such games

## Description
Some games (e.g. Brotato) have their own built-in mod system that scans workshop item directories for .zip files and handles extraction itself. Our extractZipMods() was previously extracting and deleting the archive before the game could read it, causing the game to find no mods.

## Recording

https://github.com/user-attachments/assets/f43a76d8-ec23-4812-97bf-74f1a786d8dc


## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip ZIP extraction for games that read archives directly so their mod zips remain intact and load correctly. Starts with `Brotato` (app ID 1942280).

- **Bug Fixes**
  - Added skip list of app IDs (initial: 1942280).
  - Early return in `extractZipMods()` and debug log when skipping.

<sup>Written for commit 40576f3b974e69690e153e4b873f7ad203b20634. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1316?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified mod extraction behavior for specific games to preserve archive files, preventing unnecessary deletion and re-extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->