### PR TITLE
fix: case-insensitive .exe filter in getWindowsLaunchInfos

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -833,7 +833,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             return getAppInfoOf(appId)?.let { appInfo ->
                 appInfo.config.launch.filter { launchInfo ->
                     // since configOS was unreliable and configArch was even more unreliable
-                    launchInfo.executable.endsWith(".exe")
+                    launchInfo.executable.endsWith(".exe", ignoreCase = true)
                 }
             }.orEmpty()
         }


### PR DESCRIPTION
## Problem

`getWindowsLaunchInfos` filters launch entries with a case-sensitive `endsWith(".exe")` check:

```kotlin
appInfo.config.launch.filter { launchInfo ->
    launchInfo.executable.endsWith(".exe")
}
```

Some games on Steam have their launch executable recorded with an uppercase extension (e.g. `DEVIL_BLADE.EXE` for Devil Blade Reboot, App ID 2882440). These entries are silently dropped by the filter, so `getWindowsLaunchInfos` returns an empty list for those games.

In `XServerScreen.kt`, `appLaunchInfo` is set from `getWindowsLaunchInfos(...).firstOrNull()`. When it comes back `null`, the code unconditionally falls back to `wfm.exe` — ignoring any `executablePath` the user has configured in the container — and the game never launches directly.

## Fix

Use `ignoreCase = true`:

```kotlin
launchInfo.executable.endsWith(".exe", ignoreCase = true)
```

## Steps to reproduce

1. Install **Devil Blade Reboot** (App ID 2882440) via GameNative
2. Set `executablePath` to `DEVIL_BLADE.EXE` in the container config
3. Launch the game — Wine File Manager opens instead of the game

After this fix, the launch entry is no longer filtered out, `appLaunchInfo` is non-null, and the configured executable is used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `.exe` filter in `getWindowsLaunchInfos` case-insensitive so Windows launch entries with uppercase extensions (e.g. `DEVIL_BLADE.EXE`) are detected. This prevents fallback to `wfm.exe` and uses the configured `executablePath` as expected.

<sup>Written for commit 8877d525300abebd398172c89ab6d6848ac8d406. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1318?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

