### PR TITLE
feat: show remaining storage space in Storage Manager

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Development
+
+Build via Android Studio (standard debug build). No special Gradle tasks are needed for day-to-day development.
+
+Optional: add a SteamGridDB API key to `local.properties` for Custom Games image fetching:
+```
+STEAMGRIDDB_API_KEY=your_api_key
+```
+
+## Translations
+
+**Before opening any PR:** any new string added to `app/src/main/res/values/strings.xml` must also be added to all 13 language files:
+`values-da`, `values-de`, `values-es`, `values-fr`, `values-it`, `values-ko`, `values-pl`, `values-pt-rBR`, `values-ro`, `values-ru`, `values-uk`, `values-zh-rCN`, `values-zh-rTW`
+
+## Architecture
+
+The app is a fork of [Winlator](https://github.com/brunodev85/winlator) extended with Steam, GOG, Epic, and Amazon game store integrations. It runs Windows games via Wine inside an XServer rendered to an Android `SurfaceView`.
+
+**Key layers:**
+
+- `service/SteamService` - singleton managing the Steam client connection, game installs, downloads, and session state. Exposes companion object functions and `StateFlow`/`AtomicBoolean` fields for reactive UI.
+- `service/DownloadService` - manages download queues and exposes base storage paths (`baseDataDirPath`, `baseCacheDirPath`).
+- `ui/PluviaMain.kt` - single-Activity Compose nav host; all screens are registered here as `composable()` routes using `PluviaScreen` sealed class destinations.
+- `ui/screen/library/` - library browsing and game detail screens. `AppScreen` dispatches to source-specific `BaseAppScreen` subclasses (`SteamAppScreen`, `GOGAppScreen`, etc.) via a `remember`-keyed instance. `BaseAppScreen.Content()` assembles state and calls `AppScreenContent`; source-specific behavior is injected via open functions (e.g. `buildAchievementsSection`).
+- `ui/screen/xserver/XServerScreen.kt` - the in-game screen. Owns `XServerView`, `WinHandler`, and all Wine/X11 lifecycle. Dialogs that need access to the live game session (e.g. session-conflict dialog) live here, not in `PluviaMain`.
+- `utils/ContainerStorageManager` - scans Wine containers and game install paths across all stores, computes sizes, and handles move operations.
+- `PrefManager` - shared preferences singleton; `externalStoragePath` is the user-configured external storage root.
+
+**Navigation:** `PluviaScreen` sealed class defines all routes. Navigate by calling `onNavigateRoute(PluviaScreen.Foo.route(args))` threaded down from `LibraryScreen` → `LibraryDetailPane` → `AppScreen` → `BaseAppScreen.Content()`.
+
+**Events:** `PluviaApp.events` is a shared `MutableSharedFlow<Any>` used to broadcast cross-component events (e.g. `SteamEvent`, `AndroidEvent`). Collect in composables via `LaunchedEffect`.
+
+**Dependency injection:** Hilt with `@EntryPoint` used in non-Hilt contexts (e.g. `ContainerStorageManager` uses `EntryPointAccessors` to get DAOs).

--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -234,6 +234,7 @@ class PluviaApp : SplitCompatApplication() {
             touchpadView = null
             achievementWatcher = null
             SteamService.keepAlive = false
+            SteamService.clearPlayingConflict()
             clearActiveSuspendState()
         }
 

--- a/app/src/main/java/app/gamenative/events/SteamEvent.kt
+++ b/app/src/main/java/app/gamenative/events/SteamEvent.kt
@@ -16,6 +16,7 @@ sealed interface SteamEvent<T> : Event<T> {
 
     // data object AppInfoReceived : SteamEvent<Unit>
     data object ForceCloseApp : SteamEvent<Unit>
+    data object PlayingBlocked : SteamEvent<Unit>
     data class Disconnected(val isTerminal: Boolean = false) : SteamEvent<Unit>
     data object RemotelyDisconnected : SteamEvent<Unit>
 }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -282,6 +282,7 @@ class SteamService : Service(), IChallengeUrlChanged {
 
     private val _isPlayingBlocked = MutableStateFlow(false)
     val isPlayingBlocked = _isPlayingBlocked.asStateFlow()
+    private val _isHandlingConflict = java.util.concurrent.atomic.AtomicBoolean(false)
 
     // Cache in-memory the local persona state.
     private val _localPersona = MutableStateFlow(
@@ -416,6 +417,14 @@ class SteamService : Service(), IChallengeUrlChanged {
             get() = instance?.steamClient?.steamID?.isValid == true
         var isWaitingForQRAuth: Boolean = false
             private set
+
+        val isPlayingBlocked: kotlinx.coroutines.flow.StateFlow<Boolean>
+            get() = instance?._isPlayingBlocked ?: MutableStateFlow(false)
+
+        fun clearPlayingConflict() {
+            instance?._isPlayingBlocked?.value = false
+            instance?._isHandlingConflict?.set(false)
+        }
 
         private val serverListPath: String
             get() = Paths.get(DownloadService.baseCacheDirPath, "server_list.bin").pathString
@@ -3526,10 +3535,17 @@ class SteamService : Service(), IChallengeUrlChanged {
         } else if (callback.result == EResult.LoggedInElsewhere) {
             // received when a client runs an app and wants to forcibly close another
             // client running an app
-            val event = SteamEvent.ForceCloseApp
-            PluviaApp.events.emit(event)
-
-            reconnect()
+            if (PluviaApp.xEnvironment != null) {
+                if (!_isHandlingConflict.getAndSet(true)) {
+                    _isPlayingBlocked.value = true
+                    PluviaApp.events.emit(SteamEvent.PlayingBlocked)
+                }
+                reconnect()
+            } else {
+                val event = SteamEvent.ForceCloseApp
+                PluviaApp.events.emit(event)
+                reconnect()
+            }
         } else {
             reconnect()
         }
@@ -3538,6 +3554,9 @@ class SteamService : Service(), IChallengeUrlChanged {
     private fun onPlayingSessionState(callback: PlayingSessionStateCallback) {
         Timber.d("onPlayingSessionState called with isPlayingBlocked = " + callback.isPlayingBlocked)
         _isPlayingBlocked.value = callback.isPlayingBlocked
+        if (callback.isPlayingBlocked) {
+            PluviaApp.events.emit(SteamEvent.PlayingBlocked)
+        }
     }
 
     @OptIn(ExperimentalStdlibApi::class)

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -3336,8 +3336,10 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         isConnected = false
 
-        val event = SteamEvent.Disconnected(isTerminal = false)
-        PluviaApp.events.emit(event)
+        if (!_isHandlingConflict.get()) {
+            val event = SteamEvent.Disconnected(isTerminal = false)
+            PluviaApp.events.emit(event)
+        }
 
         steamClient!!.disconnect()
     }
@@ -3378,8 +3380,10 @@ class SteamService : Service(), IChallengeUrlChanged {
 
             Timber.w("Attempting to reconnect (retry $retryAttempt) after ${backoffMs}ms")
 
-            val event = SteamEvent.RemotelyDisconnected
-            PluviaApp.events.emit(event)
+            if (!_isHandlingConflict.get()) {
+                val event = SteamEvent.RemotelyDisconnected
+                PluviaApp.events.emit(event)
+            }
 
             reconnectJob = scope.launch {
                 delay(backoffMs)

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -3556,7 +3556,7 @@ class SteamService : Service(), IChallengeUrlChanged {
     private fun onPlayingSessionState(callback: PlayingSessionStateCallback) {
         Timber.d("onPlayingSessionState called with isPlayingBlocked = " + callback.isPlayingBlocked)
         _isPlayingBlocked.value = callback.isPlayingBlocked
-        if (callback.isPlayingBlocked) {
+        if (callback.isPlayingBlocked && _isHandlingConflict.compareAndSet(false, true)) {
             val event = SteamEvent.PlayingBlocked
             PluviaApp.events.emit(event)
         }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -282,7 +282,7 @@ class SteamService : Service(), IChallengeUrlChanged {
 
     private val _isPlayingBlocked = MutableStateFlow(false)
     val isPlayingBlocked = _isPlayingBlocked.asStateFlow()
-    private val _isHandlingConflict = java.util.concurrent.atomic.AtomicBoolean(false)
+    private val _isHandlingConflict = AtomicBoolean(false)
 
     // Cache in-memory the local persona state.
     private val _localPersona = MutableStateFlow(
@@ -417,9 +417,6 @@ class SteamService : Service(), IChallengeUrlChanged {
             get() = instance?.steamClient?.steamID?.isValid == true
         var isWaitingForQRAuth: Boolean = false
             private set
-
-        val isPlayingBlocked: kotlinx.coroutines.flow.StateFlow<Boolean>
-            get() = instance?._isPlayingBlocked ?: MutableStateFlow(false)
 
         fun clearPlayingConflict() {
             instance?._isPlayingBlocked?.value = false
@@ -3542,7 +3539,8 @@ class SteamService : Service(), IChallengeUrlChanged {
             if (PluviaApp.xEnvironment != null) {
                 if (!_isHandlingConflict.getAndSet(true)) {
                     _isPlayingBlocked.value = true
-                    PluviaApp.events.emit(SteamEvent.PlayingBlocked)
+                    val event = SteamEvent.PlayingBlocked
+                    PluviaApp.events.emit(event)
                 }
                 reconnect()
             } else {
@@ -3559,7 +3557,8 @@ class SteamService : Service(), IChallengeUrlChanged {
         Timber.d("onPlayingSessionState called with isPlayingBlocked = " + callback.isPlayingBlocked)
         _isPlayingBlocked.value = callback.isPlayingBlocked
         if (callback.isPlayingBlocked) {
-            PluviaApp.events.emit(SteamEvent.PlayingBlocked)
+            val event = SteamEvent.PlayingBlocked
+            PluviaApp.events.emit(event)
         }
     }
 

--- a/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
@@ -134,7 +134,13 @@ class ContainerStorageManagerUiState internal constructor(
 
         scope.launch {
             isLoading = true
-            volumeInfo = ContainerStorageManager.getVolumeInfo(appContext)
+            runCatching {
+                ContainerStorageManager.getVolumeInfo(appContext)
+            }.onSuccess {
+                volumeInfo = it
+            }.onFailure { error ->
+                Timber.w(error, "Failed to query volume info")
+            }
             runCatching {
                 ContainerStorageManager.loadEntries(appContext)
             }.onSuccess {

--- a/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
@@ -90,6 +90,9 @@ class ContainerStorageManagerUiState internal constructor(
     var entries by mutableStateOf<List<ContainerStorageManager.Entry>>(emptyList())
         private set
 
+    var volumeInfo by mutableStateOf<List<ContainerStorageManager.VolumeInfo>>(emptyList())
+        private set
+
     var isLoading by mutableStateOf(false)
         private set
 
@@ -131,6 +134,7 @@ class ContainerStorageManagerUiState internal constructor(
 
         scope.launch {
             isLoading = true
+            volumeInfo = ContainerStorageManager.getVolumeInfo(appContext)
             runCatching {
                 ContainerStorageManager.loadEntries(appContext)
             }.onSuccess {
@@ -396,20 +400,38 @@ fun ContainerStorageManagerContent(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                text = if (state.isLoading && !state.hasLoaded) {
-                    stringResource(R.string.container_storage_loading)
-                } else {
-                    stringResource(
-                        R.string.container_storage_summary,
-                        state.entries.size,
-                        StorageUtils.formatBinarySize(inventorySummaryBytes(state.entries)),
-                    )
-                },
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.weight(1f),
-            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = if (state.isLoading && !state.hasLoaded) {
+                        stringResource(R.string.container_storage_loading)
+                    } else {
+                        stringResource(
+                            R.string.container_storage_summary,
+                            state.entries.size,
+                            StorageUtils.formatBinarySize(inventorySummaryBytes(state.entries)),
+                        )
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (state.volumeInfo.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        state.volumeInfo.forEach { vol ->
+                            Text(
+                                text = stringResource(
+                                    R.string.storage_free_of_total,
+                                    vol.label,
+                                    StorageUtils.formatBinarySize(vol.freeBytes, decimalPlaces = 1),
+                                    StorageUtils.formatBinarySize(vol.totalBytes, decimalPlaces = 1),
+                                ),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                            )
+                        }
+                    }
+                }
+            }
 
             if (onDismissRequest != null) {
                 IconButton(

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import app.gamenative.MainActivity
@@ -300,6 +301,7 @@ fun XServerScreen(
     Timber.i("Starting up XServerScreen")
     val context = LocalContext.current
     val view = LocalView.current
+    val scope = rememberCoroutineScope()
     val imm = remember(context) {
         context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
     }
@@ -411,6 +413,7 @@ fun XServerScreen(
     var showElementEditor by remember { mutableStateOf(false) }
     var elementToEdit by remember { mutableStateOf<com.winlator.inputcontrols.ControlElement?>(null) }
     var showPhysicalControllerDialog by remember { mutableStateOf(false) }
+    var showPlayingBlockedDialog by remember { mutableStateOf(false) }
     var showTouchGestureDialog by remember { mutableStateOf(false) }
     var isTouchscreenModeActive by remember { mutableStateOf(container.isTouchscreenMode) }
     var currentGestureConfig by remember {
@@ -1301,6 +1304,10 @@ fun XServerScreen(
             Timber.i("onForceCloseApp")
             exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
         }
+        val onPlayingBlocked: (SteamEvent.PlayingBlocked) -> Unit = {
+            Timber.i("onPlayingBlocked")
+            showPlayingBlockedDialog = true
+        }
         val debugCallback = Callback<String> { outputLine ->
             Timber.i(outputLine ?: "")
         }
@@ -1310,6 +1317,7 @@ fun XServerScreen(
         PluviaApp.events.on<AndroidEvent.MotionEvent, Boolean>(onMotionEvent)
         PluviaApp.events.on<AndroidEvent.GuestProgramTerminated, Unit>(onGuestProgramTerminated)
         PluviaApp.events.on<SteamEvent.ForceCloseApp, Unit>(onForceCloseApp)
+        PluviaApp.events.on<SteamEvent.PlayingBlocked, Unit>(onPlayingBlocked)
         ProcessHelper.addDebugCallback(debugCallback)
 
         onDispose {
@@ -1318,6 +1326,7 @@ fun XServerScreen(
             PluviaApp.events.off<AndroidEvent.MotionEvent, Boolean>(onMotionEvent)
             PluviaApp.events.off<AndroidEvent.GuestProgramTerminated, Unit>(onGuestProgramTerminated)
             PluviaApp.events.off<SteamEvent.ForceCloseApp, Unit>(onForceCloseApp)
+            PluviaApp.events.off<SteamEvent.PlayingBlocked, Unit>(onPlayingBlocked)
             ProcessHelper.removeDebugCallback(debugCallback)
         }
     }
@@ -2333,6 +2342,32 @@ fun XServerScreen(
                 }
             }
         }
+    }
+
+    if (showPlayingBlockedDialog) {
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = {},
+            title = { Text(text = stringResource(R.string.main_app_running_title)) },
+            text = { Text(text = stringResource(R.string.main_app_running_message, context.getString(R.string.main_another_device))) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showPlayingBlockedDialog = false
+                    scope.launch {
+                        app.gamenative.service.SteamService.kickPlayingSession(onlyGame = true)
+                    }
+                }) {
+                    Text(text = stringResource(R.string.main_play_anyway))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showPlayingBlockedDialog = false
+                    exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+                }) {
+                    Text(text = stringResource(R.string.cancel))
+                }
+            },
+        )
     }
 
     // var ranSetup by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2262,9 +2262,9 @@ fun XServerScreen(
             confirmButton = {
                 TextButton(onClick = {
                     showPlayingBlockedDialog = false
+                    SteamService.clearPlayingConflict()
                     scope.launch {
                         SteamService.kickPlayingSession(onlyGame = true)
-                        SteamService.clearPlayingConflict()
                     }
                 }) {
                     Text(text = stringResource(R.string.main_play_anyway))

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2254,6 +2254,32 @@ fun XServerScreen(
         )
     }
 
+    if (showPlayingBlockedDialog) {
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = {},
+            title = { Text(text = stringResource(R.string.main_app_running_title)) },
+            text = { Text(text = stringResource(R.string.main_app_running_message, context.getString(R.string.main_app_running_unknown_game))) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showPlayingBlockedDialog = false
+                    scope.launch {
+                        SteamService.kickPlayingSession(onlyGame = true)
+                    }
+                }) {
+                    Text(text = stringResource(R.string.main_play_anyway))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showPlayingBlockedDialog = false
+                    exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+                }) {
+                    Text(text = stringResource(R.string.cancel))
+                }
+            },
+        )
+    }
+
     // Physical Controller Config Dialog
     if (showPhysicalControllerDialog) {
         // Get profile from container settings, not from InputControlsView
@@ -2342,32 +2368,6 @@ fun XServerScreen(
                 }
             }
         }
-    }
-
-    if (showPlayingBlockedDialog) {
-        androidx.compose.material3.AlertDialog(
-            onDismissRequest = {},
-            title = { Text(text = stringResource(R.string.main_app_running_title)) },
-            text = { Text(text = stringResource(R.string.main_app_running_message, context.getString(R.string.main_another_device))) },
-            confirmButton = {
-                TextButton(onClick = {
-                    showPlayingBlockedDialog = false
-                    scope.launch {
-                        app.gamenative.service.SteamService.kickPlayingSession(onlyGame = true)
-                    }
-                }) {
-                    Text(text = stringResource(R.string.main_play_anyway))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = {
-                    showPlayingBlockedDialog = false
-                    exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
-                }) {
-                    Text(text = stringResource(R.string.cancel))
-                }
-            },
-        )
     }
 
     // var ranSetup by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2273,7 +2273,7 @@ fun XServerScreen(
             dismissButton = {
                 TextButton(onClick = {
                     showPlayingBlockedDialog = false
-                    exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+                    exit(xServerView?.getxServer()?.winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
                 }) {
                     Text(text = stringResource(R.string.cancel))
                 }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -413,7 +413,7 @@ fun XServerScreen(
     var showElementEditor by remember { mutableStateOf(false) }
     var elementToEdit by remember { mutableStateOf<com.winlator.inputcontrols.ControlElement?>(null) }
     var showPhysicalControllerDialog by remember { mutableStateOf(false) }
-    var showPlayingBlockedDialog by remember { mutableStateOf(false) }
+    var showPlayingBlockedDialog by rememberSaveable { mutableStateOf(false) }
     var showTouchGestureDialog by remember { mutableStateOf(false) }
     var isTouchscreenModeActive by remember { mutableStateOf(container.isTouchscreenMode) }
     var currentGestureConfig by remember {

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2264,6 +2264,7 @@ fun XServerScreen(
                     showPlayingBlockedDialog = false
                     scope.launch {
                         SteamService.kickPlayingSession(onlyGame = true)
+                        SteamService.clearPlayingConflict()
                     }
                 }) {
                     Text(text = stringResource(R.string.main_play_anyway))

--- a/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
@@ -77,7 +77,7 @@ object ContainerStorageManager {
         val totalBytes: Long,
     )
 
-    fun getVolumeInfo(context: Context): List<VolumeInfo> {
+    suspend fun getVolumeInfo(context: Context): List<VolumeInfo> = withContext(Dispatchers.IO) {
         val volumes = mutableListOf<VolumeInfo>()
         runCatching {
             volumes += VolumeInfo(
@@ -85,18 +85,22 @@ object ContainerStorageManager {
                 freeBytes = StorageUtils.getAvailableSpace(context.dataDir.path),
                 totalBytes = StorageUtils.getTotalSpace(context.dataDir.path),
             )
+        }.onFailure { e ->
+            Timber.w(e, "Failed to query internal storage volume info")
         }
         val externalPath = PrefManager.externalStoragePath
-        if (externalPath.isNotBlank() && java.io.File(externalPath).exists()) {
+        if (externalPath.isNotBlank() && File(externalPath).exists()) {
             runCatching {
                 volumes += VolumeInfo(
                     label = context.getString(R.string.storage_external),
                     freeBytes = StorageUtils.getAvailableSpace(externalPath),
                     totalBytes = StorageUtils.getTotalSpace(externalPath),
                 )
+            }.onFailure { e ->
+                Timber.w(e, "Failed to query external storage volume info")
             }
         }
-        return volumes
+        volumes
     }
 
     data class Entry(

--- a/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
@@ -3,6 +3,7 @@ package app.gamenative.utils
 import android.content.Context
 import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
+import app.gamenative.R
 import app.gamenative.data.GameSource
 import app.gamenative.data.LibraryItem
 import app.gamenative.data.SteamApp
@@ -68,6 +69,34 @@ object ContainerStorageManager {
         INTERNAL,
         EXTERNAL,
         UNKNOWN,
+    }
+
+    data class VolumeInfo(
+        val label: String,
+        val freeBytes: Long,
+        val totalBytes: Long,
+    )
+
+    fun getVolumeInfo(context: Context): List<VolumeInfo> {
+        val volumes = mutableListOf<VolumeInfo>()
+        runCatching {
+            volumes += VolumeInfo(
+                label = context.getString(R.string.storage_internal),
+                freeBytes = StorageUtils.getAvailableSpace(context.dataDir.path),
+                totalBytes = StorageUtils.getTotalSpace(context.dataDir.path),
+            )
+        }
+        val externalPath = PrefManager.externalStoragePath
+        if (externalPath.isNotBlank() && java.io.File(externalPath).exists()) {
+            runCatching {
+                volumes += VolumeInfo(
+                    label = context.getString(R.string.storage_external),
+                    freeBytes = StorageUtils.getAvailableSpace(externalPath),
+                    totalBytes = StorageUtils.getTotalSpace(externalPath),
+                )
+            }
+        }
+        return volumes
     }
 
     data class Entry(

--- a/app/src/main/java/app/gamenative/utils/StorageUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/StorageUtils.kt
@@ -29,6 +29,15 @@ object StorageUtils {
         return stat.blockSizeLong * stat.availableBlocksLong
     }
 
+    fun getTotalSpace(path: String): Long {
+        val file = File(path)
+        if (!file.exists()) {
+            throw IllegalArgumentException("Invalid path: $path")
+        }
+        val stat = StatFs(path)
+        return stat.blockSizeLong * stat.blockCountLong
+    }
+
     suspend fun getFolderSize(folderPath: String): Long {
         val folder = File(folderPath)
         if (folder.exists()) {

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -844,6 +844,7 @@
     <string name="main_app_running_message">Du er logget ind på en anden enhed og spiller allerede %s. \nDu kan stadig spille dette spil, men det vil afbryde den anden session fra Steam.</string>
     <string name="main_app_running_other_device">Du er logget ind på en anden enhed (%1$s) og spiller allerede %2$s (%3$s), og den gemfil er ikke i skyen endnu. \nDu kan stadig spille dette spil, men det vil afbryde den anden session fra Steam og kan skabe en gemfilkonflikt når sessionsframgangen synkroniseres</string>
     <string name="main_play_anyway">Spil alligevel</string>
+    <string name="main_app_running_unknown_game">et spil</string>
 
     <!-- TODO: Manual review - PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Gemfilkonflikt</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -61,6 +61,9 @@
     <string name="downloads_status_failed">Mislykket</string>
     <string name="downloads_status_paused">Sat på pause</string>
     <string name="downloads_summary">Administrer aktive downloads og lager ét sted</string>
+    <string name="storage_internal">Intern</string>
+    <string name="storage_external">Ekstern</string>
+    <string name="storage_free_of_total">%1$s: %2$s ledig af %3$s</string>
     <string name="container_storage_title">Lagerstyring</string>
     <string name="container_storage_subtitle">Flyt installationer mellem intern og ekstern lagerplads</string>
     <string name="container_storage_summary">%1$d elementer • %2$s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -970,6 +970,7 @@
     <string name="main_app_running_message">Du bist auf einem anderen Gerät bereits mit %s angemeldet. Du kannst trotzdem spielen, aber das beendet die andere Steam-Sitzung.</string>
     <string name="main_app_running_other_device">Du bist auf einem anderen Gerät (%1$s) mit %2$s (%3$s) angemeldet, und dieser Spielstand wurde noch nicht in der Cloud gespeichert. Du kannst trotzdem spielen, doch wird dadurch die andere Sitzung getrennt und es kann zu Speicherstandskonflikten kommen, wenn die andere Sitzung synchronisiert wird.</string>
     <string name="main_play_anyway">Trotzdem starten</string>
+    <string name="main_app_running_unknown_game">ein Spiel</string>
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Speicherstandkonflikt</string>
     <string name="main_save_conflict_message">Es wurden ein neuer lokaler und ein neuer Cloud-Spielstand gefunden. Welchen möchtest du behalten?\n\nLokal:\n\t%1$s\nCloud:\n\t%2$s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -98,6 +98,9 @@
     <string name="downloads_status_failed">Fehlgeschlagen</string>
     <string name="downloads_status_paused">Pausiert</string>
     <string name="downloads_summary">Aktive Downloads und Speicher an einem Ort verwalten</string>
+    <string name="storage_internal">Intern</string>
+    <string name="storage_external">Extern</string>
+    <string name="storage_free_of_total">%1$s: %2$s frei von %3$s</string>
     <string name="container_storage_title">Speicherverwaltung</string>
     <string name="container_storage_subtitle">Installationen zwischen internem und externem Speicher verschieben</string>
     <string name="container_storage_summary">%1$d Einträge • %2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -112,6 +112,9 @@
     <string name="downloads_status_failed">Fallido</string>
     <string name="downloads_status_paused">Pausado</string>
     <string name="downloads_summary">Gestiona descargas activas y almacenamiento en un solo lugar</string>
+    <string name="storage_internal">Interno</string>
+    <string name="storage_external">Externo</string>
+    <string name="storage_free_of_total">%1$s: %2$s libres de %3$s</string>
     <string name="container_storage_title">Administrador de almacenamiento</string>
     <string name="container_storage_subtitle">Mueve instalaciones entre almacenamiento interno y externo</string>
     <string name="container_storage_summary">%1$d elementos • %2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1034,6 +1034,7 @@
     <string name="main_app_running_message">Has iniciado sesión en otro dispositivo que ya está jugando a %s.\nAún puedes jugar a este juego, pero eso desconectará la otra sesión de Steam.</string>
     <string name="main_app_running_other_device">Has iniciado sesión en otro dispositivo (%1$s) que ya está jugando a %2$s (%3$s), y ese archivo de guardado aún no está en la nube.\nAún puedes jugar a este juego, pero eso desconectará la otra sesión de Steam y podría crear un conflicto de guardado cuando se sincronice el progreso de esa sesión.</string>
     <string name="main_play_anyway">Jugar de todos modos</string>
+    <string name="main_app_running_unknown_game">un juego</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Conflicto de guardado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -103,6 +103,9 @@
     <string name="downloads_status_failed">Échec</string>
     <string name="downloads_status_paused">En pause</string>
     <string name="downloads_summary">Gérez les téléchargements actifs et le stockage au même endroit</string>
+    <string name="storage_internal">Interne</string>
+    <string name="storage_external">Externe</string>
+    <string name="storage_free_of_total">%1$s : %2$s libre sur %3$s</string>
     <string name="container_storage_title">Gestionnaire de stockage</string>
     <string name="container_storage_subtitle">Déplacez les installations entre le stockage interne et externe</string>
     <string name="container_storage_summary">%1$d éléments • %2$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1018,6 +1018,7 @@
     <string name="main_app_running_message">Vous êtes connecté sur un autre appareil jouant déjà à %s. \nVous pouvez toujours jouer à ce jeu, mais cela déconnectera l\'autre session de Steam.</string>
     <string name="main_app_running_other_device">Vous êtes connecté sur un autre appareil (%1$s) jouant déjà à %2$s (%3$s), et cette sauvegarde n\'est pas encore dans le cloud. \nVous pouvez toujours jouer à ce jeu, mais cela déconnectera l\'autre session de Steam et peut créer un conflit de sauvegarde lorsque la progression de cette session sera synchronisée</string>
     <string name="main_play_anyway">Jouer quand même</string>
+    <string name="main_app_running_unknown_game">un jeu</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Conflit de sauvegarde</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1014,6 +1014,7 @@
     <string name="main_app_running_message">Sei connesso su un altro dispositivo che sta già giocando a %s. \nPuoi comunque giocare a questo gioco, ma ciò disconnetterà l\'altra sessione da Steam.</string>
     <string name="main_app_running_other_device">Sei connesso su un altro dispositivo (%1$s) che sta già giocando a %2$s (%3$s), e quel salvataggio non è ancora nel cloud. \nPuoi comunque giocare a questo gioco, ma ciò disconnetterà l\'altra sessione da Steam e potrebbe creare un conflitto di salvataggio quando il progresso di quella sessione verrà sincronizzato</string>
     <string name="main_play_anyway">Gioca comunque</string>
+    <string name="main_app_running_unknown_game">un gioco</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Conflitto Salvataggio</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -103,6 +103,9 @@
     <string name="downloads_status_failed">Fallito</string>
     <string name="downloads_status_paused">In pausa</string>
     <string name="downloads_summary">Gestisci download attivi e archiviazione in un unico posto</string>
+    <string name="storage_internal">Interno</string>
+    <string name="storage_external">Esterno</string>
+    <string name="storage_free_of_total">%1$s: %2$s liberi su %3$s</string>
     <string name="container_storage_title">Gestione archiviazione</string>
     <string name="container_storage_subtitle">Sposta le installazioni tra archiviazione interna ed esterna</string>
     <string name="container_storage_summary">%1$d elementi • %2$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -112,6 +112,9 @@
     <string name="downloads_status_failed">실패</string>
     <string name="downloads_status_paused">일시중지됨</string>
     <string name="downloads_summary">한곳에서 진행 중인 다운로드와 저장소를 관리합니다</string>
+    <string name="storage_internal">내부</string>
+    <string name="storage_external">외부</string>
+    <string name="storage_free_of_total">%1$s: %3$s 중 %2$s 사용 가능</string>
     <string name="container_storage_title">저장소 관리자</string>
     <string name="container_storage_subtitle">내부 저장소와 외부 저장소 사이에서 설치 항목을 이동합니다</string>
     <string name="container_storage_summary">%1$d개 항목 • %2$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1032,6 +1032,7 @@
     <string name="main_app_running_message">다른 장치에서 이미 %s을(를) 플레이 중입니다. \n이 게임을 플레이할 수 있지만 다른 세션의 Steam 연결이 끊어집니다.</string>
     <string name="main_app_running_other_device">다른 장치(%1$s)에서 이미 %2$s(%3$s)을(를) 플레이 중이며, 해당 저장 파일이 아직 클라우드에 없습니다. \n이 게임을 플레이할 수 있지만 다른 세션의 Steam 연결이 끊어지고 해당 세션의 진행 상황이 동기화될 때 저장 충돌이 발생할 수 있습니다</string>
     <string name="main_play_anyway">어쨌든 플레이</string>
+    <string name="main_app_running_unknown_game">게임</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">저장 충돌</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -112,6 +112,9 @@
     <string name="downloads_status_failed">Nieudane</string>
     <string name="downloads_status_paused">Wstrzymano</string>
     <string name="downloads_summary">Zarządzaj aktywnymi pobraniami i pamięcią w jednym miejscu</string>
+    <string name="storage_internal">Wewnętrzny</string>
+    <string name="storage_external">Zewnętrzny</string>
+    <string name="storage_free_of_total">%1$s: %2$s wolne z %3$s</string>
     <string name="container_storage_title">Menedżer pamięci</string>
     <string name="container_storage_subtitle">Przenoś instalacje między pamięcią wewnętrzną i zewnętrzną</string>
     <string name="container_storage_summary">%1$d elementów • %2$s</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1031,6 +1031,7 @@
     <string name="main_app_running_message">Jesteś zalogowany na innym urządzeniu grając w %s. \nMożesz kontynuować grę, ale to rozłączy drugą sesję ze Steam.</string>
     <string name="main_app_running_other_device">Jesteś zalogowany na innym urządzeniu (%1$s) grając w %2$s (%3$s), a zapis nie jest jeszcze w chmurze. \nMożesz kontynuować grę, ale to rozłączy drugą sesję ze Steam i może stworzyć konflikt zapisu, gdy postęp tamtej sesji zostanie zsynchronizowany.</string>
     <string name="main_play_anyway">Graj mimo to</string>
+    <string name="main_app_running_unknown_game">grę</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Konflikt zapisu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -57,6 +57,9 @@
     <string name="downloads_status_failed">Falhou</string>
     <string name="downloads_status_paused">Pausado</string>
     <string name="downloads_summary">Gerencie downloads ativos e armazenamento em um só lugar</string>
+    <string name="storage_internal">Interno</string>
+    <string name="storage_external">Externo</string>
+    <string name="storage_free_of_total">%1$s: %2$s livre de %3$s</string>
     <string name="container_storage_title">Gerenciador de armazenamento</string>
     <string name="container_storage_subtitle">Mova instalações entre armazenamento interno e externo</string>
     <string name="container_storage_summary">%1$d itens • %2$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -844,6 +844,7 @@
     <string name="main_app_running_message">Você já está logado em outro dispositivo jogando %s. \nVocê ainda pode jogar este jogo, mas isso desconectará a outra sessão do Steam.</string>
     <string name="main_app_running_other_device">Você já está logado em outro dispositivo (%1$s) jogando %2$s (%3$s), e esse save ainda não está na nuvem. \nVocê ainda pode jogar este jogo, mas isso desconectará a outra sessão do Steam e pode criar um conflito de save quando o progresso da sessão for sincronizado</string>
     <string name="main_play_anyway">Jogar mesmo assim</string>
+    <string name="main_app_running_unknown_game">um jogo</string>
 
     <!-- TODO: Revisão manual - PluviaMain: Conflitos de save -->
     <string name="main_save_conflict_title">Conflito de save</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1022,6 +1022,7 @@
 	<string name="main_app_running_message">Ești autentificat pe un alt dispozitiv care deja rulează %s.\nPoți juca în continuare, dar asta va deconecta cealaltă sesiune din Steam.</string>
 	<string name="main_app_running_other_device">Ești autentificat pe un alt dispozitiv (%1$s) care rulează deja %2$s (%3$s), iar salvarea nu este încă în cloud.\nPoți juca în continuare, dar asta va deconecta cealaltă sesiune și poate crea conflicte de salvare când progresul este sincronizat.</string>
 	<string name="main_play_anyway">Joacă oricum</string>
+	<string name="main_app_running_unknown_game">un joc</string>
 
 	<!-- PluviaMain: Save Conflicts -->
 	<string name="main_save_conflict_title">Conflict de salvare</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -103,6 +103,9 @@
     <string name="downloads_status_failed">Eșuat</string>
     <string name="downloads_status_paused">În pauză</string>
     <string name="downloads_summary">Gestionează descărcările active și stocarea într-un singur loc</string>
+    <string name="storage_internal">Intern</string>
+    <string name="storage_external">Extern</string>
+    <string name="storage_free_of_total">%1$s: %2$s liber din %3$s</string>
     <string name="container_storage_title">Manager stocare</string>
     <string name="container_storage_subtitle">Mută instalările între stocarea internă și externă</string>
     <string name="container_storage_summary">%1$d elemente • %2$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1131,6 +1131,9 @@ https://gamenative.app
     <string name="downloads_status_failed">Ошибка</string>
     <string name="downloads_status_paused">Приостановлено</string>
     <string name="downloads_summary">Управляйте активными загрузками и хранилищем в одном месте</string>
+    <string name="storage_internal">Внутренняя</string>
+    <string name="storage_external">Внешняя</string>
+    <string name="storage_free_of_total">%1$s: %2$s свободно из %3$s</string>
     <string name="container_storage_title">Менеджер хранилища</string>
     <string name="container_storage_subtitle">Перемещайте установки между внутренним и внешним хранилищем</string>
     <string name="container_storage_summary">%1$d элементов • %2$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -675,6 +675,7 @@ Ubuntu RootFs - releases.ubuntu.com/focal</string>
 Вы всё ещё можете играть в эту игру, но это может создать конфликт, когда ваш предыдущий прогресс успешно загрузится.</string>
     <string name="main_pending_upload_title">Ожидание загрузки</string>
     <string name="main_play_anyway">Играть в любом случае</string>
+    <string name="main_app_running_unknown_game">игру</string>
     <string name="main_recent_crash_message">Приносим извинения!
 Было бы хорошо узнать о недавней проблеме, которая у вас была.
 Вы можете просмотреть и экспортировать самый последний журнал сбоев в настройках приложения и приложить его как Github проблему в репозитории проекта.

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1017,6 +1017,7 @@
     <string name="main_app_running_message">Ви авторизовані на іншому пристрої, де граєте у %s. Ви все одно можете грати в цю гру, але це завершить інший сеанс у Steam.</string>
     <string name="main_app_running_other_device">Ви авторизовані на іншому пристрої (%1$s), де граєте у %2$s (%3$s), і прогрес цієї гри ще не синхронізовано з хмарою. \nВи все одно можете грати в цю гру, але це завершить інший сеанс у Steam і може створити конфлікт збережень, коли прогрес того сеансу синхронізуватиметься</string>
     <string name="main_play_anyway">Все одно грати</string>
+    <string name="main_app_running_unknown_game">гру</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Конфлікт збережень</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -100,6 +100,9 @@
     <string name="downloads_status_failed">Помилка</string>
     <string name="downloads_status_paused">Призупинено</string>
     <string name="downloads_summary">Керуйте активними завантаженнями та сховищем в одному місці</string>
+    <string name="storage_internal">Внутрішня</string>
+    <string name="storage_external">Зовнішня</string>
+    <string name="storage_free_of_total">%1$s: %2$s вільно з %3$s</string>
     <string name="container_storage_title">Менеджер сховища</string>
     <string name="container_storage_subtitle">Переміщуйте встановлення між внутрішнім і зовнішнім сховищем</string>
     <string name="container_storage_summary">%1$d елементів • %2$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -103,6 +103,9 @@
     <string name="downloads_status_failed">失败</string>
     <string name="downloads_status_paused">已暂停</string>
     <string name="downloads_summary">在一处管理活动下载和存储</string>
+    <string name="storage_internal">内部</string>
+    <string name="storage_external">外部</string>
+    <string name="storage_free_of_total">%1$s：%3$s 中有 %2$s 可用</string>
     <string name="container_storage_title">存储管理</string>
     <string name="container_storage_subtitle">在内部存储与外部存储之间移动安装内容</string>
     <string name="container_storage_summary">%1$d 项 • %2$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1011,6 +1011,7 @@
     <string name="main_app_running_message">您已在另一台设备登录并正在游玩 %s。\n您仍可继续游玩此游戏，但此操作将导致 Steam 断开另一设备的连接。</string>
     <string name="main_app_running_other_device">您已在另一台设备（%1$s）上登录并正在游玩 %2$s（%3$s），该存档尚未同步至云端。\n您仍可继续游玩此游戏，但此操作将使另一设备的 Steam 连接中断，且当该设备的进度同步时可能产生存档冲突。</string>
     <string name="main_play_anyway">仍要继续</string>
+    <string name="main_app_running_unknown_game">游戏</string>
 
     <!-- 主界面：存档冲突 -->
     <string name="main_save_conflict_title">存档冲突</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1014,6 +1014,7 @@
     <string name="main_app_running_message">您已在另一台裝置登入並正在遊玩 %s。\n您仍可繼續遊玩此遊戲，但此操作將導致 Steam 斷開另一裝置的連線。</string>
     <string name="main_app_running_other_device">您已在另一台裝置 (%1$s) 上登入並正在遊玩 %2$s (%3$s)，該存檔尚未同步至雲端。\n您仍可繼續遊玩此遊戲，但此操作將使另一裝置的 Steam 連線中斷，且當該裝置的進度同步時可能產生存檔衝突。</string>
     <string name="main_play_anyway">仍要繼續</string>
+    <string name="main_app_running_unknown_game">遊戲</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">存檔衝突</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -103,6 +103,9 @@
     <string name="downloads_status_failed">失敗</string>
     <string name="downloads_status_paused">已暫停</string>
     <string name="downloads_summary">在同一處管理進行中的下載與儲存</string>
+    <string name="storage_internal">內部</string>
+    <string name="storage_external">外部</string>
+    <string name="storage_free_of_total">%1$s：%3$s 中有 %2$s 可用</string>
     <string name="container_storage_title">儲存管理</string>
     <string name="container_storage_subtitle">在內部儲存與外部儲存之間移動安裝內容</string>
     <string name="container_storage_summary">%1$d 項 • %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1065,6 +1065,7 @@
     <string name="main_app_running_message">You are logged in on another device already playing %s. \nYou can still play this game, but that will disconnect the other session from Steam.</string>
     <string name="main_app_running_other_device">You are logged in on another device (%1$s) already playing %2$s (%3$s), and that save is not yet in the cloud. \nYou can still play this game, but that will disconnect the other session from Steam and may create a save conflict when that session progress is synced</string>
     <string name="main_play_anyway">Play anyway</string>
+    <string name="main_another_device">another device</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Save Conflict</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1065,7 +1065,7 @@
     <string name="main_app_running_message">You are logged in on another device already playing %s. \nYou can still play this game, but that will disconnect the other session from Steam.</string>
     <string name="main_app_running_other_device">You are logged in on another device (%1$s) already playing %2$s (%3$s), and that save is not yet in the cloud. \nYou can still play this game, but that will disconnect the other session from Steam and may create a save conflict when that session progress is synced</string>
     <string name="main_play_anyway">Play anyway</string>
-    <string name="main_app_running_unknown_game">another device</string>
+    <string name="main_app_running_unknown_game">a game</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Save Conflict</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1065,7 +1065,7 @@
     <string name="main_app_running_message">You are logged in on another device already playing %s. \nYou can still play this game, but that will disconnect the other session from Steam.</string>
     <string name="main_app_running_other_device">You are logged in on another device (%1$s) already playing %2$s (%3$s), and that save is not yet in the cloud. \nYou can still play this game, but that will disconnect the other session from Steam and may create a save conflict when that session progress is synced</string>
     <string name="main_play_anyway">Play anyway</string>
-    <string name="main_another_device">another device</string>
+    <string name="main_app_running_unknown_game">another device</string>
 
     <!-- PluviaMain: Save Conflicts -->
     <string name="main_save_conflict_title">Save Conflict</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -921,6 +921,9 @@
     <string name="settings_storage_title">Storage</string>
     <string name="settings_storage_manage_title">Storage Manager</string>
     <string name="settings_storage_manage_subtitle">Review game and container storage in one place</string>
+    <string name="storage_internal">Internal</string>
+    <string name="storage_external">External</string>
+    <string name="storage_free_of_total">%1$s: %2$s free of %3$s</string>
     <string name="container_storage_title">Container &amp; Storage Manager</string>
     <string name="container_storage_subtitle">Review game and container storage, including installed games without containers</string>
     <string name="container_storage_summary">%1$d items • %2$s</string>


### PR DESCRIPTION
## Problem

The Storage Manager showed total used space across all installations but gave no indication of how much free space remained on each volume. Users had no way to tell at a glance whether they had room to install or move games.

Requested by Kyoka in Discord.

## Changes

**`StorageUtils.kt`** - adds `getTotalSpace(path)` mirroring the existing `getAvailableSpace(path)` using `StatFs`.

**`ContainerStorageManager.kt`**
- Adds `VolumeInfo(label, freeBytes, totalBytes)` data class
- Adds `suspend fun getVolumeInfo(context)` (runs on `Dispatchers.IO`) that returns one entry for internal storage and one for external if configured, with `Timber` logging on failure

**`ContainerStorageManagerDialog.kt`**
- Adds `volumeInfo` state to `ContainerStorageManagerUiState`, populated at the start of `refresh()` in its own `runCatching` block
- Header now shows a second line beneath the item/size summary with free-of-total per volume, e.g. `Internal: 12.3 GiB free of 128.0 GiB  External: 45.1 GiB free of 256.0 GiB`

**`strings.xml` + all 13 language files** - adds `storage_internal`, `storage_external`, `storage_free_of_total`.

<img width="1376" height="774" alt="image" src="https://github.com/user-attachments/assets/c86f7ef5-a699-49ea-a669-81a1284f7cb9" />

## Test plan
- [x] Open Storage Manager - header shows item count + used space (existing) with free/total below
- [x] Device with no external storage configured - only Internal line appears
- [x] Device with external storage configured - both Internal and External lines appear
- [x] No regression to move, uninstall, or remove container flows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show free and total storage per volume in Storage Manager so users can see remaining space at a glance. Also adds an in-game Steam session conflict dialog to let players choose to continue or exit when another device starts a game.

- New Features
  - Storage Manager header now shows per-volume “free of total” for Internal and External storage.
  - Added `StorageUtils.getTotalSpace(path)` and `ContainerStorageManager.getVolumeInfo(context)` (runs on IO) to fetch volume stats.
  - New localized strings for `storage_internal`, `storage_external`, and `storage_free_of_total`.

- Bug Fixes
  - Handle Steam “LoggedInElsewhere” while in-game: `XServerScreen` shows an “App Running” dialog with “Play anyway” or “Cancel”.
  - Suppress disconnect banners during conflicts; add `SteamEvent.PlayingBlocked`, track with `_isHandlingConflict`, and expose `SteamService.clearPlayingConflict()`.
  - Persist dialog state across Activity recreation and use safe calls when cancelling.

<sup>Written for commit 4d10a07395d8d38293c067644383653135d54ebc. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1319?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

