### PR TITLE
feat: show remaining storage space in Storage Manager

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
@@ -134,12 +134,13 @@ class ContainerStorageManagerUiState internal constructor(
 
         scope.launch {
             isLoading = true
-            runCatching {
-                ContainerStorageManager.getVolumeInfo(appContext)
-            }.onSuccess {
-                volumeInfo = it
-            }.onFailure { error ->
-                Timber.w(error, "Failed to query volume info")
+            try {
+                volumeInfo = ContainerStorageManager.getVolumeInfo(appContext)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                volumeInfo = emptyList()
+                Timber.w(e, "Failed to query volume info")
             }
             runCatching {
                 ContainerStorageManager.loadEntries(appContext)

--- a/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
@@ -90,6 +90,9 @@ class ContainerStorageManagerUiState internal constructor(
     var entries by mutableStateOf<List<ContainerStorageManager.Entry>>(emptyList())
         private set
 
+    var volumeInfo by mutableStateOf<List<ContainerStorageManager.VolumeInfo>>(emptyList())
+        private set
+
     var isLoading by mutableStateOf(false)
         private set
 
@@ -131,6 +134,13 @@ class ContainerStorageManagerUiState internal constructor(
 
         scope.launch {
             isLoading = true
+            runCatching {
+                ContainerStorageManager.getVolumeInfo(appContext)
+            }.onSuccess {
+                volumeInfo = it
+            }.onFailure { error ->
+                Timber.w(error, "Failed to query volume info")
+            }
             runCatching {
                 ContainerStorageManager.loadEntries(appContext)
             }.onSuccess {
@@ -396,20 +406,38 @@ fun ContainerStorageManagerContent(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                text = if (state.isLoading && !state.hasLoaded) {
-                    stringResource(R.string.container_storage_loading)
-                } else {
-                    stringResource(
-                        R.string.container_storage_summary,
-                        state.entries.size,
-                        StorageUtils.formatBinarySize(inventorySummaryBytes(state.entries)),
-                    )
-                },
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.weight(1f),
-            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = if (state.isLoading && !state.hasLoaded) {
+                        stringResource(R.string.container_storage_loading)
+                    } else {
+                        stringResource(
+                            R.string.container_storage_summary,
+                            state.entries.size,
+                            StorageUtils.formatBinarySize(inventorySummaryBytes(state.entries)),
+                        )
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (state.volumeInfo.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        state.volumeInfo.forEach { vol ->
+                            Text(
+                                text = stringResource(
+                                    R.string.storage_free_of_total,
+                                    vol.label,
+                                    StorageUtils.formatBinarySize(vol.freeBytes, decimalPlaces = 1),
+                                    StorageUtils.formatBinarySize(vol.totalBytes, decimalPlaces = 1),
+                                ),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                            )
+                        }
+                    }
+                }
+            }
 
             if (onDismissRequest != null) {
                 IconButton(

--- a/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
@@ -154,16 +154,16 @@ class ContainerStorageManagerUiState internal constructor(
                 }
             }
 
-            runCatching {
-                ContainerStorageManager.loadEntries(appContext)
-            }.onSuccess {
-                entries = it
+            try {
+                entries = ContainerStorageManager.loadEntries(appContext)
                 hasLoaded = true
-            }.onFailure { error ->
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
                 hasLoaded = false
-                Timber.e(error, "Failed to load storage inventory")
+                Timber.e(e, "Failed to load storage inventory")
                 SnackbarManager.show(
-                    error.message ?: appContext.getString(R.string.container_storage_unknown_error),
+                    e.message ?: appContext.getString(R.string.container_storage_unknown_error),
                 )
             }
 

--- a/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
@@ -93,6 +93,9 @@ class ContainerStorageManagerUiState internal constructor(
     var volumeInfo by mutableStateOf<List<ContainerStorageManager.VolumeInfo>>(emptyList())
         private set
 
+    var isLoadingExternalVolume by mutableStateOf(false)
+        private set
+
     var isLoading by mutableStateOf(false)
         private set
 
@@ -134,14 +137,23 @@ class ContainerStorageManagerUiState internal constructor(
 
         scope.launch {
             isLoading = true
-            try {
-                volumeInfo = ContainerStorageManager.getVolumeInfo(appContext)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                volumeInfo = emptyList()
-                Timber.w(e, "Failed to query volume info")
+
+            val internal = ContainerStorageManager.getInternalVolumeInfo(appContext)
+            volumeInfo = listOfNotNull(internal)
+
+            val externalConfigured = ContainerStorageManager.isExternalStorageConfigured()
+            isLoadingExternalVolume = externalConfigured
+            val externalJob = launch {
+                try {
+                    val external = ContainerStorageManager.getExternalVolumeInfo(appContext)
+                    if (external != null) {
+                        volumeInfo = volumeInfo + external
+                    }
+                } finally {
+                    isLoadingExternalVolume = false
+                }
             }
+
             runCatching {
                 ContainerStorageManager.loadEntries(appContext)
             }.onSuccess {
@@ -154,6 +166,8 @@ class ContainerStorageManagerUiState internal constructor(
                     error.message ?: appContext.getString(R.string.container_storage_unknown_error),
                 )
             }
+
+            externalJob.join()
             isLoading = false
         }
     }
@@ -421,9 +435,12 @@ fun ContainerStorageManagerContent(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                if (state.volumeInfo.isNotEmpty()) {
+                if (state.volumeInfo.isNotEmpty() || state.isLoadingExternalVolume) {
                     Spacer(modifier = Modifier.height(2.dp))
-                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
                         state.volumeInfo.forEach { vol ->
                             Text(
                                 text = stringResource(
@@ -431,6 +448,16 @@ fun ContainerStorageManagerContent(
                                     vol.label,
                                     StorageUtils.formatBinarySize(vol.freeBytes, decimalPlaces = 1),
                                     StorageUtils.formatBinarySize(vol.totalBytes, decimalPlaces = 1),
+                                ),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                            )
+                        }
+                        if (state.isLoadingExternalVolume) {
+                            Text(
+                                text = stringResource(
+                                    R.string.storage_calculating,
+                                    stringResource(R.string.storage_external),
                                 ),
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),

--- a/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
@@ -422,7 +422,7 @@ fun ContainerStorageManagerContent(
                 )
                 if (state.volumeInfo.isNotEmpty()) {
                     Spacer(modifier = Modifier.height(2.dp))
-                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                         state.volumeInfo.forEach { vol ->
                             Text(
                                 text = stringResource(

--- a/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
@@ -3,6 +3,7 @@ package app.gamenative.utils
 import android.content.Context
 import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
+import app.gamenative.R
 import app.gamenative.data.GameSource
 import app.gamenative.data.LibraryItem
 import app.gamenative.data.SteamApp
@@ -68,6 +69,38 @@ object ContainerStorageManager {
         INTERNAL,
         EXTERNAL,
         UNKNOWN,
+    }
+
+    data class VolumeInfo(
+        val label: String,
+        val freeBytes: Long,
+        val totalBytes: Long,
+    )
+
+    suspend fun getVolumeInfo(context: Context): List<VolumeInfo> = withContext(Dispatchers.IO) {
+        val volumes = mutableListOf<VolumeInfo>()
+        runCatching {
+            volumes += VolumeInfo(
+                label = context.getString(R.string.storage_internal),
+                freeBytes = StorageUtils.getAvailableSpace(context.dataDir.path),
+                totalBytes = StorageUtils.getTotalSpace(context.dataDir.path),
+            )
+        }.onFailure { e ->
+            Timber.w(e, "Failed to query internal storage volume info")
+        }
+        val externalPath = PrefManager.externalStoragePath
+        if (externalPath.isNotBlank() && File(externalPath).exists()) {
+            runCatching {
+                volumes += VolumeInfo(
+                    label = context.getString(R.string.storage_external),
+                    freeBytes = StorageUtils.getAvailableSpace(externalPath),
+                    totalBytes = StorageUtils.getTotalSpace(externalPath),
+                )
+            }.onFailure { e ->
+                Timber.w(e, "Failed to query external storage volume info")
+            }
+        }
+        volumes
     }
 
     data class Entry(

--- a/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
@@ -36,6 +36,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
@@ -77,30 +78,38 @@ object ContainerStorageManager {
         val totalBytes: Long,
     )
 
-    suspend fun getVolumeInfo(context: Context): List<VolumeInfo> = withContext(Dispatchers.IO) {
-        val volumes = mutableListOf<VolumeInfo>()
-        runCatching {
-            volumes += VolumeInfo(
+    suspend fun getInternalVolumeInfo(context: Context): VolumeInfo? = withContext(Dispatchers.IO) {
+        try {
+            VolumeInfo(
                 label = context.getString(R.string.storage_internal),
                 freeBytes = StorageUtils.getAvailableSpace(context.dataDir.path),
                 totalBytes = StorageUtils.getTotalSpace(context.dataDir.path),
             )
-        }.onFailure { e ->
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             Timber.w(e, "Failed to query internal storage volume info")
+            null
         }
+    }
+
+    suspend fun getExternalVolumeInfo(context: Context): VolumeInfo? = withContext(Dispatchers.IO) {
+        if (!PrefManager.useExternalStorage) return@withContext null
         val externalPath = PrefManager.externalStoragePath
-        if (PrefManager.useExternalStorage && externalPath.isNotBlank() && File(externalPath).isDirectory) {
-            runCatching {
-                volumes += VolumeInfo(
-                    label = context.getString(R.string.storage_external),
-                    freeBytes = StorageUtils.getAvailableSpace(externalPath),
-                    totalBytes = StorageUtils.getTotalSpace(externalPath),
-                )
-            }.onFailure { e ->
-                Timber.w(e, "Failed to query external storage volume info")
-            }
+        if (externalPath.isBlank() || !File(externalPath).isDirectory) return@withContext null
+
+        try {
+            VolumeInfo(
+                label = context.getString(R.string.storage_external),
+                freeBytes = StorageUtils.getAvailableSpace(externalPath),
+                totalBytes = StorageUtils.getTotalSpace(externalPath),
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to query external storage volume info")
+            null
         }
-        volumes
     }
 
     data class Entry(

--- a/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
@@ -89,7 +89,7 @@ object ContainerStorageManager {
             Timber.w(e, "Failed to query internal storage volume info")
         }
         val externalPath = PrefManager.externalStoragePath
-        if (externalPath.isNotBlank() && File(externalPath).exists()) {
+        if (PrefManager.useExternalStorage && externalPath.isNotBlank() && File(externalPath).isDirectory) {
             runCatching {
                 volumes += VolumeInfo(
                     label = context.getString(R.string.storage_external),

--- a/app/src/main/java/app/gamenative/utils/StorageUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/StorageUtils.kt
@@ -29,6 +29,15 @@ object StorageUtils {
         return stat.blockSizeLong * stat.availableBlocksLong
     }
 
+    fun getTotalSpace(path: String): Long {
+        val file = File(path)
+        if (!file.exists()) {
+            throw IllegalArgumentException("Invalid path: $path")
+        }
+        val stat = StatFs(path)
+        return stat.blockSizeLong * stat.blockCountLong
+    }
+
     suspend fun getFolderSize(folderPath: String): Long {
         val folder = File(folderPath)
         if (folder.exists()) {

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -64,6 +64,7 @@
     <string name="storage_internal">Intern</string>
     <string name="storage_external">Ekstern</string>
     <string name="storage_free_of_total">%1$s: %2$s ledig af %3$s</string>
+    <string name="storage_calculating">%1$s: Beregner…</string>
     <string name="container_storage_title">Lagerstyring</string>
     <string name="container_storage_subtitle">Flyt installationer mellem intern og ekstern lagerplads</string>
     <string name="container_storage_summary">%1$d elementer • %2$s</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -61,6 +61,9 @@
     <string name="downloads_status_failed">Mislykket</string>
     <string name="downloads_status_paused">Sat på pause</string>
     <string name="downloads_summary">Administrer aktive downloads og lager ét sted</string>
+    <string name="storage_internal">Intern</string>
+    <string name="storage_external">Ekstern</string>
+    <string name="storage_free_of_total">%1$s: %2$s ledig af %3$s</string>
     <string name="container_storage_title">Lagerstyring</string>
     <string name="container_storage_subtitle">Flyt installationer mellem intern og ekstern lagerplads</string>
     <string name="container_storage_summary">%1$d elementer • %2$s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -101,6 +101,7 @@
     <string name="storage_internal">Intern</string>
     <string name="storage_external">Extern</string>
     <string name="storage_free_of_total">%1$s: %2$s frei von %3$s</string>
+    <string name="storage_calculating">%1$s: Wird berechnet…</string>
     <string name="container_storage_title">Speicherverwaltung</string>
     <string name="container_storage_subtitle">Installationen zwischen internem und externem Speicher verschieben</string>
     <string name="container_storage_summary">%1$d Einträge • %2$s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -98,6 +98,9 @@
     <string name="downloads_status_failed">Fehlgeschlagen</string>
     <string name="downloads_status_paused">Pausiert</string>
     <string name="downloads_summary">Aktive Downloads und Speicher an einem Ort verwalten</string>
+    <string name="storage_internal">Intern</string>
+    <string name="storage_external">Extern</string>
+    <string name="storage_free_of_total">%1$s: %2$s frei von %3$s</string>
     <string name="container_storage_title">Speicherverwaltung</string>
     <string name="container_storage_subtitle">Installationen zwischen internem und externem Speicher verschieben</string>
     <string name="container_storage_summary">%1$d Einträge • %2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -112,6 +112,9 @@
     <string name="downloads_status_failed">Fallido</string>
     <string name="downloads_status_paused">Pausado</string>
     <string name="downloads_summary">Gestiona descargas activas y almacenamiento en un solo lugar</string>
+    <string name="storage_internal">Interno</string>
+    <string name="storage_external">Externo</string>
+    <string name="storage_free_of_total">%1$s: %2$s libres de %3$s</string>
     <string name="container_storage_title">Administrador de almacenamiento</string>
     <string name="container_storage_subtitle">Mueve instalaciones entre almacenamiento interno y externo</string>
     <string name="container_storage_summary">%1$d elementos • %2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -115,6 +115,7 @@
     <string name="storage_internal">Interno</string>
     <string name="storage_external">Externo</string>
     <string name="storage_free_of_total">%1$s: %2$s libres de %3$s</string>
+    <string name="storage_calculating">%1$s: Calculando…</string>
     <string name="container_storage_title">Administrador de almacenamiento</string>
     <string name="container_storage_subtitle">Mueve instalaciones entre almacenamiento interno y externo</string>
     <string name="container_storage_summary">%1$d elementos • %2$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -103,6 +103,9 @@
     <string name="downloads_status_failed">Échec</string>
     <string name="downloads_status_paused">En pause</string>
     <string name="downloads_summary">Gérez les téléchargements actifs et le stockage au même endroit</string>
+    <string name="storage_internal">Interne</string>
+    <string name="storage_external">Externe</string>
+    <string name="storage_free_of_total">%1$s : %2$s libre sur %3$s</string>
     <string name="container_storage_title">Gestionnaire de stockage</string>
     <string name="container_storage_subtitle">Déplacez les installations entre le stockage interne et externe</string>
     <string name="container_storage_summary">%1$d éléments • %2$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -106,6 +106,7 @@
     <string name="storage_internal">Interne</string>
     <string name="storage_external">Externe</string>
     <string name="storage_free_of_total">%1$s : %2$s libre sur %3$s</string>
+    <string name="storage_calculating">%1$s : Calcul…</string>
     <string name="container_storage_title">Gestionnaire de stockage</string>
     <string name="container_storage_subtitle">Déplacez les installations entre le stockage interne et externe</string>
     <string name="container_storage_summary">%1$d éléments • %2$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -103,6 +103,9 @@
     <string name="downloads_status_failed">Fallito</string>
     <string name="downloads_status_paused">In pausa</string>
     <string name="downloads_summary">Gestisci download attivi e archiviazione in un unico posto</string>
+    <string name="storage_internal">Interno</string>
+    <string name="storage_external">Esterno</string>
+    <string name="storage_free_of_total">%1$s: %2$s liberi su %3$s</string>
     <string name="container_storage_title">Gestione archiviazione</string>
     <string name="container_storage_subtitle">Sposta le installazioni tra archiviazione interna ed esterna</string>
     <string name="container_storage_summary">%1$d elementi • %2$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -106,6 +106,7 @@
     <string name="storage_internal">Interno</string>
     <string name="storage_external">Esterno</string>
     <string name="storage_free_of_total">%1$s: %2$s liberi su %3$s</string>
+    <string name="storage_calculating">%1$s: Calcolo in corso…</string>
     <string name="container_storage_title">Gestione archiviazione</string>
     <string name="container_storage_subtitle">Sposta le installazioni tra archiviazione interna ed esterna</string>
     <string name="container_storage_summary">%1$d elementi • %2$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -112,6 +112,9 @@
     <string name="downloads_status_failed">실패</string>
     <string name="downloads_status_paused">일시중지됨</string>
     <string name="downloads_summary">한곳에서 진행 중인 다운로드와 저장소를 관리합니다</string>
+    <string name="storage_internal">내부</string>
+    <string name="storage_external">외부</string>
+    <string name="storage_free_of_total">%1$s: %3$s 중 %2$s 사용 가능</string>
     <string name="container_storage_title">저장소 관리자</string>
     <string name="container_storage_subtitle">내부 저장소와 외부 저장소 사이에서 설치 항목을 이동합니다</string>
     <string name="container_storage_summary">%1$d개 항목 • %2$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -115,6 +115,7 @@
     <string name="storage_internal">내부</string>
     <string name="storage_external">외부</string>
     <string name="storage_free_of_total">%1$s: %3$s 중 %2$s 사용 가능</string>
+    <string name="storage_calculating">%1$s: 계산 중…</string>
     <string name="container_storage_title">저장소 관리자</string>
     <string name="container_storage_subtitle">내부 저장소와 외부 저장소 사이에서 설치 항목을 이동합니다</string>
     <string name="container_storage_summary">%1$d개 항목 • %2$s</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -112,6 +112,9 @@
     <string name="downloads_status_failed">Nieudane</string>
     <string name="downloads_status_paused">Wstrzymano</string>
     <string name="downloads_summary">Zarządzaj aktywnymi pobraniami i pamięcią w jednym miejscu</string>
+    <string name="storage_internal">Wewnętrzny</string>
+    <string name="storage_external">Zewnętrzny</string>
+    <string name="storage_free_of_total">%1$s: %2$s wolne z %3$s</string>
     <string name="container_storage_title">Menedżer pamięci</string>
     <string name="container_storage_subtitle">Przenoś instalacje między pamięcią wewnętrzną i zewnętrzną</string>
     <string name="container_storage_summary">%1$d elementów • %2$s</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -115,6 +115,7 @@
     <string name="storage_internal">Wewnętrzny</string>
     <string name="storage_external">Zewnętrzny</string>
     <string name="storage_free_of_total">%1$s: %2$s wolne z %3$s</string>
+    <string name="storage_calculating">%1$s: Obliczanie…</string>
     <string name="container_storage_title">Menedżer pamięci</string>
     <string name="container_storage_subtitle">Przenoś instalacje między pamięcią wewnętrzną i zewnętrzną</string>
     <string name="container_storage_summary">%1$d elementów • %2$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -57,6 +57,9 @@
     <string name="downloads_status_failed">Falhou</string>
     <string name="downloads_status_paused">Pausado</string>
     <string name="downloads_summary">Gerencie downloads ativos e armazenamento em um só lugar</string>
+    <string name="storage_internal">Interno</string>
+    <string name="storage_external">Externo</string>
+    <string name="storage_free_of_total">%1$s: %2$s livre de %3$s</string>
     <string name="container_storage_title">Gerenciador de armazenamento</string>
     <string name="container_storage_subtitle">Mova instalações entre armazenamento interno e externo</string>
     <string name="container_storage_summary">%1$d itens • %2$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -60,6 +60,7 @@
     <string name="storage_internal">Interno</string>
     <string name="storage_external">Externo</string>
     <string name="storage_free_of_total">%1$s: %2$s livre de %3$s</string>
+    <string name="storage_calculating">%1$s: Calculando…</string>
     <string name="container_storage_title">Gerenciador de armazenamento</string>
     <string name="container_storage_subtitle">Mova instalações entre armazenamento interno e externo</string>
     <string name="container_storage_summary">%1$d itens • %2$s</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -103,6 +103,9 @@
     <string name="downloads_status_failed">Eșuat</string>
     <string name="downloads_status_paused">În pauză</string>
     <string name="downloads_summary">Gestionează descărcările active și stocarea într-un singur loc</string>
+    <string name="storage_internal">Intern</string>
+    <string name="storage_external">Extern</string>
+    <string name="storage_free_of_total">%1$s: %2$s liber din %3$s</string>
     <string name="container_storage_title">Manager stocare</string>
     <string name="container_storage_subtitle">Mută instalările între stocarea internă și externă</string>
     <string name="container_storage_summary">%1$d elemente • %2$s</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -106,6 +106,7 @@
     <string name="storage_internal">Intern</string>
     <string name="storage_external">Extern</string>
     <string name="storage_free_of_total">%1$s: %2$s liber din %3$s</string>
+    <string name="storage_calculating">%1$s: Se calculează…</string>
     <string name="container_storage_title">Manager stocare</string>
     <string name="container_storage_subtitle">Mută instalările între stocarea internă și externă</string>
     <string name="container_storage_summary">%1$d elemente • %2$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1164,6 +1164,7 @@ https://gamenative.app
     <string name="storage_internal">Внутренняя</string>
     <string name="storage_external">Внешняя</string>
     <string name="storage_free_of_total">%1$s: %2$s свободно из %3$s</string>
+    <string name="storage_calculating">%1$s: Вычисление…</string>
     <string name="container_storage_title">Менеджер хранилища</string>
     <string name="container_storage_subtitle">Перемещайте установки между внутренним и внешним хранилищем</string>
     <string name="container_storage_summary">%1$d элементов • %2$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1161,6 +1161,9 @@ https://gamenative.app
     <string name="downloads_status_failed">Ошибка</string>
     <string name="downloads_status_paused">Приостановлено</string>
     <string name="downloads_summary">Управляйте активными загрузками и хранилищем в одном месте</string>
+    <string name="storage_internal">Внутренняя</string>
+    <string name="storage_external">Внешняя</string>
+    <string name="storage_free_of_total">%1$s: %2$s свободно из %3$s</string>
     <string name="container_storage_title">Менеджер хранилища</string>
     <string name="container_storage_subtitle">Перемещайте установки между внутренним и внешним хранилищем</string>
     <string name="container_storage_summary">%1$d элементов • %2$s</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -103,6 +103,7 @@
     <string name="storage_internal">Внутрішня</string>
     <string name="storage_external">Зовнішня</string>
     <string name="storage_free_of_total">%1$s: %2$s вільно з %3$s</string>
+    <string name="storage_calculating">%1$s: Обчислення…</string>
     <string name="container_storage_title">Менеджер сховища</string>
     <string name="container_storage_subtitle">Переміщуйте встановлення між внутрішнім і зовнішнім сховищем</string>
     <string name="container_storage_summary">%1$d елементів • %2$s</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -100,6 +100,9 @@
     <string name="downloads_status_failed">Помилка</string>
     <string name="downloads_status_paused">Призупинено</string>
     <string name="downloads_summary">Керуйте активними завантаженнями та сховищем в одному місці</string>
+    <string name="storage_internal">Внутрішня</string>
+    <string name="storage_external">Зовнішня</string>
+    <string name="storage_free_of_total">%1$s: %2$s вільно з %3$s</string>
     <string name="container_storage_title">Менеджер сховища</string>
     <string name="container_storage_subtitle">Переміщуйте встановлення між внутрішнім і зовнішнім сховищем</string>
     <string name="container_storage_summary">%1$d елементів • %2$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -106,6 +106,7 @@
     <string name="storage_internal">内部</string>
     <string name="storage_external">外部</string>
     <string name="storage_free_of_total">%1$s：%3$s 中有 %2$s 可用</string>
+    <string name="storage_calculating">%1$s：计算中…</string>
     <string name="container_storage_title">存储管理</string>
     <string name="container_storage_subtitle">在内部存储与外部存储之间移动安装内容</string>
     <string name="container_storage_summary">%1$d 项 • %2$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -103,6 +103,9 @@
     <string name="downloads_status_failed">失败</string>
     <string name="downloads_status_paused">已暂停</string>
     <string name="downloads_summary">在一处管理活动下载和存储</string>
+    <string name="storage_internal">内部</string>
+    <string name="storage_external">外部</string>
+    <string name="storage_free_of_total">%1$s：%3$s 中有 %2$s 可用</string>
     <string name="container_storage_title">存储管理</string>
     <string name="container_storage_subtitle">在内部存储与外部存储之间移动安装内容</string>
     <string name="container_storage_summary">%1$d 项 • %2$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -106,6 +106,7 @@
     <string name="storage_internal">內部</string>
     <string name="storage_external">外部</string>
     <string name="storage_free_of_total">%1$s：%3$s 中有 %2$s 可用</string>
+    <string name="storage_calculating">%1$s：計算中…</string>
     <string name="container_storage_title">儲存管理</string>
     <string name="container_storage_subtitle">在內部儲存與外部儲存之間移動安裝內容</string>
     <string name="container_storage_summary">%1$d 項 • %2$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -103,6 +103,9 @@
     <string name="downloads_status_failed">失敗</string>
     <string name="downloads_status_paused">已暫停</string>
     <string name="downloads_summary">在同一處管理進行中的下載與儲存</string>
+    <string name="storage_internal">內部</string>
+    <string name="storage_external">外部</string>
+    <string name="storage_free_of_total">%1$s：%3$s 中有 %2$s 可用</string>
     <string name="container_storage_title">儲存管理</string>
     <string name="container_storage_subtitle">在內部儲存與外部儲存之間移動安裝內容</string>
     <string name="container_storage_summary">%1$d 項 • %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -950,6 +950,9 @@
     <string name="settings_storage_title">Storage</string>
     <string name="settings_storage_manage_title">Storage Manager</string>
     <string name="settings_storage_manage_subtitle">Review game and container storage in one place</string>
+    <string name="storage_internal">Internal</string>
+    <string name="storage_external">External</string>
+    <string name="storage_free_of_total">%1$s: %2$s free of %3$s</string>
     <string name="container_storage_title">Container &amp; Storage Manager</string>
     <string name="container_storage_subtitle">Review game and container storage, including installed games without containers</string>
     <string name="container_storage_summary">%1$d items • %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -953,6 +953,7 @@
     <string name="storage_internal">Internal</string>
     <string name="storage_external">External</string>
     <string name="storage_free_of_total">%1$s: %2$s free of %3$s</string>
+    <string name="storage_calculating">%1$s: Calculating…</string>
     <string name="container_storage_title">Container &amp; Storage Manager</string>
     <string name="container_storage_subtitle">Review game and container storage, including installed games without containers</string>
     <string name="container_storage_summary">%1$d items • %2$s</string>


### PR DESCRIPTION
## Description

The Storage Manager showed total used space across all installations but gave no indication of how much free space remained on each volume. Users had no way to tell at a glance whether they had room to install or move games.

Requested by Kyoka in Discord.

**Changes:**

- **`StorageUtils.kt`**: adds `getTotalSpace(path)` mirroring the existing `getAvailableSpace(path)` using `StatFs`.
- **`ContainerStorageManager.kt`**
  - Adds `VolumeInfo(label, freeBytes, totalBytes)` data class.
  - Adds `suspend fun getVolumeInfo(context)` (runs on `Dispatchers.IO`) that returns one entry for internal storage and one for external if configured, with Timber logging on failure.
- **`ContainerStorageManagerDialog.kt`**
  - Adds `volumeInfo` state to `ContainerStorageManagerUiState`, populated at the start of `refresh()` in its own `runCatching` block.
  - Header now shows a second line beneath the item/size summary with free-of-total per volume, e.g. `Internal: 12.3 GiB free of 128.0 GiB`.
- **`strings.xml` and all 13 language files**: adds `storage_internal`, `storage_external`, `storage_free_of_total`.

## Recording

<img width="1376" height="774" alt="image" src="https://github.com/user-attachments/assets/d7de5ec9-7c2c-4c7b-b16b-1300a0a856f3" />

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

## Test plan
- [x] Open Storage Manager: header shows free/total beneath existing summary
- [x] Device with no external storage configured: only Internal line appears
- [x] Device with external storage configured: both lines appear
- [x] No regression to move, uninstall, or remove container flows
- [x] Large external memory doesn't cause the screen to lockup


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show remaining free space per storage volume in Storage Manager so users can quickly see if there’s room to install or move games. The header shows “Internal/External: X free of Y” beneath the summary; external loads in parallel with a “Calculating…” placeholder and only appears when `useExternalStorage` is enabled and the path is valid.

- **New Features**
  - Added `VolumeInfo` and split into `getInternalVolumeInfo(context)` and `getExternalVolumeInfo(context)` in `ContainerStorageManager` (runs on IO, logs failures).
  - External volume info loads in parallel and shows a “Calculating…” placeholder until ready.
  - Added `getTotalSpace(path)` to `StorageUtils`; added `storage_internal`, `storage_external`, `storage_free_of_total`, `storage_calculating` strings with translations.

- **Bug Fixes**
  - Stacked per-volume lines under the header with clean wrapping.
  - Rethrow `CancellationException` from `loadEntries()` and volume lookups; gate external on valid directory when `useExternalStorage` is enabled.

<sup>Written for commit 19e13c3bcf6f0b9eb0f6f3f7db44b658be07497c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage Manager now shows per-volume "free of total" lines in the dialog header for internal and (when configured) external storage.
* **Reliability**
  * External/internal capacity queries run separately so the dialog remains responsive; external lookup shows a "calculating" line while in progress.
* **Localization**
  * Storage labels and formatted capacity strings added for many locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->