### PR TITLE
Proton symlink fixes

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/settings/ContentsManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/ContentsManagerDialog.kt
@@ -102,7 +102,7 @@ fun ContentsManagerDialog(open: Boolean, onDismiss: () -> Unit) {
                 val latch = CountDownLatch(1)
                 try {
                     mgr.extraContentFile(uri, object : ContentsManager.OnInstallFinishedCallback {
-                        override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception) {
+                        override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception?) {
                             failReason = reason
                             err = e
                             latch.countDown()
@@ -407,7 +407,7 @@ private suspend fun performFinishInstall(
         val latch = CountDownLatch(1)
         try {
             mgr.finishInstallContent(profile, object : ContentsManager.OnInstallFinishedCallback {
-                override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception) {
+                override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception?) {
                     message = when (reason) {
                         ContentsManager.InstallFailedReason.ERROR_EXIST -> "Content already exists"
                         ContentsManager.InstallFailedReason.ERROR_NOSPACE -> "Not enough space"

--- a/app/src/main/java/app/gamenative/ui/screen/settings/WineProtonManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/WineProtonManagerDialog.kt
@@ -219,7 +219,7 @@ fun WineProtonManagerDialog(open: Boolean, onDismiss: () -> Unit) {
                     val startTime = System.currentTimeMillis()
 
                     mgr.extraContentFile(uri, object : ContentsManager.OnInstallFinishedCallback {
-                        override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception) {
+                        override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception?) {
                             failReason = reason
                             err = e
                             latch.countDown()
@@ -403,7 +403,7 @@ fun WineProtonManagerDialog(open: Boolean, onDismiss: () -> Unit) {
                     val latch = CountDownLatch(1)
                     try {
                         mgr.extraContentFile(uri, object : ContentsManager.OnInstallFinishedCallback {
-                            override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception) {
+                            override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception?) {
                                 failReason = reason
                                 err = e
                                 latch.countDown()
@@ -989,12 +989,12 @@ private suspend fun performFinishInstall(
         val latch = CountDownLatch(1)
         try {
             mgr.finishInstallContent(profile, object : ContentsManager.OnInstallFinishedCallback {
-                override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception) {
+                override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception?) {
                     Timber.tag("WineProtonManagerDialog").e(e, "   ❌ finishInstallContent FAILED: $reason")
                     message = when (reason) {
                         ContentsManager.InstallFailedReason.ERROR_EXIST -> context.getString(R.string.wine_proton_version_already_exists)
                         ContentsManager.InstallFailedReason.ERROR_NOSPACE -> context.getString(R.string.wine_proton_error_nospace)
-                        else -> context.getString(R.string.wine_proton_install_failed, e.message ?: context.getString(R.string.wine_proton_error_unknown))
+                        else -> context.getString(R.string.wine_proton_install_failed, e?.message ?: context.getString(R.string.wine_proton_error_unknown))
                     }
                     success = false
                     latch.countDown()

--- a/app/src/main/java/app/gamenative/utils/ManifestInstaller.kt
+++ b/app/src/main/java/app/gamenative/utils/ManifestInstaller.kt
@@ -129,7 +129,7 @@ object ManifestInstaller {
         val latch = CountDownLatch(1)
         try {
             mgr.extraContentFile(uri, object : ContentsManager.OnInstallFinishedCallback {
-                override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception) {
+                override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception?) {
                     failReason = reason
                     err = e
                     latch.countDown()
@@ -158,7 +158,7 @@ object ManifestInstaller {
         val latch = CountDownLatch(1)
         try {
             mgr.finishInstallContent(profile, object : ContentsManager.OnInstallFinishedCallback {
-                override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception) {
+                override fun onFailed(reason: ContentsManager.InstallFailedReason, e: Exception?) {
                     latch.countDown()
                 }
 

--- a/app/src/main/java/com/winlator/contents/ContentsManager.java
+++ b/app/src/main/java/com/winlator/contents/ContentsManager.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.winlator.core.FileUtils;
 import com.winlator.core.TarCompressorUtils;
@@ -85,7 +86,7 @@ public class ContentsManager {
     }
 
     public interface OnInstallFinishedCallback {
-        void onFailed(InstallFailedReason reason, Exception e);
+        void onFailed(InstallFailedReason reason, @Nullable Exception e);
 
         void onSucceed(ContentProfile profile);
     }

--- a/app/src/main/java/com/winlator/xenvironment/ImageFSLegacyMigrator.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFSLegacyMigrator.java
@@ -78,7 +78,11 @@ public final class ImageFSLegacyMigrator {
 
             File sharedProtonDir = new File(ImageFs.getSharedProtonDir(context), entry.getName());
             if (sharedProtonDir.exists()) {
-                Log.w("ImageFSLegacyMigrator", "Shared Proton already exists; refusing to overwrite during migration: " + entry.getName());
+                Log.w("ImageFSLegacyMigrator", "Shared Proton already exists; removing duplicate legacy opt entry: " + entry.getName());
+                if (!FileUtils.delete(entry)) {
+                    Log.w("ImageFSLegacyMigrator", "Failed to remove duplicate legacy Proton directory: " + entry.getAbsolutePath());
+                    return false;
+                }
                 continue;
             }
 

--- a/app/src/test/java/app/gamenative/utils/ManifestIdCorrelationTest.kt
+++ b/app/src/test/java/app/gamenative/utils/ManifestIdCorrelationTest.kt
@@ -91,16 +91,18 @@ class ManifestIdCorrelationTest {
             println("Content download/install type=$typeKey id=${entry.id} name=${entry.name} url=${entry.url}")
             val result = ManifestInstaller.downloadAndInstallContent(context, entry, expectedType)
             println("Content install result type=$typeKey id=${entry.id} success=${result.success} message=${result.message}")
-            assertTrue(
-                "Content install failed for ${entry.id} (${typeKey}): ${result.message}",
-                result.success,
-            )
             manager.syncContents()
             val profiles = manager.getProfiles(expectedType).orEmpty()
             println("Content installed profiles type=$typeKey count=${profiles.size}")
             installedProfile = profiles.firstOrNull { profile ->
                 val installedId = "${profile.verName}-${profile.verCode}"
                 installedId.equals(entry.id, ignoreCase = true)
+            }
+            if (!result.success && installedProfile == null) {
+                assertTrue(
+                    "Content install failed for ${entry.id} (${typeKey}): ${result.message}",
+                    result.success,
+                )
             }
             val installedIds = profiles.map { "${it.verName}-${it.verCode}" }
             println("Content installed IDs type=$typeKey ids=$installedIds")

--- a/app/src/test/java/com/winlator/xenvironment/ImageFSLegacyMigratorTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFSLegacyMigratorTest.kt
@@ -119,7 +119,7 @@ class ImageFSLegacyMigratorTest {
     }
 
     @Test
-    fun migrateLegacyDirsIfNeeded_doesNotOverwriteExistingSharedProtonDir() {
+    fun migrateLegacyDirsIfNeeded_removesLegacyProtonDirWhenSharedAlreadyExists() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
         val legacyProton = File(legacyImageFsRoot, "opt/proton-ge-9-5").apply { mkdirs() }
         File(legacyProton, "from-legacy.txt").writeText("legacy")
@@ -130,7 +130,7 @@ class ImageFSLegacyMigratorTest {
         val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
 
         assertTrue(migrated)
-        assertTrue("Legacy proton should remain when shared exists", legacyProton.exists())
+        assertFalse("Legacy proton should be removed when shared exists", legacyProton.exists())
         assertEquals("shared", File(existingShared, "existing.txt").readText())
     }
 }


### PR DESCRIPTION
## Description
- Switching back and forth can cause leftover protons since they would not be deleted when they already exist in the shared dir.  Updated that now to be deleted as well.
- Also an error in Wine/Proton Manager was causing the actual error "Wine version already exists" to not be visible. Made it nullable so the actual correct error is shown.

## Recording
None

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes leftover Proton directories by deleting duplicate legacy entries during migration, and prevents crashes in Wine/Proton installs by handling nullable errors and showing the correct “already exists” message.

- **Bug Fixes**
  - Migration: `ImageFSLegacyMigrator` now removes the legacy Proton dir when a shared Proton with the same name exists; it fails migration if deletion fails; updated test asserts removal.
  - Error handling: `ContentsManager.OnInstallFinishedCallback.onFailed` accepts a nullable `Exception`; updated callers (`WineProtonManagerDialog`, `ContentsManagerDialog`, `ManifestInstaller`) to avoid NPEs and surface the proper “version already exists” message.

<sup>Written for commit cf3f0b66d206f488b2ce6b8328178b5e61c18416. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1323?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Proton legacy migration to remove duplicate legacy directories when a shared directory already exists, avoiding upgrade conflicts.

* **Improvements**
  * Improved installation and content management error handling to gracefully handle cases where detailed error information is absent, producing clearer fallback messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->