### PR TITLE
fix/feat: add FSR Fit scaling mode to preserve container aspect ratio

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
@@ -86,6 +86,7 @@ private fun scalingModeLabelRes(mode: Int): Int = when (mode) {
     ScreenEffectsConfig.SCALING_MODE_FILL -> R.string.screen_effects_scaling_mode_fill
     ScreenEffectsConfig.SCALING_MODE_STRETCH -> R.string.screen_effects_scaling_mode_stretch
     ScreenEffectsConfig.SCALING_MODE_FSR -> R.string.screen_effects_scaling_mode_fsr
+    ScreenEffectsConfig.SCALING_MODE_FSR_ASPECT -> R.string.screen_effects_scaling_mode_fsr_aspect
     else -> R.string.screen_effects_scaling_mode_none
 }
 
@@ -189,17 +190,17 @@ fun ScreenEffectsTabContent(
             progress = normalizedProgress(
                 scalingMode.toFloat(),
                 ScreenEffectsConfig.SCALING_MODE_NONE.toFloat(),
-                ScreenEffectsConfig.SCALING_MODE_FSR.toFloat(),
+                ScreenEffectsConfig.SCALING_MODE_FSR_ASPECT.toFloat(),
             ),
             onDecrease = {
                 scalingMode = (scalingMode - 1).coerceAtLeast(ScreenEffectsConfig.SCALING_MODE_NONE)
             },
             onIncrease = {
-                scalingMode = (scalingMode + 1).coerceAtMost(ScreenEffectsConfig.SCALING_MODE_FSR)
+                scalingMode = (scalingMode + 1).coerceAtMost(ScreenEffectsConfig.SCALING_MODE_FSR_ASPECT)
             },
             focusRequester = firstItemFocusRequester,
         )
-        if (scalingMode == ScreenEffectsConfig.SCALING_MODE_FSR) {
+        if (scalingMode == ScreenEffectsConfig.SCALING_MODE_FSR || scalingMode == ScreenEffectsConfig.SCALING_MODE_FSR_ASPECT) {
             ScreenEffectAdjustmentRow(
                 title = stringResource(R.string.screen_effects_fsr_sharpness),
                 valueText = stringResource(R.string.screen_effects_fsr_sharpness_value, fsrSharpnessLevel),

--- a/app/src/main/java/app/gamenative/ui/util/ScreenEffectsConfig.kt
+++ b/app/src/main/java/app/gamenative/ui/util/ScreenEffectsConfig.kt
@@ -33,6 +33,7 @@ data class ScreenEffectsConfig(
         const val SCALING_MODE_FILL = 3
         const val SCALING_MODE_STRETCH = 4
         const val SCALING_MODE_FSR = 5
+        const val SCALING_MODE_FSR_ASPECT = 6
         const val FSR_MIN_LEVEL = 1
         const val FSR_MAX_LEVEL = 5
         const val FSR_DEFAULT_LEVEL = 3
@@ -102,8 +103,10 @@ fun applyScreenEffectsConfig(renderer: GLRenderer, config: ScreenEffectsConfig) 
     val effects = mutableListOf<Effect>()
 
     when (config.scalingMode) {
-        ScreenEffectsConfig.SCALING_MODE_FSR -> {
-            effects += composer.getEffect(FSR1EasuEffect::class.java) ?: FSR1EasuEffect()
+        ScreenEffectsConfig.SCALING_MODE_FSR, ScreenEffectsConfig.SCALING_MODE_FSR_ASPECT -> {
+            val easuEffect = composer.getEffect(FSR1EasuEffect::class.java) ?: FSR1EasuEffect()
+            easuEffect.setPreserveAspect(config.scalingMode == ScreenEffectsConfig.SCALING_MODE_FSR_ASPECT)
+            effects += easuEffect
             val rcasEffect = composer.getEffect(FSR1RcasEffect::class.java) ?: FSR1RcasEffect()
             rcasEffect.sharpnessStops = fsrQuickMenuLevelToStops(config.fsrSharpnessLevel)
             effects += rcasEffect

--- a/app/src/main/java/com/winlator/renderer/effects/FSR1EasuEffect.java
+++ b/app/src/main/java/com/winlator/renderer/effects/FSR1EasuEffect.java
@@ -14,9 +14,24 @@ import com.winlator.renderer.material.ShaderMaterial;
  * Released under the MIT license by AMD.
  */
 public class FSR1EasuEffect extends Effect implements RenderScaleEffect {
+    private boolean preserveAspect = false;
+
+    public boolean isPreserveAspect() {
+        return preserveAspect;
+    }
+
+    public void setPreserveAspect(boolean preserveAspect) {
+        this.preserveAspect = preserveAspect;
+    }
+
     @Override
     protected ShaderMaterial createMaterial() {
         return new FSR1EasuMaterial();
+    }
+
+    @Override
+    protected void onUse(ShaderMaterial material, GLRenderer renderer) {
+        material.setUniformFloat("preserveAspect", preserveAspect ? 1.0f : 0.0f);
     }
 
     @Override
@@ -31,7 +46,7 @@ public class FSR1EasuEffect extends Effect implements RenderScaleEffect {
 
     private static class FSR1EasuMaterial extends ScreenMaterial {
         public FSR1EasuMaterial() {
-            setUniformNames("screenTexture", "inputResolution", "outputResolution");
+            setUniformNames("screenTexture", "inputResolution", "outputResolution", "preserveAspect");
         }
 
         @Override
@@ -41,6 +56,7 @@ public class FSR1EasuEffect extends Effect implements RenderScaleEffect {
                 "uniform sampler2D screenTexture;\n" +
                 "uniform vec2 inputResolution;\n" +
                 "uniform vec2 outputResolution;\n" +
+                "uniform float preserveAspect;\n" +
                 "varying vec2 vUV;\n" +
                 "vec3 FsrEasuCF(vec2 p) { return texture2D(screenTexture, p).rgb; }\n" +
                 "void FsrEasuCon(out vec4 con0, out vec4 con1, out vec4 con2, out vec4 con3, vec2 inputViewportInPixels, vec2 inputSizeInPixels, vec2 outputSizeInPixels) {\n" +
@@ -144,11 +160,33 @@ public class FSR1EasuEffect extends Effect implements RenderScaleEffect {
                 "    pix = min(max4, max(min4, aC / max(aW, 1e-6)));\n" +
                 "}\n" +
                 "void main() {\n" +
-                "    vec3 color;\n" +
-                "    vec4 con0, con1, con2, con3;\n" +
-                "    FsrEasuCon(con0, con1, con2, con3, inputResolution, inputResolution, outputResolution);\n" +
-                "    FsrEasuF(color, gl_FragCoord.xy, con0, con1, con2, con3);\n" +
-                "    gl_FragColor = vec4(color, texture2D(screenTexture, vUV).a);\n" +
+                "    if (preserveAspect > 0.5) {\n" +
+                "        float inputAspect = inputResolution.x / inputResolution.y;\n" +
+                "        float outputAspect = outputResolution.x / outputResolution.y;\n" +
+                "        vec2 scaledOutput = outputResolution;\n" +
+                "        if (outputAspect > inputAspect) {\n" +
+                "            scaledOutput.x = outputResolution.y * inputAspect;\n" +
+                "        } else {\n" +
+                "            scaledOutput.y = outputResolution.x / inputAspect;\n" +
+                "        }\n" +
+                "        vec2 offset = 0.5 * (outputResolution - scaledOutput);\n" +
+                "        vec2 coord = gl_FragCoord.xy - offset;\n" +
+                "        if (coord.x < 0.0 || coord.x > scaledOutput.x || coord.y < 0.0 || coord.y > scaledOutput.y) {\n" +
+                "            gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);\n" +
+                "            return;\n" +
+                "        }\n" +
+                "        vec3 color;\n" +
+                "        vec4 con0, con1, con2, con3;\n" +
+                "        FsrEasuCon(con0, con1, con2, con3, inputResolution, inputResolution, scaledOutput);\n" +
+                "        FsrEasuF(color, coord, con0, con1, con2, con3);\n" +
+                "        gl_FragColor = vec4(color, 1.0);\n" +
+                "    } else {\n" +
+                "        vec3 color;\n" +
+                "        vec4 con0, con1, con2, con3;\n" +
+                "        FsrEasuCon(con0, con1, con2, con3, inputResolution, inputResolution, outputResolution);\n" +
+                "        FsrEasuF(color, gl_FragCoord.xy, con0, con1, con2, con3);\n" +
+                "        gl_FragColor = vec4(color, texture2D(screenTexture, vUV).a);\n" +
+                "    }\n" +
                 "}";
         }
     }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1480,6 +1480,7 @@
     <string name="screen_effects_scaling_mode_fill">填充</string>
     <string name="screen_effects_scaling_mode_stretch">拉伸</string>
     <string name="screen_effects_scaling_mode_fsr">FSR</string>
+    <string name="screen_effects_scaling_mode_fsr_aspect">FSR 适配</string>
     <string name="screen_effects_fsr">FSR 1.0</string>
     <string name="screen_effects_fsr_description">官方 AMD FidelityFX Super Resolution 1.0，使用 EASU + RCAS，以较低的内部分辨率渲染并进行全分辨率放大。</string>
     <string name="screen_effects_fsr_quality">FSR 质量</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1474,6 +1474,7 @@
     <string name="screen_effects_scaling_mode_fill">填充</string>
     <string name="screen_effects_scaling_mode_stretch">拉伸</string>
     <string name="screen_effects_scaling_mode_fsr">FSR</string>
+    <string name="screen_effects_scaling_mode_fsr_aspect">FSR 適配</string>
     <string name="screen_effects_fsr">FSR 1.0</string>
     <string name="screen_effects_fsr_description">官方 AMD FidelityFX Super Resolution 1.0，使用 EASU + RCAS，以較低的內部分辨率渲染並進行全分辨率放大。</string>
     <string name="screen_effects_fsr_quality">FSR 品質</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -252,6 +252,7 @@
     <string name="screen_effects_scaling_mode_fill">Fill</string>
     <string name="screen_effects_scaling_mode_stretch">Stretch</string>
     <string name="screen_effects_scaling_mode_fsr">FSR</string>
+    <string name="screen_effects_scaling_mode_fsr_aspect">FSR Fit</string>
     <string name="screen_effects_fsr">FSR 1.0</string>
     <string name="screen_effects_fsr_description">Official AMD FidelityFX Super Resolution 1.0 using EASU + RCAS with a lower internal render resolution and full-resolution upscale.</string>
     <string name="screen_effects_fsr_quality">FSR quality</string>


### PR DESCRIPTION
## Description

per https://discord.com/channels/1378308569287622737/1498878194386993244


Adds a new "FSR Fit" scaling mode that preserves the container's aspect ratio when FSR upscaling rather than filling the target screen ratio. When the container aspect ratio differs from the display (e.g. a 16:9 container on a 16:10 screen), FSR Fit letterboxes/pillarboxes with black bars. The sharpness slider is available for both FSR and FSR Fit modes.

I dont have a non 16:9 device to demo on, so heres a 16:9 game forced into a 4:3 container to demo, I think it gets the idea across at least


## Recording

https://github.com/user-attachments/assets/4822729e-525c-4688-8d13-cf75b077e6a3


## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an FSR Fit scaling mode that preserves the container’s aspect ratio during FSR upscaling to avoid stretching. When ratios differ, it letterboxes/pillarboxes with black bars; the sharpness slider works for both FSR and FSR Fit.

- New Features
  - Added `FSR Fit` (`SCALING_MODE_FSR_ASPECT`) to the scaling slider (None → Nearest → Linear → Fill → Stretch → FSR → FSR Fit).
  - `FSR1EasuEffect` now supports a `preserveAspect` uniform and shader path to compute black bars; wired via `applyScreenEffectsConfig`.
  - UI shows FSR sharpness control for both `FSR` and `FSR Fit`, with new labels in `values`, `values-zh-rCN`, and `values-zh-rTW`.

<sup>Written for commit a0df6bb0877e20f53e2b58998830fee967b4e92e. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1326?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "FSR Fit" scaling mode that preserves aspect ratio during upscaling, offering an alternative to standard FSR scaling for improved visual presentation.

* **Localization**
  * Added Chinese (Simplified and Traditional) translations for the new scaling mode option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->