### PR TITLE
Call migration before bionic downloader as well

### DIFF
--- a/app/src/main/java/app/gamenative/utils/launchdependencies/BionicDefaultProtonDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/BionicDefaultProtonDependency.kt
@@ -7,6 +7,7 @@ import app.gamenative.utils.LOADING_PROGRESS_UNKNOWN
 import com.winlator.container.Container
 import com.winlator.core.TarCompressorUtils
 import com.winlator.xenvironment.ImageFs
+import com.winlator.xenvironment.ImageFSLegacyMigrator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
@@ -48,6 +49,14 @@ object BionicDefaultProtonDependency : LaunchDependency {
     ) = coroutineScope {
         val protonVersion = container.wineVersion
         val imageFs = withContext(Dispatchers.IO) { ImageFs.find(context) }
+
+        withContext(Dispatchers.IO) {
+            val legacyImageFsRoot = File(context.filesDir, "imagefs")
+            ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+        }
+
+        if (isSatisfied(context, container, gameSource, gameId)) return@coroutineScope
+
         val archiveName = when {
             protonVersion.contains("proton-9.0-arm64ec") -> "proton-9.0-arm64ec.txz"
             protonVersion.contains("proton-9.0-x86_64") -> "proton-9.0-x86_64.txz"

--- a/app/src/test/java/app/gamenative/utils/launchdependencies/BionicDefaultProtonDependencyTest.kt
+++ b/app/src/test/java/app/gamenative/utils/launchdependencies/BionicDefaultProtonDependencyTest.kt
@@ -7,6 +7,7 @@ import app.gamenative.service.SteamService
 import com.winlator.container.Container
 import com.winlator.core.TarCompressorUtils
 import com.winlator.xenvironment.ImageFs
+import com.winlator.xenvironment.ImageFSLegacyMigrator
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -25,9 +26,11 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import java.io.File
 
 @RunWith(RobolectricTestRunner::class)
+@Config(application = android.app.Application::class)
 class BionicDefaultProtonDependencyTest {
     private lateinit var context: Context
     private lateinit var container: Container
@@ -36,6 +39,8 @@ class BionicDefaultProtonDependencyTest {
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
         container = mockk(relaxed = true)
+        mockkStatic(ImageFSLegacyMigrator::class)
+        every { ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(any(), any()) } returns true
     }
 
     @After
@@ -96,73 +101,106 @@ class BionicDefaultProtonDependencyTest {
     }
 
     @Test
-    fun install_returnsEarly_whenProtonVersionIsUnsupported() = runBlocking {
-        every { container.wineVersion } returns "wine-ge-custom"
-        mockkObject(SteamService.Companion)
-        mockkStatic(TarCompressorUtils::class)
+    fun install_returnsEarly_whenProtonVersionIsUnsupported() {
+        runBlocking {
+            every { container.wineVersion } returns "wine-ge-custom"
+            mockkObject(SteamService.Companion)
+            mockkStatic(TarCompressorUtils::class)
 
-        BionicDefaultProtonDependency.install(
-            context = context,
-            container = container,
-            callbacks = LaunchDependencyCallbacks({}, {}),
-            gameSource = GameSource.STEAM,
-            gameId = 8,
-        )
-
-        verify(exactly = 0) {
-            SteamService.downloadFile(
-                onDownloadProgress = any(),
-                parentScope = any(),
-                context = any(),
-                fileName = any(),
+            BionicDefaultProtonDependency.install(
+                context = context,
+                container = container,
+                callbacks = LaunchDependencyCallbacks({}, {}),
+                gameSource = GameSource.STEAM,
+                gameId = 8,
             )
+
+            verify(exactly = 0) {
+                SteamService.downloadFile(
+                    onDownloadProgress = any(),
+                    parentScope = any(),
+                    context = any(),
+                    fileName = any(),
+                )
+            }
         }
     }
 
     @Test
-    fun install_downloadsArchive_andForwardsProgress() = runBlocking {
-        every { container.wineVersion } returns "proton-9.0-arm64ec"
-        mockkObject(SteamService.Companion)
+    fun install_downloadsArchive_andForwardsProgress() {
+        runBlocking {
+            every { container.wineVersion } returns "proton-9.0-arm64ec"
+            mockkObject(SteamService.Companion)
+            mockkStatic(TarCompressorUtils::class)
+            every { TarCompressorUtils.extract(any(), any<File>(), any()) } returns true
 
-        val binDir = File(ImageFs.getSharedProtonDir(context), "proton-9.0-arm64ec/bin")
-        binDir.mkdirs()
+            every { SteamService.isFileInstallable(context, "proton-9.0-arm64ec.txz") } returns false
 
-        every { SteamService.isFileInstallable(context, "proton-9.0-arm64ec.txz") } returns false
+            val onProgressSlot = slot<(Float) -> Unit>()
+            val deferred = mockk<Deferred<Unit>>()
+            every {
+                SteamService.downloadFile(
+                    onDownloadProgress = capture(onProgressSlot),
+                    parentScope = any(),
+                    context = context,
+                    fileName = "proton-9.0-arm64ec.txz",
+                )
+            } answers {
+                onProgressSlot.captured(0.42f)
+                deferred
+            }
+            coEvery { deferred.await() } returns Unit
 
-        val onProgressSlot = slot<(Float) -> Unit>()
-        val deferred = mockk<Deferred<Unit>>()
-        every {
-            SteamService.downloadFile(
-                onDownloadProgress = capture(onProgressSlot),
-                parentScope = any(),
+            val progressValues = mutableListOf<Float>()
+            BionicDefaultProtonDependency.install(
                 context = context,
-                fileName = "proton-9.0-arm64ec.txz",
+                container = container,
+                callbacks = LaunchDependencyCallbacks(
+                    setLoadingMessage = {},
+                    setLoadingProgress = { progressValues += it },
+                ),
+                gameSource = GameSource.STEAM,
+                gameId = 9,
             )
-        } returns deferred
-        coEvery { deferred.await() } returns Unit
 
-        val progressValues = mutableListOf<Float>()
-        BionicDefaultProtonDependency.install(
-            context = context,
-            container = container,
-            callbacks = LaunchDependencyCallbacks(
-                setLoadingMessage = {},
-                setLoadingProgress = { progressValues += it },
-            ),
-            gameSource = GameSource.STEAM,
-            gameId = 9,
-        )
-
-        onProgressSlot.captured(0.42f)
-
-        verify(exactly = 1) {
-            SteamService.downloadFile(
-                onDownloadProgress = any(),
-                parentScope = any(),
-                context = context,
-                fileName = "proton-9.0-arm64ec.txz",
-            )
+            verify(exactly = 1) {
+                SteamService.downloadFile(
+                    onDownloadProgress = any(),
+                    parentScope = any(),
+                    context = context,
+                    fileName = "proton-9.0-arm64ec.txz",
+                )
+            }
+            assertTrue(progressValues.contains(0.42f))
         }
-        assertEquals(listOf(0.42f), progressValues)
+    }
+
+    @Test
+    fun install_callsMigration_beforeCheckingSatisfaction() {
+        runBlocking {
+            every { container.wineVersion } returns "proton-9.0-arm64ec"
+            mockkObject(SteamService.Companion)
+
+            // Ensure it's satisfied AFTER migration by creating the bin dir in shared location
+            val sharedProtonDir = File(ImageFs.getSharedProtonDir(context), "proton-9.0-arm64ec")
+            val binDir = File(sharedProtonDir, "bin")
+            binDir.mkdirs()
+
+            BionicDefaultProtonDependency.install(
+                context = context,
+                container = container,
+                callbacks = LaunchDependencyCallbacks({}, {}),
+                gameSource = GameSource.STEAM,
+                gameId = 10,
+            )
+
+            verify(exactly = 1) {
+                ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, any())
+            }
+            // Should not download because it's now satisfied
+            verify(exactly = 0) {
+                SteamService.downloadFile(any(), any(), any(), any())
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
Fixed the proton downloading/migration order by running the migration in the proton downloader as well.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run legacy ImageFS migration before the bionic Proton downloader to fix the install order and avoid unnecessary downloads. Proton satisfaction is now checked after migration.

- **Bug Fixes**
  - Call `ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded` before `isSatisfied` in `BionicDefaultProtonDependency.install`, and exit early if already satisfied.
  - Updated tests to mock the migrator, verify no download when satisfied, and ensure progress forwarding via `SteamService.downloadFile`.

<sup>Written for commit 87451e7bc3f5cd5c0abb9f8ffc2e7e2885cce49c. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1329?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

