### PR TITLE
fix: FPS limiter undershoots target by 2-3 FPS with microstutters

### DIFF
--- a/app/src/main/java/com/winlator/widget/XServerView.java
+++ b/app/src/main/java/com/winlator/widget/XServerView.java
@@ -4,9 +4,6 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Rect;
 import android.opengl.GLSurfaceView;
-import android.os.Handler;
-import android.os.Looper;
-import android.os.SystemClock;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
@@ -27,19 +24,7 @@ public class XServerView extends GLSurfaceView {
     private final GLRenderer renderer;
     // private final ArrayList<Callback<MotionEvent>> mouseEventCallbacks = new ArrayList<>();
     private final XServer xServer;
-    private final Object renderThrottleLock = new Object();
-    private final Handler renderThrottleHandler = new Handler(Looper.getMainLooper());
     private int frameRateLimit = 0;
-    private long minRenderIntervalMs = 0L;
-    private long lastRenderRequestUptimeMs = 0L;
-    private boolean renderRequestScheduled = false;
-    private final Runnable throttledRenderRunnable = () -> {
-        synchronized (renderThrottleLock) {
-            renderRequestScheduled = false;
-            lastRenderRequestUptimeMs = SystemClock.uptimeMillis();
-        }
-        XServerView.super.requestRender();
-    };
 
     public XServerView(Context context, XServer xServer) {
         super(context);
@@ -71,60 +56,12 @@ public class XServerView extends GLSurfaceView {
     }
 
     public int getFrameRateLimit() {
-        synchronized (renderThrottleLock) {
-            return frameRateLimit;
-        }
+        return frameRateLimit;
     }
 
     public void setFrameRateLimit(int frameRateLimit) {
-        final boolean shouldRecomputeRender;
-        synchronized (renderThrottleLock) {
-            boolean hadScheduledRender = renderRequestScheduled;
-            this.frameRateLimit = Math.max(0, frameRateLimit);
-            minRenderIntervalMs = this.frameRateLimit > 0
-                ? Math.max(1L, Math.round(1000f / (float) this.frameRateLimit))
-                : 0L;
-
-            if (hadScheduledRender) {
-                renderThrottleHandler.removeCallbacks(throttledRenderRunnable);
-                renderRequestScheduled = false;
-            }
-            shouldRecomputeRender = this.frameRateLimit == 0 || hadScheduledRender;
-        }
-
-        if (shouldRecomputeRender) {
-            requestRender();
-        }
-    }
-
-    @Override
-    public void requestRender() {
-        long delayMs = 0L;
-
-        synchronized (renderThrottleLock) {
-            if (frameRateLimit <= 0) {
-                super.requestRender();
-                return;
-            }
-
-            long now = SystemClock.uptimeMillis();
-            long remainingDelay = minRenderIntervalMs - (now - lastRenderRequestUptimeMs);
-            if (!renderRequestScheduled && remainingDelay <= 0L) {
-                lastRenderRequestUptimeMs = now;
-            } else {
-                if (renderRequestScheduled) {
-                    return;
-                }
-                renderRequestScheduled = true;
-                delayMs = Math.max(1L, remainingDelay);
-            }
-        }
-
-        if (delayMs == 0L) {
-            super.requestRender();
-        } else {
-            renderThrottleHandler.postDelayed(throttledRenderRunnable, delayMs);
-        }
+        this.frameRateLimit = Math.max(0, frameRateLimit);
+        requestRender();
     }
 
     // public void addPointerEventListener(Callback<MotionEvent> listener) {

--- a/app/src/main/java/com/winlator/xserver/extensions/PresentExtension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/PresentExtension.java
@@ -214,6 +214,7 @@ public class PresentExtension implements Extension {
                 final int finalSerial = serial;
                 final int finalIdleFence = idleFence;
                 final long finalScheduledUst = scheduledUst;
+                long delayNs = delayUs * 1_000L;
                 presentScheduler.schedule(() -> {
                     try {
                         if (limitGeneration.get() == capturedGen) {
@@ -232,7 +233,7 @@ public class PresentExtension implements Extension {
                     } catch (Exception ignored) {
                         // Client may have disconnected before the scheduled notify fired.
                     }
-                }, delayUs / 1_000L, TimeUnit.MILLISECONDS);
+                }, delayNs, TimeUnit.NANOSECONDS);
             }
         }
     }


### PR DESCRIPTION
## Description

The FPS clamped to setting 60 fps gives you more like 54-57 with the number bouncing around and noticeable microstutters. Meanwhile DXVK_FRAME_RATE=60 pins it at 60 no problem. per discussion at https://discord.com/channels/1378308569287622737/1499053905391386685

There were two separate throttles running at the same time and they were both a bit sloppy. XServerView was rounding the interval to whole milliseconds (1000/60 rounds up to 17ms, which is a 58.8 fps ceiling), and PresentExtension was truncating its schedule delay from microseconds down to milliseconds so it was losing sub-ms precision too. Neither one could compensate for the other, so the frame interval always drifted above what you asked for.

here I removed the GL-side throttle from XServerView entirely since PresentExtension already handles pacing by delaying IdleNotify/CompleteNotify back to the game and also switched PresentExtension to schedule in nanoseconds instead of milliseconds so it keeps the full resolution of the interval (16,666 µs stays 16,666,000 ns instead of getting chopped to 16ms).

## Recording

https://github.com/user-attachments/assets/c8d2e78c-1a12-4dfd-b78c-e5ca35052a8f



## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved timing accuracy for scheduled events using nanosecond-precision timing instead of millisecond-based calculations.

* **Refactor**
  * Simplified frame-rate limit handling by removing the custom render throttling mechanism. Setting frame-rate limits no longer applies custom render delays; rendering follows the platform's default timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->