### PR TITLE
Run FS migrator before protons are downloaded

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -106,6 +106,7 @@ import com.winlator.container.ContainerData
 import com.winlator.container.ContainerManager
 import com.winlator.core.StringUtils
 import com.winlator.core.TarCompressorUtils
+import com.winlator.xenvironment.ImageFSLegacyMigrator
 import com.winlator.xenvironment.ImageFs
 import com.winlator.xenvironment.ImageFsInstaller
 import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientObjects.ECloudPendingRemoteOperation
@@ -1549,6 +1550,27 @@ fun preLaunchApp(
 
         val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
         val isLocalSavesOnly = ContainerUtils.isLocalSavesOnly(context, appId)
+
+        // Migrate legacy on-disk imagefs layout (e.g. legacy Proton → shared paths) before manifest
+        // installs or launch deps — resolveMissingManifestInstallRequests can install Proton too.
+        val legacyImageFsRoot = File(context.filesDir, "imagefs")
+        val migrationOk = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+        if (!migrationOk) {
+            Timber.tag("preLaunchApp").e(
+                "Legacy ImageFS migration failed: ${legacyImageFsRoot.absolutePath}",
+            )
+            setLoadingDialogVisible(false)
+            setMessageDialogState(
+                MessageDialogState(
+                    visible = true,
+                    type = DialogType.SYNC_FAIL,
+                    title = context.getString(R.string.install_failed_title),
+                    message = context.getString(R.string.install_failed_message),
+                    dismissBtnText = context.getString(R.string.ok),
+                ),
+            )
+            return@launch
+        }
 
         // When "Open container" is used we boot to desktop/file manager only — skip executable check
         if (!bootToContainer) {


### PR DESCRIPTION
# Description
Fixed the proton downloading/migration order by running the migration in the proton downloader as well.

# Type of Change
 Bug fix
 
Checklist
 [x] If I have access to #code-changes, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
[x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
[ ] I have attached a recording of the change.
[x] I have read and agree to the contribution guidelines in CONTRIBUTING.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automatic on-device data migration during app startup to ensure older data is moved into the correct place.
  * If migration fails, the app stops launch preparation, closes the loading screen, and shows a synchronous installation failure message to inform the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->