### PR TITLE
Fixed stylus handling in TouchpadView

### DIFF
--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -322,7 +322,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        boolean isStylus = isEventTriggeredByStulus(event);
+        boolean isStylus = isEventTriggeredByStylus(event);
         if (touchscreenMouseDisabled
                 && !isStylus
                 && !event.isFromSource(InputDevice.SOURCE_MOUSE)) {
@@ -339,7 +339,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
     @Override
     public boolean onHoverEvent(MotionEvent event) {
-        if (isEventTriggeredByStulus(event)) {
+        if (isEventTriggeredByStylus(event)) {
             return handleStylusHoverEvent(event);
         }
         return super.onHoverEvent(event);
@@ -388,14 +388,17 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         return true;
     }
 
-    private static boolean isEventTriggeredByStulus(MotionEvent event) {
+    private static boolean isEventTriggeredByStylus(MotionEvent event) {
         int toolType = event.getToolType(0);
         return toolType == MotionEvent.TOOL_TYPE_STYLUS || toolType == MotionEvent.TOOL_TYPE_ERASER;
     }
 
     private static boolean isStylusButtonPressed(MotionEvent event) {
         int buttonState = event.getButtonState();
-        boolean stylusButtonPressed = (buttonState & (MotionEvent.BUTTON_STYLUS_PRIMARY | MotionEvent.BUTTON_SECONDARY)) != 0;
+        boolean stylusButtonPressed = (buttonState & (MotionEvent.BUTTON_STYLUS_PRIMARY
+                | MotionEvent.BUTTON_STYLUS_SECONDARY
+                | MotionEvent.BUTTON_SECONDARY
+        )) != 0;
         boolean toolSetToEraser = event.getToolType(0) == MotionEvent.TOOL_TYPE_ERASER;
         return stylusButtonPressed || toolSetToEraser;
     }

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -381,6 +381,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
                 handleStylusMove(event);
                 break;
             case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
                 handleStylusUp(event);
                 break;
         }

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -1,21 +1,18 @@
 package com.winlator.widget;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
-import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.StateListDrawable;
-import android.os.Handler;
 import android.util.Log;
 import android.view.InputDevice;
 import android.view.MotionEvent;
-import android.view.PointerIcon;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
-import app.gamenative.R;
 import app.gamenative.data.TouchGestureConfig;
+import timber.log.Timber;
+
 import com.winlator.core.AppUtils;
 import com.winlator.math.Mathf;
 import com.winlator.math.XForm;
@@ -325,13 +322,13 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        int toolType = event.getToolType(0);
+        boolean isStylus = isEventTriggeredByStulus(event);
         if (touchscreenMouseDisabled
-                && toolType != MotionEvent.TOOL_TYPE_STYLUS
+                && !isStylus
                 && !event.isFromSource(InputDevice.SOURCE_MOUSE)) {
             return true; // consume without generating mouse events
         }
-        if (toolType == MotionEvent.TOOL_TYPE_STYLUS) {
+        if (isStylus) {
             return handleStylusEvent(event);
         } else if (isTouchscreenMode) {
             return handleTouchscreenEvent(event);
@@ -340,20 +337,28 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         }
     }
 
-    private boolean handleStylusHoverEvent(MotionEvent event) {
-        int action = event.getActionMasked();
+    @Override
+    public boolean onHoverEvent(MotionEvent event) {
+        if (isEventTriggeredByStulus(event)) {
+            return handleStylusHoverEvent(event);
+        }
+        return super.onHoverEvent(event);
+    }
 
+    private boolean handleStylusHoverEvent(MotionEvent event) {
+        if (xServer.isRelativeMouseMovement()) return false;
+
+        int action = event.getActionMasked();
         switch (action) {
             case MotionEvent.ACTION_HOVER_ENTER:
-                Log.d("StylusEvent", "Hover Enter");
-                break;
+                Timber.tag("StylusEvent").d("Hover Enter");
             case MotionEvent.ACTION_HOVER_MOVE:
-                Log.d("StylusEvent", "Hover Move: (" + event.getX() + ", " + event.getY() + ")");
+                Timber.tag("StylusEvent").d("Hover Move: (" + event.getX() + ", " + event.getY() + ")");
                 float[] transformedPoint = XForm.transformPoint(xform, event.getX(), event.getY());
                 xServer.injectPointerMove((int) transformedPoint[0], (int) transformedPoint[1]);
                 break;
             case MotionEvent.ACTION_HOVER_EXIT:
-                Log.d("StylusEvent", "Hover Exit");
+                Timber.tag("StylusEvent").d("Hover Exit");
                 break;
             default:
                 return false;
@@ -363,11 +368,10 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
     private boolean handleStylusEvent(MotionEvent event) {
         int action = event.getActionMasked();
-        int buttonState = event.getButtonState();
 
         switch (action) {
             case MotionEvent.ACTION_DOWN:
-                if ((buttonState & MotionEvent.BUTTON_SECONDARY) != 0) {
+                if (isStylusButtonPressed(event)) {
                     handleStylusRightClick(event);
                 } else {
                     handleStylusLeftClick(event);
@@ -382,6 +386,18 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         }
 
         return true;
+    }
+
+    private static boolean isEventTriggeredByStulus(MotionEvent event) {
+        int toolType = event.getToolType(0);
+        return toolType == MotionEvent.TOOL_TYPE_STYLUS || toolType == MotionEvent.TOOL_TYPE_ERASER;
+    }
+
+    private static boolean isStylusButtonPressed(MotionEvent event) {
+        int buttonState = event.getButtonState();
+        boolean stylusButtonPressed = (buttonState & (MotionEvent.BUTTON_STYLUS_PRIMARY | MotionEvent.BUTTON_SECONDARY)) != 0;
+        boolean toolSetToEraser = event.getToolType(0) == MotionEvent.TOOL_TYPE_ERASER;
+        return stylusButtonPressed || toolSetToEraser;
     }
 
     private void handleStylusLeftClick(MotionEvent event) {


### PR DESCRIPTION
## Description
Using stylus, for example S-Pen, didn't support hovering over the screen to move the mouse, so it was impossible to read tooltips. I also enabled the right click by holding the side button and tapping
It was partially implemented, but one of the methods wasn't even used anywhere

## Recording

https://github.com/user-attachments/assets/a98e027d-6f74-48f6-a9f8-d7c55bfa641d

https://github.com/user-attachments/assets/3c1581cf-c1e3-4f03-914c-3195ead38d73

## Type of Change
- [X] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stylus interactions in TouchpadView. Adds hover cursor movement and reliable right‑click with stylus buttons or eraser, so tooltips and context menus work.

- **Bug Fixes**
  - Support stylus/eraser hover with transformed coordinates; skip in relative mouse mode.
  - Reliable right‑click via stylus primary/secondary buttons or eraser tip.
  - Allow stylus and mouse input when touchscreen mode is disabled.
  - Handle ACTION_CANCEL to release presses and prevent stuck clicks.

- **Refactors**
  - Added helpers for stylus/eraser detection and button state.
  - Switched logging from `android.util.Log` to `timber.log.Timber`.

<sup>Written for commit f2b070a52a77ae4ee36edabda968788125bbdcee. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1334?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and routing of stylus and eraser inputs for more reliable touchpad behavior
  * Treated eraser as stylus and mapped eraser/tool mode to secondary (right-click) actions
  * Added hover event support for stylus interactions and proper handling when relative mouse movement is enabled
  * Now handles canceled stylus interactions consistently with lifts
  * Replaced ad-hoc debug logs with structured logging for stylus events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->