### PR TITLE
Fix glibc runtime package paths

### DIFF
--- a/app/src/main/java/com/winlator/xenvironment/GlibcRuntimePathPatcher.java
+++ b/app/src/main/java/com/winlator/xenvironment/GlibcRuntimePathPatcher.java
@@ -1,0 +1,218 @@
+package com.winlator.xenvironment;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.winlator.container.Container;
+import com.winlator.core.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public final class GlibcRuntimePathPatcher {
+    private static final String TAG = "GlibcRuntimePathPatcher";
+    private static final String IMAGEFS_ALIAS = "imgfs";
+
+    private static final String[] PATCHED_RUNTIME_FILES = {
+        "usr/lib/libX11.so",
+        "usr/lib/libX11.so.6",
+        "usr/lib/libX11.so.6.4.0",
+        "usr/lib/libxcb.so",
+        "usr/lib/libxcb.so.1",
+        "usr/lib/libxcb.so.1.1.0",
+        "usr/lib/libredirect.so",
+    };
+
+    private GlibcRuntimePathPatcher() {
+    }
+
+    public static void patch(Context context, ImageFs imageFs, String containerVariant) {
+        if (!Container.GLIBC.equals(containerVariant)) {
+            return;
+        }
+
+        ensureImageFsAlias(context);
+
+        int patched = 0;
+        for (String relativePath : PATCHED_RUNTIME_FILES) {
+            patched += patchFileForPackage(new File(imageFs.getRootDir(), relativePath), context.getPackageName());
+        }
+
+        if (patched > 0) {
+            Log.i(TAG, "Patched " + patched + " glibc runtime path reference(s)");
+        }
+    }
+
+    private static void ensureImageFsAlias(Context context) {
+        File alias = new File(context.getDataDir(), IMAGEFS_ALIAS);
+        if (Files.isSymbolicLink(alias.toPath())) {
+            return;
+        }
+
+        if (alias.exists() && !FileUtils.delete(alias)) {
+            Log.w(TAG, "Unable to replace existing imagefs alias: " + alias.getPath());
+            return;
+        }
+
+        FileUtils.symlink("files/imagefs", alias.getPath());
+    }
+
+    static int patchFileForPackage(File file, String packageName) {
+        if (!file.isFile() || Files.isSymbolicLink(file.toPath())) {
+            return 0;
+        }
+
+        byte[] data;
+        try {
+            data = Files.readAllBytes(file.toPath());
+        } catch (IOException e) {
+            Log.w(TAG, "Unable to read " + file.getPath(), e);
+            return 0;
+        }
+
+        int patched = patchBytesForPackage(data, packageName);
+        if (patched == 0) {
+            return 0;
+        }
+
+        try {
+            Files.write(file.toPath(), data);
+            FileUtils.chmod(file, 0755);
+        } catch (IOException e) {
+            Log.e(TAG, "Unable to write patched runtime file " + file.getPath(), e);
+            return 0;
+        }
+        return patched;
+    }
+
+    static int patchBytesForPackage(byte[] data, String packageName) {
+        String aliasPath = "/data/data/" + packageName + "/" + IMAGEFS_ALIAS;
+        String aliasRelativePath = packageName + "/" + IMAGEFS_ALIAS;
+
+        List<Replacement> replacements = new ArrayList<>();
+        replacements.add(new Replacement(
+            "/data/data/com.winlator/files/imagefs/usr/tmp/.X11-unix/X",
+            aliasPath + "/usr/tmp/.X11-unix/X"
+        ));
+        replacements.add(new Replacement(
+            "/data/data/com.winlator/files/imagefs/usr/tmp/.XIM-unix/XIM",
+            aliasPath + "/usr/tmp/.XIM-unix/XIM"
+        ));
+        replacements.add(new Replacement(
+            "/data/data/com.winlator/files/imagefs/usr/share/X11/XErrorDB",
+            aliasPath + "/usr/share/X11/XErrorDB"
+        ));
+        replacements.add(new Replacement(
+            "/data/data/com.winlator/files/imagefs/usr/share/X11/XKeysymDB",
+            aliasPath + "/usr/share/X11/XKeysymDB"
+        ));
+        replacements.add(new Replacement(
+            "/data/data/com.winlator/files/imagefs/usr/share/X11/locale",
+            aliasPath + "/usr/share/X11/locale"
+        ));
+        replacements.add(new Replacement(
+            "/data/data/com.winlator/files/imagefs/usr/lib/X11/locale",
+            aliasPath + "/usr/lib/X11/locale"
+        ));
+        replacements.add(new Replacement(
+            "/data/data/com.winlator/files/imagefs/usr/share/X11/Xcms.txt",
+            aliasPath + "/usr/share/X11/Xcms.txt"
+        ));
+        replacements.add(new Replacement(
+            "/data/data/com.winlator/files/imagefs/usr/lib",
+            aliasPath + "/usr/lib"
+        ));
+        replacements.add(new Replacement(
+            "LD_PRELOAD=/data/data/app.gamenative/files/imagefs/libpluviagoldberg.so",
+            "LD_PRELOAD=" + aliasPath + "/libpluviagoldberg.so"
+        ));
+        replacements.add(new Replacement(
+            "/data/data/app.gamenative/files/imagefs/preload_loaded.txt",
+            aliasPath + "/preload_loaded.txt"
+        ));
+        replacements.add(new Replacement(
+            "/data/data/app.gamenative/files/imagefs/usr/tmp",
+            aliasPath + "/usr/tmp"
+        ));
+        replacements.add(new Replacement(
+            "app.gamenative/files/imagefs",
+            aliasRelativePath
+        ));
+
+        replacements.sort(Comparator.comparingInt((Replacement replacement) -> replacement.oldValue.length()).reversed());
+
+        int patched = 0;
+        for (Replacement replacement : replacements) {
+            patched += replaceNullTerminatedAscii(data, replacement.oldValue, replacement.newValue);
+        }
+        return patched;
+    }
+
+    private static int replaceNullTerminatedAscii(byte[] data, String oldValue, String newValue) {
+        byte[] oldBytes = oldValue.getBytes(StandardCharsets.US_ASCII);
+        byte[] newBytes = newValue.getBytes(StandardCharsets.US_ASCII);
+
+        int patched = 0;
+        int start = 0;
+        while (start <= data.length - oldBytes.length) {
+            int index = indexOf(data, oldBytes, start);
+            if (index < 0) {
+                break;
+            }
+
+            int end = index + oldBytes.length;
+            if (end < data.length && data[end] != 0) {
+                start = index + 1;
+                continue;
+            }
+
+            int capacityEnd = end;
+            while (capacityEnd < data.length && data[capacityEnd] == 0) {
+                capacityEnd++;
+            }
+
+            int capacity = capacityEnd - index;
+            if (newBytes.length + 1 > capacity) {
+                start = index + 1;
+                continue;
+            }
+
+            System.arraycopy(newBytes, 0, data, index, newBytes.length);
+            for (int i = index + newBytes.length; i < index + capacity; i++) {
+                data[i] = 0;
+            }
+            patched++;
+            start = index + capacity;
+        }
+
+        return patched;
+    }
+
+    private static int indexOf(byte[] data, byte[] needle, int start) {
+        outer:
+        for (int i = start; i <= data.length - needle.length; i++) {
+            for (int j = 0; j < needle.length; j++) {
+                if (data[i + j] != needle[j]) {
+                    continue outer;
+                }
+            }
+            return i;
+        }
+        return -1;
+    }
+
+    private static final class Replacement {
+        private final String oldValue;
+        private final String newValue;
+
+        private Replacement(String oldValue, String newValue) {
+            this.oldValue = oldValue;
+            this.newValue = newValue;
+        }
+    }
+}

--- a/app/src/main/java/com/winlator/xenvironment/ImageFs.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFs.java
@@ -1,9 +1,11 @@
 package com.winlator.xenvironment;
 
 import android.content.Context;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.winlator.container.Container;
 import com.winlator.core.FileUtils;
 
 import java.io.File;
@@ -54,7 +56,35 @@ public class ImageFs {
     }
 
     public boolean isValid() {
-        return rootDir.isDirectory() && getImgVersionFile().exists();
+        if (!rootDir.isDirectory() || !getImgVersionFile().exists()) return false;
+
+        String variant = getVariant();
+        return hasRequiredRuntimeFiles(variant);
+    }
+
+    public boolean hasRequiredRuntimeFiles(String variant) {
+        if (Container.GLIBC.equals(variant)) {
+            return hasRequiredGlibcRuntimeFiles();
+        }
+
+        return true;
+    }
+
+    private boolean hasRequiredGlibcRuntimeFiles() {
+        String[] requiredPaths = {
+            "usr/lib/ld-linux-aarch64.so.1",
+            "usr/lib/libc.so.6",
+        };
+
+        for (String path : requiredPaths) {
+            File file = new File(rootDir, path);
+            if (!file.isFile()) {
+                Log.w("ImageFs", "Invalid glibc imagefs: missing " + file.getPath());
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public int getVersion() {

--- a/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
@@ -42,7 +42,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class ImageFsInstaller {
-    public static final byte LATEST_VERSION = 28;
+    public static final byte LATEST_VERSION = 29;
 
     private static void resetContainerImgVersions(Context context) {
         ContainerManager manager = new ContainerManager(context);
@@ -137,12 +137,21 @@ public abstract class ImageFsInstaller {
                 });
             }
 
+            ContainerManager containerManager = null;
             if (success) {
                 Log.d("ImageFsInstaller", "Successfully installed system files");
-                ContainerManager containerManager = new ContainerManager(context);
+                containerManager = new ContainerManager(context);
 
                 installWineFromDownloads(context);
                 installGuestLibs(context);
+                GlibcRuntimePathPatcher.patch(context, imageFs, containerVariant);
+                if (!imageFs.hasRequiredRuntimeFiles(containerVariant)) {
+                    Log.e("ImageFsInstaller", "Installed imagefs is missing required runtime files for " + containerVariant);
+                    success = false;
+                }
+            }
+
+            if (success) {
                 imageFs.createImgVersionFile(LATEST_VERSION);
                 resetContainerImgVersions(context);
 
@@ -201,13 +210,17 @@ public abstract class ImageFsInstaller {
         return installIfNeededFuture(context, assetManager, null, null);
     }
     public static Future<Boolean> installIfNeededFuture(final Context context, AssetManager assetManager, Container container, Callback<Integer> onProgress) {
+        String containerVariant = container != null ? container.getContainerVariant() : Container.DEFAULT_VARIANT;
         ImageFs imageFs = ImageFs.find(context);
-        if (!imageFs.isValid() || imageFs.getVersion() < LATEST_VERSION || !imageFs.getVariant().equals(container.getContainerVariant())) {
+        if (!imageFs.isValid() || imageFs.getVersion() < LATEST_VERSION || !imageFs.getVariant().equals(containerVariant)) {
             Log.d("ImageFsInstaller", "Installing image from assets");
-            return installFromAssetsFuture(context, assetManager, container.getContainerVariant(), onProgress);
+            return installFromAssetsFuture(context, assetManager, containerVariant, onProgress);
         } else {
             Log.d("ImageFsInstaller", "Image FS already valid and at latest version");
-            return Executors.newSingleThreadExecutor().submit(() -> true);
+            return Executors.newSingleThreadExecutor().submit(() -> {
+                GlibcRuntimePathPatcher.patch(context, imageFs, containerVariant);
+                return true;
+            });
         }
     }
 

--- a/app/src/test/java/com/winlator/xenvironment/GlibcRuntimePathPatcherTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/GlibcRuntimePathPatcherTest.kt
@@ -1,0 +1,63 @@
+package com.winlator.xenvironment
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GlibcRuntimePathPatcherTest {
+    @Test
+    fun patchBytesForPackage_rewritesX11SocketPathToPackageAlias() {
+        val oldPath = "/data/data/com.winlator/files/imagefs/usr/tmp/.X11-unix/X"
+        val newPath = "/data/data/app.gamenative.debug/imgfs/usr/tmp/.X11-unix/X"
+        val bytes = "before\u0000$oldPath\u0000after".toByteArray(Charsets.US_ASCII)
+
+        val patched = GlibcRuntimePathPatcher.patchBytesForPackage(bytes, "app.gamenative.debug")
+        val patchedText = bytes.toString(Charsets.US_ASCII)
+
+        assertEquals(1, patched)
+        assertFalse(patchedText.contains(oldPath))
+        assertTrue(patchedText.contains(newPath))
+        assertTrue(patchedText.contains("after"))
+    }
+
+    @Test
+    fun patchBytesForPackage_doesNotTruncateUnknownPathsThatShareAPrefix() {
+        val unknownPath = "/data/data/com.winlator/files/imagefs/usr/lib/not-listed"
+        val bytes = "$unknownPath\u0000".toByteArray(Charsets.US_ASCII)
+
+        val patched = GlibcRuntimePathPatcher.patchBytesForPackage(bytes, "app.gamenative.debug")
+        val patchedText = bytes.toString(Charsets.US_ASCII)
+
+        assertEquals(0, patched)
+        assertTrue(patchedText.contains(unknownPath))
+    }
+
+    @Test
+    fun patchBytesForPackage_rewritesLibredirectPathsAndIsIdempotent() {
+        val oldPath = "/data/data/app.gamenative/files/imagefs/usr/tmp"
+        val newPath = "/data/data/app.gamenative.debug/imgfs/usr/tmp"
+        val bytes = "$oldPath\u0000".toByteArray(Charsets.US_ASCII)
+
+        assertEquals(1, GlibcRuntimePathPatcher.patchBytesForPackage(bytes, "app.gamenative.debug"))
+        assertEquals(0, GlibcRuntimePathPatcher.patchBytesForPackage(bytes, "app.gamenative.debug"))
+
+        val patchedText = bytes.toString(Charsets.US_ASCII)
+        assertFalse(patchedText.contains(oldPath))
+        assertTrue(patchedText.contains(newPath))
+    }
+
+    @Test
+    fun patchBytesForPackage_skipsReplacementWhenCapacityIsTooSmall() {
+        val oldPath = "/data/data/com.winlator/files/imagefs/usr/tmp/.X11-unix/X"
+        val bytes = "$oldPath\u0000".toByteArray(Charsets.US_ASCII)
+
+        val patched = GlibcRuntimePathPatcher.patchBytesForPackage(
+            bytes,
+            "app.gamenative.debug.with.a.very.long.suffix",
+        )
+
+        assertEquals(0, patched)
+        assertTrue(bytes.toString(Charsets.US_ASCII).contains(oldPath))
+    }
+}


### PR DESCRIPTION
## Summary
- add a glibc imagefs runtime path patcher for extracted libraries that still contain Winlator/app.gamenative absolute paths
- create a package-local `imgfs -> files/imagefs` alias and rewrite null-terminated runtime strings to `/data/data/<package>/imgfs/...`
- rerun the repair for existing glibc imagefs installs and bump the imagefs version so stale installs are repaired
- validate required glibc runtime files before marking the imagefs install successful

## Why
GameNative runs the glibc stack without Winlator proot path virtualization. Some extracted glibc runtime libraries still point at `/data/data/com.winlator/files/imagefs/...`, which makes `XOpenDisplay(NULL)` fail because Xlib/XCB probes a socket path outside the GameNative package.

## Validation
- `./gradlew :app:testDebugUnitTest --tests com.winlator.xenvironment.GlibcRuntimePathPatcherTest`
- `./gradlew :app:assembleDebugSidecar`
- Real device repro on Samsung SM-F966U1 with glibc + `sd-8-elite` + Wine 9.2 + Box64:
  - imagefs repaired to version 29
  - `libxcb`/`libX11` strings changed from `com.winlator` paths to `app.gamenative.debug/imgfs` paths
  - `winex11.drv` `PROCESS_ATTACH` completed
  - the previous `XOpenDisplay` / `nodrv_CreateWindow` / `Initialization of L"winex11.drv" failed` signature did not recur
  - Backpack Battles launched and remained alive; a later black-surface rendering state remains separate from this X11 path fix


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes glibc runtime libraries that referenced `com.winlator` absolute paths by rewriting them to a package-local `imgfs` alias so X11 looks inside the correct app data and `XOpenDisplay(NULL)` succeeds. Also validates required glibc runtime files and bumps `imagefs` to version 29 to trigger repair on stale installs.

- **Bug Fixes**
  - Adds a patcher that rewrites null-terminated strings in `libX11`, `libxcb`, and `libredirect` from `/data/data/com.winlator/files/imagefs/...` (and `app.gamenative/files/imagefs`) to `/data/data/<package>/imgfs/...`.
  - Creates a package-local `imgfs` symlink under app data and runs the patcher after installs and on existing installs; checks for required glibc files (`ld-linux-aarch64.so.1`, `libc.so.6`) before marking install successful; bumps `imagefs` to v29 to force repair.
  - Adds unit tests for path rewriting, idempotency, and capacity safety.

<sup>Written for commit c2bfda189b9906b19040bf8ed79a3824cb5a2fc5. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1335?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container compatibility through enhanced runtime library validation
  * Automatic adjustment of runtime paths during system installation
  * Added variant-specific filesystem validation checks for proper setup
  * Upgraded system installer with comprehensive validation safeguards (version 29)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->