### PR TITLE
fix: show suspended quick menu processes

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -94,7 +94,6 @@ import app.gamenative.utils.MathUtils.normalizedProgress
 import com.winlator.container.Container
 import com.winlator.renderer.GLRenderer
 import com.winlator.winhandler.ProcessInfo
-import com.winlator.winhandler.WinHandler
 import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 
@@ -237,10 +236,10 @@ fun QuickMenu(
     onItemSelected: (Int) -> Boolean,
     renderer: GLRenderer? = null,
     container: Container? = null,
-    winHandler: WinHandler? = null,
     wineProcesses: List<ProcessInfo> = emptyList(),
     isWineProcessesLoading: Boolean = false,
     onToolsVisibilityChanged: (Boolean) -> Unit = {},
+    onEndWineProcess: (ProcessInfo) -> Unit = {},
     isPerformanceHudEnabled: Boolean = false,
     performanceHudConfig: PerformanceHudConfig = PerformanceHudConfig(),
     fpsLimiterEnabled: Boolean = true,
@@ -571,9 +570,9 @@ fun QuickMenu(
 
                                     QuickMenuTab.TOOLS -> {
                                         ToolsQuickMenuTab(
-                                            winHandler = winHandler,
                                             processes = wineProcesses,
                                             isLoadingProcesses = isWineProcessesLoading,
+                                            onEndProcess = onEndWineProcess,
                                             firstItemFocusRequester = toolsItemFocusRequester,
                                             modifier = Modifier.fillMaxSize(),
                                         )
@@ -638,9 +637,9 @@ fun QuickMenu(
 
 @Composable
 private fun ToolsQuickMenuTab(
-    winHandler: WinHandler?,
     processes: List<ProcessInfo>,
     isLoadingProcesses: Boolean,
+    onEndProcess: (ProcessInfo) -> Unit,
     firstItemFocusRequester: FocusRequester? = null,
     modifier: Modifier = Modifier,
 ) {
@@ -675,7 +674,7 @@ private fun ToolsQuickMenuTab(
                     subtitle = process.formattedMemoryUsage,
                     accentColor = accentColor,
                     onEndProcess = {
-                        winHandler?.killProcess(process.name, process.pid)
+                        onEndProcess(process)
                     },
                     focusRequester = if (index == 0) firstItemFocusRequester else null,
                 )

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -283,46 +283,108 @@ private fun buildEssentialProcessAllowlist(): Set<String> {
     return (essentialServices + CORE_WINE_PROCESSES).toSet()
 }
 
-private suspend fun requestWineProcessSnapshot(winHandler: WinHandler): List<ProcessInfo>? {
-    val previousListener = winHandler.getOnGetProcessInfoListener()
-    val lock = Any()
-    var currentList = mutableListOf<ProcessInfo>()
-    var expectedCount = 0
-    val deferred = CompletableDeferred<List<ProcessInfo>?>()
+private fun readWineProcessSnapshotFromProc(): List<ProcessInfo> {
+    val procDir = File("/proc")
+    val pidDirs = try {
+        procDir.listFiles { file -> file.isDirectory && file.name.all { it.isDigit() } } ?: return emptyList()
+    } catch (_: Exception) {
+        return emptyList()
+    }
 
-    val listener = OnGetProcessInfoListener { index, count, processInfo ->
-        previousListener?.onGetProcessInfo(index, count, processInfo)
-        synchronized(lock) {
-            if (count == 0 && processInfo == null) {
-                if (!deferred.isCompleted) deferred.complete(emptyList())
-                return@synchronized
+    val myUid = android.os.Process.myUid()
+    val processes = mutableListOf<ProcessInfo>()
+
+    for (pidDir in pidDirs) {
+        try {
+            val pid = pidDir.name.toIntOrNull() ?: continue
+            if (pid == android.os.Process.myPid()) continue
+
+            val statusLines = try {
+                File(pidDir, "status").readLines()
+            } catch (_: Exception) {
+                emptyList()
             }
-            if (index == 0) {
-                currentList = mutableListOf()
-                expectedCount = count
-                if (count == 0 && !deferred.isCompleted) {
-                    deferred.complete(emptyList())
-                    return@synchronized
-                }
+            val uid = statusLines
+                .firstOrNull { it.startsWith("Uid:") }
+                ?.trim()
+                ?.split(Regex("\\s+"))
+                ?.getOrNull(1)
+                ?.toIntOrNull()
+            if (uid != null && uid != myUid) continue
+
+            val comm = try { File(pidDir, "comm").readText().trim() } catch (_: Exception) { "" }
+            val stat = try { File(pidDir, "stat").readText() } catch (_: Exception) { "" }
+            val cmdlineBytes = try { File(pidDir, "cmdline").readBytes() } catch (_: Exception) { ByteArray(0) }
+            val cmdlineArgs = cmdlineBytes.toNullSeparatedStrings()
+            val searchableText = buildString {
+                append(comm)
+                append(' ')
+                append(stat)
+                append(' ')
+                append(cmdlineArgs.joinToString(" "))
             }
-            if (processInfo != null) {
-                currentList.add(processInfo)
+
+            if (!searchableText.contains("wine", ignoreCase = true) &&
+                !searchableText.contains(".exe", ignoreCase = true)) {
+                continue
             }
-            if (currentList.size >= expectedCount && !deferred.isCompleted) {
-                deferred.complete(currentList.toList())
-            }
+
+            val name = cmdlineArgs
+                .firstOrNull { it.endsWith(".exe", ignoreCase = true) }
+                ?: cmdlineArgs.firstOrNull { it.contains(".exe", ignoreCase = true) }
+                ?: cmdlineArgs.firstOrNull { it.contains("wine", ignoreCase = true) }
+                ?: comm.ifBlank { null }
+                ?: continue
+
+            val rssBytes = statusLines
+                .firstOrNull { it.startsWith("VmRSS:") }
+                ?.trim()
+                ?.split(Regex("\\s+"))
+                ?.getOrNull(1)
+                ?.toLongOrNull()
+                ?.times(1024L)
+                ?: 0L
+
+            processes.add(
+                ProcessInfo(
+                    pid,
+                    name.substringAfterLast('/').substringAfterLast('\\'),
+                    rssBytes,
+                    0,
+                    false,
+                ),
+            )
+        } catch (_: Exception) {
+            // Process exited or became unreadable while enumerating /proc.
         }
     }
 
-    return try {
-        winHandler.setOnGetProcessInfoListener(listener)
-        winHandler.listProcesses()
-        withTimeoutOrNull(EXIT_PROCESS_RESPONSE_TIMEOUT_MS) {
-            deferred.await()
+    val allowlist = buildEssentialProcessAllowlist()
+    return processes.sortedWith(
+        compareByDescending<ProcessInfo> { normalizeProcessName(it.name) !in allowlist }
+            .thenByDescending { it.memoryUsage },
+    )
+}
+
+private fun ByteArray.toNullSeparatedStrings(): List<String> {
+    if (isEmpty()) return emptyList()
+
+    val result = mutableListOf<String>()
+    var start = 0
+    for (i in indices) {
+        if (this[i] == 0.toByte()) {
+            if (i > start) {
+                val value = String(this, start, i - start).trim()
+                if (value.isNotBlank()) result.add(value)
+            }
+            start = i + 1
         }
-    } finally {
-        winHandler.setOnGetProcessInfoListener(previousListener)
     }
+    if (start < size) {
+        val value = String(this, start, size - start).trim()
+        if (value.isNotBlank()) result.add(value)
+    }
+    return result
 }
 
 // TODO logs in composables are 'unstable' which can cause recomposition (performance issues)
@@ -941,24 +1003,10 @@ fun XServerScreen(
             return@LaunchedEffect
         }
 
-        val winHandler = xServerView?.getxServer()?.winHandler
-        if (winHandler == null) {
-            quickMenuWineProcesses = emptyList()
-            quickMenuWineProcessesLoading = false
-            return@LaunchedEffect
-        }
-
         quickMenuWineProcessesLoading = true
         while (showQuickMenu && quickMenuToolsVisible) {
-            val snapshot = withContext(Dispatchers.IO) {
-                requestWineProcessSnapshot(winHandler)
-                    ?.sortedWith(
-                        compareByDescending<ProcessInfo> { normalizeProcessName(it.name) !in buildEssentialProcessAllowlist() }
-                            .thenByDescending { it.memoryUsage },
-                    )
-            }
-            if (snapshot != null) {
-                quickMenuWineProcesses = snapshot
+            quickMenuWineProcesses = withContext(Dispatchers.IO) {
+                readWineProcessSnapshotFromProc()
             }
             quickMenuWineProcessesLoading = false
             delay(QUICK_MENU_PROCESS_POLL_INTERVAL_MS)
@@ -2381,10 +2429,13 @@ fun XServerScreen(
             onItemSelected = onQuickMenuItemSelected,
             renderer = xServerView?.renderer,
             container = container,
-            winHandler = xServerView?.getxServer()?.winHandler,
             wineProcesses = quickMenuWineProcesses,
             isWineProcessesLoading = quickMenuWineProcessesLoading,
             onToolsVisibilityChanged = { quickMenuToolsVisible = it },
+            onEndWineProcess = { process ->
+                ProcessHelper.killProcess(process.pid)
+                quickMenuWineProcesses = quickMenuWineProcesses.filterNot { it.pid == process.pid }
+            },
             isPerformanceHudEnabled = isPerformanceHudEnabled,
             performanceHudConfig = performanceHudConfig,
             fpsLimiterEnabled = fpsLimiterEnabled,

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -106,6 +106,7 @@ import app.gamenative.utils.ManifestComponentHelper
 import app.gamenative.utils.PreInstallSteps
 import app.gamenative.utils.SteamTokenLogin
 import app.gamenative.utils.SteamUtils
+import app.gamenative.utils.WineProcessSnapshotHelper
 import com.posthog.PostHog
 import com.winlator.alsaserver.ALSAClient
 import com.winlator.container.Container
@@ -281,110 +282,6 @@ private fun buildEssentialProcessAllowlist(): Set<String> {
     val essentialServices = WineUtils.getEssentialServiceNames()
         .map { normalizeProcessName(it) }
     return (essentialServices + CORE_WINE_PROCESSES).toSet()
-}
-
-private fun readWineProcessSnapshotFromProc(): List<ProcessInfo> {
-    val procDir = File("/proc")
-    val pidDirs = try {
-        procDir.listFiles { file -> file.isDirectory && file.name.all { it.isDigit() } } ?: return emptyList()
-    } catch (_: Exception) {
-        return emptyList()
-    }
-
-    val myUid = android.os.Process.myUid()
-    val processes = mutableListOf<ProcessInfo>()
-
-    for (pidDir in pidDirs) {
-        try {
-            val pid = pidDir.name.toIntOrNull() ?: continue
-            if (pid == android.os.Process.myPid()) continue
-
-            val statusLines = try {
-                File(pidDir, "status").readLines()
-            } catch (_: Exception) {
-                emptyList()
-            }
-            val uid = statusLines
-                .firstOrNull { it.startsWith("Uid:") }
-                ?.trim()
-                ?.split(Regex("\\s+"))
-                ?.getOrNull(1)
-                ?.toIntOrNull()
-            if (uid == null || uid != myUid) continue
-
-            val comm = try { File(pidDir, "comm").readText().trim() } catch (_: Exception) { "" }
-            val stat = try { File(pidDir, "stat").readText() } catch (_: Exception) { "" }
-            val cmdlineBytes = try { File(pidDir, "cmdline").readBytes() } catch (_: Exception) { ByteArray(0) }
-            val cmdlineArgs = cmdlineBytes.toNullSeparatedStrings()
-            val searchableText = buildString {
-                append(comm)
-                append(' ')
-                append(stat)
-                append(' ')
-                append(cmdlineArgs.joinToString(" "))
-            }
-
-            if (!searchableText.contains("wine", ignoreCase = true) &&
-                !searchableText.contains(".exe", ignoreCase = true)) {
-                continue
-            }
-
-            val name = cmdlineArgs
-                .firstOrNull { it.endsWith(".exe", ignoreCase = true) }
-                ?: cmdlineArgs.firstOrNull { it.contains(".exe", ignoreCase = true) }
-                ?: cmdlineArgs.firstOrNull { it.contains("wine", ignoreCase = true) }
-                ?: comm.ifBlank { null }
-                ?: continue
-
-            val rssBytes = statusLines
-                .firstOrNull { it.startsWith("VmRSS:") }
-                ?.trim()
-                ?.split(Regex("\\s+"))
-                ?.getOrNull(1)
-                ?.toLongOrNull()
-                ?.times(1024L)
-                ?: 0L
-
-            processes.add(
-                ProcessInfo(
-                    pid,
-                    name.substringAfterLast('/').substringAfterLast('\\'),
-                    rssBytes,
-                    0,
-                    false,
-                ),
-            )
-        } catch (_: Exception) {
-            // Process exited or became unreadable while enumerating /proc.
-        }
-    }
-
-    val allowlist = buildEssentialProcessAllowlist()
-    return processes.sortedWith(
-        compareByDescending<ProcessInfo> { normalizeProcessName(it.name) !in allowlist }
-            .thenByDescending { it.memoryUsage },
-    )
-}
-
-private fun ByteArray.toNullSeparatedStrings(): List<String> {
-    if (isEmpty()) return emptyList()
-
-    val result = mutableListOf<String>()
-    var start = 0
-    for (i in indices) {
-        if (this[i] == 0.toByte()) {
-            if (i > start) {
-                val value = String(this, start, i - start).trim()
-                if (value.isNotBlank()) result.add(value)
-            }
-            start = i + 1
-        }
-    }
-    if (start < size) {
-        val value = String(this, start, size - start).trim()
-        if (value.isNotBlank()) result.add(value)
-    }
-    return result
 }
 
 // TODO logs in composables are 'unstable' which can cause recomposition (performance issues)
@@ -1006,7 +903,7 @@ fun XServerScreen(
         quickMenuWineProcessesLoading = true
         while (showQuickMenu && quickMenuToolsVisible) {
             quickMenuWineProcesses = withContext(Dispatchers.IO) {
-                readWineProcessSnapshotFromProc()
+                WineProcessSnapshotHelper.readFromProc()
             }
             quickMenuWineProcessesLoading = false
             delay(QUICK_MENU_PROCESS_POLL_INTERVAL_MS)

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -310,7 +310,7 @@ private fun readWineProcessSnapshotFromProc(): List<ProcessInfo> {
                 ?.split(Regex("\\s+"))
                 ?.getOrNull(1)
                 ?.toIntOrNull()
-            if (uid != null && uid != myUid) continue
+            if (uid == null || uid != myUid) continue
 
             val comm = try { File(pidDir, "comm").readText().trim() } catch (_: Exception) { "" }
             val stat = try { File(pidDir, "stat").readText() } catch (_: Exception) { "" }
@@ -2433,8 +2433,15 @@ fun XServerScreen(
             isWineProcessesLoading = quickMenuWineProcessesLoading,
             onToolsVisibilityChanged = { quickMenuToolsVisible = it },
             onEndWineProcess = { process ->
-                ProcessHelper.killProcess(process.pid)
-                quickMenuWineProcesses = quickMenuWineProcesses.filterNot { it.pid == process.pid }
+                val killed = runCatching {
+                    ProcessHelper.killProcess(process.pid)
+                }.onFailure { error ->
+                    Timber.w(error, "Failed to kill Wine process pid=%d", process.pid)
+                }.isSuccess
+
+                if (killed) {
+                    quickMenuWineProcesses = quickMenuWineProcesses.filterNot { it.pid == process.pid }
+                }
             },
             isPerformanceHudEnabled = isPerformanceHudEnabled,
             performanceHudConfig = performanceHudConfig,

--- a/app/src/main/java/app/gamenative/utils/WineProcessSnapshotHelper.kt
+++ b/app/src/main/java/app/gamenative/utils/WineProcessSnapshotHelper.kt
@@ -1,0 +1,136 @@
+package app.gamenative.utils
+
+import com.winlator.core.WineUtils
+import com.winlator.winhandler.ProcessInfo
+import java.io.File
+import java.util.Locale
+
+object WineProcessSnapshotHelper {
+    private val coreWineProcesses = setOf(
+        "wineserver",
+        "services",
+        "start",
+        "winhandler",
+        "tabtip",
+        "explorer",
+        "winedevice",
+        "svchost",
+    )
+
+    fun readFromProc(): List<ProcessInfo> {
+        val procDir = File("/proc")
+        val pidDirs = try {
+            procDir.listFiles { file -> file.isDirectory && file.name.all { it.isDigit() } } ?: return emptyList()
+        } catch (_: Exception) {
+            return emptyList()
+        }
+
+        val myUid = android.os.Process.myUid()
+        val processes = mutableListOf<ProcessInfo>()
+
+        for (pidDir in pidDirs) {
+            try {
+                val pid = pidDir.name.toIntOrNull() ?: continue
+                if (pid == android.os.Process.myPid()) continue
+
+                val statusLines = try {
+                    File(pidDir, "status").readLines()
+                } catch (_: Exception) {
+                    emptyList()
+                }
+                val uid = statusLines
+                    .firstOrNull { it.startsWith("Uid:") }
+                    ?.trim()
+                    ?.split(Regex("\\s+"))
+                    ?.getOrNull(1)
+                    ?.toIntOrNull()
+                if (uid == null || uid != myUid) continue
+
+                val comm = try { File(pidDir, "comm").readText().trim() } catch (_: Exception) { "" }
+                val stat = try { File(pidDir, "stat").readText() } catch (_: Exception) { "" }
+                val cmdlineBytes = try { File(pidDir, "cmdline").readBytes() } catch (_: Exception) { ByteArray(0) }
+                val cmdlineArgs = cmdlineBytes.toNullSeparatedStrings()
+                val searchableText = buildString {
+                    append(comm)
+                    append(' ')
+                    append(stat)
+                    append(' ')
+                    append(cmdlineArgs.joinToString(" "))
+                }
+
+                if (!searchableText.contains("wine", ignoreCase = true) &&
+                    !searchableText.contains(".exe", ignoreCase = true)) {
+                    continue
+                }
+
+                val name = cmdlineArgs
+                    .firstOrNull { it.endsWith(".exe", ignoreCase = true) }
+                    ?: cmdlineArgs.firstOrNull { it.contains(".exe", ignoreCase = true) }
+                    ?: cmdlineArgs.firstOrNull { it.contains("wine", ignoreCase = true) }
+                    ?: comm.ifBlank { null }
+                    ?: continue
+
+                val rssBytes = statusLines
+                    .firstOrNull { it.startsWith("VmRSS:") }
+                    ?.trim()
+                    ?.split(Regex("\\s+"))
+                    ?.getOrNull(1)
+                    ?.toLongOrNull()
+                    ?.times(1024L)
+                    ?: 0L
+
+                processes.add(
+                    ProcessInfo(
+                        pid,
+                        name.substringAfterLast('/').substringAfterLast('\\'),
+                        rssBytes,
+                        0,
+                        false,
+                    ),
+                )
+            } catch (_: Exception) {
+                // Process exited or became unreadable while enumerating /proc.
+            }
+        }
+
+        val allowlist = buildEssentialProcessAllowlist()
+        return processes.sortedWith(
+            compareByDescending<ProcessInfo> { normalizeProcessName(it.name) !in allowlist }
+                .thenByDescending { it.memoryUsage },
+        )
+    }
+
+    private fun buildEssentialProcessAllowlist(): Set<String> {
+        val essentialServices = WineUtils.getEssentialServiceNames()
+            .map { normalizeProcessName(it) }
+        return (essentialServices + coreWineProcesses).toSet()
+    }
+
+    private fun normalizeProcessName(name: String): String {
+        val trimmed = name.trim().trim('"')
+        val base = trimmed.substringAfterLast('/').substringAfterLast('\\')
+        val lower = base.lowercase(Locale.getDefault())
+        return if (lower.endsWith(".exe")) lower.removeSuffix(".exe") else lower
+    }
+
+    private fun ByteArray.toNullSeparatedStrings(): List<String> {
+        if (isEmpty()) return emptyList()
+
+        val result = mutableListOf<String>()
+        var start = 0
+        for (i in indices) {
+            if (this[i] == 0.toByte()) {
+                if (i > start) {
+                    val value = String(this, start, i - start).trim()
+                    if (value.isNotBlank()) result.add(value)
+                }
+                start = i + 1
+            }
+        }
+        if (start < size) {
+            val value = String(this, start, size - start).trim()
+            if (value.isNotBlank()) result.add(value)
+        }
+        return result
+    }
+}


### PR DESCRIPTION
## Description
The quick-menu task manager now reads Wine processes from Android `/proc` and kills by host PID, so stopped Wine processes still appear and can be terminated while the overlay suspend policy is active.

## Recording

https://github.com/user-attachments/assets/4d3767b3-ba76-4134-b233-3d2864f7e5ba

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-device Wine process discovery to enumerate and surface running Wine processes.

* **Improvements**
  * More reliable Wine process detection via direct system enumeration.
  * Faster, more responsive Quick Menu polling for up-to-date process listings.
  * Simplified process termination flow in the Quick Menu using a unified end-process callback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->