### PR TITLE
Made home and proton immediately symlinked after migration

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1554,7 +1554,11 @@ fun preLaunchApp(
         // Migrate legacy on-disk imagefs layout (e.g. legacy Proton → shared paths) before manifest
         // installs or launch deps — resolveMissingManifestInstallRequests can install Proton too.
         val legacyImageFsRoot = File(context.filesDir, "imagefs")
-        val migrationOk = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+        val migrationOk = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(
+            context,
+            legacyImageFsRoot,
+            container.wineVersion,
+        )
         if (!migrationOk) {
             Timber.tag("preLaunchApp").e(
                 "Legacy ImageFS migration failed: ${legacyImageFsRoot.absolutePath}",

--- a/app/src/main/java/com/winlator/xenvironment/ImageFSLegacyMigrator.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFSLegacyMigrator.java
@@ -10,13 +10,18 @@ import java.io.File;
 public final class ImageFSLegacyMigrator {
     private ImageFSLegacyMigrator() {}
 
-    public static boolean migrateLegacyDirsIfNeeded(Context context, File legacyImageFsRoot) {
+    /**
+     * Migrate legacy directories if needed. After that, ensure the shared home and proton are symlinked.
+     */
+    public static boolean migrateLegacyDirsIfNeeded(Context context, File legacyImageFsRoot, String wineVersion) {
         if (!migrateLegacyHomeToShared(context, legacyImageFsRoot)) {
             return false;
         }
         if (!migrateLegacyProtonToShared(context, legacyImageFsRoot)) {
             return false;
         }
+        ImageFsInstaller.ensureSharedHomeRoot(context, legacyImageFsRoot);
+        ImageFsInstaller.ensureProtonVersionSymlink(context, legacyImageFsRoot, wineVersion);
         return true;
     }
 

--- a/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFsInstaller.java
@@ -211,7 +211,7 @@ public abstract class ImageFsInstaller {
     public static Future<Boolean> installIfNeededFuture(final Context context, AssetManager assetManager, Container container, Callback<Integer> onProgress) {
         ImageFs imageFs = ImageFs.find(context);
         String wineVersion = container.getWineVersion();
-        if (!ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, imageFs.getRootDir())) {
+        if (!ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, imageFs.getRootDir(), wineVersion)) {
             Log.w("ImageFsInstaller", "Failed to migrate legacy directories before installation.");
             return Executors.newSingleThreadExecutor().submit(() -> false);
         }
@@ -227,8 +227,6 @@ public abstract class ImageFsInstaller {
         } else {
             Log.d("ImageFsInstaller", "Image FS already valid and at latest version");
             return Executors.newSingleThreadExecutor().submit(() -> {
-                ensureSharedHomeRoot(context, imageFs.getRootDir());
-                ensureProtonVersionSymlink(context, imageFs.getRootDir(), wineVersion);
                 return true;
             });
         }
@@ -409,7 +407,7 @@ public abstract class ImageFsInstaller {
      *
      * This allows the same user home (e.g. .wine, .cache) to be shared across variants.
      */
-    private static void ensureSharedHomeRoot(Context context, File rootDir) {
+    public static void ensureSharedHomeRoot(Context context, File rootDir) {
         File sharedHomeRoot = new File(ImageFs.getImageFsSharedDir(context), "home");
         if (!sharedHomeRoot.exists()) {
             sharedHomeRoot.mkdirs();

--- a/app/src/test/java/com/winlator/xenvironment/ImageFSLegacyMigratorTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFSLegacyMigratorTest.kt
@@ -2,7 +2,12 @@ package com.winlator.xenvironment
 
 import androidx.test.core.app.ApplicationProvider
 import java.io.File
-import java.nio.file.Files
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkStatic
+import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -24,22 +29,34 @@ class ImageFSLegacyMigratorTest {
         filesDir = context.filesDir
         legacyImageFsRoot = File(filesDir, "legacy-imagefs-test-${System.nanoTime()}").apply { mkdirs() }
         sharedDir = File(filesDir, "imagefs_shared").apply { deleteRecursively() }
+        mockkStatic(ImageFsInstaller::class)
+        every { ImageFsInstaller.ensureSharedHomeRoot(any(), any()) } just runs
+        every { ImageFsInstaller.ensureProtonVersionSymlink(any(), any(), any()) } just runs
     }
 
     @After
     fun tearDown() {
+        unmockkStatic(ImageFsInstaller::class)
         legacyImageFsRoot.deleteRecursively()
         sharedDir.deleteRecursively()
+    }
+
+    private fun assertEnsureCalls(wineVersion: String) {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        verify(exactly = 1) { ImageFsInstaller.ensureSharedHomeRoot(context, legacyImageFsRoot) }
+        verify(exactly = 1) {
+            ImageFsInstaller.ensureProtonVersionSymlink(context, legacyImageFsRoot, wineVersion)
+        }
     }
 
     @Test
     fun migrateLegacyDirsIfNeeded_returnsTrueWhenLegacyHomeMissing() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
 
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "")
 
         assertTrue(migrated)
-        assertFalse(File(legacyImageFsRoot, "home").exists())
+        assertEnsureCalls("")
     }
 
     @Test
@@ -48,10 +65,10 @@ class ImageFSLegacyMigratorTest {
         val legacyHome = File(legacyImageFsRoot, "home").apply { mkdirs() }
         val legacyFile = File(legacyHome, "marker.txt").apply { writeText("legacy-content") }
 
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "")
 
         assertTrue(migrated)
-        assertFalse("Legacy home should have been moved away", legacyHome.exists())
+        assertEnsureCalls("")
         val sharedHome = File(sharedDir, "home")
         assertTrue(sharedHome.exists())
         assertEquals("legacy-content", File(sharedHome, legacyFile.name).readText())
@@ -66,24 +83,21 @@ class ImageFSLegacyMigratorTest {
         val legacyHome = File(legacyImageFsRoot, "home").apply { mkdirs() }
         File(legacyHome, "new.txt").writeText("new-legacy")
 
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "")
 
         assertTrue(migrated)
+        assertEnsureCalls("")
         assertFalse(File(sharedHome, "old.txt").exists())
         assertEquals("new-legacy", File(sharedHome, "new.txt").readText())
     }
 
     @Test
-    fun migrateLegacyDirsIfNeeded_noopWhenLegacyHomeIsSymlink() {
+    fun migrateLegacyDirsIfNeeded_callsEnsureMethodsWhenNoLegacyHomeExists() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
-        val realHome = File(legacyImageFsRoot, "real-home").apply { mkdirs() }
-        val symlinkPath = File(legacyImageFsRoot, "home").toPath()
-        Files.createSymbolicLink(symlinkPath, realHome.toPath())
-
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "")
 
         assertTrue(migrated)
-        assertTrue("Symlink should remain untouched", Files.isSymbolicLink(symlinkPath))
+        assertEnsureCalls("")
     }
 
     @Test
@@ -92,10 +106,11 @@ class ImageFSLegacyMigratorTest {
         val protonDir = File(legacyImageFsRoot, "opt/proton-ge-9-2").apply { mkdirs() }
         val protonFile = File(protonDir, "version.txt").apply { writeText("ge-9-2") }
 
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "proton-ge-9-2")
 
         val sharedProtonDir = File(sharedDir, "proton/proton-ge-9-2")
         assertTrue(migrated)
+        assertEnsureCalls("proton-ge-9-2")
         assertFalse("Legacy proton dir should be moved away", protonDir.exists())
         assertTrue("Shared proton dir should exist", sharedProtonDir.exists())
         assertEquals("ge-9-2", File(sharedProtonDir, protonFile.name).readText())
@@ -107,15 +122,11 @@ class ImageFSLegacyMigratorTest {
         val optDir = File(legacyImageFsRoot, "opt").apply { mkdirs() }
         File(optDir, "wine-ge-custom").apply { mkdirs() }
 
-        val protonReal = File(legacyImageFsRoot, "proton-real").apply { mkdirs() }
-        val protonSymlinkPath = File(optDir, "proton-symlink").toPath()
-        Files.createSymbolicLink(protonSymlinkPath, protonReal.toPath())
-
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "")
 
         assertTrue(migrated)
+        assertEnsureCalls("")
         assertTrue(File(optDir, "wine-ge-custom").exists())
-        assertTrue(Files.isSymbolicLink(protonSymlinkPath))
     }
 
     @Test
@@ -127,9 +138,10 @@ class ImageFSLegacyMigratorTest {
         val existingShared = File(sharedDir, "proton/proton-ge-9-5").apply { mkdirs() }
         File(existingShared, "existing.txt").writeText("shared")
 
-        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot)
+        val migrated = ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded(context, legacyImageFsRoot, "")
 
         assertTrue(migrated)
+        assertEnsureCalls("")
         assertFalse("Legacy proton should be removed when shared exists", legacyProton.exists())
         assertEquals("shared", File(existingShared, "existing.txt").readText())
     }


### PR DESCRIPTION
## Description
Makes sure there is no moment where there is no home or proton

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure shared home and Proton symlinks are created immediately after legacy ImageFS migration, removing any gap where home or proton might be missing during launch or install.

- **Bug Fixes**
  - `ImageFSLegacyMigrator.migrateLegacyDirsIfNeeded` now takes `wineVersion` and calls `ImageFsInstaller.ensureSharedHomeRoot` and `ensureProtonVersionSymlink` after migrating.
  - Updated `PluviaMain` and `ImageFsInstaller.installIfNeededFuture` to pass `wineVersion`; removed redundant ensure calls when the image FS is already valid.
  - Made `ensureSharedHomeRoot` public for use in migration.
  - Tests updated to mock and verify ensure calls, ensuring symlinks are created post-migration.

<sup>Written for commit 1571e1fe6048838db548a2e4fdecda75e93467fb. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1343?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy directory migration to properly handle wine version requirements and ensure necessary directory structures and links are correctly established during the migration process.

* **Tests**
  * Enhanced migration test suite to verify proper installer setup and directory configuration during legacy migration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->