### PR TITLE
Added expired filter, fixed some games showing as expired, fixed some…

### DIFF
--- a/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/SteamAppDao.kt
@@ -14,14 +14,37 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 
+// An app is considered "owned" if there's any non-expired license that grants access
+// to it: either its own package's license, or any DLC of it (e.g. for free-to-start
+// titles like Diablo IV where the actual purchase is a separate "Standard Edition"
+// DLC sub that unlocks the base appid). Without the DLC arm, F2P-with-paid-DLC games
+// disappear after the user's free-weekend sub on the base appid expires, even though
+// they still own the game via the DLC entitlement.
+//
+// The two arms are split into two separate EXISTS clauses on purpose: most apps will
+// be decided by the first (own-license) arm, which is an O(1) PK lookup on
+// steam_license. SQLite short-circuits the second (DLC scan) arm in that common case,
+// keeping load times comparable to the original PR #985 query for large libraries.
+//
+// When :includeExpired is 1, the license predicate is bypassed entirely, surfacing
+// apps that are normally hidden (used by the "Expired" library filter for diagnostics).
 private const val OWNED_APPS_WHERE =
     "WHERE app.id != 480 " + // Actively filter out Spacewar
     "AND app.package_id != :invalidPkgId " +
     "AND app.type != 0 " +
-    "AND EXISTS (" +
-    "  SELECT 1 FROM steam_license AS license " +
-    "  WHERE license.packageId = app.package_id " +
-    "  AND (license.license_flags & 8 = 0) " + // exclude expired licenses (e.g. free weekends)
+    "AND (" +
+    "  :includeExpired = 1 " +
+    "  OR EXISTS (" +
+    "    SELECT 1 FROM steam_license AS license " +
+    "    WHERE license.packageId = app.package_id " +
+    "    AND (license.license_flags & 8) = 0 " + // exclude expired licenses (e.g. free weekends)
+    "  ) " +
+    "  OR EXISTS (" +
+    "    SELECT 1 FROM steam_app AS dlc " +
+    "    INNER JOIN steam_license AS license ON dlc.package_id = license.packageId " +
+    "    WHERE dlc.dlc_for_app_id = app.id " +
+    "    AND (license.license_flags & 8) = 0 " +
+    "  ) " +
     ") "
 
 private const val PAGE_SIZE = 50
@@ -44,6 +67,7 @@ interface SteamAppDao {
     )
     fun _observeOwnedAppCount(
         invalidPkgId: Int = INVALID_PKG_ID,
+        includeExpired: Int = 0,
     ): Flow<Int>
 
     // paged data load — each page fits comfortably in a CursorWindow
@@ -55,10 +79,14 @@ interface SteamAppDao {
         limit: Int,
         offset: Int,
         invalidPkgId: Int = INVALID_PKG_ID,
+        includeExpired: Int = 0,
     ): List<SteamApp>
 
     @Transaction
-    suspend fun _getAllOwnedAppsPaged(invalidPkgId: Int = INVALID_PKG_ID): List<SteamApp> {
+    suspend fun _getAllOwnedAppsPaged(
+        invalidPkgId: Int = INVALID_PKG_ID,
+        includeExpired: Int = 0,
+    ): List<SteamApp> {
         val result = mutableListOf<SteamApp>()
         var offset = 0
         while (true) {
@@ -66,7 +94,7 @@ interface SteamAppDao {
             var pageSize = if (offset == 0) Int.MAX_VALUE else PAGE_SIZE
             while (true) {
                 try {
-                    val page = _getOwnedAppsPage(pageSize, offset, invalidPkgId)
+                    val page = _getOwnedAppsPage(pageSize, offset, invalidPkgId, includeExpired)
                     if (page.isEmpty()) return result
                     result += page
                     if (pageSize == Int.MAX_VALUE) return result // got everything in one shot
@@ -82,14 +110,20 @@ interface SteamAppDao {
 
     // emits full list on count changes, loaded in pages to avoid CursorWindow overflow.
     // property-only updates (name, icon) won't re-emit until the next count change.
+    // Pass includeExpired = true to surface apps whose license is flagged Expired or
+    // is missing entirely — used by the library "Expired" filter for diagnostics.
     @OptIn(ExperimentalCoroutinesApi::class)
     fun getAllOwnedApps(
         invalidPkgId: Int = INVALID_PKG_ID,
-    ): Flow<List<SteamApp>> = _observeOwnedAppCount(invalidPkgId)
-        .distinctUntilChanged() // skip reload when count unchanged
-        .flatMapLatest { // cancel stale reloads during rapid PICS inserts
-            flow { emit(_getAllOwnedAppsPaged(invalidPkgId)) }
-        }
+        includeExpired: Boolean = false,
+    ): Flow<List<SteamApp>> {
+        val includeExpiredFlag = if (includeExpired) 1 else 0
+        return _observeOwnedAppCount(invalidPkgId, includeExpiredFlag)
+            .distinctUntilChanged() // skip reload when count unchanged
+            .flatMapLatest { // cancel stale reloads during rapid PICS inserts
+                flow { emit(_getAllOwnedAppsPaged(invalidPkgId, includeExpiredFlag)) }
+            }
+    }
 
     @Query(
         "SELECT * FROM steam_app " +

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -4018,7 +4018,28 @@ class SteamService : Service(), IChallengeUrlChanged {
                         val queue = Collections.synchronizedList(mutableListOf<Int>())
 
                         db.withTransaction {
-                            picsCallback.packages.values.forEach { pkg ->
+                            // When the same app appears in multiple packages (e.g. user owns the game and
+                            // also has a free-weekend / demo / family-shared sub for it), the previous
+                            // implementation overwrote SteamApp.packageId with whichever pkg was iterated
+                            // last — non-deterministic and prone to landing on a non-user-owned package,
+                            // which then makes the user's own game appear as family-shared in the library.
+                            // To fix that we (a) process user-owned packages last so they win the
+                            // last-write-wins assignment within this batch and (b) refuse to downgrade an
+                            // existing user-owned packageId across batches.
+                            val accountId = userSteamId?.accountID?.toInt()
+                            val userOwnedPackageIds: Set<Int> = if (accountId != null) {
+                                val packageIds = picsCallback.packages.values.map { it.id }
+                                licenseDao.findLicenses(packageIds)
+                                    .filter { it.ownerAccountId.contains(accountId) }
+                                    .mapTo(HashSet()) { it.packageId }
+                            } else {
+                                emptySet()
+                            }
+
+                            val orderedPackages = picsCallback.packages.values
+                                .sortedBy { pkg -> if (pkg.id in userOwnedPackageIds) 1 else 0 }
+
+                            orderedPackages.forEach { pkg ->
                                 val appIds = pkg.keyValues["appids"].children.map { it.asInteger() }
                                 licenseDao.updateApps(pkg.id, appIds)
 
@@ -4027,13 +4048,23 @@ class SteamService : Service(), IChallengeUrlChanged {
 
                                 // Insert a stub row (or update) of SteamApps to the database.
                                 appIds.forEach { appid ->
-                                    val steamApp = appDao.findApp(appid)?.copy(packageId = pkg.id)
-                                    if (steamApp != null) {
-                                        appDao.update(steamApp)
-                                    } else {
-                                        val stubSteamApp = SteamApp(id = appid, packageId = pkg.id)
-                                        appDao.insert(stubSteamApp)
+                                    val existing = appDao.findApp(appid)
+                                    if (existing == null) {
+                                        appDao.insert(SteamApp(id = appid, packageId = pkg.id))
+                                        return@forEach
                                     }
+                                    if (existing.packageId == pkg.id) {
+                                        return@forEach
+                                    }
+                                    if (accountId != null && existing.packageId != INVALID_PKG_ID) {
+                                        val existingIsUserOwned = licenseDao.findLicense(existing.packageId)
+                                            ?.ownerAccountId?.contains(accountId) == true
+                                        val newIsUserOwned = pkg.id in userOwnedPackageIds
+                                        if (existingIsUserOwned && !newIsUserOwned) {
+                                            return@forEach
+                                        }
+                                    }
+                                    appDao.update(existing.copy(packageId = pkg.id))
                                 }
 
                                 queue.addAll(appIds)

--- a/app/src/main/java/app/gamenative/ui/enums/AppFilter.kt
+++ b/app/src/main/java/app/gamenative/ui/enums/AppFilter.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.filled.AvTimer
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.Diversity3
+import androidx.compose.material.icons.filled.HourglassEmpty
 import androidx.compose.material.icons.filled.InstallMobile
 import androidx.compose.material.icons.filled.VideogameAsset
 import androidx.compose.material.icons.rounded.Verified
@@ -52,6 +53,11 @@ enum class AppFilter(
         code = 0x40,
         displayText = "Compatible",
         icon = Icons.Rounded.Verified,
+    ),
+    EXPIRED(
+        code = 0x80,
+        displayText = "Expired",
+        icon = Icons.Default.HourglassEmpty,
     ),
     // ALPHABETIC(
     //     code = 0x20,

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -48,11 +48,15 @@ import javax.inject.Inject
 import kotlin.math.max
 import kotlin.math.min
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -124,17 +128,24 @@ class LibraryViewModel @Inject constructor(
     }
 
     init {
+        @OptIn(ExperimentalCoroutinesApi::class)
         viewModelScope.launch(Dispatchers.IO) {
-            steamAppDao.getAllOwnedApps(
-                // ownerIds = SteamService.familyMembers.ifEmpty { listOf(SteamService.userSteamId!!.accountID.toInt()) },
-            ).collect { apps ->
-                Timber.tag("LibraryViewModel").d("Collecting ${apps.size} apps")
-                // Check if the list has actually changed before triggering a re-filter
-                if (appList.size != apps.size) {
-                    appList = apps
-                    onFilterApps(paginationCurrentPage)
+            // Re-create the underlying DAO Flow whenever the EXPIRED filter is toggled,
+            // so apps with Expired or missing licenses are surfaced/hidden accordingly.
+            _state
+                .map { it.appInfoSortType.contains(AppFilter.EXPIRED) }
+                .distinctUntilChanged()
+                .flatMapLatest { includeExpired ->
+                    steamAppDao.getAllOwnedApps(includeExpired = includeExpired)
                 }
-            }
+                .collect { apps ->
+                    Timber.tag("LibraryViewModel").d("Collecting ${apps.size} apps")
+                    // Check if the list has actually changed before triggering a re-filter
+                    if (appList.size != apps.size) {
+                        appList = apps
+                        onFilterApps(paginationCurrentPage)
+                    }
+                }
         }
 
         // Collect GOG games

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryOptionsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryOptionsPanel.kt
@@ -237,6 +237,7 @@ fun LibraryOptionsPanel(
                                         AppFilter.INSTALLED,
                                         AppFilter.SHARED,
                                         AppFilter.COMPATIBLE,
+                                        AppFilter.EXPIRED,
                                     )
                                 ) {
                                     OptionListItem(


### PR DESCRIPTION
… games showing as family shared by default even when owned

## Description
Some games were hidden by the new expired filter even when not expired.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Expired filter and fixes ownership detection so owned games no longer show as family-shared or get hidden as expired. DLC entitlements now count as ownership and are preserved during package updates.

- **New Features**
  - Added EXPIRED filter (hourglass). When enabled, shows apps with expired or missing licenses.

- **Bug Fixes**
  - Ownership query counts DLC licenses and only hides truly expired subs, keeping F2P-with-paid-DLC titles visible.
  - Package assignment now favors user-owned packages and prevents downgrades, fixing games incorrectly marked as family-shared.

<sup>Written for commit 2da59cea4b37b77d3a216d6d59892b60afaa5436. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Expired" filter option to the library interface for filtering apps by expiration status.
  * Library now reactively updates when toggling the expired filter.

* **Bug Fixes**
  * Fixed issue where owned apps could be incorrectly marked as family-shared due to non-deterministic package handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->