### PR TITLE
fix: let XI2 throw error on unimplemented opcode

### DIFF
--- a/app/src/main/java/com/winlator/xserver/extensions/XInput2Extension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/XInput2Extension.java
@@ -430,8 +430,7 @@ public class XInput2Extension implements Extension {
                 Timber.w("XInput2Extension: unhandled minor opcode=%d, requestData=%d, requestLength=%d",
                         opcode, client.getRequestData(), client.getRemainingRequestLength());
                 inputStream.skip(client.getRemainingRequestLength());
-                // throw new BadImplementation();
-                break;
+                throw new BadImplementation();
         }
     }
 


### PR DESCRIPTION
## Description
let XI2 throw an error to requests it cannot respond to 
this fixes applications, such as those that depend on wintab32.dll, from hanging and stop working 
EA launcher opens now... kinda

## Recording

tested with proton 11 arm64ec

https://github.com/user-attachments/assets/400fcaf5-c37e-45fb-8a83-32ea6a62b291



## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Have XI2 throw BadImplementation for unhandled minor opcodes instead of skipping them, so clients get a proper error. This prevents hangs for apps that probe XInput2 (e.g., those using wintab32.dll); EA Launcher now opens.

<sup>Written for commit 87d21330d7b9a584b899c4e02bae91324b86339f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for input extension requests. Invalid or unsupported input requests are now properly reported with error messages instead of being silently ignored, improving system reliability and making it easier to diagnose issues with unexpected input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->