### PR TITLE
fix: strip DXVK/VKD3D frame rate caps from best-config API responses

### DIFF
--- a/app/src/main/java/app/gamenative/utils/BestConfigService.kt
+++ b/app/src/main/java/app/gamenative/utils/BestConfigService.kt
@@ -831,7 +831,11 @@ object BestConfigService {
                     resultMap["steamOfflineMode"] = filteredJson.optBoolean("steamOfflineMode", PrefManager.steamOfflineMode)
                 }
                 if (filteredJson.has("envVars") && !filteredJson.isNull("envVars")) {
-                    resultMap["envVars"] = filteredJson.optString("envVars", PrefManager.envVars)
+                    var envVars = filteredJson.optString("envVars", PrefManager.envVars)
+                    // Strip DXVK/VKD3D frame rate caps from backend config - client-side limiter handles this
+                    envVars = envVars.replace(Regex("""\s*DXVK_FRAME_RATE=\d+"""), "")
+                    envVars = envVars.replace(Regex("""\s*VKD3D_FRAME_RATE=\d+"""), "")
+                    resultMap["envVars"] = envVars.trim()
                 }
                 if (filteredJson.has("cpuList") && !filteredJson.isNull("cpuList")) {
                     resultMap["cpuList"] = filteredJson.optString("cpuList", PrefManager.cpuList)


### PR DESCRIPTION
## Description
The backend best-config API was sending `DXVK_FRAME_RATE=60` in environment variables, causing games to be hard-capped at 60 FPS regardless of device refresh rate or user settings. This interfered with the client-side FPS limiter which properly detects display refresh rate and respects user toggle state.

This fix strips `DXVK_FRAME_RATE` and `VKD3D_FRAME_RATE` from API-provided envVars before applying configs, matching the previous fix that removed these from Container.java defaults in commit 6f2d060a.

**Discord discussion:** https://discord.com/channels/1378308569287622737/1495745226822647979

**Behavior after fix:**
- Toggle OFF → Uncapped (limited only by vsync/display refresh)
- Toggle ON → Capped at detected display refresh rate (60/120/144Hz)
- No more hard 60 FPS lock from backend configs

**Note:** Manual edits to envVars (via Environment tab or config import) are preserved — this only strips the automatic best-config API values.

## Type of Change
- [x] Bug fix

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips DXVK/VKD3D frame rate caps from best-config API responses to prevent a forced 60 FPS lock and let the client-side limiter manage FPS based on display and user toggle.

- **Bug Fixes**
  - Remove DXVK_FRAME_RATE and VKD3D_FRAME_RATE from API-provided envVars before applying configs; user-edited envVars remain unchanged.
  - FPS behavior: Toggle OFF = uncapped (vsync/display-limited), Toggle ON = capped to detected refresh; no backend 60 FPS lock.

<sup>Written for commit 8a3a03b09e607c4da4cdee09222936288a5690c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration processing by filtering out redundant frame rate settings during environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->