### PR TITLE
Don't discard DLC if it doesn't match preferred language AND the DLC …

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -781,6 +781,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             ownedDlc: Map<Int, DepotInfo>?,
             licensedDepotIds: Set<Int>? = null,
             hasSteamUnlockedBranch: Boolean = false,
+            dlcGroupsWithPreferredLanguage: Set<Int>? = null,
         ): Boolean {
             if (depot.manifests.isEmpty() && depot.encryptedManifests.isNotEmpty() && !hasSteamUnlockedBranch)
                 return false
@@ -808,8 +809,11 @@ class SteamService : Service(), IChallengeUrlChanged {
             if (depot.dlcAppId != INVALID_APP_ID && ownedDlc != null && !ownedDlc.containsKey(depot.depotId))
                 return false
             // 5. Language filter - if depot has language, it must match preferred language
-            if (depot.language.isNotEmpty() && depot.language != preferredLanguage)
-                return false
+            //    unless the DLC only exists for a tagged language that is not the preferred language
+            if (depot.language.isNotEmpty() && depot.language != preferredLanguage) {
+                val groupHasPreferred = dlcGroupsWithPreferredLanguage?.contains(depot.dlcAppId) ?: true
+                if (groupHasPreferred) return false
+            }
             // 6. Package grants this depot — prevents grabbing region depots the user has no license for.
             //    Skip for DLC and systemDefined depots: DLC licensed via own package (check 4), systemDefined always granted.
             if (depot.dlcAppId == INVALID_APP_ID && !depot.systemDefined && licensedDepotIds != null && depot.depotId !in licensedDepotIds)
@@ -832,9 +836,24 @@ class SteamService : Service(), IChallengeUrlChanged {
             preferredLanguage: String,
             ownedDlc: Map<Int, DepotInfo>?,
             licensedDepotIds: Set<Int>?,
-        ): Collection<DepotInfo> = depots.values.filter { depot ->
-            filterForDownloadableDepots(depot, prefer64Bit = false, preferNonDeckWindows = false, preferredLanguage, ownedDlc, licensedDepotIds)
+        ): Collection<DepotInfo> {
+            val dlcGroupsWithPreferredLanguage = dlcGroupsWithPreferredLanguageFor(depots, preferredLanguage)
+            return depots.values.filter { depot ->
+                filterForDownloadableDepots(
+                    depot, prefer64Bit = false, preferNonDeckWindows = false, preferredLanguage,
+                    ownedDlc, licensedDepotIds,
+                    dlcGroupsWithPreferredLanguage = dlcGroupsWithPreferredLanguage,
+                )
+            }
         }
+
+        /** Set of dlcAppIds (incl. INVALID_APP_ID for base) that have a depot in [preferredLanguage]. */
+        private fun dlcGroupsWithPreferredLanguageFor(
+            depots: Map<Int, DepotInfo>,
+            preferredLanguage: String,
+        ): Set<Int> = depots.values
+            .filter { it.language == preferredLanguage }
+            .mapTo(mutableSetOf()) { it.dlcAppId }
 
         /**
          * Two-pass depot resolution: derives preference flags from [eligibleDepots],
@@ -847,11 +866,15 @@ class SteamService : Service(), IChallengeUrlChanged {
             licensedDepotIds: Set<Int>?,
             hasSteamUnlockedBranch: Boolean = false,
         ): Map<Int, DepotInfo> {
+            val dlcGroupsWithPreferredLanguage = dlcGroupsWithPreferredLanguageFor(depots, preferredLanguage)
             val eligible = eligibleDepots(depots, preferredLanguage, ownedDlc, licensedDepotIds)
             val has64Bit = eligible.any { it.osArch == OSArch.Arch64 }
             val hasNonDeckWin = eligible.any { !it.steamDeck && it.isWindowsCompatible }
             return depots.filter { (_, depot) ->
-                filterForDownloadableDepots(depot, has64Bit, hasNonDeckWin, preferredLanguage, ownedDlc, licensedDepotIds)
+                filterForDownloadableDepots(
+                    depot, has64Bit, hasNonDeckWin, preferredLanguage, ownedDlc, licensedDepotIds,
+                    dlcGroupsWithPreferredLanguage = dlcGroupsWithPreferredLanguage,
+                )
             }
         }
 
@@ -923,10 +946,11 @@ class SteamService : Service(), IChallengeUrlChanged {
                 val dlcLicensedDepots = getLicensedDepotIds(dlcApp.id)
                 val dlcEligible = eligibleDepots(dlcApp.depots, preferredLanguage, null, dlcLicensedDepots)
                 val dlcHasNonDeckWin = dlcEligible.any { !it.steamDeck && it.isWindowsCompatible }
+                val dlcGroupsWithPreferredLanguage = dlcGroupsWithPreferredLanguageFor(dlcApp.depots, preferredLanguage)
                 dlcApp.depots
                     .filter { (_, depot) ->
                         filterForDownloadableDepots(depot, has64Bit, dlcHasNonDeckWin, preferredLanguage, null, dlcLicensedDepots,
-                            hasSteamUnlockedBranch)
+                            hasSteamUnlockedBranch, dlcGroupsWithPreferredLanguage)
                     }
                     .forEach { (depotId, depot) ->
                         // Add DLC Depots with custom object

--- a/app/src/test/java/app/gamenative/service/DepotFilteringTest.kt
+++ b/app/src/test/java/app/gamenative/service/DepotFilteringTest.kt
@@ -152,4 +152,46 @@ class DepotFilteringTest {
         val d = depot(manifests = mapOf("public" to manifest()), steamDeck = false)
         assertTrue(SteamService.filterForDownloadableDepots(d, true, true, "english", null))
     }
+
+    // -- language filter fallback (publisher-mistagged single-language DLCs) --
+
+    @Test
+    fun `non-matching language depot rejected when group has preferred-language alternative`() {
+        val d = depot(
+            manifests = mapOf("public" to manifest()),
+            dlcAppId = 42,
+            language = "english",
+        )
+        assertFalse(
+            SteamService.filterForDownloadableDepots(
+                d, true, false, "french", null, null, false,
+                dlcGroupsWithPreferredLanguage = setOf(42),
+            ),
+        )
+    }
+
+    @Test
+    fun `non-matching language depot accepted when group has no preferred-language alternative`() {
+        val d = depot(
+            manifests = mapOf("public" to manifest()),
+            dlcAppId = 42,
+            language = "english",
+        )
+        assertTrue(
+            SteamService.filterForDownloadableDepots(
+                d, true, false, "french", null, null, false,
+                dlcGroupsWithPreferredLanguage = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `null dlcGroupsWithPreferredLanguage preserves strict legacy behavior`() {
+        val d = depot(
+            manifests = mapOf("public" to manifest()),
+            dlcAppId = 42,
+            language = "english",
+        )
+        assertFalse(SteamService.filterForDownloadableDepots(d, true, false, "french", null))
+    }
 }


### PR DESCRIPTION
…only exists for another language, add tests

## Description
DLC for games didn't show if the DLC had a language on it which didn't match the preferred language, AND there was no other depot for the DLC. This happened for A Date with Death in French.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DLC filtering so we don’t hide DLC when its depot language doesn’t match the preferred language and no preferred-language depot exists for that DLC. This makes single-language or mistagged DLC (e.g. “A Date with Death”) show up correctly.

- **Bug Fixes**
  - Language filter now allows non-matching DLC depots only when their DLC group has no depot in the preferred language; still rejects them if an alternative exists.
  - Added `dlcGroupsWithPreferredLanguage` detection and passed it through eligible/resolution/DLC paths to inform filtering.
  - Added tests for acceptance/rejection cases and for preserving legacy behavior when the set is null.

<sup>Written for commit 248960f5cafb7697a37f1401c7d412ca8cd21c3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved depot language preference handling with smarter fallback logic for DLC content selection
* **Tests**
  * Added test coverage for language preference fallback scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->