### PR TITLE
fix: respect quick-menu LSFG multiplier Off state on relaunch

### DIFF
--- a/app/src/main/java/app/gamenative/utils/LsfgVkManager.kt
+++ b/app/src/main/java/app/gamenative/utils/LsfgVkManager.kt
@@ -345,7 +345,7 @@ object LsfgVkManager {
         if (enabled && !dllPath.isNullOrBlank()) {
             appendLine("[[game]]")
             appendLine("exe = ${tomlString(PROCESS_EXE_IDENTIFIER)}")
-            appendLine("multiplier = ${multiplier.coerceIn(2, 4)}")
+            appendLine("multiplier = ${multiplier.coerceIn(1, 4)}")
             appendLine("flow_scale = ${formatFlowScale(flowScale)}")
             appendLine("performance_mode = ${if (performanceMode) "true" else "false"}")
             appendLine("hdr_mode = false")


### PR DESCRIPTION
## Description

Setting LSFG to Off in the Quick Menu saves multiplier=0 to the container extras, but buildConfigToml coerced it to 2 via coerceIn(2, 4). On relaunch the layer loaded at 2x while the Quick Menu showed Off. Changed the lower bound to 1 so multiplier 0 writes as pass-through (1) in conf.toml — layer still loads and hooks are active so the user can bump back to 2x mid-session via Quick Menu.

## Recording

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Graphics-layer multiplier range adjusted: when enabled and required native components are present, multiplier now accepts 1–4 (previous minimum of 2 removed). Multiplier 0 still disables the layer to prevent unintended activation.
  * Other configuration fields and hot-reload behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->