### PR TITLE
fix: pre-create only 1 controller as some games get confused with ext…

### DIFF
--- a/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
@@ -182,7 +182,7 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
 
         // Always pre-create all 4 mem files so controllers can be hot-plugged during gameplay.
         // Unused gamepads just read zeroes (no-op in evshim).
-        final int enabledPlayerCount = WinHandler.MAX_PLAYERS;
+        final int enabledPlayerCount = 1;
         for (int i = 0; i < enabledPlayerCount; i++) {
             String memPath;
             if (i == 0) {


### PR DESCRIPTION
…ra controllers pre-created

## Description
some games seem to be getting confused with extra controllers being created from the get go
temporary fix for #1261 

## Recording

https://github.com/user-attachments/assets/94ec9c43-cb7e-4ead-bdd4-ed9f088f6bcb



## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-create only one controller at launch to prevent some games from misdetecting extra gamepads. Temporary workaround for #1261.

<sup>Written for commit cc723729d2949a214d7dd1bfc6a6e854e4122357. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified maximum player support from multiple to single-player mode. The system now initializes only the first gamepad shared-memory file instead of pre-creating files for four controllers, and the corresponding environment variable is updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->