### PR TITLE
Epic denuvo support

### DIFF
--- a/app/src/main/java/app/gamenative/gamefixes/EPIC_864c7bc2c2394f7dbd1b534aa068ff56.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/EPIC_864c7bc2c2394f7dbd1b534aa068ff56.kt
@@ -8,8 +8,8 @@ import app.gamenative.data.GameSource
  * Wipes C:\ProgramData\Hogwarts Legacy on every boot. The game caches state there
  * that occasionally leaves Denuvo / EOS in a bad mood after a previous session.
  */
-val EPIC_Fix_fa4240e57a3c46b39f169041b7811293: KeyedGameFix = KeyedDeleteFolderFix(
+val EPIC_Fix_864c7bc2c2394f7dbd1b534aa068ff56: KeyedGameFix = KeyedDeleteFolderFix(
     gameSource = GameSource.EPIC,
-    gameId = "fa4240e57a3c46b39f169041b7811293",
+    gameId = "864c7bc2c2394f7dbd1b534aa068ff56",
     driveCRelativePaths = listOf("ProgramData/Hogwarts Legacy"),
 )

--- a/app/src/main/java/app/gamenative/gamefixes/EPIC_fa4240e57a3c46b39f169041b7811293.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/EPIC_fa4240e57a3c46b39f169041b7811293.kt
@@ -1,0 +1,15 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Hogwarts Legacy (Epic)
+ *
+ * Wipes C:\ProgramData\Hogwarts Legacy on every boot. The game caches state there
+ * that occasionally leaves Denuvo / EOS in a bad mood after a previous session.
+ */
+val EPIC_Fix_fa4240e57a3c46b39f169041b7811293: KeyedGameFix = KeyedDeleteFolderFix(
+    gameSource = GameSource.EPIC,
+    gameId = "fa4240e57a3c46b39f169041b7811293",
+    driveCRelativePaths = listOf("ProgramData/Hogwarts Legacy"),
+)

--- a/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
@@ -40,10 +40,12 @@ object GameFixesRegistry {
         STEAM_Fix_1637320,
         STEAM_Fix_2868840,
         STEAM_Fix_3373660,
+        STEAM_Fix_990080,
         EPIC_Fix_b1b4e0b67a044575820cb5e63028dcae,
         EPIC_Fix_dabb52e328834da7bbe99691e374cb84,
         EPIC_Fix_e345fdb9186645a48d30c3f85a8951dc,
         EPIC_Fix_59a0c86d02da42e8ba6444cb171e61bf,
+        EPIC_Fix_fa4240e57a3c46b39f169041b7811293,
     ).associateBy { it.gameSource to it.gameId }
 
     private var fixesProvider: () -> Map<Pair<GameSource, String>, GameFix> = { fixes }

--- a/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
@@ -45,7 +45,7 @@ object GameFixesRegistry {
         EPIC_Fix_dabb52e328834da7bbe99691e374cb84,
         EPIC_Fix_e345fdb9186645a48d30c3f85a8951dc,
         EPIC_Fix_59a0c86d02da42e8ba6444cb171e61bf,
-        EPIC_Fix_fa4240e57a3c46b39f169041b7811293,
+        EPIC_Fix_864c7bc2c2394f7dbd1b534aa068ff56,
     ).associateBy { it.gameSource to it.gameId }
 
     private var fixesProvider: () -> Map<Pair<GameSource, String>, GameFix> = { fixes }

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_990080.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_990080.kt
@@ -1,0 +1,15 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Hogwarts Legacy (Steam)
+ *
+ * Wipes C:\ProgramData\Hogwarts Legacy on every boot. The game caches state there
+ * that occasionally leaves Denuvo / EOS in a bad mood after a previous session.
+ */
+val STEAM_Fix_990080: KeyedGameFix = KeyedDeleteFolderFix(
+    gameSource = GameSource.STEAM,
+    gameId = "990080",
+    driveCRelativePaths = listOf("ProgramData/Hogwarts Legacy"),
+)

--- a/app/src/main/java/app/gamenative/gamefixes/types/DeleteFolderFix.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/types/DeleteFolderFix.kt
@@ -1,0 +1,49 @@
+package app.gamenative.gamefixes
+
+import android.content.Context
+import app.gamenative.data.GameSource
+import com.winlator.container.Container
+import java.io.File
+import timber.log.Timber
+
+/**
+ * Deletes folders relative to the container's `drive_c/` on every launch.
+ *
+ * Used for games that leave stale per-run state in ProgramData (or similar) that
+ * trips up DRM / bootstrap on the next start.
+ */
+class DeleteFolderFix(
+    private val driveCRelativePaths: List<String>,
+) : GameFix {
+    override fun apply(
+        context: Context,
+        gameId: String,
+        installPath: String,
+        installPathWindows: String,
+        container: Container,
+    ): Boolean {
+        var allSucceeded = true
+        for (relativePath in driveCRelativePaths) {
+            val target = File(container.rootDir, ".wine/drive_c/$relativePath")
+            if (!target.exists()) continue
+            try {
+                if (target.deleteRecursively()) {
+                    Timber.tag("GameFixes").i("Deleted '${target.absolutePath}' for game $gameId")
+                } else {
+                    Timber.tag("GameFixes").w("Partial delete of '${target.absolutePath}' for game $gameId")
+                    allSucceeded = false
+                }
+            } catch (e: Exception) {
+                Timber.tag("GameFixes").e(e, "Failed deleting '${target.absolutePath}' for game $gameId")
+                allSucceeded = false
+            }
+        }
+        return allSucceeded
+    }
+}
+
+class KeyedDeleteFolderFix(
+    override val gameSource: GameSource,
+    override val gameId: String,
+    driveCRelativePaths: List<String>,
+) : KeyedGameFix, GameFix by DeleteFolderFix(driveCRelativePaths)

--- a/app/src/main/java/app/gamenative/service/epic/EpicAuthManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicAuthManager.kt
@@ -3,6 +3,7 @@ package app.gamenative.service.epic
 import android.content.Context
 import app.gamenative.data.EpicCredentials
 import app.gamenative.data.EpicGameToken
+import app.gamenative.utils.sanitizeForFilename
 import org.json.JSONObject
 import timber.log.Timber
 import java.io.File
@@ -12,12 +13,41 @@ import java.io.File
  */
 object EpicAuthManager {
 
+    // Denuvo ownership tokens are valid ~30 minutes and the endpoint is rate-limited
+    // (~5 requests / 24h / game). Cache to disk and re-use a few minutes under the
+    // server-side validity window to avoid burning the quota on relaunches.
+    private const val OWNERSHIP_TOKEN_CACHE_TTL_MS = 25L * 60L * 1000L
+
     private fun getCredentialsFilePath(context: Context): String {
         val dir = File(context.filesDir, "epic")
         if (!dir.exists()) {
             dir.mkdirs()
         }
         return File(dir, "credentials.json").absolutePath
+    }
+
+    private fun ownershipTokenCacheFile(context: Context, namespace: String, catalogItemId: String): File {
+        val dir = File(context.filesDir, "epic/ownership_tokens").also { it.mkdirs() }
+        return File(dir, "${namespace.sanitizeForFilename()}_${catalogItemId.sanitizeForFilename()}.hex")
+    }
+
+    private fun readCachedOwnershipTokenHex(context: Context, namespace: String, catalogItemId: String): String? {
+        val file = ownershipTokenCacheFile(context, namespace, catalogItemId)
+        if (!file.exists()) return null
+        if (System.currentTimeMillis() - file.lastModified() >= OWNERSHIP_TOKEN_CACHE_TTL_MS) return null
+        return runCatching { file.readText().trim().takeIf { it.isNotEmpty() } }.getOrNull()
+    }
+
+    private fun writeOwnershipTokenHex(context: Context, namespace: String, catalogItemId: String, hex: String) {
+        runCatching {
+            ownershipTokenCacheFile(context, namespace, catalogItemId).writeText(hex)
+        }.onFailure { Timber.tag("Epic").w(it, "Failed caching ownership token for $namespace:$catalogItemId") }
+    }
+
+    private fun clearOwnershipTokenCache(context: Context) {
+        runCatching {
+            File(context.filesDir, "epic/ownership_tokens").listFiles()?.forEach { it.delete() }
+        }.onFailure { Timber.tag("Epic").w(it, "Failed clearing ownership token cache") }
     }
 
 
@@ -31,6 +61,7 @@ object EpicAuthManager {
          */
         fun clearStoredCredentials(context: Context): Boolean {
             return try {
+                clearOwnershipTokenCache(context)
                 val authFile = File(getCredentialsFilePath(context))
                 if (authFile.exists()) {
                     authFile.delete()
@@ -192,26 +223,33 @@ object EpicAuthManager {
                     return Result.failure(Exception("Namespace and catalogItemId required for ownership token"))
                 }
 
-                Timber.d("Getting ownership token for $namespace:$catalogItemId...")
-                val ownershipResult = EpicAuthClient.getOwnershipToken(
-                    accessToken = credentials.accessToken,
-                    accountId = credentials.accountId,
-                    namespace = namespace,
-                    catalogItemId = catalogItemId
-                )
-
-                if (ownershipResult.isFailure) {
-                    val error = ownershipResult.exceptionOrNull()?.message ?: "Unknown error"
-                    Timber.e("Failed to get required ownership token: $error")
-                    return Result.failure(
-                        Exception("Failed to get ownership token for DRM-protected game: $error")
-                    )
+                val cachedHex = readCachedOwnershipTokenHex(context, namespace, catalogItemId)
+                if (cachedHex != null) {
+                    Timber.d("Using cached ownership token for $namespace:$catalogItemId")
+                    ownershipTokenHex = cachedHex
                 } else {
-                    // Convert binary token to hex string for easier handling
-                    // Use toInt() and 0xFF to prevent sign extension of negative bytes
-                    val tokenBytes = ownershipResult.getOrNull()!!
-                    ownershipTokenHex = tokenBytes.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
-                    Timber.d("Ownership token obtained (${tokenBytes.size} bytes)")
+                    Timber.d("Getting ownership token for $namespace:$catalogItemId...")
+                    val ownershipResult = EpicAuthClient.getOwnershipToken(
+                        accessToken = credentials.accessToken,
+                        accountId = credentials.accountId,
+                        namespace = namespace,
+                        catalogItemId = catalogItemId
+                    )
+
+                    if (ownershipResult.isFailure) {
+                        val error = ownershipResult.exceptionOrNull()?.message ?: "Unknown error"
+                        Timber.e("Failed to get required ownership token: $error")
+                        return Result.failure(
+                            Exception("Failed to get ownership token for DRM-protected game: $error")
+                        )
+                    } else {
+                        // Convert binary token to hex string for easier handling
+                        // Use toInt() and 0xFF to prevent sign extension of negative bytes
+                        val tokenBytes = ownershipResult.getOrNull()!!
+                        ownershipTokenHex = tokenBytes.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+                        writeOwnershipTokenHex(context, namespace, catalogItemId, ownershipTokenHex)
+                        Timber.d("Ownership token obtained (${tokenBytes.size} bytes) and cached")
+                    }
                 }
             }
 
@@ -232,6 +270,7 @@ object EpicAuthManager {
 
     suspend fun logout(context: Context): Result<Unit> {
         return try {
+            clearOwnershipTokenCache(context)
             val credentialsFile = File(getCredentialsFilePath(context))
             if (credentialsFile.exists()) {
                 credentialsFile.delete()

--- a/app/src/main/java/app/gamenative/service/epic/EpicGameLauncher.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicGameLauncher.kt
@@ -3,6 +3,7 @@ package app.gamenative.service.epic
 import android.content.Context
 import app.gamenative.data.EpicGame
 import app.gamenative.data.EpicGameToken
+import app.gamenative.utils.sanitizeForFilename
 import com.winlator.container.Container
 import timber.log.Timber
 import java.io.File
@@ -123,7 +124,7 @@ object EpicGameLauncher {
                 appName = game.appName,
             )
             if (!additionalCommandLine.isNullOrBlank()) {
-                val extraArgs = additionalCommandLine.trim().split(Regex("\\s+"))
+                val extraArgs = tokenizeArgs(additionalCommandLine)
                 params.addAll(extraArgs)
                 Timber.tag("EPIC").d("Added ${extraArgs.size} additional command-line args for ${game.appName}")
             }
@@ -134,6 +135,37 @@ object EpicGameLauncher {
             Timber.e(e, "Failed to build launch parameters")
             Result.failure(e)
         }
+    }
+
+    /**
+     * Tokenize a command-line string, preserving quoted segments. Adjacent
+     * quoted/unquoted runs collapse into one token (so `-arg="value with spaces"`
+     * yields `-arg=value with spaces`). Unbalanced quotes consume to end-of-string.
+     */
+    private fun tokenizeArgs(input: String): List<String> {
+        val tokens = mutableListOf<String>()
+        val current = StringBuilder()
+        var inDouble = false
+        var inSingle = false
+        var hasToken = false
+        for (c in input) {
+            when {
+                inDouble -> if (c == '"') inDouble = false else current.append(c)
+                inSingle -> if (c == '\'') inSingle = false else current.append(c)
+                c == '"' -> { inDouble = true; hasToken = true }
+                c == '\'' -> { inSingle = true; hasToken = true }
+                c.isWhitespace() -> {
+                    if (hasToken) {
+                        tokens.add(current.toString())
+                        current.setLength(0)
+                        hasToken = false
+                    }
+                }
+                else -> { current.append(c); hasToken = true }
+            }
+        }
+        if (hasToken) tokens.add(current.toString())
+        return tokens
     }
 
     /**
@@ -159,9 +191,7 @@ object EpicGameLauncher {
         }
 
         // Sanitize namespace and catalogItemId to prevent path traversal
-        val sanitizedNamespace = namespace.replace(Regex("[^a-zA-Z0-9_-]"), "_")
-        val sanitizedCatalogId = catalogItemId.replace(Regex("[^a-zA-Z0-9_-]"), "_")
-        val fileName = "$sanitizedNamespace$sanitizedCatalogId.ovt"
+        val fileName = "${namespace.sanitizeForFilename()}${catalogItemId.sanitizeForFilename()}.ovt"
 
         val tokenDirInPrefix = File(container.rootDir, ".wine/drive_c/users/Public/Documents/EpicTokens")
         if (!tokenDirInPrefix.exists() && !tokenDirInPrefix.mkdirs()) {

--- a/app/src/main/java/app/gamenative/service/epic/EpicGameLauncher.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicGameLauncher.kt
@@ -3,6 +3,7 @@ package app.gamenative.service.epic
 import android.content.Context
 import app.gamenative.data.EpicGame
 import app.gamenative.data.EpicGameToken
+import com.winlator.container.Container
 import timber.log.Timber
 import java.io.File
 import java.io.IOException
@@ -26,6 +27,7 @@ object EpicGameLauncher {
     */
     suspend fun buildLaunchParameters(
         context: Context,
+        container: Container,
         game: EpicGame,
         offline: Boolean = false,
         languageCode: String = "en-US"
@@ -67,7 +69,7 @@ object EpicGameLauncher {
 
             // Save ownership token to temp file if present
             val ownershipTokenPath = if (gameToken.ownershipToken != null) {
-                saveOwnershipTokenToFile(context, game.namespace, game.catalogId, gameToken.ownershipToken)
+                saveOwnershipTokenToFile(container, game.namespace, game.catalogId, gameToken.ownershipToken)
             } else {
                 null
             }
@@ -114,9 +116,17 @@ object EpicGameLauncher {
                 Timber.tag("EPIC").d("Added ownership token path: $ownershipTokenPath")
             }
 
-            // Additional command-line parameters from game metadata
-            // This would come from game.metadata.customAttributes.AdditionalCommandLine -- We should take this into account if need be
-            // TODO: Do a follow-up to include additional parameters where required for some games
+            val additionalCommandLine = EpicService.getInstance()?.epicManager?.fetchAdditionalCommandLine(
+                context = context,
+                namespace = game.namespace,
+                catalogItemId = game.catalogId,
+                appName = game.appName,
+            )
+            if (!additionalCommandLine.isNullOrBlank()) {
+                val extraArgs = additionalCommandLine.trim().split(Regex("\\s+"))
+                params.addAll(extraArgs)
+                Timber.tag("EPIC").d("Added ${extraArgs.size} additional command-line args for ${game.appName}")
+            }
 
             Timber.tag("EPIC").d("Built ${params.size} launch parameters for ${game.appName}")
             Result.success(params)
@@ -127,15 +137,12 @@ object EpicGameLauncher {
     }
 
     /**
-     * Save ownership token bytes to temp file
-     * File path format: {temp_dir}/{namespace}{catalogItemId}.ovt
-     *
-     * @return Absolute path to the saved token file
-     * @throws IllegalArgumentException if ownershipTokenHex is invalid
-     * @throws IOException if file write fails
+     * Save ownership token bytes inside the container's Wine prefix and return the
+     * Windows-style path. Must be inside the prefix because Pluvia's dosdevices map
+     * doesn't expose the app cache dir on any drive letter.
      */
     private fun saveOwnershipTokenToFile(
-        context: Context,
+        container: Container,
         namespace: String,
         catalogItemId: String,
         ownershipTokenHex: String
@@ -151,15 +158,17 @@ object EpicGameLauncher {
             throw IllegalArgumentException("Ownership token hex string contains invalid characters")
         }
 
-        val tempDir = File(context.cacheDir, "epic_tokens")
-        if (!tempDir.exists()) {
-            tempDir.mkdirs()
-        }
-
         // Sanitize namespace and catalogItemId to prevent path traversal
         val sanitizedNamespace = namespace.replace(Regex("[^a-zA-Z0-9_-]"), "_")
         val sanitizedCatalogId = catalogItemId.replace(Regex("[^a-zA-Z0-9_-]"), "_")
-        val tokenFile = File(tempDir, "$sanitizedNamespace$sanitizedCatalogId.ovt")
+        val fileName = "$sanitizedNamespace$sanitizedCatalogId.ovt"
+
+        val tokenDirInPrefix = File(container.rootDir, ".wine/drive_c/users/Public/Documents/EpicTokens")
+        if (!tokenDirInPrefix.exists() && !tokenDirInPrefix.mkdirs()) {
+            throw IOException("Failed to create OT directory: ${tokenDirInPrefix.absolutePath}")
+        }
+
+        val tokenFile = File(tokenDirInPrefix, fileName)
 
         try {
             // Convert hex string back to bytes
@@ -174,8 +183,9 @@ object EpicGameLauncher {
                 .toByteArray()
 
             tokenFile.writeBytes(tokenBytes)
-            Timber.tag("EPIC").d("Ownership token saved to: ${tokenFile.absolutePath}")
-            return tokenFile.absolutePath
+            val winPath = "C:\\users\\Public\\Documents\\EpicTokens\\$fileName"
+            Timber.tag("EPIC").d("Ownership token saved to: ${tokenFile.absolutePath} (wine path: $winPath)")
+            return winPath
         } catch (e: IllegalArgumentException) {
             Timber.tag("EPIC").e(e, "Failed to parse ownership token hex string")
             throw e
@@ -188,7 +198,23 @@ object EpicGameLauncher {
     /**
      * Clean up temporary ownership token files after game exits
      */
-    fun cleanupOwnershipTokens(context: Context) {
+    fun cleanupOwnershipTokens(context: Context, container: Container? = null) {
+        if (container != null) {
+            try {
+                val tokenDirInPrefix = File(container.rootDir, ".wine/drive_c/users/Public/Documents/EpicTokens")
+                if (tokenDirInPrefix.exists() && tokenDirInPrefix.isDirectory) {
+                    tokenDirInPrefix.listFiles()?.forEach { file ->
+                        if (file.extension == "ovt") {
+                            file.delete()
+                            Timber.tag("EPIC").d("Deleted ownership token file: ${file.name}")
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to cleanup ownership token files")
+            }
+        }
+
         try {
             val tempDir = File(context.cacheDir, "epic_tokens")
             if (tempDir.exists() && tempDir.isDirectory) {

--- a/app/src/main/java/app/gamenative/service/epic/EpicGameLauncher.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicGameLauncher.kt
@@ -138,22 +138,22 @@ object EpicGameLauncher {
     }
 
     /**
-     * Tokenize a command-line string, preserving quoted segments. Adjacent
-     * quoted/unquoted runs collapse into one token (so `-arg="value with spaces"`
-     * yields `-arg=value with spaces`). Unbalanced quotes consume to end-of-string.
+     * Tokenize a Windows-style command-line string, preserving double-quoted
+     * segments. Adjacent quoted/unquoted runs collapse into one token (so
+     * `-arg="value with spaces"` yields `-arg=value with spaces`). Single quotes
+     * are treated as literal characters to match `CommandLineToArgvW` semantics —
+     * args like `-name=Don't` must not be split or merged. Unbalanced double
+     * quotes consume to end-of-string.
      */
     private fun tokenizeArgs(input: String): List<String> {
         val tokens = mutableListOf<String>()
         val current = StringBuilder()
         var inDouble = false
-        var inSingle = false
         var hasToken = false
         for (c in input) {
             when {
                 inDouble -> if (c == '"') inDouble = false else current.append(c)
-                inSingle -> if (c == '\'') inSingle = false else current.append(c)
                 c == '"' -> { inDouble = true; hasToken = true }
-                c == '\'' -> { inSingle = true; hasToken = true }
                 c.isWhitespace() -> {
                     if (hasToken) {
                         tokens.add(current.toString())

--- a/app/src/main/java/app/gamenative/service/epic/EpicManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicManager.kt
@@ -7,6 +7,7 @@ import app.gamenative.data.LaunchInfo
 import app.gamenative.data.LibraryItem
 import app.gamenative.db.dao.EpicGameDao
 import app.gamenative.utils.Net
+import app.gamenative.utils.sanitizeForFilename
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -212,10 +213,21 @@ class EpicManager @Inject constructor(
 
             // Re-fetch catalog metadata for every game so customAttributes-derived
             // fields (requiresOT, canRunOffline, ...) backfill on existing rows.
+            // Hoist credential read out of the per-game loop — refreshing once is
+            // sufficient since a library scan completes in seconds and the token
+            // has a 5-minute expiry buffer in getStoredCredentials.
+            val credentialsResult = EpicAuthManager.getStoredCredentials(context)
+            val accessToken = credentialsResult.getOrNull()?.accessToken
+            if (credentialsResult.isFailure || accessToken.isNullOrEmpty()) {
+                val error = credentialsResult.exceptionOrNull() ?: Exception("No access token")
+                Timber.tag("Epic").e(error, "Cannot refresh library: ${error.message}")
+                return@withContext Result.failure(error)
+            }
+
             val epicGames = mutableListOf<EpicGame>()
             var processedCount = 0
             for ((index, game) in gamesList.withIndex()) {
-                val result = fetchGameInfo(context, game)
+                val result = fetchGameInfo(context, game, accessToken)
 
                 if (result.isSuccess) {
                     val epicGame = result.getOrNull()
@@ -402,59 +414,62 @@ class EpicManager @Inject constructor(
     private suspend fun fetchGameInfo(
         context: Context,
         game: ParsedLibraryItem,
+        accessToken: String,
     ): Result<EpicGame> = withContext(Dispatchers.IO) {
         try {
-            // Get Credentials and restore them
-            val credentials = EpicAuthManager.getStoredCredentials(context)
-            if (credentials.isFailure) {
-                return@withContext Result.failure(credentials.exceptionOrNull() ?: Exception("No credentials"))
-            }
-
-            val accessToken = credentials.getOrNull()?.accessToken
-            if (accessToken.isNullOrEmpty()) {
-                return@withContext Result.failure(Exception("No access token"))
-            }
-
-            val country = game.country ?: "US" // Do we really need this?
-
             // ! We should expertiment with the country to see what affects language downloads
-            val url = "${EpicConstants.EPIC_CATALOG_API_URL}/shared/namespace/${game.namespace}/bulk/items" +
-                "?id=${game.catalogItemId}&includeDLCDetails=true&includeMainGameDetails=true" +
-                "&country=$country"
+            val gameData = fetchCatalogItem(
+                namespace = game.namespace,
+                catalogItemId = game.catalogItemId,
+                accessToken = accessToken,
+                country = game.country ?: "US",
+                includeDLCDetails = true,
+                includeMainGameDetails = true,
+            ) ?: return@withContext Result.failure(Exception("Game data not found in response"))
 
-            Timber.tag("Epic").d("fetching game info for ${game.appName} - url: $url")
-
-            val request = Request.Builder()
-                .url(url)
-                .header("Authorization", "Bearer $accessToken")
-                .header("User-Agent", EpicConstants.EPIC_USER_AGENT)
-                .get()
-                .build()
-
-            val response = httpClient.newCall(request).execute()
-
-            if (!response.isSuccessful) {
-                Timber.w("Failed to fetch game info for ${game.catalogItemId}: ${response.code}")
-                return@withContext Result.failure(Exception("Could not fetch game info: ${response.code}"))
-            }
-
-            val body = response.body?.string()
-            if (body.isNullOrEmpty()) {
-                return@withContext Result.failure(Exception("Could not fetch game info for ${game.catalogItemId}"))
-            }
-
-            val json = JSONObject(body)
-            val gameData: JSONObject? = json.optJSONObject(game.catalogItemId)
-
-            if (gameData != null) {
-                val epicGame = parseGameFromCatalog(gameData, game.appName)
-                return@withContext Result.success(epicGame)
-            } else {
-                return@withContext Result.failure(Exception("Game data not found in response"))
-            }
+            Result.success(parseGameFromCatalog(gameData, game.appName))
         } catch (e: Exception) {
             Timber.w(e, "Error fetching game info for ${game.catalogItemId}")
-            return@withContext Result.failure(e)
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * GET a single item from `/shared/namespace/{ns}/bulk/items` and return the
+     * per-`catalogItemId` JSONObject (or null if the request failed / item missing).
+     * Caller must be on a background dispatcher; the underlying HTTP call is blocking.
+     */
+    private fun fetchCatalogItem(
+        namespace: String,
+        catalogItemId: String,
+        accessToken: String,
+        country: String = "US",
+        includeDLCDetails: Boolean = false,
+        includeMainGameDetails: Boolean = false,
+    ): JSONObject? {
+        val params = buildString {
+            append("?id=").append(catalogItemId)
+            if (includeDLCDetails) append("&includeDLCDetails=true")
+            if (includeMainGameDetails) append("&includeMainGameDetails=true")
+            append("&country=").append(country)
+        }
+        val url = "${EpicConstants.EPIC_CATALOG_API_URL}/shared/namespace/$namespace/bulk/items$params"
+
+        val request = Request.Builder()
+            .url(url)
+            .header("Authorization", "Bearer $accessToken")
+            .header("User-Agent", EpicConstants.EPIC_USER_AGENT)
+            .get()
+            .build()
+
+        return httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                Timber.tag("Epic").w("Catalog fetch failed for $namespace:$catalogItemId: ${response.code}")
+                return@use null
+            }
+            val body = response.body?.string()
+            if (body.isNullOrEmpty()) return@use null
+            JSONObject(body).optJSONObject(catalogItemId)
         }
     }
 
@@ -951,8 +966,7 @@ class EpicManager @Inject constructor(
         forceRefresh: Boolean = false,
     ): String? = withContext(Dispatchers.IO) {
         val cacheDir = File(context.filesDir, "epic/deployment_ids").also { it.mkdirs() }
-        val sanitized = appName.replace(Regex("[^a-zA-Z0-9_-]"), "_")
-        val cacheFile = File(cacheDir, "$sanitized.txt")
+        val cacheFile = File(cacheDir, "${appName.sanitizeForFilename()}.txt")
 
         if (!forceRefresh && cacheFile.exists()) {
             val cacheAgeMs = System.currentTimeMillis() - cacheFile.lastModified()
@@ -1037,8 +1051,7 @@ class EpicManager @Inject constructor(
         forceRefresh: Boolean = false,
     ): String? = withContext(Dispatchers.IO) {
         val cacheDir = File(context.filesDir, "epic/additional_cmdline").also { it.mkdirs() }
-        val sanitized = appName.replace(Regex("[^a-zA-Z0-9_-]"), "_")
-        val cacheFile = File(cacheDir, "$sanitized.txt")
+        val cacheFile = File(cacheDir, "${appName.sanitizeForFilename()}.txt")
 
         if (!forceRefresh && cacheFile.exists()) {
             val cacheAgeMs = System.currentTimeMillis() - cacheFile.lastModified()
@@ -1052,24 +1065,12 @@ class EpicManager @Inject constructor(
             val accessToken = credentials.getOrNull()?.accessToken
             if (accessToken.isNullOrEmpty()) return@withContext null
 
-            val url = "${EpicConstants.EPIC_CATALOG_API_URL}/shared/namespace/$namespace/bulk/items" +
-                "?id=$catalogItemId&country=US"
+            val gameData = fetchCatalogItem(
+                namespace = namespace,
+                catalogItemId = catalogItemId,
+                accessToken = accessToken,
+            ) ?: return@withContext null
 
-            val request = Request.Builder()
-                .url(url)
-                .header("Authorization", "Bearer $accessToken")
-                .header("User-Agent", EpicConstants.EPIC_USER_AGENT)
-                .get()
-                .build()
-
-            val catalogJson = httpClient.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) return@withContext null
-                val body = response.body?.string()
-                if (body.isNullOrEmpty()) return@withContext null
-                JSONObject(body)
-            }
-
-            val gameData = catalogJson.optJSONObject(catalogItemId) ?: return@withContext null
             val additionalCommandLine = parseCustomAttributes(
                 gameData.optJSONObject("customAttributes"),
             ).additionalCommandline

--- a/app/src/main/java/app/gamenative/service/epic/EpicManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicManager.kt
@@ -116,6 +116,7 @@ class EpicManager @Inject constructor(
     // Custom Attributes from the payload.
     data class EpicCustomAttributes(
         val canRunOffline: Boolean = false,
+        val ownershipToken: Boolean = false,
         val cloudSaveFolder: String? = null,
         val cloudIncludeList: String? = null,
         val neverUpdate: Boolean = false,
@@ -209,17 +210,11 @@ class EpicManager @Inject constructor(
                 return@withContext Result.success(0)
             }
 
-            // Get existing game IDs from database to avoid re-fetching
-            val existingCatalogIds = epicGameDao.getAllCatalogIds().toSet()
-            Timber.tag("Epic").d("Found ${existingCatalogIds.size} games already in database")
-
-            // Filter to only new games that need details fetched
-            val newGamesList = gamesList.filter { it.catalogItemId !in existingCatalogIds }
-            Timber.tag("Epic").d("${newGamesList.size} new games need details fetched")
-
+            // Re-fetch catalog metadata for every game so customAttributes-derived
+            // fields (requiresOT, canRunOffline, ...) backfill on existing rows.
             val epicGames = mutableListOf<EpicGame>()
             var processedCount = 0
-            for ((index, game) in newGamesList.withIndex()) {
+            for ((index, game) in gamesList.withIndex()) {
                 val result = fetchGameInfo(context, game)
 
                 if (result.isSuccess) {
@@ -233,10 +228,10 @@ class EpicManager @Inject constructor(
                     Timber.tag("Epic").w("Epic game ${game.appName} could not be fetched")
                 }
 
-                if ((index + 1) % REFRESH_BATCH_SIZE == 0 || index == newGamesList.lastIndex) {
+                if ((index + 1) % REFRESH_BATCH_SIZE == 0 || index == gamesList.lastIndex) {
                     if (epicGames.isNotEmpty()) {
                         epicGameDao.upsertPreservingInstallStatus(epicGames)
-                        Timber.tag("Epic").d("Batch inserted ${epicGames.size} games (processed ${index + 1}/${newGamesList.size})")
+                        Timber.tag("Epic").d("Batch inserted ${epicGames.size} games (processed ${index + 1}/${gamesList.size})")
                         epicGames.clear()
                     }
                 }
@@ -489,6 +484,7 @@ class EpicManager @Inject constructor(
 
         return EpicCustomAttributes(
             canRunOffline = getBooleanAttribute("CanRunOffline", false),
+            ownershipToken = getBooleanAttribute("OwnershipToken", false),
             cloudSaveFolder = getAttribute("CloudSaveFolder"),
             cloudIncludeList = getAttribute("CloudIncludeList"),
             folderName = getAttribute("FolderName"),
@@ -499,6 +495,7 @@ class EpicManager @Inject constructor(
             thirdPartyManagedApp = getAttribute("ThirdPartyManagedApp"),
             thirdPartyManagedProvider = getAttribute("ThirdPartyManagedProvider"),
             partnerLinkType = getAttribute("partnerLinkType"),
+            additionalCommandline = getAttribute("AdditionalCommandLine"),
             executableName = getAttribute("MainWindowProcessName"),
         )
     }
@@ -585,6 +582,7 @@ class EpicManager @Inject constructor(
         // Parse custom attributes for cloud saves and offline support
         val parsedAttributes = parseCustomAttributes(data.optJSONObject("customAttributes"))
         val canRunOffline = parsedAttributes.canRunOffline
+        val requiresOwnershipToken = parsedAttributes.ownershipToken
         val cloudSaveEnabled = !parsedAttributes.cloudSaveFolder.isNullOrEmpty()
         val saveFolder = parsedAttributes.cloudSaveFolder ?: ""
         val executable = parsedAttributes.executableName ?: ""
@@ -629,8 +627,8 @@ class EpicManager @Inject constructor(
             executable = executable,
             installSize = 0,
             downloadSize = 0,
-            canRunOffline = canRunOffline, // Unknown from catalog API, will need manifest
-            requiresOT = false,
+            canRunOffline = canRunOffline,
+            requiresOT = requiresOwnershipToken,
             cloudSaveEnabled = cloudSaveEnabled,
             saveFolder = saveFolder,
             thirdPartyManagedApp = thirdPartyApp,
@@ -1022,6 +1020,64 @@ class EpicManager @Inject constructor(
             deploymentId
         } catch (e: Exception) {
             Timber.tag("Epic").e(e, "Exception fetching deployment id for $appName")
+            null
+        }
+    }
+
+    /**
+     * Fetch `customAttributes.AdditionalCommandLine` from the Epic catalog API.
+     * Mirrors legendary `Game.additional_command_line`. Cached per app-name with
+     * the same TTL as deployment ids.
+     */
+    suspend fun fetchAdditionalCommandLine(
+        context: Context,
+        namespace: String,
+        catalogItemId: String,
+        appName: String,
+        forceRefresh: Boolean = false,
+    ): String? = withContext(Dispatchers.IO) {
+        val cacheDir = File(context.filesDir, "epic/additional_cmdline").also { it.mkdirs() }
+        val sanitized = appName.replace(Regex("[^a-zA-Z0-9_-]"), "_")
+        val cacheFile = File(cacheDir, "$sanitized.txt")
+
+        if (!forceRefresh && cacheFile.exists()) {
+            val cacheAgeMs = System.currentTimeMillis() - cacheFile.lastModified()
+            if (cacheAgeMs < DEPLOYMENT_ID_CACHE_TTL_MS) {
+                return@withContext cacheFile.readText().trim().takeIf { it.isNotEmpty() }
+            }
+        }
+
+        try {
+            val credentials = EpicAuthManager.getStoredCredentials(context)
+            val accessToken = credentials.getOrNull()?.accessToken
+            if (accessToken.isNullOrEmpty()) return@withContext null
+
+            val url = "${EpicConstants.EPIC_CATALOG_API_URL}/shared/namespace/$namespace/bulk/items" +
+                "?id=$catalogItemId&country=US"
+
+            val request = Request.Builder()
+                .url(url)
+                .header("Authorization", "Bearer $accessToken")
+                .header("User-Agent", EpicConstants.EPIC_USER_AGENT)
+                .get()
+                .build()
+
+            val catalogJson = httpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@withContext null
+                val body = response.body?.string()
+                if (body.isNullOrEmpty()) return@withContext null
+                JSONObject(body)
+            }
+
+            val gameData = catalogJson.optJSONObject(catalogItemId) ?: return@withContext null
+            val additionalCommandLine = parseCustomAttributes(
+                gameData.optJSONObject("customAttributes"),
+            ).additionalCommandline
+
+            cacheFile.writeText(additionalCommandLine ?: "")
+            additionalCommandLine
+        } catch (e: Exception) {
+            Timber.tag("Epic").e(e, "Exception fetching additional command line for $appName")
             null
         }
     }

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -528,15 +528,16 @@ class EpicService : Service() {
 
         suspend fun buildLaunchParameters(
             context: Context,
+            container: Container,
             game: EpicGame,
             offline: Boolean = false,
             languageCode: String = "en-US"
         ): Result<List<String>> {
-            return EpicGameLauncher.buildLaunchParameters(context, game, offline, languageCode)
+            return EpicGameLauncher.buildLaunchParameters(context, container, game, offline, languageCode)
         }
 
-        fun cleanupLaunchTokens(context: Context) {
-            EpicGameLauncher.cleanupOwnershipTokens(context)
+        fun cleanupLaunchTokens(context: Context, container: Container? = null) {
+            EpicGameLauncher.cleanupOwnershipTokens(context, container)
         }
 
         // ==========================================================================

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1852,7 +1852,7 @@ fun preLaunchApp(
 
             // Delete Ownership Token if exists
             Timber.tag("Epic").i("[Ownership Tokens] Cleaning up launch tokens for Epic games...")
-            EpicService.cleanupLaunchTokens(context)
+            EpicService.cleanupLaunchTokens(context, container)
 
             setLoadingDialogVisible(false)
             onSuccess(context, appId)

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3444,7 +3444,7 @@ private fun getWineStartCommand(
         // Get Epic launch parameters
         Timber.tag("XServerScreen").d("Building Epic launch parameters for ${game.appName}...")
         val runArguments: List<String> = runBlocking {
-            val result = EpicService.buildLaunchParameters(context, game, false)
+            val result = EpicService.buildLaunchParameters(context, container, game, false)
             if (result.isFailure) {
                 Timber.tag("XServerScreen").e(result.exceptionOrNull(), "Failed to build Epic launch parameters")
             }

--- a/app/src/main/java/app/gamenative/utils/StringUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/StringUtils.kt
@@ -5,6 +5,7 @@ import app.gamenative.Constants
 import java.text.Normalizer
 
 private val REGEX_UNACCENT = "\\p{M}+".toRegex()
+private val REGEX_FILENAME_UNSAFE = Regex("[^a-zA-Z0-9_-]")
 
 
 /**
@@ -23,6 +24,13 @@ fun CharSequence.unaccent(): String {
     val temp = Normalizer.normalize(this, Normalizer.Form.NFKD)
     return REGEX_UNACCENT.replace(temp, "")
 }
+
+/**
+ * Replaces any character that isn't ASCII alphanumeric, underscore, or hyphen with an
+ * underscore. Intended for turning identifiers (app names, namespaces, catalog ids)
+ * into safe filename components.
+ */
+fun String.sanitizeForFilename(): String = REGEX_FILENAME_UNSAFE.replace(this, "_")
 
 // This doesn't belong here, but i'm tired.
 fun Long.getProfileUrl(): String = "${Constants.Persona.PROFILE_URL}$this/"


### PR DESCRIPTION
## Description
Denuvo DRM was not working in Epic. This fixes Hogwarts Legacy on Epic for instance.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Denuvo support for Epic by saving ownership tokens inside the Wine prefix and honoring catalog-provided command-line args. Also fixes Hogwarts Legacy on Epic and Steam by deleting stale ProgramData on each launch.

- **New Features**
  - `EpicAuthManager`: caches Denuvo ownership tokens (~25‑min TTL) and clears the cache on logout.
  - `EpicGameLauncher`: writes `.ovt` tokens to `C:\users\Public\Documents\EpicTokens\`, tokenizes and appends catalog `AdditionalCommandLine`, and removes tokens on exit.
  - `EpicManager`: parses `OwnershipToken` and `AdditionalCommandLine`, sets `requiresOT`, caches extra args, and re-fetches catalog metadata for all apps.
  - `DeleteFolderFix`: adds Hogwarts Legacy fixes for Epic (`864c7bc2...`) and Steam (`990080`) to delete `ProgramData/Hogwarts Legacy` on every launch.

- **Migration**
  - Log out and log in to Epic once to refresh ownership tokens.

<sup>Written for commit b5959fd18e49bdfbaf0f70b562ca2bf5f408970f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic clearing of Hogwarts Legacy cache/folders on each launch for Epic and Steam.
  * Epic launches now handle ownership tokens and can include additional command-line arguments.

* **Improvements**
  * Epic library sync reloads metadata for all games to backfill attributes.
  * Client-side caching for Epic tokens with TTL and safer filename handling for cached data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->