### PR TITLE
fix: correct half-texel offset in FSR RCAS sampling

### DIFF
--- a/app/src/main/java/com/winlator/renderer/effects/FSR1RcasEffect.java
+++ b/app/src/main/java/com/winlator/renderer/effects/FSR1RcasEffect.java
@@ -49,7 +49,7 @@ public class FSR1RcasEffect extends Effect {
                 "varying vec2 vUV;\n" +
                 "#define FSR_RCAS_LIMIT (0.25 - (1.0 / 16.0))\n" +
                 "void FsrRcasCon(out float con, float sharpness) { con = exp2(-sharpness); }\n" +
-                "vec4 FsrRcasLoadF(vec2 p) { return texture2D(screenTexture, p / resolution); }\n" +
+                "vec4 FsrRcasLoadF(vec2 p) { return texture2D(screenTexture, (p + 0.5) / resolution); }\n" +
                 "vec3 FsrRcasF(vec2 ip, float con) {\n" +
                 "    vec2 sp = vec2(ip);\n" +
                 "    vec3 b = FsrRcasLoadF(sp + vec2(0.0, -1.0)).rgb;\n" +


### PR DESCRIPTION
## Description

The FSR RCAS sharpening pass was producing jagged, nearest-neighbor-like output because `FsrRcasLoadF` converted integer texel coordinates to UV space using `p / resolution`, which produces texel-boundary UVs. OpenGL textures sample at texel centers, so the correct formula is `(p + 0.5) / resolution`. This half-texel misalignment caused all neighborhood sharpening taps to sample between texels instead of at their centers.

This was originally flagged by the cubic code review bot on PR #1112 

https://discord.com/channels/1378308569287622737/1501666776289771590

## Recording

Will attach after on-device verification.

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [ ] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the FSR RCAS sharpening pass by sampling texel centers with a half-texel offset in the fragment shader. This removes jagged, nearest-neighbor artifacts and restores correct sharpening output.

<sup>Written for commit 77d643b0f6ee2ad092b76cf062fa6b45e64fbc50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image sharpening accuracy by refining texture coordinate sampling in the graphics rendering pipeline for enhanced visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->