### PR TITLE
fix: limit XI2 to bionic container

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1577,11 +1577,12 @@ fun XServerScreen(
             }
             performanceHudHost = frameLayout
             val appId = appId
+            val usrGlibc: Boolean = container.getContainerVariant().equals(Container.GLIBC, ignoreCase = true)
             val existingXServer =
                 PluviaApp.xEnvironment
                     ?.getComponent<XServerComponent>(XServerComponent::class.java)
                     ?.xServer
-            val xServerToUse = existingXServer ?: XServer(ScreenInfo(xServerState.value.screenSize))
+            val xServerToUse = existingXServer ?: XServer(ScreenInfo(xServerState.value.screenSize), usrGlibc)
             val xServerView = XServerView(
                 context,
                 xServerToUse,

--- a/app/src/main/java/com/winlator/xserver/XClient.java
+++ b/app/src/main/java/com/winlator/xserver/XClient.java
@@ -104,7 +104,8 @@ public class XClient implements XResourceManager.OnResourceLifecycleListener {
         }
 
         XInput2Extension xi2 = xServer.getExtension(XInput2Extension.MAJOR_OPCODE);
-        xi2.onClientDisconnected(this);
+        if (xi2 != null)
+            xi2.onClientDisconnected(this);
     }
 
     public void generateSequenceNumber() {

--- a/app/src/main/java/com/winlator/xserver/XServer.java
+++ b/app/src/main/java/com/winlator/xserver/XServer.java
@@ -45,8 +45,9 @@ public class XServer {
     private final EnumMap<Lockable, ReentrantLock> locks = new EnumMap<>(Lockable.class);
     private boolean relativeMouseMovement = false;
     private boolean simulateTouchScreen = false;
+    private boolean runningFromGlibc = false;
 
-    public XServer(ScreenInfo screenInfo) {
+    public XServer(ScreenInfo screenInfo, boolean useGlibcContainer) {
         Log.d("XServer", "Creating xServer " + screenInfo);
         this.screenInfo = screenInfo;
         for (Lockable lockable : Lockable.values()) locks.put(lockable, new ReentrantLock());
@@ -58,6 +59,7 @@ public class XServer {
         selectionManager = new SelectionManager(windowManager);
         inputDeviceManager = new InputDeviceManager(this);
         grabManager = new GrabManager(this);
+        runningFromGlibc = useGlibcContainer;
 
         DesktopHelper.attachTo(this);
         setupExtensions();
@@ -208,7 +210,8 @@ public class XServer {
             }
 
             XInput2Extension xi = getExtension(XInput2Extension.MAJOR_OPCODE);
-            xi.emitRawMotion(2, dx, dy);
+            if (xi != null)
+                xi.emitRawMotion(2, dx, dy);
         }
     }
 
@@ -217,7 +220,8 @@ public class XServer {
             pointer.setButton(buttonCode, true);
 
             XInput2Extension xi = getExtension(XInput2Extension.MAJOR_OPCODE);
-            xi.emitRawButton(2, buttonCode.code(), true);
+            if (xi != null)
+                xi.emitRawButton(2, buttonCode.code(), true);
         }
     }
 
@@ -226,7 +230,8 @@ public class XServer {
             pointer.setButton(buttonCode, false);
 
             XInput2Extension xi = getExtension(XInput2Extension.MAJOR_OPCODE);
-            xi.emitRawButton(2, buttonCode.code(), false);
+            if (xi != null)
+                xi.emitRawButton(2, buttonCode.code(), false);
         }
     }
 
@@ -267,7 +272,8 @@ public class XServer {
         registerExtension(new DRI3Extension(),      nextEventId, nextErrorId);
         registerExtension(new PresentExtension(),   nextEventId, nextErrorId);
         registerExtension(new SyncExtension(),      nextEventId, nextErrorId);
-        registerExtension(new XInput2Extension(),   nextEventId, nextErrorId);
+        if (!runningFromGlibc)
+            registerExtension(new XInput2Extension(),   nextEventId, nextErrorId);
     }
 
     public <T extends Extension> T getExtension(int opcode) {


### PR DESCRIPTION
## Description
tentative fix for https://discord.com/channels/1378308569287622737/1501145964919128115
glibc wine could be using broken XI2 implementation, breaking camera movement in games

## Recording
-

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable XInput2 (XI2) on `glibc` containers to avoid buggy input handling in Wine that breaks camera movement in games. XI2 remains enabled on `bionic` containers, and XI2 calls are now null-safe.

- **Bug Fixes**
  - Register `XInput2Extension` only when not running from `glibc` (`XServer` now takes a `useGlibcContainer` flag).
  - Pass the container variant from `XServerScreen` to the `XServer` constructor.
  - Add null checks before calling XI2 methods (`emitRawMotion`, `emitRawButton`, `onClientDisconnected`).

<sup>Written for commit c4f02a4c1b8d2bdb75b989f36cccfe7a469b2afc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crash during X server client disconnection by adding null-checks.

* **Improvements**
  * Added support for GLIBC container variants during X server initialization.
  * Enhanced input event handling stability with conditional extension availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->