### PR TITLE
fix: default FPS limiter to disabled for pre-0.9.1 containers

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -212,7 +212,7 @@ private const val FPS_LIMITER_ENABLED_EXTRA = "fpsLimiterEnabled"
 private const val FPS_LIMITER_TARGET_EXTRA = "fpsLimiterTarget"
 
 private fun initialFpsLimiterEnabled(container: Container): Boolean =
-    parseBooleanExtra(container.getExtra(FPS_LIMITER_ENABLED_EXTRA)) ?: true
+    parseBooleanExtra(container.getExtra(FPS_LIMITER_ENABLED_EXTRA)) ?: false
 
 private fun initialFpsLimiterTarget(container: Container): Int =
     parsePositiveFpsLimit(container.getExtra(FPS_LIMITER_TARGET_EXTRA))


### PR DESCRIPTION
## Description

The built-in FPS limiter introduced in 0.9.1 defaults to enabled at 60fps. For every container created before 0.9.1 (which is essentially all of them), the limiter silently activates on first launch because there is no saved `fpsLimiterEnabled` extra yet. The `parseBooleanExtra` call falls through to the hardcoded `true` default.

This causes users to be capped at 60fps regardless of disabling the sidebar toggle, removing DXVK_FRAME_RATE from environment, or setting in-game fps to unlimited. The only workaround is manually toggling the limiter on then off in the quick menu so the `false` value gets persisted, or reverting to 0.9.0.

The fix is a one-character change: default `initialFpsLimiterEnabled` to `false` instead of `true`. Existing containers where the user already toggled the limiter on are unaffected since their saved extra takes precedence. New containers and pre-0.9.1 containers will now start uncapped, and users can opt in to the limiter from the quick menu.

### Discord reports

https://discord.com/channels/1378308569287622737/1501131331575218307
https://discord.com/channels/1378308569287622737/1501640621704609812
https://discord.com/channels/1378308569287622737/1500055122766463026

## Recording


## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the built-in FPS limiter to off for containers created before 0.9.1 to prevent a silent 60 FPS cap on first launch.

- **Bug Fixes**
  - Changed fallback for `fpsLimiterEnabled` to false when the extra is missing.
  - Containers with a saved setting are unaffected; new and legacy containers start uncapped and can enable the limiter from the quick menu.

<sup>Written for commit 0178b80dfb0895d43cd47671e007d08c121bdaf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated FPS limiter initialization to default to disabled when configuration is unavailable, improving initial application performance and startup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->