### PR TITLE
Fix RenPy workshop mod duplication

### DIFF
--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -1476,6 +1476,27 @@ object WorkshopManager {
             .any { it.isFile && it.name == "gameinfo.txt" && !it.absolutePath.contains("steam_settings") }
 
     /**
+     * Detects Ren'Py installs by their standard runtime layout.
+     *
+     * Ren'Py recursively scans the install's game/ tree. Workshop item
+     * symlinks placed under game/ or game/steam_settings/mods therefore expose
+     * the same scripts a second time when the game also loads Workshop items
+     * through Steam/Ren'Py integration.
+     */
+    private fun isRenPyGame(gameRootDir: File): Boolean {
+        val gameDir = File(gameRootDir, "game")
+        if (!gameDir.isDirectory) return false
+
+        if (File(gameRootDir, "renpy").isDirectory) return true
+        if (File(gameRootDir, "renpy.py").isFile) return true
+
+        val hasRenPyPayload = gameDir.listFiles()?.any { file ->
+            file.isFile && file.extension.lowercase() in setOf("rpy", "rpyc", "rpym", "rpymc", "rpa")
+        } == true
+        return hasRenPyPayload && File(gameRootDir, "lib").isDirectory
+    }
+
+    /**
      * Copies preview images from workshop item directories into a
      * `mod_images/<itemId>/` tree under [settingsDir] for gbe_fork.
      */
@@ -2109,13 +2130,25 @@ object WorkshopManager {
         val isLeft4Dead2 = appId == 550
         val isSkyrim = appId == 72850 || gameName.contains("skyrim", ignoreCase = true)
         val isSourceEngine = isSourceEngine(gameRootDir)
+        val isRenPy = isRenPyGame(gameRootDir)
+        if (isRenPy) {
+            cleanupNestedSteamSettingsWorkshopArtifacts(workshopContentDir)
+            cleanupNestedSteamSettingsWorkshopArtifacts(gameRootDir)
+        }
 
         // ── Manual mod path override ────────────────────────────────────────
         // When the user has set a custom mod folder, symlink all workshop
         // items into that directory. mods.json is still populated for games
         // that use ISteamUGC. All automatic detection is bypassed.
         val hasManualModPath = workshopModPath.isNotEmpty()
-        if (hasManualModPath) {
+        val useManualModPath = hasManualModPath && !isRenPy
+        if (hasManualModPath && isRenPy) {
+            Timber.tag(TAG).i(
+                "Ren'Py game detected for $gameName; ignoring manual Workshop mod path " +
+                    "to avoid duplicate script loading"
+            )
+        }
+        if (useManualModPath) {
             val targetDir = File(workshopModPath)
 
             // ── Clean ALL workshop symlinks from every possible location ─────
@@ -2260,10 +2293,15 @@ object WorkshopManager {
         //  • .NET / Unity games (no ISteamUGC in exe)     → filesystem path
         var stdSeenWithHighDir = false
 
-        val willUseFilesystemMods = if (hasManualModPath) {
+        val willUseFilesystemMods = if (useManualModPath) {
             // User chose a specific mod folder — always populate mods.json
             // alongside the manual symlinks (covers ISteamUGC games too)
             Timber.tag(TAG).i("Manual mod path set for $gameName — forcing ISteamUGC mods.json")
+            false
+        } else if (isRenPy) {
+            Timber.tag(TAG).i(
+                "Ren'Py game detected for $gameName; using Steam Workshop metadata only"
+            )
             false
         } else if (appId in forceStandardAppIds) {
             stdSeenWithHighDir = true // treat like stdSeen so Phase 6 + cleanup runs
@@ -2296,7 +2334,7 @@ object WorkshopManager {
         } else {
             Timber.tag(TAG).d(
                 "Strategy detection skipped (winePrefix=${winePrefix.isNotEmpty()}, " +
-                    "isSkyrim=$isSkyrim, isSourceEngine=$isSourceEngine)"
+                    "isSkyrim=$isSkyrim, isSourceEngine=$isSourceEngine, isRenPy=$isRenPy)"
             )
             false
         }
@@ -2382,11 +2420,13 @@ object WorkshopManager {
                         clearModEntries(modsDir)
                         modsDir.delete()
                     }
-                    modsDir.mkdirs()
+                    if (!isRenPy) {
+                        modsDir.mkdirs()
 
-                    modDirs.forEach { itemDir ->
-                        val linkPath = modsDir.toPath().resolve(itemDir.name)
-                        Files.createSymbolicLink(linkPath, itemDir.toPath())
+                        modDirs.forEach { itemDir ->
+                            val linkPath = modsDir.toPath().resolve(itemDir.name)
+                            Files.createSymbolicLink(linkPath, itemDir.toPath())
+                        }
                     }
 
                     // Write mods.json with titles and primary_filename so
@@ -2398,9 +2438,15 @@ object WorkshopManager {
                     copyPreviewImages(modDirs, settingsDir)
 
                     configuredCount++
-                    Timber.tag(TAG).d(
-                        "Configured ${modDirs.size} mod symlinks at ${modsDir.absolutePath}"
-                    )
+                    if (isRenPy) {
+                        Timber.tag(TAG).d(
+                            "Configured mods.json only at ${settingsDir.absolutePath} for Ren'Py"
+                        )
+                    } else {
+                        Timber.tag(TAG).d(
+                            "Configured ${modDirs.size} mod symlinks at ${modsDir.absolutePath}"
+                        )
+                    }
                     Timber.tag(TAG).d(
                         "mods.json written (${modDirs.size} entries) next to ${file.name}: " +
                             modDirs.joinToString { it.name }
@@ -2851,14 +2897,14 @@ object WorkshopManager {
         }.getOrElse { workshopContentDir.absolutePath }
         // When the user has a manual mod path inside the game tree, skip
         // cleaning symlinks in that directory — they were just created above.
-        val manualTargetCanonical = if (hasManualModPath) {
+        val manualTargetCanonical = if (useManualModPath) {
             runCatching { File(workshopModPath).canonicalPath }.getOrElse { workshopModPath }
         } else ""
         gameRootDir.walkTopDown().maxDepth(6).forEach { entry ->
             if (!Files.isSymbolicLink(entry.toPath())) return@forEach
             if (entry.absolutePath.contains("steam_settings")) return@forEach
             // Protect manual mod path symlinks from stale cleanup
-            if (hasManualModPath && manualTargetCanonical.isNotEmpty()) {
+            if (useManualModPath && manualTargetCanonical.isNotEmpty()) {
                 val parentCanonical = runCatching {
                     entry.parentFile?.canonicalPath ?: ""
                 }.getOrElse { entry.parentFile?.absolutePath ?: "" }
@@ -2924,7 +2970,7 @@ object WorkshopManager {
         // already fully handled by the VPK→addons/ and BSP→maps/workshop/
         // symlinks above. Running the detector on them causes regressions
         // (e.g. item-directory symlinks in maps/ confuse L4D2).
-        if (winePrefix.isNotEmpty() && modDirs.isNotEmpty() && !isSourceEngine && !stdSeenWithHighDir && !hasManualModPath) {
+        if (winePrefix.isNotEmpty() && modDirs.isNotEmpty() && !isSourceEngine && !isRenPy && !stdSeenWithHighDir && !useManualModPath) {
             // Check if Phase 7 (Unity AppData) will handle mod directories.
             // If it does, skip Phase 6 SymlinkIntoDir for the same directory
             // names so mods aren't placed at both the install dir AND AppData.
@@ -3181,7 +3227,7 @@ object WorkshopManager {
         // launches may have created symlinks in the game's mod directories
         // (e.g. mods/). Remove them so the game doesn't see duplicate
         // workshop items (one from ISteamUGC/mods.json and one from the filesystem).
-        if (stdSeenWithHighDir && winePrefix.isNotEmpty() && !hasManualModPath) {
+        if ((stdSeenWithHighDir || isRenPy) && winePrefix.isNotEmpty() && !useManualModPath) {
             try {
                 val detection = getOrDetectStrategy(gameRootDir, winePrefix, gameName)
                 val strategy = detection.strategy
@@ -3271,6 +3317,32 @@ object WorkshopManager {
                 Files.deleteIfExists(entry.toPath())
             } else if (entry.isDirectory) {
                 entry.deleteRecursively()
+            }
+        }
+    }
+
+    /**
+     * Removes GameNative Workshop exposure artifacts accidentally created inside
+     * trees that Ren'Py may scan for scripts. Nested steam_settings/mods links
+     * can make the same .rpy/.rpyc files visible twice.
+     */
+    private fun cleanupNestedSteamSettingsWorkshopArtifacts(rootDir: File) {
+        if (!rootDir.isDirectory) return
+        rootDir.walkTopDown().maxDepth(8).forEach { dir ->
+            if (!dir.isDirectory || !dir.name.equals("steam_settings", ignoreCase = true)) {
+                return@forEach
+            }
+            val modsDir = File(dir, "mods")
+            if (modsDir.isDirectory) {
+                clearModEntries(modsDir)
+                if (modsDir.listFiles()?.isEmpty() != false) {
+                    modsDir.delete()
+                }
+            }
+            File(dir, "mods.json").apply { if (isFile) writeText("{}") }
+            File(dir, "mod_images").deleteRecursively()
+            if (dir.listFiles()?.isEmpty() == true) {
+                dir.delete()
             }
         }
     }

--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -16,6 +16,7 @@ import android.content.Context
 import app.gamenative.PrefManager
 import app.gamenative.R
 import app.gamenative.data.DownloadInfo
+import app.gamenative.data.GameSource
 import app.gamenative.service.SteamService
 import app.gamenative.utils.ContainerUtils
 import com.winlator.xenvironment.ImageFs
@@ -39,6 +40,9 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import app.gamenative.utils.Net
+import app.gamenative.workshop.compatibility.WorkshopCompatibilityOverride
+import app.gamenative.workshop.compatibility.WorkshopCompatibilityRegistry
+import app.gamenative.workshop.compatibility.WorkshopExposureMode
 import okhttp3.Request
 import org.json.JSONObject
 import org.tukaani.xz.LZMAInputStream
@@ -1476,27 +1480,6 @@ object WorkshopManager {
             .any { it.isFile && it.name == "gameinfo.txt" && !it.absolutePath.contains("steam_settings") }
 
     /**
-     * Detects Ren'Py installs by their standard runtime layout.
-     *
-     * Ren'Py recursively scans the install's game/ tree. Workshop item
-     * symlinks placed under game/ or game/steam_settings/mods therefore expose
-     * the same scripts a second time when the game also loads Workshop items
-     * through Steam/Ren'Py integration.
-     */
-    private fun isRenPyGame(gameRootDir: File): Boolean {
-        val gameDir = File(gameRootDir, "game")
-        if (!gameDir.isDirectory) return false
-
-        if (File(gameRootDir, "renpy").isDirectory) return true
-        if (File(gameRootDir, "renpy.py").isFile) return true
-
-        val hasRenPyPayload = gameDir.listFiles()?.any { file ->
-            file.isFile && file.extension.lowercase() in setOf("rpy", "rpyc", "rpym", "rpymc", "rpa")
-        } == true
-        return hasRenPyPayload && File(gameRootDir, "lib").isDirectory
-    }
-
-    /**
      * Copies preview images from workshop item directories into a
      * `mod_images/<itemId>/` tree under [settingsDir] for gbe_fork.
      */
@@ -2074,6 +2057,7 @@ object WorkshopManager {
      * @param items The subscribed workshop items with metadata
      * @param winePrefix The Wine prefix path (for AppData detection)
      * @param gameName The game's display name (for fuzzy AppData matching)
+     * @param compatibilityOverride Optional per-game Workshop compatibility behavior.
      */
     fun configureModSymlinks(
         gameRootDir: File,
@@ -2082,6 +2066,7 @@ object WorkshopManager {
         winePrefix: String = "",
         gameName: String = "",
         workshopModPath: String = "",
+        compatibilityOverride: WorkshopCompatibilityOverride? = null,
     ) {
         if (!workshopContentDir.exists()) {
             Timber.tag(TAG).d("Workshop content dir doesn't exist yet, skipping symlink config")
@@ -2130,8 +2115,9 @@ object WorkshopManager {
         val isLeft4Dead2 = appId == 550
         val isSkyrim = appId == 72850 || gameName.contains("skyrim", ignoreCase = true)
         val isSourceEngine = isSourceEngine(gameRootDir)
-        val isRenPy = isRenPyGame(gameRootDir)
-        if (isRenPy) {
+        val useMetadataOnly =
+            compatibilityOverride?.exposureMode == WorkshopExposureMode.METADATA_ONLY
+        if (compatibilityOverride?.cleanupNestedSteamSettingsArtifacts == true) {
             cleanupNestedSteamSettingsWorkshopArtifacts(gameRootDir)
         }
 
@@ -2140,11 +2126,12 @@ object WorkshopManager {
         // items into that directory. mods.json is still populated for games
         // that use ISteamUGC. All automatic detection is bypassed.
         val hasManualModPath = workshopModPath.isNotEmpty()
-        val useManualModPath = hasManualModPath && !isRenPy
-        if (hasManualModPath && isRenPy) {
+        val ignoreManualModPath =
+            compatibilityOverride?.ignoreManualModPath == true || useMetadataOnly
+        val useManualModPath = hasManualModPath && !ignoreManualModPath
+        if (hasManualModPath && ignoreManualModPath) {
             Timber.tag(TAG).i(
-                "Ren'Py game detected for $gameName; ignoring manual Workshop mod path " +
-                    "to avoid duplicate script loading"
+                "Workshop compatibility override for $gameName ignores manual Workshop mod path"
             )
         }
         if (useManualModPath) {
@@ -2297,9 +2284,9 @@ object WorkshopManager {
             // alongside the manual symlinks (covers ISteamUGC games too)
             Timber.tag(TAG).i("Manual mod path set for $gameName — forcing ISteamUGC mods.json")
             false
-        } else if (isRenPy) {
+        } else if (useMetadataOnly) {
             Timber.tag(TAG).i(
-                "Ren'Py game detected for $gameName; using Steam Workshop metadata only"
+                "Workshop compatibility override for $gameName: using Steam metadata only"
             )
             false
         } else if (appId in forceStandardAppIds) {
@@ -2333,7 +2320,8 @@ object WorkshopManager {
         } else {
             Timber.tag(TAG).d(
                 "Strategy detection skipped (winePrefix=${winePrefix.isNotEmpty()}, " +
-                    "isSkyrim=$isSkyrim, isSourceEngine=$isSourceEngine, isRenPy=$isRenPy)"
+                    "isSkyrim=$isSkyrim, isSourceEngine=$isSourceEngine, " +
+                    "useMetadataOnly=$useMetadataOnly)"
             )
             false
         }
@@ -2419,7 +2407,7 @@ object WorkshopManager {
                         clearModEntries(modsDir)
                         modsDir.delete()
                     }
-                    if (!isRenPy) {
+                    if (!useMetadataOnly) {
                         modsDir.mkdirs()
 
                         modDirs.forEach { itemDir ->
@@ -2437,9 +2425,10 @@ object WorkshopManager {
                     copyPreviewImages(modDirs, settingsDir)
 
                     configuredCount++
-                    if (isRenPy) {
+                    if (useMetadataOnly) {
                         Timber.tag(TAG).d(
-                            "Configured mods.json only at ${settingsDir.absolutePath} for Ren'Py"
+                            "Configured mods.json only at ${settingsDir.absolutePath} " +
+                                "by compatibility override"
                         )
                     } else {
                         Timber.tag(TAG).d(
@@ -2969,7 +2958,14 @@ object WorkshopManager {
         // already fully handled by the VPK→addons/ and BSP→maps/workshop/
         // symlinks above. Running the detector on them causes regressions
         // (e.g. item-directory symlinks in maps/ confuse L4D2).
-        if (winePrefix.isNotEmpty() && modDirs.isNotEmpty() && !isSourceEngine && !isRenPy && !stdSeenWithHighDir && !useManualModPath) {
+        if (
+            winePrefix.isNotEmpty() &&
+            modDirs.isNotEmpty() &&
+            !isSourceEngine &&
+            !useMetadataOnly &&
+            !stdSeenWithHighDir &&
+            !useManualModPath
+        ) {
             // Check if Phase 7 (Unity AppData) will handle mod directories.
             // If it does, skip Phase 6 SymlinkIntoDir for the same directory
             // names so mods aren't placed at both the install dir AND AppData.
@@ -3226,7 +3222,7 @@ object WorkshopManager {
         // launches may have created symlinks in the game's mod directories
         // (e.g. mods/). Remove them so the game doesn't see duplicate
         // workshop items (one from ISteamUGC/mods.json and one from the filesystem).
-        if ((stdSeenWithHighDir || isRenPy) && winePrefix.isNotEmpty() && !useManualModPath) {
+        if ((stdSeenWithHighDir || useMetadataOnly) && winePrefix.isNotEmpty() && !useManualModPath) {
             try {
                 val detection = getOrDetectStrategy(gameRootDir, winePrefix, gameName)
                 val strategy = detection.strategy
@@ -3322,8 +3318,8 @@ object WorkshopManager {
 
     /**
      * Removes GameNative Workshop exposure artifacts accidentally created inside
-     * trees that Ren'Py may scan for scripts. Nested steam_settings/mods links
-     * can make the same .rpy/.rpyc files visible twice.
+     * trees covered by a per-game compatibility override. Nested
+     * steam_settings/mods links can expose the same Workshop files twice.
      */
     private fun cleanupNestedSteamSettingsWorkshopArtifacts(rootDir: File) {
         if (!rootDir.isDirectory) return
@@ -3382,6 +3378,10 @@ object WorkshopManager {
     ) {
         val gameRootDir = File(SteamService.getAppDirPath(appId))
         val gameName = SteamService.getAppInfoOf(appId)?.name ?: ""
+        val compatibilityOverride = WorkshopCompatibilityRegistry.get(
+            GameSource.STEAM,
+            appId.toString(),
+        )
 
         // Read the user's manual mod path override from the container
         val containerId = "STEAM_$appId"
@@ -3400,6 +3400,7 @@ object WorkshopManager {
             winePrefix = winePrefix,
             gameName = gameName,
             workshopModPath = modPathOverride,
+            compatibilityOverride = compatibilityOverride,
         )
     }
 

--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -2132,7 +2132,6 @@ object WorkshopManager {
         val isSourceEngine = isSourceEngine(gameRootDir)
         val isRenPy = isRenPyGame(gameRootDir)
         if (isRenPy) {
-            cleanupNestedSteamSettingsWorkshopArtifacts(workshopContentDir)
             cleanupNestedSteamSettingsWorkshopArtifacts(gameRootDir)
         }
 

--- a/app/src/main/java/app/gamenative/workshop/compatibility/STEAM_331470.kt
+++ b/app/src/main/java/app/gamenative/workshop/compatibility/STEAM_331470.kt
@@ -1,0 +1,20 @@
+package app.gamenative.workshop.compatibility
+
+import app.gamenative.data.GameSource
+
+/**
+ * Everlasting Summer (Steam)
+ *
+ * Ren'Py scans its game/ tree recursively. This game can load Workshop items
+ * through Steam metadata, so filesystem links under the game tree expose the
+ * same .rpy/.rpyc files twice and crash with duplicate script definitions.
+ */
+val STEAM_WorkshopOverride_331470 = KeyedWorkshopCompatibilityOverride(
+    gameSource = GameSource.STEAM,
+    gameId = "331470",
+    override = WorkshopCompatibilityOverride(
+        exposureMode = WorkshopExposureMode.METADATA_ONLY,
+        ignoreManualModPath = true,
+        cleanupNestedSteamSettingsArtifacts = true,
+    ),
+)

--- a/app/src/main/java/app/gamenative/workshop/compatibility/WorkshopCompatibilityOverride.kt
+++ b/app/src/main/java/app/gamenative/workshop/compatibility/WorkshopCompatibilityOverride.kt
@@ -1,0 +1,29 @@
+package app.gamenative.workshop.compatibility
+
+import app.gamenative.data.GameSource
+
+/**
+ * Describes a per-game Workshop compatibility override.
+ *
+ * The default behavior is intentionally represented by the absence of an
+ * override in [WorkshopCompatibilityRegistry].
+ */
+data class WorkshopCompatibilityOverride(
+    val exposureMode: WorkshopExposureMode,
+    val ignoreManualModPath: Boolean = false,
+    val cleanupNestedSteamSettingsArtifacts: Boolean = false,
+)
+
+enum class WorkshopExposureMode {
+    /**
+     * Expose Workshop items through Steam metadata only. GameNative still
+     * writes mods.json, but skips filesystem Workshop links inside the game.
+     */
+    METADATA_ONLY,
+}
+
+data class KeyedWorkshopCompatibilityOverride(
+    val gameSource: GameSource,
+    val gameId: String,
+    val override: WorkshopCompatibilityOverride,
+)

--- a/app/src/main/java/app/gamenative/workshop/compatibility/WorkshopCompatibilityRegistry.kt
+++ b/app/src/main/java/app/gamenative/workshop/compatibility/WorkshopCompatibilityRegistry.kt
@@ -1,0 +1,24 @@
+package app.gamenative.workshop.compatibility
+
+import app.gamenative.data.GameSource
+
+object WorkshopCompatibilityRegistry {
+    private val overrides: Map<Pair<GameSource, String>, WorkshopCompatibilityOverride> = listOf(
+        STEAM_WorkshopOverride_331470,
+    ).associate { keyedOverride ->
+        (keyedOverride.gameSource to keyedOverride.gameId) to keyedOverride.override
+    }
+
+    private var overridesProvider: () -> Map<Pair<GameSource, String>, WorkshopCompatibilityOverride> = {
+        overrides
+    }
+
+    fun get(source: GameSource, gameId: String): WorkshopCompatibilityOverride? =
+        overridesProvider()[source to gameId]
+
+    internal fun setOverridesProviderForTests(
+        provider: (() -> Map<Pair<GameSource, String>, WorkshopCompatibilityOverride>)?,
+    ) {
+        overridesProvider = provider ?: { overrides }
+    }
+}

--- a/app/src/test/java/app/gamenative/workshop/WorkshopManagerTest.kt
+++ b/app/src/test/java/app/gamenative/workshop/WorkshopManagerTest.kt
@@ -51,7 +51,25 @@ class WorkshopManagerTest {
 
     private fun addContent(itemId: Long, fileName: String = "data.bin") {
         val dir = File(workshopContentDir, itemId.toString()).apply { mkdirs() }
-        File(dir, fileName).writeText("content")
+        val file = File(dir, fileName)
+        file.parentFile?.mkdirs()
+        file.writeText("content")
+    }
+
+    private fun useSteamWorkshopContentDir(appId: Int = 331470) {
+        workshopContentDir = File(
+            tempDir,
+            "Steam/steamapps/workshop/content/$appId",
+        ).apply { mkdirs() }
+    }
+
+    private fun makeRenPyGameRoot(): File {
+        val gameRootDir = File(tempDir, "renpy_game").apply { mkdirs() }
+        File(gameRootDir, "renpy").mkdirs()
+        val gameDir = File(gameRootDir, "game").apply { mkdirs() }
+        File(gameDir, "script.rpyc").writeText("compiled")
+        File(gameRootDir, "steam_api.dll").writeText("dll")
+        return gameRootDir
     }
 
     // ── parseEnabledIds ─────────────────────────────────────────────────
@@ -362,7 +380,53 @@ class WorkshopManagerTest {
         )
     }
 
-    // ── getWorkshopContentDir ───────────────────────────────────────────
+    // Ren'Py Workshop routing
+
+    @Test
+    fun configureSymlinks_renPyUsesModsJsonOnly() {
+        useSteamWorkshopContentDir()
+        addContent(111, "extra_resources/extra_map.rpyc")
+        val gameRootDir = makeRenPyGameRoot()
+        File(gameRootDir, "game/mods").mkdirs()
+        val winePrefix = File(tempDir, "wine").apply { mkdirs() }.absolutePath
+
+        WorkshopManager.configureModSymlinks(
+            gameRootDir = gameRootDir,
+            workshopContentDir = workshopContentDir,
+            items = listOf(makeItem(111)),
+            winePrefix = winePrefix,
+            gameName = "RenPy Game",
+        )
+
+        val settingsDir = File(gameRootDir, "steam_settings")
+        assertTrue(File(settingsDir, "mods.json").isFile)
+        assertFalse(File(settingsDir, "mods").exists())
+        assertFalse(File(gameRootDir, "game/mods/111").exists())
+    }
+
+    @Test
+    fun configureSymlinks_renPyIgnoresManualGameModPath() {
+        useSteamWorkshopContentDir()
+        addContent(111)
+        val gameRootDir = makeRenPyGameRoot()
+        val manualModsDir = File(gameRootDir, "game/mods").apply { mkdirs() }
+        val winePrefix = File(tempDir, "wine").apply { mkdirs() }.absolutePath
+
+        WorkshopManager.configureModSymlinks(
+            gameRootDir = gameRootDir,
+            workshopContentDir = workshopContentDir,
+            items = listOf(makeItem(111)),
+            winePrefix = winePrefix,
+            gameName = "RenPy Game",
+            workshopModPath = manualModsDir.absolutePath,
+        )
+
+        assertTrue(File(gameRootDir, "steam_settings/mods.json").isFile)
+        assertFalse(File(gameRootDir, "steam_settings/mods").exists())
+        assertFalse(File(manualModsDir, "111").exists())
+    }
+
+    // getWorkshopContentDir
 
     @Test
     fun getWorkshopContentDir_buildsCorrectPath() {

--- a/app/src/test/java/app/gamenative/workshop/WorkshopManagerTest.kt
+++ b/app/src/test/java/app/gamenative/workshop/WorkshopManagerTest.kt
@@ -1,5 +1,9 @@
 package app.gamenative.workshop
 
+import app.gamenative.data.GameSource
+import app.gamenative.workshop.compatibility.WorkshopCompatibilityOverride
+import app.gamenative.workshop.compatibility.WorkshopCompatibilityRegistry
+import app.gamenative.workshop.compatibility.WorkshopExposureMode
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -71,6 +75,12 @@ class WorkshopManagerTest {
         File(gameRootDir, "steam_api.dll").writeText("dll")
         return gameRootDir
     }
+
+    private fun metadataOnlyWorkshopOverride() = WorkshopCompatibilityOverride(
+        exposureMode = WorkshopExposureMode.METADATA_ONLY,
+        ignoreManualModPath = true,
+        cleanupNestedSteamSettingsArtifacts = true,
+    )
 
     // ── parseEnabledIds ─────────────────────────────────────────────────
 
@@ -380,10 +390,20 @@ class WorkshopManagerTest {
         )
     }
 
-    // Ren'Py Workshop routing
+    // Workshop compatibility overrides
 
     @Test
-    fun configureSymlinks_renPyUsesModsJsonOnly() {
+    fun workshopCompatibilityRegistry_everlastingSummerUsesMetadataOnlyOverride() {
+        val override = WorkshopCompatibilityRegistry.get(GameSource.STEAM, "331470")
+
+        assertEquals(WorkshopExposureMode.METADATA_ONLY, override?.exposureMode)
+        assertTrue(override?.ignoreManualModPath == true)
+        assertTrue(override?.cleanupNestedSteamSettingsArtifacts == true)
+        assertEquals(null, WorkshopCompatibilityRegistry.get(GameSource.STEAM, "12345"))
+    }
+
+    @Test
+    fun configureSymlinks_metadataOnlyOverrideUsesModsJsonOnly() {
         useSteamWorkshopContentDir()
         addContent(111, "extra_resources/extra_map.rpyc")
         val gameRootDir = makeRenPyGameRoot()
@@ -396,16 +416,19 @@ class WorkshopManagerTest {
             items = listOf(makeItem(111)),
             winePrefix = winePrefix,
             gameName = "RenPy Game",
+            compatibilityOverride = metadataOnlyWorkshopOverride(),
         )
 
         val settingsDir = File(gameRootDir, "steam_settings")
-        assertTrue(File(settingsDir, "mods.json").isFile)
+        val modsJson = File(settingsDir, "mods.json")
+        assertTrue(modsJson.isFile)
+        assertTrue(modsJson.readText().contains("\"111\""))
         assertFalse(File(settingsDir, "mods").exists())
         assertFalse(File(gameRootDir, "game/mods/111").exists())
     }
 
     @Test
-    fun configureSymlinks_renPyIgnoresManualGameModPath() {
+    fun configureSymlinks_metadataOnlyOverrideIgnoresManualGameModPath() {
         useSteamWorkshopContentDir()
         addContent(111)
         val gameRootDir = makeRenPyGameRoot()
@@ -419,11 +442,30 @@ class WorkshopManagerTest {
             winePrefix = winePrefix,
             gameName = "RenPy Game",
             workshopModPath = manualModsDir.absolutePath,
+            compatibilityOverride = metadataOnlyWorkshopOverride(),
         )
 
-        assertTrue(File(gameRootDir, "steam_settings/mods.json").isFile)
+        val modsJson = File(gameRootDir, "steam_settings/mods.json")
+        assertTrue(modsJson.isFile)
+        assertTrue(modsJson.readText().contains("\"111\""))
         assertFalse(File(gameRootDir, "steam_settings/mods").exists())
         assertFalse(File(manualModsDir, "111").exists())
+    }
+
+    @Test
+    fun configureSymlinks_withoutOverrideKeepsDefaultWorkshopBehavior() {
+        useSteamWorkshopContentDir()
+        addContent(111)
+        val gameRootDir = makeRenPyGameRoot()
+
+        WorkshopManager.configureModSymlinks(
+            gameRootDir = gameRootDir,
+            workshopContentDir = workshopContentDir,
+            items = listOf(makeItem(111)),
+            gameName = "RenPy Game",
+        )
+
+        assertTrue(File(gameRootDir, "steam_settings/mods").isDirectory)
     }
 
     // getWorkshopContentDir


### PR DESCRIPTION
## Description
Fixes a Ren'Py Workshop duplication issue where the same Workshop item could be exposed through both Steam Workshop metadata and filesystem symlinks inside the Ren'Py `game/` tree.

Ren'Py recursively scans the `game/` directory for scripts. When GameNative linked Workshop content into `game/mods/...` while also exposing the item through Steam Workshop metadata / `mods.json`, Ren'Py could load the same `.rpy` / `.rpyc` files twice and abort with a `defined twice` error.

This change:
- detects Ren'Py installs by their standard runtime layout;
- avoids creating `steam_settings/mods` symlinks for Ren'Py games;
- ignores manual Workshop mod paths for Ren'Py games to avoid linking Workshop items into `game/mods`;
- cleans stale nested `steam_settings` Workshop artifacts that may have been created by previous runs;
- adds unit coverage for Ren'Py Workshop routing.

Tested with Everlasting Summer and Workshop item `354397869`. The game now launches successfully with the Workshop mod enabled.

## Recording
I can provide one if required. I tested this on-device by installing a debug build and launching Everlasting Summer with Workshop item `354397869`; the previous Ren'Py `defined twice` crash no longer occurs.

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the Ren’Py Workshop duplication fix behind a per‑game compatibility override and applies it to Everlasting Summer (Steam `331470`). This prevents “defined twice” crashes by exposing Workshop mods via Steam metadata only and ignoring manual mod paths for that title.

- **Bug Fixes**
  - Introduce `WorkshopCompatibilityRegistry` and `WorkshopCompatibilityOverride`; register Everlasting Summer with `METADATA_ONLY`, `ignoreManualModPath`, and nested cleanup.
  - Honor overrides in symlink config: skip `steam_settings/mods` links, write `mods.json` only, and remove nested `steam_settings` artifacts.
  - Keep default Workshop behavior unchanged for other games.
  - Add tests for the registry, metadata-only mode, and manual-path behavior.

<sup>Written for commit 40a00470e91762cd81803f64d4d2fa4f3e398484. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-game workshop compatibility overrides and a registry; a new "metadata-only" exposure mode for select games (e.g., Steam 331470).

* **Bug Fixes**
  * Ren'Py-specific: removes nested workshop artifacts, skips filesystem mod link exposure when metadata-only, and tightens stale symlink/manual-path handling with informational logging.

* **Tests**
  * Added tests for compatibility overrides, metadata-only behavior, artifact cleanup, and manual-path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->