### PR TITLE
fix: don't block local launch when remote runs a non-Steam shortcut

### DIFF
--- a/app/src/main/java/app/gamenative/events/SteamEvent.kt
+++ b/app/src/main/java/app/gamenative/events/SteamEvent.kt
@@ -16,7 +16,7 @@ sealed interface SteamEvent<T> : Event<T> {
 
     // data object AppInfoReceived : SteamEvent<Unit>
     data object ForceCloseApp : SteamEvent<Unit>
-    data object PlayingBlocked : SteamEvent<Unit>
+    data class PlayingBlocked(val remoteAppName: String?) : SteamEvent<Unit>
     data class Disconnected(val isTerminal: Boolean = false) : SteamEvent<Unit>
     data object RemotelyDisconnected : SteamEvent<Unit>
 }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -3687,17 +3687,16 @@ class SteamService : Service(), IChallengeUrlChanged {
             scope.launch { stop() }
         } else if (callback.result == EResult.LoggedInElsewhere) {
             // received when a client runs an app and wants to forcibly close another
-            // client running an app
+            // client running an app. The callback doesn't carry the remote app id, so the
+            // dialog falls back to a generic "another game" label.
             if (PluviaApp.xEnvironment != null) {
                 if (!_isHandlingConflict.getAndSet(true)) {
                     _isPlayingBlocked.value = true
-                    val event = SteamEvent.PlayingBlocked
-                    PluviaApp.events.emit(event)
+                    PluviaApp.events.emit(SteamEvent.PlayingBlocked(remoteAppName = null))
                 }
                 reconnect()
             } else {
-                val event = SteamEvent.ForceCloseApp
-                PluviaApp.events.emit(event)
+                PluviaApp.events.emit(SteamEvent.ForceCloseApp)
                 reconnect()
             }
         } else {
@@ -3706,11 +3705,20 @@ class SteamService : Service(), IChallengeUrlChanged {
     }
 
     private fun onPlayingSessionState(callback: PlayingSessionStateCallback) {
-        Timber.d("onPlayingSessionState called with isPlayingBlocked = " + callback.isPlayingBlocked)
+        Timber.d("onPlayingSessionState: blocked=${callback.isPlayingBlocked} remoteAppId=${callback.playingAppID}")
         _isPlayingBlocked.value = callback.isPlayingBlocked
-        if (callback.isPlayingBlocked && _isHandlingConflict.compareAndSet(false, true)) {
-            val event = SteamEvent.PlayingBlocked
-            PluviaApp.events.emit(event)
+
+        if (!callback.isPlayingBlocked) return
+
+        // Only show the dialog if the remote app is in our local DB. Non-Steam shortcuts get
+        // synthetic IDs we can't kick and have no name for, so let the local launch proceed.
+        val knownApp = callback.playingAppID
+            .takeIf { it != 0 }
+            ?.let { getAppInfoOf(it) }
+            ?: return
+
+        if (_isHandlingConflict.compareAndSet(false, true)) {
+            PluviaApp.events.emit(SteamEvent.PlayingBlocked(remoteAppName = knownApp.name))
         }
     }
 

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1759,25 +1759,29 @@ fun preLaunchApp(
         // must activate container before downloading save files
         containerManager.activateContainer(container)
 
-        // If another game is running on this account elsewhere, prompt user first (cross-app session)
+        // If another Steam game is running on this account elsewhere, prompt the user.
+        // Skip the prompt for apps we don't recognise — non-Steam shortcuts on the remote
+        // device report synthetic IDs that aren't kickable.
         val isSteamGame = gameSource == GameSource.STEAM
-        if(isSteamGame) {
+        if (isSteamGame) {
             try {
                 val currentPlaying = SteamService.getSelfCurrentlyPlayingAppId()
                 if (!isOffline && currentPlaying != null && currentPlaying != gameId) {
-                    val otherGameName = SteamService.getAppInfoOf(currentPlaying)?.name ?: "another game"
-                    setLoadingDialogVisible(false)
-                    setMessageDialogState(
-                        MessageDialogState(
-                            visible = true,
-                            type = DialogType.ACCOUNT_SESSION_ACTIVE,
-                            title = context.getString(R.string.main_app_running_title),
-                            message = context.getString(R.string.main_app_running_message, otherGameName),
-                            confirmBtnText = context.getString(R.string.main_play_anyway),
-                            dismissBtnText = context.getString(R.string.cancel),
-                        ),
-                    )
-                    return@launch
+                    val otherApp = SteamService.getAppInfoOf(currentPlaying)
+                    if (otherApp != null) {
+                        setLoadingDialogVisible(false)
+                        setMessageDialogState(
+                            MessageDialogState(
+                                visible = true,
+                                type = DialogType.ACCOUNT_SESSION_ACTIVE,
+                                title = context.getString(R.string.main_app_running_title),
+                                message = context.getString(R.string.main_app_running_message, otherApp.name),
+                                confirmBtnText = context.getString(R.string.main_play_anyway),
+                                dismissBtnText = context.getString(R.string.cancel),
+                            ),
+                        )
+                        return@launch
+                    }
                 }
             } catch (_: Exception) { /* ignore persona read errors */ }
         }

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1438,10 +1438,12 @@ fun PluviaMain(
 
                 /** Game Screen **/
                 composable(route = PluviaScreen.XServer.route) {
+                    val xServerIsOffline by viewModel.isOffline.collectAsStateWithLifecycle()
                     XServerScreen(
                         appId = state.launchedAppId,
                         bootToContainer = state.bootToContainer,
                         testGraphics = state.testGraphics,
+                        isOffline = xServerIsOffline,
                         registerBackAction = { cb ->
                             Timber.d("registerBackAction called: $cb")
                             gameBackAction = cb

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -294,6 +294,7 @@ fun XServerScreen(
     appId: String,
     bootToContainer: Boolean,
     testGraphics: Boolean = false,
+    isOffline: Boolean = false,
     registerBackAction: ( ( ) -> Unit ) -> Unit,
     navigateBack: () -> Unit,
     onExit: (onComplete: (() -> Unit)?) -> Unit,
@@ -1379,9 +1380,13 @@ fun XServerScreen(
             exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
         }
         val onPlayingBlocked: (SteamEvent.PlayingBlocked) -> Unit = { event ->
-            Timber.i("onPlayingBlocked remoteAppName=${event.remoteAppName}")
-            playingBlockedRemoteName = event.remoteAppName
-            showPlayingBlockedDialog = true
+            if (isOffline || container.isSteamOfflineMode()) {
+                Timber.i("onPlayingBlocked suppressed (offline=$isOffline, containerOffline=${container.isSteamOfflineMode()})")
+            } else {
+                Timber.i("onPlayingBlocked remoteAppName=${event.remoteAppName}")
+                playingBlockedRemoteName = event.remoteAppName
+                showPlayingBlockedDialog = true
+            }
         }
         val debugCallback = Callback<String> { outputLine ->
             Timber.i(outputLine ?: "")

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -417,6 +417,7 @@ fun XServerScreen(
     var elementToEdit by remember { mutableStateOf<com.winlator.inputcontrols.ControlElement?>(null) }
     var showPhysicalControllerDialog by remember { mutableStateOf(false) }
     var showPlayingBlockedDialog by rememberSaveable { mutableStateOf(false) }
+    var playingBlockedRemoteName by rememberSaveable { mutableStateOf<String?>(null) }
     var showTouchGestureDialog by remember { mutableStateOf(false) }
     var isTouchscreenModeActive by remember { mutableStateOf(container.isTouchscreenMode) }
     var currentGestureConfig by remember {
@@ -1377,8 +1378,9 @@ fun XServerScreen(
             Timber.i("onForceCloseApp")
             exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
         }
-        val onPlayingBlocked: (SteamEvent.PlayingBlocked) -> Unit = {
-            Timber.i("onPlayingBlocked")
+        val onPlayingBlocked: (SteamEvent.PlayingBlocked) -> Unit = { event ->
+            Timber.i("onPlayingBlocked remoteAppName=${event.remoteAppName}")
+            playingBlockedRemoteName = event.remoteAppName
             showPlayingBlockedDialog = true
         }
         val debugCallback = Callback<String> { outputLine ->
@@ -2460,13 +2462,15 @@ fun XServerScreen(
     }
 
     if (showPlayingBlockedDialog) {
+        val remoteName = playingBlockedRemoteName ?: stringResource(R.string.main_app_running_unknown_game)
         androidx.compose.material3.AlertDialog(
             onDismissRequest = {},
             title = { Text(text = stringResource(R.string.main_app_running_title)) },
-            text = { Text(text = stringResource(R.string.main_app_running_message, context.getString(R.string.main_app_running_unknown_game))) },
+            text = { Text(text = stringResource(R.string.main_app_running_message, remoteName)) },
             confirmButton = {
                 TextButton(onClick = {
                     showPlayingBlockedDialog = false
+                    playingBlockedRemoteName = null
                     SteamService.clearPlayingConflict()
                     scope.launch {
                         SteamService.kickPlayingSession(onlyGame = true)
@@ -2478,6 +2482,7 @@ fun XServerScreen(
             dismissButton = {
                 TextButton(onClick = {
                     showPlayingBlockedDialog = false
+                    playingBlockedRemoteName = null
                     exit(xServerView?.getxServer()?.winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
                 }) {
                     Text(text = stringResource(R.string.cancel))


### PR DESCRIPTION
## Description

Two related fixes to the Steam session-conflict flow.

**1. Non-Steam shortcut on remote should not block local launch**

Tapping Play on a Steam game while a non-Steam shortcut (e.g. Chrome on a Steam Deck) was running on another signed-in device showed the "App Running" conflict dialog. Play Anyway couldn't actually kick a non-Steam process, leaving the user stuck. Pre-#1306 the local launch would have proceeded normally.

Non-Steam shortcuts get synthetic high-range app IDs: they pass an `appID != 0` check but aren't in our local app DB and can't be kicked. The fix gates the conflict dialog on `SteamService.getAppInfoOf(currentPlaying) != null` in both `PluviaMain.preLaunchApp` and `SteamService.onPlayingSessionState`. Unknown apps fall through to a normal local launch. The dialog also now shows the actual remote game name when we have the app in the local DB, instead of the generic "another game" label. `SteamEvent.PlayingBlocked` changes from `data object` to `data class` carrying `remoteAppName: String?`.

**2. In-game conflict dialog should respect offline mode**

When the user has opted out of online play (per-container "Steam Offline Mode" or app-level "Go Offline (Steam)" from the System menu), the in-game `PlayingBlocked` dialog still interrupted the session if Steam reported a remote conflict. The local session isn't tied to the user's Steam account in either case.

Fix is a gate in `XServerScreen.onPlayingBlocked`: suppress the dialog when `isOffline || container.isSteamOfflineMode()`. `_isHandlingConflict` is intentionally left set so the disconnect banner from the follow-up `reconnect()` stays suppressed too; `shutdownEnvironment` clears the flag on game exit.

Touched: `PluviaMain.kt`, `SteamService.kt`, `XServerScreen.kt`, `SteamEvent.kt`. No new strings, no new public API, no test changes.

## Recording

<img width="1010" height="758" alt="image" src="https://github.com/user-attachments/assets/9cb2b030-2f3c-40a9-a18c-893421fc3878" />
<img width="1010" height="758" alt="image" src="https://github.com/user-attachments/assets/81cccf18-d17d-48b3-a63b-2e3166e3a7c6" />

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.