### PR TITLE
fix: Ensure single-depot DLCs are not filtered by language

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -781,7 +781,6 @@ class SteamService : Service(), IChallengeUrlChanged {
             ownedDlc: Map<Int, DepotInfo>?,
             licensedDepotIds: Set<Int>? = null,
             hasSteamUnlockedBranch: Boolean = false,
-            dlcGroupsWithPreferredLanguage: Set<Int>? = null,
         ): Boolean {
             if (depot.manifests.isEmpty() && depot.encryptedManifests.isNotEmpty() && !hasSteamUnlockedBranch)
                 return false
@@ -809,11 +808,8 @@ class SteamService : Service(), IChallengeUrlChanged {
             if (depot.dlcAppId != INVALID_APP_ID && ownedDlc != null && !ownedDlc.containsKey(depot.depotId))
                 return false
             // 5. Language filter - if depot has language, it must match preferred language
-            //    unless the DLC only exists for a tagged language that is not the preferred language
-            if (depot.language.isNotEmpty() && depot.language != preferredLanguage) {
-                val groupHasPreferred = dlcGroupsWithPreferredLanguage?.contains(depot.dlcAppId) ?: true
-                if (groupHasPreferred) return false
-            }
+            if (depot.language.isNotEmpty() && depot.language != preferredLanguage)
+                return false
             // 6. Package grants this depot — prevents grabbing region depots the user has no license for.
             //    Skip for DLC and systemDefined depots: DLC licensed via own package (check 4), systemDefined always granted.
             if (depot.dlcAppId == INVALID_APP_ID && !depot.systemDefined && licensedDepotIds != null && depot.depotId !in licensedDepotIds)
@@ -836,24 +832,9 @@ class SteamService : Service(), IChallengeUrlChanged {
             preferredLanguage: String,
             ownedDlc: Map<Int, DepotInfo>?,
             licensedDepotIds: Set<Int>?,
-        ): Collection<DepotInfo> {
-            val dlcGroupsWithPreferredLanguage = dlcGroupsWithPreferredLanguageFor(depots, preferredLanguage)
-            return depots.values.filter { depot ->
-                filterForDownloadableDepots(
-                    depot, prefer64Bit = false, preferNonDeckWindows = false, preferredLanguage,
-                    ownedDlc, licensedDepotIds,
-                    dlcGroupsWithPreferredLanguage = dlcGroupsWithPreferredLanguage,
-                )
-            }
+        ): Collection<DepotInfo> = depots.values.filter { depot ->
+            filterForDownloadableDepots(depot, prefer64Bit = false, preferNonDeckWindows = false, preferredLanguage, ownedDlc, licensedDepotIds)
         }
-
-        /** Set of dlcAppIds (incl. INVALID_APP_ID for base) that have a depot in [preferredLanguage]. */
-        private fun dlcGroupsWithPreferredLanguageFor(
-            depots: Map<Int, DepotInfo>,
-            preferredLanguage: String,
-        ): Set<Int> = depots.values
-            .filter { it.language == preferredLanguage }
-            .mapTo(mutableSetOf()) { it.dlcAppId }
 
         /**
          * Two-pass depot resolution: derives preference flags from [eligibleDepots],
@@ -866,15 +847,11 @@ class SteamService : Service(), IChallengeUrlChanged {
             licensedDepotIds: Set<Int>?,
             hasSteamUnlockedBranch: Boolean = false,
         ): Map<Int, DepotInfo> {
-            val dlcGroupsWithPreferredLanguage = dlcGroupsWithPreferredLanguageFor(depots, preferredLanguage)
             val eligible = eligibleDepots(depots, preferredLanguage, ownedDlc, licensedDepotIds)
             val has64Bit = eligible.any { it.osArch == OSArch.Arch64 }
             val hasNonDeckWin = eligible.any { !it.steamDeck && it.isWindowsCompatible }
             return depots.filter { (_, depot) ->
-                filterForDownloadableDepots(
-                    depot, has64Bit, hasNonDeckWin, preferredLanguage, ownedDlc, licensedDepotIds,
-                    dlcGroupsWithPreferredLanguage = dlcGroupsWithPreferredLanguage,
-                )
+                filterForDownloadableDepots(depot, has64Bit, hasNonDeckWin, preferredLanguage, ownedDlc, licensedDepotIds)
             }
         }
 
@@ -946,11 +923,10 @@ class SteamService : Service(), IChallengeUrlChanged {
                 val dlcLicensedDepots = getLicensedDepotIds(dlcApp.id)
                 val dlcEligible = eligibleDepots(dlcApp.depots, preferredLanguage, null, dlcLicensedDepots)
                 val dlcHasNonDeckWin = dlcEligible.any { !it.steamDeck && it.isWindowsCompatible }
-                val dlcGroupsWithPreferredLanguage = dlcGroupsWithPreferredLanguageFor(dlcApp.depots, preferredLanguage)
                 dlcApp.depots
                     .filter { (_, depot) ->
                         filterForDownloadableDepots(depot, has64Bit, dlcHasNonDeckWin, preferredLanguage, null, dlcLicensedDepots,
-                            hasSteamUnlockedBranch, dlcGroupsWithPreferredLanguage)
+                            hasSteamUnlockedBranch)
                     }
                     .forEach { (depotId, depot) ->
                         // Add DLC Depots with custom object

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -781,6 +781,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             ownedDlc: Map<Int, DepotInfo>?,
             licensedDepotIds: Set<Int>? = null,
             hasSteamUnlockedBranch: Boolean = false,
+            dlcAppIdsWithSingleDepots: Set<Int>? = null,
         ): Boolean {
             if (depot.manifests.isEmpty() && depot.encryptedManifests.isNotEmpty() && !hasSteamUnlockedBranch)
                 return false
@@ -808,8 +809,17 @@ class SteamService : Service(), IChallengeUrlChanged {
             if (depot.dlcAppId != INVALID_APP_ID && ownedDlc != null && !ownedDlc.containsKey(depot.depotId))
                 return false
             // 5. Language filter - if depot has language, it must match preferred language
-            if (depot.language.isNotEmpty() && depot.language != preferredLanguage)
-                return false
+            if (depot.language.isNotEmpty() && depot.language != preferredLanguage) {
+                // Note here, this logic is added to resolve A Date with Death - Expansion DLC (depotID: 2696090)
+                // the depot is in english language but there is only 1 depot in the dlcApp, we should always include it
+                if (depot.dlcAppId != INVALID_APP_ID) {
+                    if (dlcAppIdsWithSingleDepots != null && !dlcAppIdsWithSingleDepots.contains(depot.dlcAppId)) {
+                        return false
+                    }
+                } else {
+                    return false
+                }
+            }
             // 6. Package grants this depot — prevents grabbing region depots the user has no license for.
             //    Skip for DLC and systemDefined depots: DLC licensed via own package (check 4), systemDefined always granted.
             if (depot.dlcAppId == INVALID_APP_ID && !depot.systemDefined && licensedDepotIds != null && depot.depotId !in licensedDepotIds)
@@ -819,6 +829,19 @@ class SteamService : Service(), IChallengeUrlChanged {
                 return false
 
             return true
+        }
+
+
+        /**
+         * Returns all DLC App IDs that have exactly one depot.
+         * Used to identify DLCs with a single depot configuration.
+         */
+        fun getDlcAppIdsWithSingleDepot(depots: Map<Int, DepotInfo>): Set<Int> {
+            return depots.values
+                .filter { it.dlcAppId != INVALID_APP_ID }
+                .groupBy { it.dlcAppId }
+                .filterValues { it.size == 1 }
+                .keys
         }
 
         /**
@@ -832,8 +855,14 @@ class SteamService : Service(), IChallengeUrlChanged {
             preferredLanguage: String,
             ownedDlc: Map<Int, DepotInfo>?,
             licensedDepotIds: Set<Int>?,
-        ): Collection<DepotInfo> = depots.values.filter { depot ->
-            filterForDownloadableDepots(depot, prefer64Bit = false, preferNonDeckWindows = false, preferredLanguage, ownedDlc, licensedDepotIds)
+        ): Collection<DepotInfo> {
+            val dlcAppIdsWithSingleDepots = getDlcAppIdsWithSingleDepot(depots)
+            return depots.values.filter { depot ->
+                filterForDownloadableDepots(depot, prefer64Bit = false, preferNonDeckWindows = false, preferredLanguage,
+                    ownedDlc, licensedDepotIds,
+                    dlcAppIdsWithSingleDepots = dlcAppIdsWithSingleDepots
+                )
+            }
         }
 
         /**
@@ -847,11 +876,15 @@ class SteamService : Service(), IChallengeUrlChanged {
             licensedDepotIds: Set<Int>?,
             hasSteamUnlockedBranch: Boolean = false,
         ): Map<Int, DepotInfo> {
+            val dlcAppIdsWithSingleDepots = getDlcAppIdsWithSingleDepot(depots)
             val eligible = eligibleDepots(depots, preferredLanguage, ownedDlc, licensedDepotIds)
             val has64Bit = eligible.any { it.osArch == OSArch.Arch64 }
             val hasNonDeckWin = eligible.any { !it.steamDeck && it.isWindowsCompatible }
             return depots.filter { (_, depot) ->
-                filterForDownloadableDepots(depot, has64Bit, hasNonDeckWin, preferredLanguage, ownedDlc, licensedDepotIds)
+                filterForDownloadableDepots(depot, has64Bit, hasNonDeckWin, preferredLanguage,
+                    ownedDlc, licensedDepotIds,
+                    dlcAppIdsWithSingleDepots = dlcAppIdsWithSingleDepots
+                )
             }
         }
 

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -953,13 +953,16 @@ class SteamService : Service(), IChallengeUrlChanged {
 
             val indirectDlcApps = getDownloadableDlcAppsOf(appId).orEmpty()
             indirectDlcApps.forEach { dlcApp ->
+                val dlcAppIdsWithSingleDepots = getDlcAppIdsWithSingleDepot(dlcApp.depots)
                 val dlcLicensedDepots = getLicensedDepotIds(dlcApp.id)
                 val dlcEligible = eligibleDepots(dlcApp.depots, preferredLanguage, null, dlcLicensedDepots)
                 val dlcHasNonDeckWin = dlcEligible.any { !it.steamDeck && it.isWindowsCompatible }
                 dlcApp.depots
                     .filter { (_, depot) ->
-                        filterForDownloadableDepots(depot, has64Bit, dlcHasNonDeckWin, preferredLanguage, null, dlcLicensedDepots,
-                            hasSteamUnlockedBranch)
+                        filterForDownloadableDepots(depot, has64Bit, dlcHasNonDeckWin, preferredLanguage,
+                            null, dlcLicensedDepots, hasSteamUnlockedBranch,
+                            dlcAppIdsWithSingleDepots = dlcAppIdsWithSingleDepots
+                        )
                     }
                     .forEach { (depotId, depot) ->
                         // Add DLC Depots with custom object

--- a/app/src/test/java/app/gamenative/service/DepotFilteringTest.kt
+++ b/app/src/test/java/app/gamenative/service/DepotFilteringTest.kt
@@ -152,46 +152,4 @@ class DepotFilteringTest {
         val d = depot(manifests = mapOf("public" to manifest()), steamDeck = false)
         assertTrue(SteamService.filterForDownloadableDepots(d, true, true, "english", null))
     }
-
-    // -- language filter fallback (publisher-mistagged single-language DLCs) --
-
-    @Test
-    fun `non-matching language depot rejected when group has preferred-language alternative`() {
-        val d = depot(
-            manifests = mapOf("public" to manifest()),
-            dlcAppId = 42,
-            language = "english",
-        )
-        assertFalse(
-            SteamService.filterForDownloadableDepots(
-                d, true, false, "french", null, null, false,
-                dlcGroupsWithPreferredLanguage = setOf(42),
-            ),
-        )
-    }
-
-    @Test
-    fun `non-matching language depot accepted when group has no preferred-language alternative`() {
-        val d = depot(
-            manifests = mapOf("public" to manifest()),
-            dlcAppId = 42,
-            language = "english",
-        )
-        assertTrue(
-            SteamService.filterForDownloadableDepots(
-                d, true, false, "french", null, null, false,
-                dlcGroupsWithPreferredLanguage = emptySet(),
-            ),
-        )
-    }
-
-    @Test
-    fun `null dlcGroupsWithPreferredLanguage preserves strict legacy behavior`() {
-        val d = depot(
-            manifests = mapOf("public" to manifest()),
-            dlcAppId = 42,
-            language = "english",
-        )
-        assertFalse(SteamService.filterForDownloadableDepots(d, true, false, "french", null))
-    }
 }


### PR DESCRIPTION
## Description
Previously, if a DLC consisted of only one depot and its language did not match the user's preferred language, it would be entirely filtered out, making it unavailable. This change adjusts the language filter to always include single-depot DLCs, regardless of a language mismatch.

This resolves cases like "A Date with Death - Expansion DLC" where the single available depot would otherwise be incorrectly discarded. It improves DLC discoverability and ensures that the only available version of a single-depot DLC is always presented.

(Summarized by GitKraken)

## Recording
<img width="1920" height="1080" alt="Screenshot_20260508_104438" src="https://github.com/user-attachments/assets/056dc913-1b8b-4435-a596-032493d7584a" />


## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops filtering out single-depot DLCs when the DLC language doesn’t match the user’s preference. Applies to direct and indirect DLCs so items like “A Date with Death - Expansion DLC” stay visible and downloadable.

- **Bug Fixes**
  - Always include DLCs with exactly one depot, even on language mismatch, including during indirect DLC app resolution.
  - Added helper to compute single-depot DLC app IDs and pass them into filtering; removed the preferred-language group check and updated filter signatures and call sites.
  - Removed tests tied to the previous language-group fallback logic.

<sup>Written for commit 1ec5ccc6daeb2673be7057059aa0510e52d75b02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined DLC download filtering so language-matching exclusions apply only for multi-depot DLCs; base-game behavior unchanged.
  * Improved compatibility for Steam Deck filtering of non-deck depots.

* **Tests**
  * Updated test suite to validate the revised depot selection and Steam Deck filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->