### PR TITLE
fix: Exclude Steam China depots from download consideration

### DIFF
--- a/app/src/main/java/app/gamenative/data/DepotInfo.kt
+++ b/app/src/main/java/app/gamenative/data/DepotInfo.kt
@@ -1,8 +1,10 @@
 package app.gamenative.data
 
 import app.gamenative.db.serializers.OsEnumSetSerializer
+import app.gamenative.db.serializers.SteamRealmSerializer
 import app.gamenative.enums.OS
 import app.gamenative.enums.OSArch
+import app.gamenative.enums.SteamRealm
 import app.gamenative.service.SteamService
 import java.util.EnumSet
 import kotlinx.serialization.Serializable
@@ -20,7 +22,8 @@ data class DepotInfo(
     val manifests: Map<String, ManifestInfo>,
     val encryptedManifests: Map<String, ManifestInfo>,
     val language: String = "",
-    val realm: String = "",
+    @Serializable(with = SteamRealmSerializer::class)
+    val realm: SteamRealm = SteamRealm.Unknown,
     val systemDefined: Boolean = false,
     val steamDeck: Boolean = false,
 ) {

--- a/app/src/main/java/app/gamenative/db/serializers/SteamRealmSerializer.kt
+++ b/app/src/main/java/app/gamenative/db/serializers/SteamRealmSerializer.kt
@@ -1,0 +1,22 @@
+package app.gamenative.db.serializers
+
+import app.gamenative.enums.SteamRealm
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object SteamRealmSerializer : KSerializer<SteamRealm> {
+
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("SteamRealm", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: SteamRealm) {
+        encoder.encodeString(value.keyValue ?: "unknown")
+    }
+
+    override fun deserialize(decoder: Decoder): SteamRealm {
+        return SteamRealm.from(decoder.decodeString())
+    }
+}

--- a/app/src/main/java/app/gamenative/enums/SteamRealm.kt
+++ b/app/src/main/java/app/gamenative/enums/SteamRealm.kt
@@ -1,0 +1,18 @@
+package app.gamenative.enums
+
+enum class SteamRealm(val keyValue: String?) {
+    SteamGlobal(keyValue = "steamglobal"),
+    SteamChina(keyValue = "steamchina"),
+    Unknown(keyValue = "unknown"),
+    ;
+
+    companion object {
+        fun from(keyValue: String?): SteamRealm {
+            return when (keyValue) {
+                SteamGlobal.keyValue -> SteamGlobal
+                SteamChina.keyValue -> SteamChina
+                else -> Unknown
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -163,6 +163,7 @@ import app.gamenative.data.DownloadingAppInfo
 import app.gamenative.data.SteamUnlockedBranch
 import app.gamenative.db.dao.DownloadingAppInfoDao
 import app.gamenative.db.dao.SteamUnlockedBranchDao
+import app.gamenative.enums.SteamRealm
 import kotlinx.coroutines.flow.update
 import java.util.concurrent.CopyOnWriteArrayList
 import okhttp3.OkHttpClient
@@ -820,6 +821,9 @@ class SteamService : Service(), IChallengeUrlChanged {
                 return false
             // 7. Prefer non-Steam-Deck depot when both exist (we're on Android, not Deck)
             if (depot.steamDeck && preferNonDeckWindows)
+                return false
+            // 8. Skip depot if the realm is SteamChina
+            if (depot.realm == SteamRealm.SteamChina)
                 return false
 
             return true

--- a/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
@@ -20,6 +20,7 @@ import app.gamenative.enums.OS
 import app.gamenative.enums.OSArch
 import app.gamenative.enums.PathType
 import app.gamenative.enums.ReleaseState
+import app.gamenative.enums.SteamRealm
 import app.gamenative.service.SteamService.Companion.INVALID_APP_ID
 import `in`.dragonbra.javasteam.types.KeyValue
 import java.util.Date
@@ -57,7 +58,7 @@ fun KeyValue.generateSteamApp(): SteamApp {
                     manifests = manifests,
                     encryptedManifests = encryptedManifests,
                     language = currentDepot["config"]["language"].value.orEmpty(),
-                    realm = currentDepot["config"]["realm"].value.orEmpty(),
+                    realm = SteamRealm.from(currentDepot["config"]["realm"].value.orEmpty()),
                     systemDefined = currentDepot["systemdefined"].asBoolean(),
                     optionalDlcId = currentDepot["config"]["optionaldlc"].asInteger(INVALID_APP_ID),
                     steamDeck = currentDepot["config"]["steamdeck"].asBoolean(false),


### PR DESCRIPTION
## Description
Introduce SteamRealm enum to properly identify and differentiate between global and China-specific depots. Update the depot relevancy check to skip any depots explicitly marked for the Steam China client, ensuring only relevant global depots are considered for download.

It fixed language issue in Eastward (977880), it should skip steamchina depot (977885) when download.
https://steamdb.info/app/977880/depots/

## Recording
```
SteamService$Companion                I  Starting download for 977880
SteamService$Companion                I  App contains 3 depot(s): [228988, 977882, 977884]
SteamService$Companion                I  DLC contains 0 depot(s): []
```
<img width="1920" height="1080" alt="Screenshot_20260508_115007" src="https://github.com/user-attachments/assets/7b78dd45-8c31-48d1-afa5-fb699969ec32" />
<img width="1920" height="1080" alt="Screenshot_20260508_115015" src="https://github.com/user-attachments/assets/e1592120-9ed6-4d0e-8d35-452ce4b3dcb7" />

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip Steam China–only depots during downloads by parsing depot realm into a new enum and filtering them out. Fixes incorrect language/region downloads (e.g., Eastward 977880 no longer considers depot 977885).

- **Bug Fixes**
  - Added `app.gamenative.enums.SteamRealm` and `SteamRealmSerializer`; changed `DepotInfo.realm` from `String` to enum.
  - Parse depot `config.realm` into the enum in `KeyValueUtils`.
  - Updated depot relevancy in `SteamService` to exclude `SteamChina` depots.

<sup>Written for commit 8cb0585dbe3a5404f48f70babd0df7966780b7e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added region-aware content filtering to properly distinguish and handle different Steam regional variants.

* **Bug Fixes**
  * Fixed issue where depots from China's regional platform were incorrectly included in download operations.
  * Improved region data handling to ensure accurate tracking across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->