### PR TITLE
Use clientIcon instead of icon for steam shortcuts

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -261,7 +261,7 @@ class SteamAppScreen : BaseAppScreen() {
 
         // Get icon URL
         val iconUrl = remember(appInfo.id) {
-            appInfo.iconUrl
+            appInfo.clientIconUrl
         }
 
         // Get install location

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -261,7 +261,11 @@ class SteamAppScreen : BaseAppScreen() {
 
         // Get icon URL
         val iconUrl = remember(appInfo.id) {
-            appInfo.clientIconUrl
+            if (appInfo.clientIconHash.isNotEmpty()) {
+                appInfo.clientIconUrl
+            } else{
+                appInfo.iconUrl
+            }
         }
 
         // Get install location


### PR DESCRIPTION
## Description
Uses clientIcon instead of regular icon when generating android shortcuts for steam games as they tend to have a higher resolution. Improves the image quality of shortcuts for some steam games.

## Recording
Before         |  After
:-------------------------:|:-------------------------:
<img width="480" height="1040" alt="Before" src="https://github.com/user-attachments/assets/c0f69311-dfd5-487c-a9f9-6cfe6c4e8a0d" /> |  <img width="480" height="1040" alt="After" src="https://github.com/user-attachments/assets/69fff646-3521-4c76-905e-f28ab03beb8e" />

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [X] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `clientIconUrl` instead of `iconUrl` when generating Android shortcuts for Steam games, with a fallback to `iconUrl` when the client icon is missing. Shortcut icons are now sharper and remain reliable when `clientIconUrl` is unavailable.

<sup>Written for commit e7486948c0b9ab5cc696fe05024e4d58c863b9aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Steam app icons in the library now prefer the updated client-provided icon when available, falling back to the previous icon otherwise.
  * This improves visual accuracy of game entries so icons reflect the most current client-supplied artwork.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->