### PR TITLE
Removed "delete container" for games in storage manager (doesn't work…

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -907,6 +907,8 @@ class SteamService : Service(), IChallengeUrlChanged {
                 // Make sure licensedDepots contains the dlc depots
                 licensedDepots.addAll(dlcDepotIds)
 
+                if (mainPackageDepotIds.isEmpty()) return@forEach
+
                 val dlcOnlyDepotIds = dlcDepotIds.filter { it !in mainPackageDepotIds }
                 if (dlcOnlyDepotIds.isNotEmpty()) {
                     mapDlcDepotIds[dlcAppId] = dlcOnlyDepotIds
@@ -1750,7 +1752,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                     val mInfo = depot.manifests[branch]
                         ?: depot.encryptedManifests[branch]
                         ?: return@map 1L
-                    (mInfo.size ?: 1).toLong()
+                    SteamUtils.getDownloadBytes(mInfo).coerceAtLeast(1L)
                 }
                 sizes.forEachIndexed { i, bytes -> di.setWeight(i, bytes) }
 
@@ -2151,9 +2153,10 @@ class SteamService : Service(), IChallengeUrlChanged {
             private val downloadInfo: DownloadInfo,
             private val depotIdToIndex: Map<Int, Int>,
         ) : IDownloadListener {
-            // Track cumulative uncompressed bytes per depot to calculate deltas
-            // (uncompressedBytes from onChunkCompleted is cumulative per depot)
-            private val depotCumulativeUncompressedBytes = mutableMapOf<Int, Long>()
+            // Track cumulative compressed (network) bytes per depot to calculate deltas.
+            // compressedBytes from onChunkCompleted is cumulative per depot, and matches the
+            // unit of totalExpectedBytes which is summed from manifest.download.
+            private val depotCumulativeCompressedBytes = mutableMapOf<Int, Long>()
             override fun onItemAdded(item: DownloadItem) {
                 Timber.d("Item ${item.appId} added to queue")
             }
@@ -2192,15 +2195,13 @@ class SteamService : Service(), IChallengeUrlChanged {
                 compressedBytes: Long,
                 uncompressedBytes: Long,
             ) {
-                val isFirstCallForDepot = !depotCumulativeUncompressedBytes.containsKey(depotId)
+                val isFirstCallForDepot = !depotCumulativeCompressedBytes.containsKey(depotId)
 
-                // uncompressedBytes is cumulative per depot, so calculate delta
-                val previousBytes = depotCumulativeUncompressedBytes[depotId] ?: 0L
-                val deltaBytes = uncompressedBytes - previousBytes
-                depotCumulativeUncompressedBytes[depotId] = uncompressedBytes
+                val previousBytes = depotCumulativeCompressedBytes[depotId] ?: 0L
+                val deltaBytes = compressedBytes - previousBytes
+                depotCumulativeCompressedBytes[depotId] = compressedBytes
 
                 if (deltaBytes > 0L) {
-                    // Normal case: add the delta
                     downloadInfo.updateBytesDownloaded(deltaBytes, System.currentTimeMillis())
                 }
 
@@ -2215,10 +2216,9 @@ class SteamService : Service(), IChallengeUrlChanged {
             override fun onDepotCompleted(depotId: Int, compressedBytes: Long, uncompressedBytes: Long) {
                 Timber.i("Depot $depotId completed (compressed: $compressedBytes, uncompressed: $uncompressedBytes)")
 
-                // Ensure we capture any remaining bytes
-                val previousBytes = depotCumulativeUncompressedBytes[depotId] ?: 0L
-                val deltaBytes = uncompressedBytes - previousBytes
-                depotCumulativeUncompressedBytes[depotId] = uncompressedBytes
+                val previousBytes = depotCumulativeCompressedBytes[depotId] ?: 0L
+                val deltaBytes = compressedBytes - previousBytes
+                depotCumulativeCompressedBytes[depotId] = compressedBytes
 
                 if (deltaBytes > 0L) {
                     downloadInfo.updateBytesDownloaded(deltaBytes, System.currentTimeMillis())

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GameManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GameManagerDialog.kt
@@ -91,8 +91,11 @@ fun GameManagerDialog(
     val displayInfo = onGetDisplayInfo(context)
     val gameId = displayInfo.gameId
 
-    val installedApp = remember(gameId) {
-        SteamService.getInstalledApp(gameId)
+    val isBaseGameInstalled = remember(gameId) {
+        SteamService.isAppInstalled(gameId)
+    }
+    val installedApp = remember(gameId, isBaseGameInstalled) {
+        if (isBaseGameInstalled) SteamService.getInstalledApp(gameId) else null
     }
     val installedDlcIds = installedApp?.dlcDepots.orEmpty()
 
@@ -130,13 +133,13 @@ fun GameManagerDialog(
                 .toMap()
             .forEach { (_, depotInfo) ->
                 allDownloadableApps.add(Pair(depotInfo.dlcAppId, depotInfo))
-                val installed = SteamService.getInstalledApp(depotInfo.dlcAppId)
+                val installed = SteamService.isAppInstalled(depotInfo.dlcAppId)
                 selectedAppIds[depotInfo.dlcAppId] =
-                        installed != null || // For installed Base Game and Indirect DLC App
+                        installed || // For installed Base Game and Indirect DLC App
                         installedDlcIds.contains(depotInfo.dlcAppId) || // For installed DLC from Main Depot
                         ( !indirectDlcAppIds.contains(depotInfo.dlcAppId) && !optionalDlcIds.contains(depotInfo.dlcAppId) ) // Not in indirect DLC and not in optional DLC ids
 
-                enabledAppIds[depotInfo.dlcAppId] = !installedDlcIds.contains(depotInfo.dlcAppId) && installed == null
+                enabledAppIds[depotInfo.dlcAppId] = !installedDlcIds.contains(depotInfo.dlcAppId) && !installed
             }
 
         allDownloadableApps.sortBy { it.first }
@@ -200,7 +203,7 @@ fun GameManagerDialog(
     fun getInstallSizeInfo(): InstallSizeInfo {
         val availableBytes = StorageUtils.getAvailableSpace(SteamService.defaultStoragePath)
 
-        val baseGameInstallBytes = if (installedApp == null) {
+        val baseGameInstallBytes = if (!isBaseGameInstalled) {
             downloadableDepots
                 .filter { (_, depot) ->
                     depot.dlcAppId == INVALID_APP_ID
@@ -209,7 +212,7 @@ fun GameManagerDialog(
             0L
         }
 
-        val baseGameDownloadBytes = if (installedApp == null) {
+        val baseGameDownloadBytes = if (!isBaseGameInstalled) {
             downloadableDepots
                 .filter { (_, depot) ->
                     depot.dlcAppId == INVALID_APP_ID
@@ -273,7 +276,7 @@ fun GameManagerDialog(
             return false
         }
 
-        if (installedApp != null) {
+        if (isBaseGameInstalled) {
             val installed = installedDlcIds.toSet() - mainAppDlcIdsWithoutProperDepotDlcIds.toSet()
             val realSelectedAppIds = selectedAppIds.filter { it.value }.keys - installed
             return (realSelectedAppIds.size - 1) > 0 // -1 for main app

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -1200,11 +1200,8 @@ abstract class BaseAppScreen {
                 }
             },
             onPauseResumeClick = {
+                isDownloadingState = !isDownloadingState
                 onPauseResumeClick(context, libraryItem)
-                uiScope.launch {
-                    delay(100)
-                    performStateRefresh(false)
-                }
             },
             onDeleteDownloadClick = {
                 onDeleteDownloadClick(context, libraryItem)

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
@@ -303,8 +303,7 @@ class EpicAppScreen : BaseAppScreen() {
 
     override fun isDownloading(context: Context, libraryItem: LibraryItem): Boolean {
         val downloadInfo = EpicService.getDownloadInfo(libraryItem.gameId) ?: return false
-        val progress = downloadInfo.getProgress() ?: 0f
-        return downloadInfo.isPostInstallSyncing() || (downloadInfo.isActive() && progress < 1f)
+        return downloadInfo.isPostInstallSyncing() || downloadInfo.isActive()
     }
 
     override fun getDownloadProgress(context: Context, libraryItem: LibraryItem): Float {

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -233,10 +233,9 @@ class GOGAppScreen : BaseAppScreen() {
     override fun isDownloading(context: Context, libraryItem: LibraryItem): Boolean {
         Timber.tag(TAG).d("isDownloading: checking appId=${libraryItem.appId}")
         val downloadInfo = GOGService.getDownloadInfo(libraryItem.gameId.toString()) ?: return false
-        val progress = downloadInfo.getProgress() ?: 0f
-        val downloading = downloadInfo.isPostInstallSyncing() || (downloadInfo.isActive() && progress < 1f)
+        val downloading = downloadInfo.isPostInstallSyncing() || downloadInfo.isActive()
         Timber.tag(TAG).d(
-            "isDownloading: appId=${libraryItem.appId}, postInstallSyncing=${downloadInfo.isPostInstallSyncing()}, active=${downloadInfo.isActive()}, progress=$progress, result=$downloading",
+            "isDownloading: appId=${libraryItem.appId}, postInstallSyncing=${downloadInfo.isPostInstallSyncing()}, active=${downloadInfo.isActive()}, result=$downloading",
         )
         return downloading
     }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -498,8 +498,7 @@ class SteamAppScreen : BaseAppScreen() {
         onClickPlay: (Boolean) -> Unit,
     ) {
         val gameId = libraryItem.gameId
-        val downloadInfo = SteamService.getAppDownloadInfo(gameId)
-        val isDownloading = downloadInfo != null && (downloadInfo.getProgress() ?: 0f) < 1f
+        val isDownloading = isDownloading(context, libraryItem)
         val isInstalled = SteamService.isAppInstalled(gameId)
 
         if (isDownloading) {
@@ -553,8 +552,7 @@ class SteamAppScreen : BaseAppScreen() {
     override fun onDeleteDownloadClick(context: Context, libraryItem: LibraryItem) {
         val gameId = libraryItem.gameId
         val isInstalled = SteamService.isAppInstalled(gameId)
-        val downloadInfo = SteamService.getAppDownloadInfo(gameId)
-        val isDownloading = downloadInfo != null && (downloadInfo.getProgress() ?: 0f) < 1f
+        val isDownloading = isDownloading(context, libraryItem)
 
         if (isDownloading || SteamService.hasPartialDownload(gameId)) {
             // Show cancel download dialog when downloading

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -363,8 +363,7 @@ class SteamAppScreen : BaseAppScreen() {
 
     override fun isDownloading(context: Context, libraryItem: LibraryItem): Boolean {
         val downloadInfo = SteamService.getAppDownloadInfo(libraryItem.gameId) ?: return false
-        val progress = downloadInfo.getProgress() ?: 0f
-        return downloadInfo.isPostInstallSyncing() || (downloadInfo.isActive() && progress < 1f)
+        return downloadInfo.isPostInstallSyncing() || downloadInfo.isActive()
     }
 
     override fun getDownloadProgress(context: Context, libraryItem: LibraryItem): Float {

--- a/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
@@ -655,7 +655,8 @@ private fun StorageEntryCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
-            if (canMoveToExternal || canMoveToInternal || entry.canUninstallGame || entry.hasContainer) {
+            val canRemoveOrphanContainer = entry.hasContainer && !entry.canUninstallGame
+            if (canMoveToExternal || canMoveToInternal || entry.canUninstallGame || canRemoveOrphanContainer) {
                 Spacer(modifier = Modifier.height(14.dp))
                 FlowRow(
                     modifier = Modifier.fillMaxWidth(),
@@ -692,7 +693,7 @@ private fun StorageEntryCard(
                             contentColor = MaterialTheme.colorScheme.onErrorContainer,
                         )
                     }
-                    if (entry.hasContainer) {
+                    if (canRemoveOrphanContainer) {
                         StorageActionButton(
                             text = stringResource(R.string.container_storage_remove_button),
                             icon = Icons.Default.Delete,

--- a/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
@@ -12,6 +12,7 @@ import app.gamenative.db.dao.AppInfoDao
 import app.gamenative.db.dao.EpicGameDao
 import app.gamenative.db.dao.GOGGameDao
 import app.gamenative.db.dao.SteamAppDao
+import app.gamenative.enums.AppType
 import app.gamenative.enums.OSArch
 import app.gamenative.events.AndroidEvent
 import app.gamenative.service.DownloadService
@@ -118,6 +119,9 @@ object ContainerStorageManager {
             StorageManagerDaoEntryPoint::class.java,
         )
         val installedGames = loadInstalledGames(context, entryPoint)
+        val claimedInstallPaths = installedGames.values
+            .mapNotNull { it.installPath?.let(::normalizePath) }
+            .toSet()
 
         Timber.tag("ContainerStorageManager").i(
             "Scanning storage inventory in %s (%d container dirs, %d installed games)",
@@ -127,7 +131,7 @@ object ContainerStorageManager {
         )
 
         val containerEntries = dirs.map { dir ->
-            buildContainerEntry(context, dir, prefix, installedGames)
+            buildContainerEntry(context, dir, prefix, installedGames, claimedInstallPaths)
         }
         val coveredInstalledIds = containerEntries
             .mapTo(mutableSetOf()) { normalizeContainerId(it.containerId) }
@@ -531,31 +535,42 @@ object ContainerStorageManager {
         val appInfosById = appInfoDao.getAll().associateBy { it.id }
         val recoveredAppInfos = mutableListOf<AppInfo>()
 
-        val installedGames = steamAppDao.getAllOwnedAppsAsList()
-            .mapNotNull { app ->
-                val installPath = resolveSteamInstallPath(app) ?: return@mapNotNull null
-                val appInfo = appInfosById[app.id]
-                val installSizeBytes = estimateSteamInstallSize(app)
-                    ?: appInfo?.recoveredInstallSizeBytes?.takeIf { it > 0L }
-                    ?: getDirectorySizeIfPresent(installPath)?.also { recoveredSizeBytes ->
-                        buildRecoveredSteamInstallSizeAppInfo(appInfo, app.id, recoveredSizeBytes)?.let { updatedAppInfo ->
-                            recoveredAppInfos += updatedAppInfo
-                        }
-                        Timber.tag("ContainerStorageManager").i(
-                            "Recovered and cached on-disk Steam size for %s (%s) because installed depot metadata is unavailable",
-                            app.id,
-                            installPath,
-                        )
-                    }
-                InstalledGame(
-                    appId = "${GameSource.STEAM.name}_${app.id}",
-                    displayName = app.name.ifBlank { app.id.toString() },
-                    gameSource = GameSource.STEAM,
-                    installPath = installPath,
-                    iconUrl = app.clientIconUrl.takeIf { app.clientIconHash.isNotEmpty() }.orEmpty(),
-                    installSizeBytes = installSizeBytes,
+        val ownerByPath = steamAppDao.getAllOwnedAppsAsList()
+            .mapNotNull { app -> resolveSteamInstallPath(app)?.let { app to it } }
+            .groupBy { (_, path) -> normalizePath(path) }
+            .mapValues { (_, group) ->
+                group.minWith(
+                    compareBy(
+                        { (app, _) -> if (app.type == AppType.game) 0 else 1 },
+                        { (app, _) -> if (appInfosById[app.id]?.downloadedDepots?.isNotEmpty() == true) 0 else 1 },
+                        { (app, _) -> app.id },
+                    ),
                 )
             }
+
+        val installedGames = ownerByPath.values.map { (app, installPath) ->
+            val appInfo = appInfosById[app.id]
+            val installSizeBytes = estimateSteamInstallSize(app)
+                ?: appInfo?.recoveredInstallSizeBytes?.takeIf { it > 0L }
+                ?: getDirectorySizeIfPresent(installPath)?.also { recoveredSizeBytes ->
+                    buildRecoveredSteamInstallSizeAppInfo(appInfo, app.id, recoveredSizeBytes)?.let { updatedAppInfo ->
+                        recoveredAppInfos += updatedAppInfo
+                    }
+                    Timber.tag("ContainerStorageManager").i(
+                        "Recovered and cached on-disk Steam size for %s (%s) because installed depot metadata is unavailable",
+                        app.id,
+                        installPath,
+                    )
+                }
+            InstalledGame(
+                appId = "${GameSource.STEAM.name}_${app.id}",
+                displayName = app.name.ifBlank { app.id.toString() },
+                gameSource = GameSource.STEAM,
+                installPath = installPath,
+                iconUrl = app.clientIconUrl.takeIf { app.clientIconHash.isNotEmpty() }.orEmpty(),
+                installSizeBytes = installSizeBytes,
+            )
+        }
 
         if (recoveredAppInfos.isNotEmpty()) {
             appInfoDao.insertAll(recoveredAppInfos)
@@ -596,6 +611,7 @@ object ContainerStorageManager {
         dir: File,
         prefix: String,
         installedGames: Map<String, InstalledGame>,
+        claimedInstallPaths: Set<String>,
     ): Entry {
         val containerId = dir.name.removePrefix(prefix)
         val normalizedContainerId = normalizeContainerId(containerId)
@@ -631,6 +647,9 @@ object ContainerStorageManager {
         }
 
         val installPath = resolved?.installPath?.takeIf { it.isNotBlank() }
+        val installPathOwnedByOtherApp = installedGame == null &&
+            installPath != null &&
+            normalizePath(installPath) in claimedInstallPaths
         val displayName = installedGame?.displayName?.takeIf { it.isNotBlank() }
             ?: resolved?.name?.takeIf { it.isNotBlank() }
             ?: config.optString("name", "").takeIf { it.isNotBlank() }
@@ -638,6 +657,7 @@ object ContainerStorageManager {
 
         val status = when {
             installedGame != null -> Status.READY
+            installPathOwnedByOtherApp -> Status.ORPHANED
             resolved == null || !resolved.known -> Status.ORPHANED
             installPath.isNullOrBlank() -> Status.GAME_FILES_MISSING
             !File(installPath).exists() -> Status.GAME_FILES_MISSING
@@ -834,10 +854,6 @@ object ContainerStorageManager {
         if (recoveredSizeBytes <= 0L || existingAppInfo?.recoveredInstallSizeBytes == recoveredSizeBytes) return null
 
         return existingAppInfo?.copy(
-            isDownloaded = true,
-            recoveredInstallSizeBytes = recoveredSizeBytes,
-        ) ?: AppInfo(
-            id = appId,
             isDownloaded = true,
             recoveredInstallSizeBytes = recoveredSizeBytes,
         )


### PR DESCRIPTION
Removed "delete container" for games in storage manager (doesn't work…), recover from partially deleted games from storage manager that were showing as 0B. Fixed download bytes calculation. Fixed Resume button not working.

## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the broken “Delete container” action and improved storage scanning to recover partially deleted installs that showed 0B. Also fixed download byte accounting and made Resume/Pause work reliably.

- **Bug Fixes**
  - Storage Manager: Hide delete for installed games; show “Remove container” only for orphan containers. Detect containers whose install path is claimed by another app, and recover on‑disk sizes to eliminate 0B entries.
  - Steam downloads: Use manifest download bytes for weights and track progress with compressed (network) bytes; guard against empty main depots.
  - Pause/Resume: Toggle state immediately in `BaseAppScreen` to fix Resume not taking effect.
  - Downloading status: Rely on `isActive()` (Steam/Epic/GOG) instead of progress < 1.0; use consistently in Steam actions to avoid stuck states.
  - Game manager: Use `SteamService.isAppInstalled()` to avoid misclassifying base game/DLC and to compute install/download sizes correctly.

<sup>Written for commit b35b4984d195b796b88c131bd317b9691868087d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to remove orphaned game containers and improved orphan detection.

* **Bug Fixes**
  * Improved download progress/ETA tracking accuracy.
  * More reliable download state detection across Steam, Epic, and GOG.
  * Immediate pause/resume button responsiveness and clearer install selection/size logic when base game presence changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->