### PR TITLE
Disable fps cap when framegen is active to stop judder, add subtitles…

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -565,6 +565,7 @@ fun QuickMenu(
                                             fpsLimiterEnabled = fpsLimiterEnabled,
                                             fpsLimiterTarget = fpsLimiterTarget,
                                             fpsLimiterMax = fpsLimiterMax,
+                                            lsfgMultiplier = if (isLsfgAvailable) lsfgMultiplier else 0,
                                             onTogglePerformanceHud = {
                                                 onItemSelected(QuickMenuAction.PERFORMANCE_HUD)
                                             },
@@ -740,6 +741,7 @@ private fun PerformanceHudQuickMenuTab(
     fpsLimiterEnabled: Boolean,
     fpsLimiterTarget: Int,
     fpsLimiterMax: Int,
+    lsfgMultiplier: Int,
     onTogglePerformanceHud: () -> Unit,
     onPerformanceHudConfigChanged: (PerformanceHudConfig) -> Unit,
     onFpsLimiterEnabledChanged: (Boolean) -> Unit,
@@ -757,16 +759,22 @@ private fun PerformanceHudQuickMenuTab(
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         // ── FPS Limiter (topmost) ────────────────────────────────────────
+        val limiterControlledByLsfg = lsfgMultiplier >= 2
         QuickMenuToggleRow(
             title = stringResource(R.string.performance_hud_fps_limiter),
-            enabled = fpsLimiterEnabled,
-            onToggle = { onFpsLimiterEnabledChanged(!fpsLimiterEnabled) },
+            subtitle = if (limiterControlledByLsfg) {
+                stringResource(R.string.performance_hud_fps_limiter_lsfg_override)
+            } else null,
+            enabled = fpsLimiterEnabled && !limiterControlledByLsfg,
+            onToggle = {
+                if (!limiterControlledByLsfg) onFpsLimiterEnabledChanged(!fpsLimiterEnabled)
+            },
             accentColor = accentColor,
             focusRequester = focusRequester,
         )
 
         AnimatedVisibility(
-            visible = fpsLimiterEnabled,
+            visible = fpsLimiterEnabled && !limiterControlledByLsfg,
             enter = expandVertically() + fadeIn(),
             exit = shrinkVertically() + fadeOut(),
         ) {
@@ -1124,6 +1132,7 @@ private fun LsfgQuickMenuTab(
                 // ── Flow Scale ────────────────────────────────────────────
                 QuickMenuAdjustmentRow(
                     title = stringResource(R.string.lsfg_flow_scale),
+                    subtitle = stringResource(R.string.lsfg_flow_scale_desc),
                     valueText = String.format(java.util.Locale.US, "%.2f", flowScale),
                     progress = (flowScale - 0.25f) / 0.75f, // 0.25..1.0 → 0..1
                     onDecrease = {
@@ -1456,6 +1465,7 @@ private fun QuickMenuAdjustmentRow(
     accentColor: Color,
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester? = null,
+    subtitle: String? = null,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
@@ -1572,6 +1582,15 @@ private fun QuickMenuAdjustmentRow(
                     )
                 }
             }
+        }
+
+        if (subtitle != null) {
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
 
         Spacer(modifier = Modifier.height(10.dp))

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -1161,7 +1161,7 @@ fun ContainerConfigDialog(
                                 .weight(1f),
                         ) {
                             if (selectedTab == 0) GeneralTabContent(state, nonzeroResolutionError, aspectResolutionError)
-                            if (selectedTab == 1) GraphicsTabContent(state)
+                            if (selectedTab == 1) GraphicsTabContent(state, default)
                             if (selectedTab == 2) EmulationTabContent(state)
                             if (selectedTab == 3) ControllerTabContent(state, default)
                             if (selectedTab == 4) WineTabContent(state)

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GraphicsTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GraphicsTab.kt
@@ -29,7 +29,7 @@ import com.winlator.core.envvars.EnvVars
 import kotlin.math.roundToInt
 
 @Composable
-fun GraphicsTabContent(state: ContainerConfigState) {
+fun GraphicsTabContent(state: ContainerConfigState, default: Boolean = false) {
     val config = state.config.value
     SettingsGroup() {
         if (config.containerVariant.equals(Container.BIONIC, ignoreCase = true)) {
@@ -323,7 +323,7 @@ fun GraphicsTabContent(state: ContainerConfigState) {
         // Frame Generation (LSFG) — hooks the Vulkan swapchain for
         // transparent frame generation. Only effective on Bionic containers
         // with a Vortek/Adreno graphics driver.
-        LsfgSection(state)
+        if (!default) LsfgSection(state)
 
         SettingsSwitch(
             colors = settingsTileColorsAlt(),

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -529,9 +529,14 @@ fun XServerScreen(
             ?.setFrameRateLimit(limit)
     }
 
+    fun effectiveFpsLimit(): Int =
+        if (lsfgMultiplier >= 2) 0
+        else if (fpsLimiterEnabled) fpsLimiterTarget
+        else 0
+
     fun applyFpsLimiterEnabled(enabled: Boolean) {
         fpsLimiterEnabled = enabled
-        applyFpsLimiterToEngines(if (enabled) fpsLimiterTarget else 0)
+        applyFpsLimiterToEngines(effectiveFpsLimit())
         persistFpsLimiterState()
     }
 
@@ -539,7 +544,7 @@ fun XServerScreen(
         val sanitized = target.coerceAtLeast(5).coerceAtMost(detectedMaxRefreshRateHz)
         fpsLimiterTarget = sanitized
         if (fpsLimiterEnabled) {
-            applyFpsLimiterToEngines(sanitized)
+            applyFpsLimiterToEngines(effectiveFpsLimit())
         }
         persistFpsLimiterState()
     }
@@ -554,6 +559,7 @@ fun XServerScreen(
     fun applyLsfgMultiplier(mult: Int) {
         lsfgMultiplier = LsfgQuickMenuHelper.sanitizeMultiplier(mult)
         applyLsfgSettings()
+        applyFpsLimiterToEngines(effectiveFpsLimit())
     }
 
     fun applyLsfgFlowScale(scale: Float) {
@@ -573,8 +579,7 @@ fun XServerScreen(
         if (clampedTarget != fpsLimiterTarget) {
             fpsLimiterTarget = clampedTarget
         }
-        val appliedLimit = if (fpsLimiterEnabled) clampedTarget else 0
-        applyFpsLimiterToEngines(appliedLimit)
+        applyFpsLimiterToEngines(effectiveFpsLimit())
     }
 
     fun restorePerformanceHudPosition() {
@@ -648,7 +653,9 @@ fun XServerScreen(
         val hud = PerformanceHudView(
             context = context,
             fpsProvider = {
-                frameRating?.currentFPS ?: 0f
+                val raw = frameRating?.currentFPS ?: 0f
+                val mult = if (isLsfgAvailable && lsfgMultiplier >= 2) lsfgMultiplier else 1
+                raw * mult
             },
             initialConfig = performanceHudConfig,
             initialCompactMode = PrefManager.performanceHudCompactMode,
@@ -3072,6 +3079,8 @@ private fun setupXEnvironment(
         guestProgramLauncherComponent.setSteamType(container.getSteamType())
 
         envVars.putAll(container.envVars)
+        envVars.remove("DXVK_FRAME_RATE")
+        envVars.remove("VKD3D_FRAME_RATE")
         if (!envVars.has("WINEESYNC")) envVars.put("WINEESYNC", "1")
         val graphicsDriverConfig = KeyValueSet(container.getGraphicsDriverConfig())
         if (graphicsDriverConfig.get("version").lowercase(Locale.getDefault()).contains("gen8")) {

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -530,7 +530,7 @@ fun XServerScreen(
     }
 
     fun effectiveFpsLimit(): Int =
-        if (lsfgMultiplier >= 2) 0
+        if (isLsfgAvailable && lsfgMultiplier >= 2) 0
         else if (fpsLimiterEnabled) fpsLimiterTarget
         else 0
 

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -1,6 +1,7 @@
 package app.gamenative.utils
 
 import android.content.Context
+import android.os.Build
 import app.gamenative.PrefManager
 import app.gamenative.data.GameSource
 import app.gamenative.enums.Marker
@@ -18,6 +19,7 @@ import com.winlator.container.ContainerManager
 import com.winlator.core.DefaultVersion
 import com.winlator.core.FileUtils
 import com.winlator.core.GPUInformation
+import com.winlator.core.envvars.EnvVars
 import com.winlator.core.WineRegistryEditor
 import com.winlator.core.WineThemeManager
 import com.winlator.fexcore.FEXCoreManager
@@ -865,6 +867,14 @@ object ContainerUtils {
             applyBestConfigMapToContainerData(containerData, bestConfigMap)
         } else {
             containerData
+        }
+
+        if (Build.MANUFACTURER.equals("samsung", ignoreCase = true)) {
+            val ev = EnvVars(containerData.envVars)
+            if (!ev.has("FD_DEV_FEATURES")) {
+                ev.put("FD_DEV_FEATURES", "enable_tp_ubwc_flag_hint=1")
+                containerData = containerData.copy(envVars = ev.toString())
+            }
         }
 
         // If custom config is provided, just apply it and return

--- a/app/src/main/java/app/gamenative/utils/LsfgVkManager.kt
+++ b/app/src/main/java/app/gamenative/utils/LsfgVkManager.kt
@@ -223,14 +223,16 @@ object LsfgVkManager {
 
         return try {
             val dllPath = containerDllPath(container)
-            val armed = parseBool(container.getExtra(EXTRA_ARMED, "false")) && dllPath != null
+            val savedMultiplier = multiplier(container)
+            val frameGenActive = parseBool(container.getExtra(EXTRA_ARMED, "false")) &&
+                dllPath != null && savedMultiplier >= 2
             val configFile = File(container.rootDir, CONFIG_RELATIVE_PATH)
             val configText = buildConfigToml(
                 dllPath = dllPath,
-                enabled = armed,
-                multiplier = multiplier(container),
+                enabled = frameGenActive,
+                multiplier = if (frameGenActive) savedMultiplier else 1,
                 flowScale = flowScale(container),
-                performanceMode = performanceMode(container),
+                performanceMode = performanceMode(container) && frameGenActive,
             )
             val ok = FileUtils.writeString(configFile, configText)
             if (ok && configFile.exists()) {
@@ -342,12 +344,13 @@ object LsfgVkManager {
         appendLine("no_fp16 = false")
         appendLine()
 
-        if (enabled && !dllPath.isNullOrBlank()) {
+        if (!dllPath.isNullOrBlank()) {
+            val effectiveMultiplier = if (enabled) multiplier.coerceIn(2, 4) else 1
             appendLine("[[game]]")
             appendLine("exe = ${tomlString(PROCESS_EXE_IDENTIFIER)}")
-            appendLine("multiplier = ${multiplier.coerceIn(2, 4)}")
+            appendLine("multiplier = $effectiveMultiplier")
             appendLine("flow_scale = ${formatFlowScale(flowScale)}")
-            appendLine("performance_mode = ${if (performanceMode) "true" else "false"}")
+            appendLine("performance_mode = ${if (enabled && performanceMode) "true" else "false"}")
             appendLine("hdr_mode = false")
             appendLine("experimental_present_mode = ${tomlString("fifo")}")
         }

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -233,6 +233,7 @@
     <string name="performance_hud_fps_limiter_target">Mål-FPS</string>
     <string name="performance_hud_fps_limiter_off">Ubegrænset</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">Begrænser tilsidesat, mens LSFG er aktiv. Kildehastigheden styres af multiplikatoren.</string>
     <string name="performance_hud_presets">Forudindstillinger</string>
     <string name="performance_hud_presets_description">Skift hurtigt mellem almindelige HUD-layouts.</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1302,6 +1303,7 @@
     <string name="lsfg_enable">Aktivér LSFG-VK billedgenerering</string>
     <string name="lsfg_multiplier">Billedmultiplikator</string>
     <string name="lsfg_flow_scale">Flow-skala</string>
+    <string name="lsfg_flow_scale_desc">Lavere er mere stabilt; højere er mere flydende men kan give artefakter.</string>
     <string name="lsfg_performance_mode">Ydelsestilstand</string>
     <string name="lsfg_not_supported">Billedgenerering kræver en Bionic-container</string>
     <string name="lsfg_install_prompt">Lossless Scaling er ikke installeret. Tryk for at installere. Virkede kun på Adreno 6xx og nyere, så vidt vides.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -295,6 +295,7 @@
     <string name="performance_hud_fps_limiter_target">Ziel-FPS</string>
     <string name="performance_hud_fps_limiter_off">Unbegrenzt</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">Limiter wird bei aktivem LSFG ignoriert. Die Quellrate wird durch den Multiplikator bestimmt.</string>
     <string name="performance_hud_presets">Voreinstellungen</string>
     <string name="performance_hud_presets_description">Schnell zwischen gängigen HUD-Layouts wechseln.</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1372,6 +1373,7 @@
     <string name="lsfg_enable">LSFG-VK Bildgenerierung aktivieren</string>
     <string name="lsfg_multiplier">Bildmultiplikator</string>
     <string name="lsfg_flow_scale">Flow-Skala</string>
+    <string name="lsfg_flow_scale_desc">Niedriger ist stabiler; höher ist flüssiger, kann aber Artefakte verursachen.</string>
     <string name="lsfg_performance_mode">Leistungsmodus</string>
     <string name="lsfg_not_supported">Bildgenerierung erfordert einen Bionic-Container</string>
     <string name="lsfg_install_prompt">Lossless Scaling nicht installiert. Zum Installieren tippen. Funktioniert bekanntermaßen nur auf Adreno 6xx und neuer.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -317,6 +317,7 @@
     <string name="performance_hud_fps_limiter_target">FPS objetivo</string>
     <string name="performance_hud_fps_limiter_off">Ilimitado</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">Limitador anulado mientras LSFG está activo. La tasa de origen está controlada por el multiplicador.</string>
     <string name="performance_hud_presets">Preajustes</string>
     <string name="performance_hud_presets_description">Cambia rápidamente entre diseños de HUD comunes.</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1438,6 +1439,7 @@
     <string name="lsfg_enable">Habilitar generación de fotogramas LSFG-VK</string>
     <string name="lsfg_multiplier">Multiplicador de fotogramas</string>
     <string name="lsfg_flow_scale">Escala de flujo</string>
+    <string name="lsfg_flow_scale_desc">Más bajo es más estable; más alto es más fluido pero puede generar artefactos.</string>
     <string name="lsfg_performance_mode">Modo de rendimiento</string>
     <string name="lsfg_not_supported">La generación de fotogramas requiere un contenedor Bionic</string>
     <string name="lsfg_install_prompt">Lossless Scaling no está instalado. Toca para instalar. Solo se sabe que funciona en Adreno 6xx y posteriores.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -302,6 +302,7 @@
     <string name="performance_hud_fps_limiter_target">FPS cible</string>
     <string name="performance_hud_fps_limiter_off">Illimité</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">Limiteur ignoré tant que LSFG est actif. La fréquence source est contrôlée par le multiplicateur.</string>
     <string name="performance_hud_presets">Préréglages</string>
     <string name="performance_hud_presets_description">Basculer rapidement entre des dispositions HUD courantes.</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1432,6 +1433,7 @@
     <string name="lsfg_enable">Activer la génération d\'images LSFG-VK</string>
     <string name="lsfg_multiplier">Multiplicateur d\'images</string>
     <string name="lsfg_flow_scale">Échelle de flux</string>
+    <string name="lsfg_flow_scale_desc">Plus bas = plus stable ; plus élevé = plus fluide mais peut créer des artefacts.</string>
     <string name="lsfg_performance_mode">Mode performance</string>
     <string name="lsfg_not_supported">La génération d\'images nécessite un conteneur Bionic</string>
     <string name="lsfg_install_prompt">Lossless Scaling n\'est pas installé. Appuyez pour installer. Fonctionne uniquement sur Adreno 6xx et supérieur, à notre connaissance.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -306,6 +306,7 @@
     <string name="performance_hud_fps_limiter_target">FPS obiettivo</string>
     <string name="performance_hud_fps_limiter_off">Illimitato</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">Limitatore ignorato mentre LSFG è attivo. La frequenza sorgente è controllata dal moltiplicatore.</string>
     <string name="performance_hud_presets">Predefiniti</string>
     <string name="performance_hud_presets_description">Passa rapidamente tra layout HUD comuni.</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1428,6 +1429,7 @@
     <string name="lsfg_enable">Abilita generazione fotogrammi LSFG-VK</string>
     <string name="lsfg_multiplier">Moltiplicatore fotogrammi</string>
     <string name="lsfg_flow_scale">Scala di flusso</string>
+    <string name="lsfg_flow_scale_desc">Più basso è più stabile; più alto è più fluido ma può introdurre artefatti.</string>
     <string name="lsfg_performance_mode">Modalità prestazioni</string>
     <string name="lsfg_not_supported">La generazione di fotogrammi richiede un contenitore Bionic</string>
     <string name="lsfg_install_prompt">Lossless Scaling non installato. Tocca per installare. Funziona solo su Adreno 6xx e successivi, a quanto se ne sa.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -315,6 +315,7 @@
     <string name="performance_hud_fps_limiter_target">목표 FPS</string>
     <string name="performance_hud_fps_limiter_off">무제한</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">LSFG 사용 중에는 제한기가 비활성화됩니다. 소스 속도는 배수로 결정됩니다.</string>
     <string name="performance_hud_presets">프리셋</string>
     <string name="performance_hud_presets_description">일반적인 HUD 레이아웃으로 빠르게 전환합니다.</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1436,6 +1437,7 @@
     <string name="lsfg_enable">LSFG-VK 프레임 생성 활성화</string>
     <string name="lsfg_multiplier">프레임 배율</string>
     <string name="lsfg_flow_scale">플로우 스케일</string>
+    <string name="lsfg_flow_scale_desc">낮을수록 더 안정적이고, 높을수록 더 부드럽지만 아티팩트가 생길 수 있습니다.</string>
     <string name="lsfg_performance_mode">성능 모드</string>
     <string name="lsfg_not_supported">프레임 생성에는 Bionic 컨테이너가 필요합니다</string>
     <string name="lsfg_install_prompt">Lossless Scaling이 설치되지 않았습니다. 탭하여 설치하세요. Adreno 6xx 이상에서만 작동하는 것으로 알려져 있습니다.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -314,6 +314,7 @@
     <string name="performance_hud_fps_limiter_target">Docelowy FPS</string>
     <string name="performance_hud_fps_limiter_off">Bez limitu</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">Limiter pomijany gdy LSFG jest aktywny. Tempo źródła kontroluje mnożnik.</string>
     <string name="performance_hud_presets">Presety</string>
     <string name="performance_hud_presets_description">Szybko przełączaj między typowymi układami HUD.</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1435,6 +1436,7 @@
     <string name="lsfg_enable">Włącz generowanie klatek LSFG-VK</string>
     <string name="lsfg_multiplier">Mnożnik klatek</string>
     <string name="lsfg_flow_scale">Skala przepływu</string>
+    <string name="lsfg_flow_scale_desc">Niższa wartość jest stabilniejsza; wyższa jest płynniejsza, ale może powodować artefakty.</string>
     <string name="lsfg_performance_mode">Tryb wydajności</string>
     <string name="lsfg_not_supported">Generowanie klatek wymaga kontenera Bionic</string>
     <string name="lsfg_install_prompt">Lossless Scaling nie jest zainstalowany. Dotknij, aby zainstalować. Wiadomo, że działa tylko na Adreno 6xx i nowszych.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -233,6 +233,7 @@
     <string name="performance_hud_fps_limiter_target">FPS alvo</string>
     <string name="performance_hud_fps_limiter_off">Ilimitado</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">Limitador ignorado enquanto LSFG está ativo. A taxa da fonte é controlada pelo multiplicador.</string>
     <string name="performance_hud_presets">Predefinições</string>
     <string name="performance_hud_presets_description">Alterne rapidamente entre layouts comuns de HUD.</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1302,6 +1303,7 @@
     <string name="lsfg_enable">Ativar geração de quadros LSFG-VK</string>
     <string name="lsfg_multiplier">Multiplicador de quadros</string>
     <string name="lsfg_flow_scale">Escala de fluxo</string>
+    <string name="lsfg_flow_scale_desc">Mais baixo é mais estável; mais alto é mais suave, mas pode gerar artefatos.</string>
     <string name="lsfg_performance_mode">Modo de desempenho</string>
     <string name="lsfg_not_supported">A geração de quadros requer um contêiner Bionic</string>
     <string name="lsfg_install_prompt">Lossless Scaling não instalado. Toque para instalar. Funciona apenas em Adreno 6xx e posteriores, conforme se sabe.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -304,6 +304,7 @@
     <string name="performance_hud_fps_limiter_target">FPS țintă</string>
     <string name="performance_hud_fps_limiter_off">Nelimitat</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">Limitatorul este ignorat cât timp LSFG este activ. Rata sursei este controlată de multiplicator.</string>
     <string name="performance_hud_presets">Presetări</string>
     <string name="performance_hud_presets_description">Comută rapid între aspecte HUD comune.</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1437,6 +1438,7 @@
     <string name="lsfg_enable">Activează generarea de cadre LSFG-VK</string>
     <string name="lsfg_multiplier">Multiplicator cadre</string>
     <string name="lsfg_flow_scale">Scară flux</string>
+    <string name="lsfg_flow_scale_desc">Mai mic este mai stabil; mai mare este mai fluid, dar poate produce artefacte.</string>
     <string name="lsfg_performance_mode">Mod performanță</string>
     <string name="lsfg_not_supported">Generarea de cadre necesită un container Bionic</string>
     <string name="lsfg_install_prompt">Lossless Scaling nu este instalat. Atingeți pentru a instala. Se știe că funcționează doar pe Adreno 6xx și mai nou.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -878,6 +878,7 @@ https://gamenative.app
     <string name="performance_hud_fps_limiter_target">Целевой FPS</string>
     <string name="performance_hud_fps_limiter_off">Без ограничений</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">Ограничитель отключён, пока активен LSFG. Частоту источника задаёт множитель.</string>
     <string name="performance_hud_presets">Предустановки</string>
     <string name="performance_hud_presets_description">Быстро переключаться между типовыми макетами HUD.</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1365,6 +1366,7 @@ https://gamenative.app
     <string name="lsfg_enable">Включить генерацию кадров LSFG-VK</string>
     <string name="lsfg_multiplier">Множитель кадров</string>
     <string name="lsfg_flow_scale">Масштаб потока</string>
+    <string name="lsfg_flow_scale_desc">Ниже — стабильнее; выше — плавнее, но могут появляться артефакты.</string>
     <string name="lsfg_performance_mode">Режим производительности</string>
     <string name="lsfg_not_supported">Для генерации кадров требуется контейнер Bionic</string>
     <string name="lsfg_install_prompt">Lossless Scaling не установлен. Нажмите для установки. Известно, что работает только на Adreno 6xx и новее.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -301,6 +301,7 @@
     <string name="performance_hud_fps_limiter_target">Цільовий FPS</string>
     <string name="performance_hud_fps_limiter_off">Без обмежень</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">Обмежувач вимкнено, поки активний LSFG. Частоту джерела задає множник.</string>
     <string name="performance_hud_presets">Набори</string>
     <string name="performance_hud_presets_description">Швидко перемикайтеся між типовими макетами HUD.</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1431,6 +1432,7 @@
     <string name="lsfg_enable">Увімкнути генерацію кадрів LSFG-VK</string>
     <string name="lsfg_multiplier">Множник кадрів</string>
     <string name="lsfg_flow_scale">Масштаб потоку</string>
+    <string name="lsfg_flow_scale_desc">Нижче — стабільніше; вище — плавніше, але можуть з’являтися артефакти.</string>
     <string name="lsfg_performance_mode">Режим продуктивності</string>
     <string name="lsfg_not_supported">Для генерації кадрів потрібен контейнер Bionic</string>
     <string name="lsfg_install_prompt">Lossless Scaling не встановлено. Натисніть для встановлення. Відомо, що працює лише на Adreno 6xx і новіших.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -300,6 +300,7 @@
     <string name="performance_hud_fps_limiter_target">目标 FPS</string>
     <string name="performance_hud_fps_limiter_off">无限制</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">LSFG 启用时，限制器被覆盖。源帧率由倍数控制。</string>
     <string name="performance_hud_presets">预设</string>
     <string name="performance_hud_presets_description">快速切换常用 HUD 布局。</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1505,6 +1506,7 @@
     <string name="lsfg_enable">启用 LSFG-VK 帧生成</string>
     <string name="lsfg_multiplier">帧倍率</string>
     <string name="lsfg_flow_scale">光流缩放</string>
+    <string name="lsfg_flow_scale_desc">数值越低越稳定；越高越流畅，但可能出现伪影。</string>
     <string name="lsfg_performance_mode">性能模式</string>
     <string name="lsfg_not_supported">帧生成需要 Bionic 容器</string>
     <string name="lsfg_install_prompt">Lossless Scaling 未安装。点击安装。已知仅在 Adreno 6xx 及更高版本上可用。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -300,6 +300,7 @@
     <string name="performance_hud_fps_limiter_target">目標 FPS</string>
     <string name="performance_hud_fps_limiter_off">無限制</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">LSFG 啟用時，限制器被覆蓋。來源幀率由倍數控制。</string>
     <string name="performance_hud_presets">預設</string>
     <string name="performance_hud_presets_description">快速切換常用 HUD 版面配置。</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1497,6 +1498,7 @@
     <string name="lsfg_enable">啟用 LSFG-VK 幀生成</string>
     <string name="lsfg_multiplier">幀倍率</string>
     <string name="lsfg_flow_scale">光流縮放</string>
+    <string name="lsfg_flow_scale_desc">數值越低越穩定；越高越流暢，但可能出現偽影。</string>
     <string name="lsfg_performance_mode">效能模式</string>
     <string name="lsfg_not_supported">幀生成需要 Bionic 容器</string>
     <string name="lsfg_install_prompt">Lossless Scaling 未安裝。點擊安裝。已知僅在 Adreno 6xx 及更高版本上可用。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,6 +290,7 @@
     <string name="performance_hud_fps_limiter_target">Target FPS</string>
     <string name="performance_hud_fps_limiter_off">Unlimited</string>
     <string name="performance_hud_fps_limiter_value">%1$d FPS</string>
+    <string name="performance_hud_fps_limiter_lsfg_override">Limiter overridden while LSFG is active. Source rate is paced by the multiplier.</string>
     <string name="performance_hud_presets">Presets</string>
     <string name="performance_hud_presets_description">Quickly switch between common HUD layouts.</string>
     <string name="performance_hud_preset_fps_only">1</string>
@@ -1480,6 +1481,7 @@
     <string name="lsfg_enable">Enable LSFG-VK frame generation</string>
     <string name="lsfg_multiplier">Frame multiplier</string>
     <string name="lsfg_flow_scale">Flow scale</string>
+    <string name="lsfg_flow_scale_desc">Lower is more stable; higher is smoother but can artifact.</string>
     <string name="lsfg_performance_mode">Performance mode</string>
     <string name="lsfg_not_supported">Frame generation requires a Bionic container</string>
     <string name="lsfg_install_prompt">Lossless Scaling not installed. Tap to install. Only known to work on Adreno 6xx and above.</string>


### PR DESCRIPTION
## Description
Framgen was causing judder on boot. To disable this, we have to completely disable fps cap when framegen is active.
Secondly, framegen was launching enabled even when set to 0 on the previous run. This would again cause issues with fps cap and cause judder.
Show the multiplied frame rate in the perf overlay.
Add subtitles to show why fps cap disabled and what flow rate is
Added env var for samsung devices to prevent flickering

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the FPS limiter whenever LSFG frame generation is active and fix LSFG boot state to remove startup judder. The HUD now shows multiplied FPS, the Quick Menu explains limiter overrides and Flow Scale, and Samsung flicker is mitigated via an env var.

- **Bug Fixes**
  - Disable FPS cap when LSFG multiplier ≥ 2; limiter controls are locked with an override note.
  - LSFG no longer auto-enables on boot if previously off; config only enables when armed and multiplier ≥ 2.
  - Remove `DXVK_FRAME_RATE` and `VKD3D_FRAME_RATE` to avoid double-capping.
  - Add `FD_DEV_FEATURES=enable_tp_ubwc_flag_hint=1` on Samsung devices to prevent flicker.

- **New Features**
  - Performance HUD reports FPS multiplied by the LSFG multiplier.
  - Quick Menu adds subtitles: why the limiter is overridden under LSFG, and a tip for Flow Scale.
  - Hide LSFG settings in the default Graphics tab to avoid accidental changes.

<sup>Written for commit e4331ccb796c2626cdc935e4ef3753cea5a5764c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FPS limiter auto-disabled and visually indicated when LSFG frame generation is active (multiplier ≥ 2).
  * Performance HUD FPS now reflects LSFG multiplier.
  * Quick menu shows contextual subtitles for adjustment rows.

* **Behavior Changes**
  * LSFG settings are hidden in the default graphics profile; shown only when editing non-default configs.

* **Localization**
  * Added LSFG/FPS-limiter strings in 15+ languages.

* **Bug Fixes**
  * Improved Samsung container environment handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utkarshdalal/GameNative/pull/1420)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->