### PR TITLE
fix(envvars): escape spaces on round-trip; fix crash on save

### DIFF
--- a/app/src/main/java/com/winlator/core/envvars/EnvVars.java
+++ b/app/src/main/java/com/winlator/core/envvars/EnvVars.java
@@ -20,11 +20,12 @@ public class EnvVars implements Iterable<String> {
 
     public void putAll(String values) {
         if (values == null || values.isEmpty()) return;
-        String[] parts = values.split(" ");
-        for (String part : parts) {
+        for (String part : splitOnUnescapedSpaces(values)) {
             int index = part.indexOf("=");
-            String name = part.substring(0, index);
-            String value = part.substring(index+1);
+            // tolerate stray tokens (legacy data corrupted by old unescaped serializer)
+            if (index < 0) continue;
+            String name = unescape(part.substring(0, index));
+            String value = unescape(part.substring(index + 1));
             data.put(name, value);
         }
     }
@@ -53,22 +54,24 @@ public class EnvVars implements Iterable<String> {
         return data.isEmpty();
     }
 
+    // canonical persistence form: escape so putAll round-trips losslessly
     @NonNull
     @Override
     public String toString() {
-        return String.join(" ", toStringArray());
-    }
-
-    public String toEscapedString() {
-        String result = "";
+        StringBuilder sb = new StringBuilder();
         for (String key : data.keySet()) {
-            if (!result.isEmpty()) result += " ";
-            String value = data.get(key);
-            result += key+"="+value.replace(" ", "\\ ");
+            if (sb.length() > 0) sb.append(' ');
+            sb.append(escape(key)).append('=').append(escape(data.get(key)));
         }
-        return result;
+        return sb.toString();
     }
 
+    // for shell composition (env KEY=val ... cmd) — same escape rules
+    public String toEscapedString() {
+        return toString();
+    }
+
+    // for execve envp — values must be raw, no escaping
     public String[] toStringArray() {
         String[] stringArray = new String[data.size()];
         int index = 0;
@@ -80,5 +83,43 @@ public class EnvVars implements Iterable<String> {
     @Override
     public Iterator<String> iterator() {
         return data.keySet().iterator();
+    }
+
+    private static String escape(String s) {
+        // escape backslash FIRST so we don't double-escape the slashes we add for spaces
+        return s.replace("\\", "\\\\").replace(" ", "\\ ");
+    }
+
+    private static String unescape(String s) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '\\' && i + 1 < s.length()) {
+                sb.append(s.charAt(++i));
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    private static java.util.List<String> splitOnUnescapedSpaces(String s) {
+        java.util.List<String> out = new java.util.ArrayList<>();
+        StringBuilder cur = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '\\' && i + 1 < s.length()) {
+                cur.append(c).append(s.charAt(++i));
+            } else if (c == ' ') {
+                if (cur.length() > 0) {
+                    out.add(cur.toString());
+                    cur.setLength(0);
+                }
+            } else {
+                cur.append(c);
+            }
+        }
+        if (cur.length() > 0) out.add(cur.toString());
+        return out;
     }
 }

--- a/app/src/test/java/com/winlator/core/envvars/EnvVarsTest.kt
+++ b/app/src/test/java/com/winlator/core/envvars/EnvVarsTest.kt
@@ -1,0 +1,98 @@
+package com.winlator.core.envvars
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EnvVarsTest {
+
+    @Test
+    fun roundTripPlainValues() {
+        val src = EnvVars().apply {
+            put("DXVK_HUD", "1")
+            put("WINEDEBUG", "fixme-all")
+        }
+        val parsed = EnvVars(src.toString())
+        assertEquals("1", parsed.get("DXVK_HUD"))
+        assertEquals("fixme-all", parsed.get("WINEDEBUG"))
+    }
+
+    // crash repro: spaces in value used to throw StringIndexOutOfBoundsException on re-parse
+    @Test
+    fun roundTripValueWithSpaces() {
+        val src = EnvVars().apply {
+            put("DXVK_CONFIG", "d3d9.presentInterval = 1;")
+            put("WINEDEBUG", "fixme-all")
+        }
+        val parsed = EnvVars(src.toString())
+        assertEquals("d3d9.presentInterval = 1;", parsed.get("DXVK_CONFIG"))
+        assertEquals("fixme-all", parsed.get("WINEDEBUG"))
+    }
+
+    @Test
+    fun roundTripValueWithMultipleSpacesEqualsAndSemicolons() {
+        // multi-clause DXVK config: spaces, '=', ';' all inside one value
+        val src = EnvVars().apply {
+            put("DXVK_CONFIG", "d3d9.presentInterval = 1; d3d9.somethingElse = 2")
+        }
+        val parsed = EnvVars(src.toString())
+        assertEquals("d3d9.presentInterval = 1; d3d9.somethingElse = 2", parsed.get("DXVK_CONFIG"))
+    }
+
+    @Test
+    fun roundTripValueWithSemicolonOnly() {
+        val src = EnvVars().apply { put("DXVK_CONFIG", "d3d9.presentInterval=1;") }
+        val parsed = EnvVars(src.toString())
+        assertEquals("d3d9.presentInterval=1;", parsed.get("DXVK_CONFIG"))
+    }
+
+    @Test
+    fun roundTripValueWithBackslash() {
+        val src = EnvVars().apply { put("WINEPATH", "C:\\Program Files\\foo") }
+        val parsed = EnvVars(src.toString())
+        assertEquals("C:\\Program Files\\foo", parsed.get("WINEPATH"))
+    }
+
+    @Test
+    fun roundTripValueWithEscapedSpaceLiteral() {
+        // value already contains a backslash followed by a space — must survive round-trip
+        val src = EnvVars().apply { put("FOO", "a\\ b") }
+        val parsed = EnvVars(src.toString())
+        assertEquals("a\\ b", parsed.get("FOO"))
+    }
+
+    @Test
+    fun roundTripEmptyValue() {
+        val src = EnvVars().apply { put("EMPTY", "") }
+        val parsed = EnvVars(src.toString())
+        assertEquals("", parsed.get("EMPTY"))
+        assert(parsed.has("EMPTY"))
+    }
+
+    @Test
+    fun toStringArrayReturnsRawValuesForExecve() {
+        // execve envp must NOT contain backslash escapes — it's the actual env vector
+        val src = EnvVars().apply { put("DXVK_CONFIG", "d3d9.presentInterval = 1;") }
+        assertArrayEquals(arrayOf("DXVK_CONFIG=d3d9.presentInterval = 1;"), src.toStringArray())
+    }
+
+    @Test
+    fun emptyAndNullParseSafely() {
+        assert(EnvVars("").isEmpty)
+        assert(EnvVars(null).isEmpty)
+    }
+
+    @Test
+    fun multipleVarsPreserveOrderAndSpaces() {
+        val src = EnvVars().apply {
+            put("A", "with space")
+            put("B", "no_space")
+            put("C", "another with spaces")
+        }
+        val parsed = EnvVars(src.toString())
+        assertEquals(listOf("A", "B", "C"), parsed.toList())
+        assertEquals("with space", parsed.get("A"))
+        assertEquals("no_space", parsed.get("B"))
+        assertEquals("another with spaces", parsed.get("C"))
+    }
+}

--- a/app/src/test/java/com/winlator/core/envvars/EnvVarsTest.kt
+++ b/app/src/test/java/com/winlator/core/envvars/EnvVarsTest.kt
@@ -2,6 +2,7 @@ package com.winlator.core.envvars
 
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class EnvVarsTest {
@@ -66,7 +67,7 @@ class EnvVarsTest {
         val src = EnvVars().apply { put("EMPTY", "") }
         val parsed = EnvVars(src.toString())
         assertEquals("", parsed.get("EMPTY"))
-        assert(parsed.has("EMPTY"))
+        assertTrue(parsed.has("EMPTY"))
     }
 
     @Test
@@ -78,8 +79,8 @@ class EnvVarsTest {
 
     @Test
     fun emptyAndNullParseSafely() {
-        assert(EnvVars("").isEmpty)
-        assert(EnvVars(null).isEmpty)
+        assertTrue(EnvVars("").isEmpty)
+        assertTrue(EnvVars(null).isEmpty)
     }
 
     @Test


### PR DESCRIPTION
## Description
Fixes a crash when saving an environment variable whose value contains a space (e.g. `DXVK_CONFIG = d3d9.presentInterval = 1;`).

`EnvVars.toString()` joined `KEY=value` pairs with a literal space, but `EnvVars.putAll(String)` split on a literal space and then `substring(0, indexOf("="))` on each token. A spaced value produced tokens without `=`, so `indexOf` returned `-1` and `substring(0, -1)` threw `StringIndexOutOfBoundsException` on the recompose right after the user tapped OK.

Made `toString()` / `putAll(String)` escape-aware (backslash-escapes `\` and ` `). `toStringArray()` stays raw — that's the env vector handed to `execve`, which must not see escapes. `toEscapedString()` (used to compose `env KEY=val ... cmd` shell strings) now aliases `toString()` since the new format is also shell-safe and was previously slightly different (didn't escape `\`).

Closes #1428

## Recording
N/A — crash fix, no visible behavior change beyond "doesn't crash". Happy to attach a before/after if needed.

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

## Tests
New `EnvVarsTest` covers the round-trip contract: plain values, value-with-spaces (the crash repro), value with multiple spaces + `=` + `;` (multi-clause DXVK config), semicolon-only values, embedded backslashes, pre-escaped `\<space>` literal in source, empty values, and that `toStringArray()` returns raw values for `execve`.

## Verified on device
Built `:app:assembleDebug`, installed on a physical device, manually entered `DXVK_CONFIG = d3d9.presentInterval = 1;` (with and without surrounding quotes) — no crash, value persists across dialog open/close.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when saving environment variables with spaces by making `EnvVars` parse/serialize escape-aware. Round-trips are now lossless while `execve` env values stay raw.

- **Bug Fixes**
  - `EnvVars`: escape-aware `toString()` and `putAll(String)` for spaces and backslashes; tolerates stray tokens without `=`.
  - `toEscapedString()` now aliases `toString()`; `toStringArray()` stays raw for `execve`.
  - Added `EnvVarsTest` covering spaces, backslashes, empty values, order, and raw `toStringArray()`; switched to JUnit `assertTrue` so checks run without `-ea`.

<sup>Written for commit d5d38be9425aa5bd641ab3255ee7c9ce8312d619. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parsing now correctly handles escaped spaces and skips stray/invalid tokens to tolerate corrupted legacy data.

* **Improvements**
  * Canonicalized serialization with consistent escaping rules; shell-facing escaped-string API unified with persistence format.
  * Env var array output remains raw KEY=VALUE entries; insertion order and empty/null values preserved.

* **Tests**
  * Added comprehensive round-trip tests covering spaces, backslashes, empty values, and ordering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utkarshdalal/GameNative/pull/1429)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->