### PR TITLE
fix(steam/download): close race that hangs Update/Verify at 0%

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1767,6 +1767,15 @@ class SteamService : Service(), IChallengeUrlChanged {
                     Timber.i("Resumed download: initialized with $persistedBytes bytes")
                 }
 
+                // register BEFORE launching: a fast verify/update on up-to-date data can
+                // complete the launch body synchronously (DepotDownloader has no chunks to
+                // fetch). removeDownloadJob inside that body must find the entry to emit
+                // DownloadStatusChanged(false); otherwise the UI hangs at 0% and the next
+                // downloadApp call returns the stale DownloadInfo from the still-populated
+                // map (line ~1666 short-circuit).
+                downloadJobs[appId] = di
+                notifyDownloadStarted(appId)
+
                 val downloadJob = instance!!.scope.launch {
                     try {
                         // Get licenses from database
@@ -2034,16 +2043,18 @@ class SteamService : Service(), IChallengeUrlChanged {
                     }
                 }
                 downloadJob.invokeOnCompletion { throwable ->
+                    // safety net for paths the inline removeDownloadJob doesn't cover:
+                    // early `return@launch` on empty licenses, exceptions before the catch
+                    // handlers, and cancellations thrown out of suspension points.
+                    // second call is a no-op if the inline path already removed the entry.
+                    removeDownloadJob(appId)
                     if (throwable is kotlinx.coroutines.CancellationException) {
                         Timber.d(throwable, "Download canceled for app $appId")
-                        removeDownloadJob(appId)
                     }
                 }
                 di.setDownloadJob(downloadJob)
             }
 
-            downloadJobs[appId] = info
-            notifyDownloadStarted(appId)
             return info
         }
 


### PR DESCRIPTION
## Description
Fixes a long-standing race in `SteamService.downloadApp(...)` that hangs Update and Verify at 0% on games whose depot work completes synchronously inside the launched coroutine.

`downloadJobs[appId] = info` was assigned **after** `instance!!.scope.launch { ... }` had already kicked off the download body. For a fast verify/update (game already on disk, DepotDownloader has no chunks to fetch) the launched coroutine can complete and reach its inline `removeDownloadJob(appId)` **before** the outer assignment runs. `removeDownloadJob` finds no entry, skips `notifyDownloadStopped`, and then the outer code populates the map with a now-stale completed-job `DownloadInfo` and emits `notifyDownloadStarted`. The UI sits at 0% with no stop event ever coming.

Cancel can't recover either: `DownloadInfo.downloadJob` may still be `null` (the `setDownloadJob` line hadn't run yet), and even if set, the job is already complete — so `cancel()` is a no-op. The retry path returns the same stale `DownloadInfo` via the `if (downloadJobs.contains(appId)) return getAppDownloadInfo(appId)` short-circuit at line ~1666, so the second attempt hangs identically.

Two surgical changes:
- Register `downloadJobs[appId]` + emit `notifyDownloadStarted` **before** launching the coroutine. The inline `removeDownloadJob` inside the launch body now always finds the entry and emits `DownloadStatusChanged(false)`.
- `invokeOnCompletion` now unconditionally calls `removeDownloadJob(appId)` as a safety net for paths the inline call doesn't cover: the early `return@launch` on empty licenses, exceptions thrown before the `catch` handlers, and cancellations out of suspension points. The second call is a no-op when the inline path already removed the entry, so the existing event ordering is preserved on the success path (inline `removeDownloadJob` → `LibraryInstallStatusChanged` → safety-net no-op).

Closes #1433

## Recording
N/A — fix is for a hang. Before: progress bar parks at 0% forever on Update/Verify of an up-to-date title. After: completes and Play button returns. Happy to attach a screen recording if needed.

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

## Verified on device
Built `:app:assembleDebug`, installed on a physical device, ran Update and Verify on an already-installed title repeatedly. No more hang at 0%; Play button returns reliably.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `SteamService.downloadApp` that caused Update/Verify to hang at 0% on up-to-date games (fixes #1433). Ensures start/stop events emit correctly and cancel/retry work reliably.

- **Bug Fixes**
  - Register `downloadJobs[appId]` and call `notifyDownloadStarted` before launching the coroutine so `removeDownloadJob` always finds the entry and the UI receives the stop event.
  - Call `removeDownloadJob(appId)` unconditionally in `invokeOnCompletion` to cover early returns, exceptions, and cancellations without leaving stale state.

<sup>Written for commit 9c0188b424292cab679f484e75bc6c42f93759e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of download state tracking by ensuring notifications are sent immediately when downloads start, preventing stale state issues.
  * Enhanced download cleanup logic to consistently handle job completion and properly categorize cancellation events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utkarshdalal/GameNative/pull/1434)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->