### PR TITLE
Fix simultaneous dpad and left stick input

### DIFF
--- a/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
@@ -188,14 +188,14 @@ public class ExternalController {
             float axisX = getCenteredAxis(event, MotionEvent.AXIS_HAT_X, historyPos);
             float axisY = getCenteredAxis(event, MotionEvent.AXIS_HAT_Y, historyPos);
             GamepadState gamepadState = this.state;
-            gamepadState.dpad[0] = axisY == -1.0f && Math.abs(gamepadState.thumbLY) < STICK_DEAD_ZONE;
+            gamepadState.dpad[0] = axisY == -1.0f;
             GamepadState gamepadState2 = this.state;
-            gamepadState2.dpad[1] = axisX == 1.0f && Math.abs(gamepadState2.thumbLX) < STICK_DEAD_ZONE;
+            gamepadState2.dpad[1] = axisX == 1.0f;
             GamepadState gamepadState3 = this.state;
-            gamepadState3.dpad[2] = axisY == 1.0f && Math.abs(gamepadState3.thumbLY) < STICK_DEAD_ZONE;
+            gamepadState3.dpad[2] = axisY == 1.0f;
             GamepadState gamepadState4 = this.state;
             boolean[] zArr = gamepadState4.dpad;
-            if (axisX == -1.0f && Math.abs(gamepadState4.thumbLX) < STICK_DEAD_ZONE) {
+            if (axisX == -1.0f) {
                 z = true;
             }
             zArr[3] = z;
@@ -286,12 +286,12 @@ public class ExternalController {
         switch (keyCode) {
             case KeyEvent.KEYCODE_DPAD_UP:
                 GamepadState gamepadState = this.state;
-                gamepadState.dpad[0] = pressed && Math.abs(gamepadState.thumbLY) < STICK_DEAD_ZONE;
+                gamepadState.dpad[0] = pressed;
                 return true;
             case KeyEvent.KEYCODE_DPAD_DOWN:
                 GamepadState gamepadState2 = this.state;
                 boolean[] zArr = gamepadState2.dpad;
-                if (pressed && Math.abs(gamepadState2.thumbLY) < STICK_DEAD_ZONE) {
+                if (pressed) {
                     z = true;
                 }
                 zArr[2] = z;
@@ -299,7 +299,7 @@ public class ExternalController {
             case KeyEvent.KEYCODE_DPAD_LEFT:
                 GamepadState gamepadState3 = this.state;
                 boolean[] zArr2 = gamepadState3.dpad;
-                if (pressed && Math.abs(gamepadState3.thumbLX) < STICK_DEAD_ZONE) {
+                if (pressed) {
                     z = true;
                 }
                 zArr2[3] = z;
@@ -307,7 +307,7 @@ public class ExternalController {
             case KeyEvent.KEYCODE_DPAD_RIGHT:
                 GamepadState gamepadState4 = this.state;
                 boolean[] zArr3 = gamepadState4.dpad;
-                if (pressed && Math.abs(gamepadState4.thumbLX) < STICK_DEAD_ZONE) {
+                if (pressed) {
                     z = true;
                 }
                 zArr3[1] = z;


### PR DESCRIPTION
## Description
This is a fix for:

https://discord.com/channels/1378308569287622737/1503022980098166925

Right now when a user is using the left joystick and D-Pad on an external controller at the same time, only the joystick works. This PR fixes that issue.

## Recording

https://github.com/user-attachments/assets/ec972451-cb47-44c0-b070-caf6f07ea56a

Recording shows me moving around (left joystick) and names appearing/disappearing (using d-pad)

## Type of Change
- [X] Bug fix
- [] Performance / stability improvement
- [] Compatibility improvements
- [] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes D‑pad being ignored when the left stick is in use. D‑pad and left stick now work at the same time on external controllers.

- **Bug Fixes**
  - Removed left-stick dead‑zone checks from D‑pad updates in `com.winlator.inputcontrols.ExternalController` for hat axis and key events.
  - D‑pad now reflects `AXIS_HAT_X/Y` and `KEYCODE_DPAD_*` regardless of `thumbLX/thumbLY`.

<sup>Written for commit d65a4b304b8cef9ac886afd53e0648977aa0f809. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1445?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved D-pad input responsiveness on external controllers. The D-pad now operates independently of analog stick positioning, ensuring more reliable directional input detection for games requiring precise D-pad control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utkarshdalal/GameNative/pull/1445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->