### PR TITLE
fix: compatibility fix for steam bionic client on samsung and odin 3

### DIFF
--- a/app/src/main/java/app/gamenative/SteamBootstrap.kt
+++ b/app/src/main/java/app/gamenative/SteamBootstrap.kt
@@ -103,7 +103,7 @@ object SteamBootstrap {
             return 0
         }
 
-        installSqliteCompatLink(libsteamclientPath)
+        installSqliteCompatLinkIfNeeded(libsteamclientPath)
 
         val flat = ArrayList<String>(extraEnv.size * 2)
         for ((k, v) in extraEnv) {
@@ -161,14 +161,96 @@ object SteamBootstrap {
     }
 
     /**
-     * Install `<libsteamclient.so's dir>/libsqlite.so -> libsqlite3.so.0` for the duration of
-     * this bionic-Steam session.
+     * Conditionally install `<libsteamclient.so's dir>/libsqlite.so -> libsqlite3.so.0` only if
+     * needed on this device.
+     *
+     * Strategy:
+     * 1. Check if system libsqlite.so exists - if not, no symlink needed
+     * 2. Use readelf to inspect system libsqlite.so for problematic OpenSSL 1.0.x symbols
+     * 3. If readelf unavailable, fall back to conservative approach (create symlink)
      *
      * Why: on devices whose `/system/lib64/libsqlite.so` references the OpenSSL 1.0.x symbol
      * `OpenSSL_add_all_algorithms` (deprecated, gone in OpenSSL 3 which we bundle), the bionic
      * linker chains into that system libsqlite when nothing earlier on `LD_LIBRARY_PATH` provides
      * a `libsqlite.so`, and dlopen of libsteamclient.so fails. Pointing the bare name at our
      * SQLite-3 file short-circuits that fall-through.
+     */
+    private fun installSqliteCompatLinkIfNeeded(libsteamclientPath: String) {
+        if (!needsSqliteCompatLink()) {
+            Log.i(TAG, "SQLite compat symlink not needed on this device")
+            return
+        }
+        Log.i(TAG, "SQLite compat symlink needed, installing...")
+        installSqliteCompatLink(libsteamclientPath)
+    }
+
+    /**
+     * Determine if the SQLite compatibility symlink is needed on this device.
+     * Uses symbol check to inspect system libsqlite.so for OpenSSL 1.0.x symbols (if readelf available).
+     * Falls back to conservative approach (create symlink) if check is unavailable.
+     */
+    private fun needsSqliteCompatLink(): Boolean {
+        val is64Bit = android.os.Build.SUPPORTED_64_BIT_ABIS.isNotEmpty()
+        val systemSqlitePath = if (is64Bit) "/system/lib64/libsqlite.so" else "/system/lib/libsqlite.so"
+
+        val systemSqlite = File(systemSqlitePath)
+        if (!systemSqlite.exists()) {
+            Log.i(TAG, "System libsqlite.so not found at $systemSqlitePath, symlink not needed")
+            return false
+        }
+
+        // Check for problematic OpenSSL symbols using readelf
+        val symbolCheckResult = checkSystemSqliteSymbols(systemSqlitePath)
+        if (symbolCheckResult != null) {
+            Log.i(TAG, "Symbol check completed: symlink ${if (symbolCheckResult) "needed" else "not needed"}")
+            return symbolCheckResult
+        }
+
+        // Conservative fallback: if we can't check, create the symlink to be safe
+        Log.i(TAG, "Symbol check unavailable, defaulting to creating symlink (conservative approach)")
+        return true
+    }
+
+    /**
+     * Check if system libsqlite.so contains problematic OpenSSL 1.0.x symbols using readelf.
+     * Returns null if readelf is not available or check fails.
+     */
+    private fun checkSystemSqliteSymbols(systemSqlitePath: String): Boolean? {
+        // First check if readelf exists
+        val readelfPaths = listOf("/system/bin/readelf", "/system/xbin/readelf")
+        val readelfPath = readelfPaths.firstOrNull { File(it).exists() }
+
+        if (readelfPath == null) {
+            Log.i(TAG, "readelf not found, skipping symbol check")
+            return null
+        }
+
+        return try {
+            val process = ProcessBuilder(readelfPath, "-s", systemSqlitePath)
+                .redirectErrorStream(true)
+                .start()
+
+            val output = process.inputStream.bufferedReader().use { it.readText() }
+            val exitCode = process.waitFor()
+
+            if (exitCode != 0) {
+                Log.w(TAG, "readelf exited with code $exitCode")
+                return null
+            }
+
+            // Check if the problematic OpenSSL 1.0.x symbol is referenced
+            val hasProblematicSymbol = output.contains("OpenSSL_add_all_algorithms")
+            Log.i(TAG, "System libsqlite.so ${if (hasProblematicSymbol) "contains" else "does not contain"} OpenSSL_add_all_algorithms")
+            hasProblematicSymbol
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to check system libsqlite symbols: $e")
+            null
+        }
+    }
+
+    /**
+     * Install `<libsteamclient.so's dir>/libsqlite.so -> libsqlite3.so.0` for the duration of
+     * this bionic-Steam session.
      *
      * The Wine subprocess we spawn later does its own dlopen of the same libsteamclient.so, so
      * the symlink must persist until [stop] runs; we tear it down there to keep it ephemeral


### PR DESCRIPTION
## Description
The SQLite compatibility symlink, required on some devices to resolve `libsteamclient.so` loading issues due to problematic system `libsqlite.so`, is now installed only when truly needed.

This implements a check using `readelf` to inspect the system's `libsqlite.so` for references to deprecated OpenSSL 1.0.x symbols (`OpenSSL_add_all_algorithms`). The symlink is created only if these problematic symbols are detected. If `readelf` is unavailable or the check fails, the symlink is installed as a conservative fallback.

This refinement avoids unnecessary symlink creation on compatible devices.

## Recording

On compatible devices like odin 3:
```
SteamBootstrap                        I  System libsqlite.so does not contain OpenSSL_add_all_algorithms
SteamBootstrap                        I  Symbol check completed: symlink not needed
SteamBootstrap                        I  SQLite compat symlink not needed on this device
```

On Incompatible devices like samsung:
```
SteamBootstrap                        I  System libsqlite.so contains OpenSSL_add_all_algorithms
SteamBootstrap                        I  Symbol check completed: symlink needed
SteamBootstrap                        I  SQLite compat symlink needed, installing...
SteamBootstrap                        I  Created sqlite compat symlink /data/user/0/app.gamenative/files/imagefs/usr/lib/libsqlite.so -> libsqlite3.so.0
```

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install the SQLite compatibility symlink only when the system `libsqlite.so` references deprecated OpenSSL 1.0.x symbols, preventing `libsteamclient.so` load failures while avoiding unnecessary changes on compatible devices.

- **Bug Fixes**
  - Check `/system/lib[64]/libsqlite.so` with `readelf -s` for `OpenSSL_add_all_algorithms`.
  - Create `libsqlite.so -> libsqlite3.so.0` only when the symbol is found; fall back to installing if `readelf` is unavailable.

<sup>Written for commit bec794a6bda5ccc916ffb6bcab2e71e741a63d2c. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1448?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized app startup speed by intelligently managing library compatibility installations. The app now checks if compatibility components are actually needed on your device before installing them, reducing initialization time and resource usage while maintaining reliable fallback behavior. This enhancement ensures faster app launches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utkarshdalal/GameNative/pull/1448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->