### PR TITLE
fix: Improve process handling for reliable suspend/resume

### DIFF
--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public abstract class ProcessHelper {
     public static final boolean PRINT_DEBUG = true; // FIXME change to false
@@ -152,6 +153,21 @@ public abstract class ProcessHelper {
             if (terminationCallback != null) terminationCallback.call(-1);
         }
         return pid;
+    }
+
+    public static java.lang.Process startProcess(String command, String[] envp, File workingDir) {
+        try {
+            Log.d("ProcessHelper", "Executing: " + Arrays.toString(splitCommand(command)) + ", " + Arrays.toString(envp) + ", " + workingDir);
+            java.lang.Process process = Runtime.getRuntime().exec(splitCommand(command), envp, workingDir);
+            if (!debugCallbacks.isEmpty()) {
+                createDebugThread(process.getInputStream());
+                createDebugThread(process.getErrorStream());
+            }
+
+            return process;
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     public static List<ProcessInfo> listSubProcesses() {

--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -166,6 +166,7 @@ public abstract class ProcessHelper {
 
             return process;
         } catch (Exception e) {
+            Log.e("ProcessHelper", "Failed to execute command: " + e);
             return null;
         }
     }

--- a/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
@@ -60,6 +60,7 @@ public class PulseAudioComponent extends EnvironmentComponent {
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
+                pulseProcess = null;
             }
             isPaused = false;
         }

--- a/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
@@ -15,13 +15,16 @@ import com.winlator.xenvironment.EnvironmentComponent;
 import com.winlator.xenvironment.XEnvironment;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
 
 import app.gamenative.BuildConfig;
 
 public class PulseAudioComponent extends EnvironmentComponent {
     private final UnixSocketConfig socketConfig;
-    private static int pid = -1;
-    private static final Object lock = new Object();
+
+    private java.lang.Process pulseProcess;
+    private final Object lock = new Object();
     private float volume = 1.0f;
     private byte performanceMode = 1;
     private int sampleRate = 48000;
@@ -35,9 +38,10 @@ public class PulseAudioComponent extends EnvironmentComponent {
     public void start() {
         Log.d("PulseAudioComponent", "Starting...");
         synchronized (lock) {
-            stop();
-            pid = execPulseAudio();
-            isPaused = false;
+            if (pulseProcess == null) {
+                pulseProcess = execPulseAudio();
+                isPaused = false;
+            }
         }
     }
 
@@ -45,9 +49,17 @@ public class PulseAudioComponent extends EnvironmentComponent {
     public void stop() {
         Log.d("PulseAudioComponent", "Stopping...");
         synchronized (lock) {
-            if (pid != -1) {
-                Process.killProcess(pid);
-                pid = -1;
+            if (isServerRunning()) {
+                pulseProcess.destroy(); // Sends SIGTERM
+                try {
+                    // Wait for it to exit cleanly to guarantee the sink is closed
+                    boolean exited = pulseProcess.waitFor(800, TimeUnit.MILLISECONDS);
+                    if (!exited) {
+                        pulseProcess.destroyForcibly(); // fallback to SIGKILL if stuck
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
             isPaused = false;
         }
@@ -56,18 +68,20 @@ public class PulseAudioComponent extends EnvironmentComponent {
     public void pause() {
         Log.d("PulseAudioComponent", "Pausing...");
         synchronized (lock) {
-            if (!isPaused && pid != -1) {
-                executePactl(true);
-                isPaused = true;
-                final int capturedPid = pid;
-                new Handler(Looper.getMainLooper()).postDelayed(() -> {
-                    synchronized (lock) {
-                        if (isPaused && capturedPid == pid) {
-                            ProcessHelper.suspendProcess(capturedPid);
-                            Log.d("PulseAudioComponent", "Audio paused");
+            if (!isPaused) {
+                if (isServerRunning()) {
+                    executePactl(true);
+                    isPaused = true;
+                    final int capturedPid = getPid();
+                    new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                        synchronized (lock) {
+                            if (isPaused && capturedPid == getPid()) {
+                                ProcessHelper.suspendProcess(capturedPid);
+                                Log.d("PulseAudioComponent", "Audio paused");
+                            }
                         }
-                    }
-                }, 200);
+                    }, 200);
+                }
             }
         }
     }
@@ -75,19 +89,42 @@ public class PulseAudioComponent extends EnvironmentComponent {
     public void resume() {
         Log.d("PulseAudioComponent", "Resuming...");
         synchronized (lock) {
-            if (isPaused && pid != -1) {
-                final int capturedPid = pid;
-                ProcessHelper.resumeProcess(capturedPid);
-                isPaused = false;
-                new Handler(Looper.getMainLooper()).postDelayed(() -> {
-                    synchronized (lock) {
-                        if (!isPaused && capturedPid == pid) {
-                            executePactl(false);
-                            Log.d("PulseAudioComponent", "Audio resumed");
+            if (isPaused) {
+                if (isServerRunning()) {
+                    final int capturedPid = getPid();
+                    ProcessHelper.resumeProcess(capturedPid);
+                    isPaused = false;
+                    new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                        synchronized (lock) {
+                            if (!isPaused && capturedPid == getPid()) {
+                                executePactl(false);
+                                Log.d("PulseAudioComponent", "Audio resumed");
+                            }
                         }
-                    }
-                }, 200);
+                    }, 200);
+                } else {
+                    pulseProcess = null;
+                    start();
+                }
             }
+        }
+    }
+
+    public boolean isServerRunning() {
+        return pulseProcess != null && pulseProcess.isAlive();
+    }
+
+    public int getPid() {
+        if (isServerRunning()) {
+            try {
+                Field pidField = pulseProcess.getClass().getDeclaredField("pid");
+                pidField.setAccessible(true);
+                return pidField.getInt(pulseProcess);
+            } catch (Exception e) {
+                return -1;
+            }
+        } else {
+            return -1;
         }
     }
 
@@ -103,7 +140,7 @@ public class PulseAudioComponent extends EnvironmentComponent {
         this.sampleRate = sampleRate;
     }
 
-    private int execPulseAudio() {
+    private java.lang.Process execPulseAudio() {
         Context context = environment.getContext();
         String nativeLibraryDir = context.getApplicationInfo().nativeLibraryDir;
         // nativeLibraryDir = nativeLibraryDir.replace("arm64", "arm64-v8a");
@@ -138,7 +175,7 @@ public class PulseAudioComponent extends EnvironmentComponent {
         command += " --use-pid-file=false";
         command += " --exit-idle-time=-1";
 
-        return ProcessHelper.exec(command, envVars.toStringArray(), workingDir);
+        return ProcessHelper.startProcess(command, envVars.toStringArray(), workingDir);
     }
 
     private void executePactl(boolean suspend) {


### PR DESCRIPTION
## Description
Switches from tracking the PulseAudio server by its process ID (PID) to managing the `java.lang.Process` object directly.

This refactoring enables more robust process control, addressing issues where PID-based management could become stale or inconsistent. Key improvements include:
- Graceful shutdown and forcible termination of the PulseAudio process.
- Direct `isAlive()` checks for accurate server state detection.
- Automatic restart of the PulseAudio server if it's found to be stopped during a resume operation.
- Enhanced synchronization and consistency in suspend and resume operations.

## Recording
None

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch PulseAudio control from PID tracking to `java.lang.Process` for reliable suspend/resume and clean lifecycle handling.

- **Bug Fixes**
  - Manage PulseAudio via a process handle; stop sends SIGTERM, waits up to 800ms, then forces kill if needed.
  - Use `isAlive()` for state; add `isServerRunning()` and a safe `getPid()` via reflection.
  - Guard pause/resume with a captured PID to avoid races; auto-restart the server on resume if not running.
  - Add `ProcessHelper.startProcess(...)` to spawn the process and attach debug streams.

<sup>Written for commit 4509ca96d8a16860d07f922a114af12e31121c77. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1457?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized process-launching to return managed process handles for safer lifecycle control
  * Reworked audio server management to use per-instance process tracking instead of PID-based control
  * Simplified pause/resume flows with improved synchronization and conditional follow-up actions
  * Improved shutdown and force-stop behavior for more reliable termination handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utkarshdalal/GameNative/pull/1457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->