### PR TITLE
Steam launch installscript

### DIFF
--- a/app/src/main/java/app/gamenative/data/LaunchInfo.kt
+++ b/app/src/main/java/app/gamenative/data/LaunchInfo.kt
@@ -15,4 +15,5 @@ data class LaunchInfo(
     @Serializable(with = OsEnumSetSerializer::class)
     val configOS: EnumSet<OS>,
     val configArch: OSArch,
+    val arguments: String = "",
 )

--- a/app/src/main/java/app/gamenative/enums/Marker.kt
+++ b/app/src/main/java/app/gamenative/enums/Marker.kt
@@ -12,4 +12,5 @@ enum class Marker(val fileName: String ) {
     OPENAL_INSTALLED(".openal_installed"),
     XNA_INSTALLED(".xna_installed"),
     UBISOFT_CONNECT_INSTALLED(".ubisoft_connect_installed"),
+    STEAM_INSTALL_SCRIPT_RUN(".steam_install_script_run"),
 }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2092,10 +2092,10 @@ class SteamService : Service(), IChallengeUrlChanged {
             }.orEmpty()
         }
 
-        fun getAllLaunchInfos(appId: Int): List<LaunchInfo> {
-            return getAppInfoOf(appId)?.let { appInfo ->
-                appInfo.config.launch
-            }.orEmpty()
+        suspend fun getAllLaunchInfos(appId: Int): List<LaunchInfo> {
+            return withContext(Dispatchers.IO) {
+                instance?.appDao?.findApp(appId)
+            }?.config?.launch.orEmpty()
         }
 
         suspend fun notifyRunningProcesses(vararg gameProcesses: GameProcessInfo) = withContext(Dispatchers.IO) {

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2092,6 +2092,12 @@ class SteamService : Service(), IChallengeUrlChanged {
             }.orEmpty()
         }
 
+        fun getAllLaunchInfos(appId: Int): List<LaunchInfo> {
+            return getAppInfoOf(appId)?.let { appInfo ->
+                appInfo.config.launch
+            }.orEmpty()
+        }
+
         suspend fun notifyRunningProcesses(vararg gameProcesses: GameProcessInfo) = withContext(Dispatchers.IO) {
             instance?.let { steamInstance ->
                 if (isConnected) {

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -45,7 +45,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -166,15 +165,6 @@ fun ContainerConfigDialog(
             mutableStateOf(initialConfig)
         }
         var config by configState
-
-        var steamLaunchEntries by remember { mutableStateOf(emptyList<LaunchInfo>()) }
-        LaunchedEffect(steamAppId, gameSource) {
-            steamLaunchEntries = if (steamAppId > 0 && gameSource == GameSource.STEAM) {
-                withContext(Dispatchers.IO) { SteamService.getAllLaunchInfos(steamAppId) }
-            } else {
-                emptyList()
-            }
-        }
 
         val screenSizes = stringArrayResource(R.array.screen_size_entries).toList()
         val baseGraphicsDrivers = stringArrayResource(R.array.graphics_driver_entries).toList()
@@ -1050,7 +1040,8 @@ fun ContainerConfigDialog(
             applyScreenSizeToConfig = applyScreenSizeToConfig,
             vkd3dForcedVersion = { vkd3dForcedVersion() },
             currentDxvkContext = { currentDxvkContext() },
-            steamLaunchEntries = steamLaunchEntries,
+            steamAppId = steamAppId,
+            gameSource = gameSource,
         )
 
         LoadingDialog(
@@ -1236,20 +1227,29 @@ internal fun ExecutablePathDropdown(
     onValueChange: (String) -> Unit,
     onLaunchEntrySelected: ((LaunchInfo) -> Unit)? = null,
     containerData: ContainerData,
-    steamLaunchEntries: List<LaunchInfo> = emptyList(),
+    steamAppId: Int = 0,
+    gameSource: GameSource? = null,
 ) {
     var expanded by remember { mutableStateOf(false) }
     var executables by remember { mutableStateOf<List<String>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
+    var steamLaunchEntries by remember { mutableStateOf(emptyList<LaunchInfo>()) }
     val context = LocalContext.current
 
-    // Load executables from A: drive when component is first created
     LaunchedEffect(containerData.drives) {
         isLoading = true
         executables = withContext(Dispatchers.IO) {
             ContainerUtils.scanExecutablesInADrive(containerData.drives)
         }
         isLoading = false
+    }
+
+    LaunchedEffect(steamAppId, gameSource) {
+        steamLaunchEntries = if (steamAppId > 0 && gameSource == GameSource.STEAM) {
+            withContext(Dispatchers.IO) { SteamService.getAllLaunchInfos(steamAppId) }
+        } else {
+            emptyList()
+        }
     }
 
     ExposedDropdownMenuBox(

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -167,9 +167,10 @@ fun ContainerConfigDialog(
         }
         var config by configState
 
-        val steamLaunchEntries = remember(steamAppId, gameSource) {
-            if (steamAppId > 0 && gameSource == GameSource.STEAM) {
-                SteamService.getAllLaunchInfos(steamAppId)
+        var steamLaunchEntries by remember { mutableStateOf(emptyList<LaunchInfo>()) }
+        LaunchedEffect(steamAppId, gameSource) {
+            steamLaunchEntries = if (steamAppId > 0 && gameSource == GameSource.STEAM) {
+                withContext(Dispatchers.IO) { SteamService.getAllLaunchInfos(steamAppId) }
             } else {
                 emptyList()
             }
@@ -1285,7 +1286,7 @@ internal fun ExecutablePathDropdown(
                     DropdownMenuItem(
                         text = {
                             Text(
-                                text = "Steam Launch Options",
+                                text = stringResource(R.string.container_config_steam_launch_options),
                                 style = MaterialTheme.typography.labelMedium,
                                 color = MaterialTheme.colorScheme.primary,
                             )
@@ -1316,7 +1317,7 @@ internal fun ExecutablePathDropdown(
                         DropdownMenuItem(
                             text = {
                                 Text(
-                                    text = "Detected Files",
+                                    text = stringResource(R.string.container_config_detected_files),
                                     style = MaterialTheme.typography.labelMedium,
                                     color = MaterialTheme.colorScheme.primary,
                                 )

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -89,6 +89,8 @@ import app.gamenative.utils.ManifestContentTypes
 import app.gamenative.utils.ManifestData
 import app.gamenative.utils.ManifestEntry
 import app.gamenative.utils.ManifestInstaller
+import app.gamenative.data.GameSource
+import app.gamenative.data.LaunchInfo
 import app.gamenative.service.SteamService
 import app.gamenative.utils.ManifestComponentHelper.VersionOptionList
 import app.gamenative.utils.ManifestRepository
@@ -143,6 +145,8 @@ fun ContainerConfigDialog(
     default: Boolean = false,
     title: String,
     initialConfig: ContainerData = ContainerData(),
+    steamAppId: Int = 0,
+    gameSource: GameSource? = null,
     onDismissRequest: () -> Unit,
     onSave: (ContainerData) -> Unit,
 ) {
@@ -162,6 +166,14 @@ fun ContainerConfigDialog(
             mutableStateOf(initialConfig)
         }
         var config by configState
+
+        val steamLaunchEntries = remember(steamAppId, gameSource) {
+            if (steamAppId > 0 && gameSource == GameSource.STEAM) {
+                SteamService.getAllLaunchInfos(steamAppId)
+            } else {
+                emptyList()
+            }
+        }
 
         val screenSizes = stringArrayResource(R.array.screen_size_entries).toList()
         val baseGraphicsDrivers = stringArrayResource(R.array.graphics_driver_entries).toList()
@@ -1037,6 +1049,7 @@ fun ContainerConfigDialog(
             applyScreenSizeToConfig = applyScreenSizeToConfig,
             vkd3dForcedVersion = { vkd3dForcedVersion() },
             currentDxvkContext = { currentDxvkContext() },
+            steamLaunchEntries = steamLaunchEntries,
         )
 
         LoadingDialog(

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -1209,6 +1209,21 @@ private fun Preview_ContainerConfigDialog() {
     }
 }
 
+private fun buildLaunchEntryDisplayText(entry: LaunchInfo): String {
+    val execAndArgs = buildString {
+        append(entry.executable)
+        if (entry.arguments.isNotEmpty()) {
+            append(" ")
+            append(entry.arguments)
+        }
+    }
+    return if (entry.description.isNotEmpty()) {
+        "${entry.description} ($execAndArgs)"
+    } else {
+        execAndArgs
+    }
+}
+
 /**
  * Editable dropdown for selecting executable paths from the container's A: drive
  */
@@ -1218,7 +1233,9 @@ internal fun ExecutablePathDropdown(
     modifier: Modifier = Modifier,
     value: String,
     onValueChange: (String) -> Unit,
+    onLaunchEntrySelected: ((LaunchInfo) -> Unit)? = null,
     containerData: ContainerData,
+    steamLaunchEntries: List<LaunchInfo> = emptyList(),
 ) {
     var expanded by remember { mutableStateOf(false) }
     var executables by remember { mutableStateOf<List<String>>(emptyList()) }
@@ -1258,33 +1275,79 @@ internal fun ExecutablePathDropdown(
             singleLine = true
         )
 
-        if (!isLoading && executables.isNotEmpty()) {
+        if (!isLoading && (executables.isNotEmpty() || steamLaunchEntries.isNotEmpty())) {
             ExposedDropdownMenu(
                 expanded = expanded,
                 onDismissRequest = { expanded = false }
             ) {
-                executables.forEach { executable ->
+                // Section 1: Steam Launch Options
+                if (steamLaunchEntries.isNotEmpty()) {
                     DropdownMenuItem(
                         text = {
-                            Column {
-                                Text(
-                                    text = executable.substringAfterLast('\\'),
-                                    style = MaterialTheme.typography.bodyMedium
-                                )
-                                if (executable.contains('\\')) {
-                                    Text(
-                                        text = executable.substringBeforeLast('\\'),
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
-                            }
+                            Text(
+                                text = "Steam Launch Options",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
                         },
-                        onClick = {
-                            onValueChange(executable)
-                            expanded = false
-                        }
+                        onClick = {},
+                        enabled = false,
                     )
+                    steamLaunchEntries.forEach { entry ->
+                        val displayText = buildLaunchEntryDisplayText(entry)
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    text = displayText,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            },
+                            onClick = {
+                                onLaunchEntrySelected?.invoke(entry)
+                                expanded = false
+                            },
+                        )
+                    }
+                }
+
+                // Section 2: Detected Files
+                if (executables.isNotEmpty()) {
+                    if (steamLaunchEntries.isNotEmpty()) {
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    text = "Detected Files",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                            },
+                            onClick = {},
+                            enabled = false,
+                        )
+                    }
+                    executables.forEach { executable ->
+                        DropdownMenuItem(
+                            text = {
+                                Column {
+                                    Text(
+                                        text = executable.substringAfterLast('\\'),
+                                        style = MaterialTheme.typography.bodyMedium
+                                    )
+                                    if (executable.contains('\\')) {
+                                        Text(
+                                            text = executable.substringBeforeLast('\\'),
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                }
+                            },
+                            onClick = {
+                                onValueChange(executable)
+                                expanded = false
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigState.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigState.kt
@@ -2,7 +2,7 @@ package app.gamenative.ui.component.dialog
 
 import androidx.compose.runtime.MutableIntState
 import androidx.compose.runtime.MutableState
-import app.gamenative.data.LaunchInfo
+import app.gamenative.data.GameSource
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.ManifestComponentHelper
 import app.gamenative.utils.ManifestEntry
@@ -136,5 +136,6 @@ class ContainerConfigState(
     val applyScreenSizeToConfig: () -> Unit,
     val vkd3dForcedVersion: () -> String,
     val currentDxvkContext: () -> ManifestComponentHelper.DxvkContext,
-    val steamLaunchEntries: List<LaunchInfo> = emptyList(),
+    val steamAppId: Int = 0,
+    val gameSource: GameSource? = null,
 )

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigState.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigState.kt
@@ -2,6 +2,7 @@ package app.gamenative.ui.component.dialog
 
 import androidx.compose.runtime.MutableIntState
 import androidx.compose.runtime.MutableState
+import app.gamenative.data.LaunchInfo
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.ManifestComponentHelper
 import app.gamenative.utils.ManifestEntry
@@ -135,4 +136,5 @@ class ContainerConfigState(
     val applyScreenSizeToConfig: () -> Unit,
     val vkd3dForcedVersion: () -> String,
     val currentDxvkContext: () -> ManifestComponentHelper.DxvkContext,
+    val steamLaunchEntries: List<LaunchInfo> = emptyList(),
 )

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
@@ -40,6 +40,7 @@ import com.winlator.container.ContainerData
 import com.winlator.core.DefaultVersion
 import com.winlator.core.KeyValueSet
 import com.winlator.core.StringUtils
+import app.gamenative.data.LaunchInfo
 import com.winlator.contents.ContentProfile
 import java.util.Locale
 
@@ -260,7 +261,14 @@ fun GeneralTabContent(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
             value = config.executablePath,
             onValueChange = { state.config.value = config.copy(executablePath = it) },
+            onLaunchEntrySelected = { entry ->
+                state.config.value = config.copy(
+                    executablePath = entry.executable,
+                    execArgs = entry.arguments,
+                )
+            },
             containerData = config,
+            steamLaunchEntries = state.steamLaunchEntries,
         )
         NoExtractOutlinedTextField(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
@@ -268,7 +268,8 @@ fun GeneralTabContent(
                 )
             },
             containerData = config,
-            steamLaunchEntries = state.steamLaunchEntries,
+            steamAppId = state.steamAppId,
+            gameSource = state.gameSource,
         )
         NoExtractOutlinedTextField(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -1029,6 +1029,8 @@ abstract class BaseAppScreen {
             ContainerConfigDialog(
                 title = "${displayInfo.name} Config",
                 initialConfig = containerData,
+                steamAppId = if (libraryItem.gameSource == GameSource.STEAM) libraryItem.gameId else 0,
+                gameSource = libraryItem.gameSource,
                 onDismissRequest = { showConfigDialog = false },
                 onSave = {
                     saveContainerConfig(context, libraryItem, it)

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2914,6 +2914,7 @@ private fun setupXEnvironment(
     )
     return environment
 }
+
 private fun buildWineExeFragment(winPath: String, driveLetter: Char = 'A'): String {
     return when {
         winPath.contains("://") -> "start \"$winPath\""
@@ -2922,6 +2923,7 @@ private fun buildWineExeFragment(winPath: String, driveLetter: Char = 'A'): Stri
         else -> "\"$driveLetter:\\${winPath.replace('/', '\\')}\""
     }
 }
+
 private fun getWineStartCommand(
     context: Context,
     appId: String,

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2914,6 +2914,14 @@ private fun setupXEnvironment(
     )
     return environment
 }
+private fun buildWineExeFragment(winPath: String, driveLetter: Char = 'A'): String {
+    return when {
+        winPath.contains("://") -> "start \"$winPath\""
+        winPath.lowercase().let { it.endsWith(".bat") || it.endsWith(".cmd") } ->
+            "cmd /c \"$driveLetter:\\${winPath.replace('/', '\\')}\""
+        else -> "\"$driveLetter:\\${winPath.replace('/', '\\')}\""
+    }
+}
 private fun getWineStartCommand(
     context: Context,
     appId: String,
@@ -3270,10 +3278,8 @@ private fun getWineStartCommand(
         val executableDir = gameFolderPath + "/" + executablePath.substringBeforeLast("/", "")
         guestProgramLauncherComponent.workingDir = File(executableDir)
 
-        // Normalize path separators (ensure Windows-style backslashes)
-        val normalizedPath = executablePath.replace('/', '\\')
         envVars.put("WINEPATH", "A:\\")
-        "\"A:\\${normalizedPath}\""
+        buildWineExeFragment(executablePath, 'A')
     } else if (container.executablePath.isEmpty()) {
         // For Steam games, we need appLaunchInfo
         Timber.tag("XServerScreen").w("appLaunchInfo is null for Steam game: $appId")
@@ -3311,7 +3317,7 @@ private fun getWineStartCommand(
                 if (appLaunchInfo != null){
                     envVars.put("WINEPATH", "$drive:/${appLaunchInfo.workingDir}")
                 }
-                "\"$drive:/${executablePath}\""
+                buildWineExeFragment(executablePath, drive)
             } else {
                 "\"C:\\\\Program Files (x86)\\\\Steam\\\\steamclient_loader_x64.exe\""
             }

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -1251,11 +1251,11 @@ object ContainerUtils {
 
             fileName.contains("launcher") && !fileName.contains("unins") -> 75
 
-            // High priority: probable main executables
-            baseName.length >= 4 && !isSystemExecutable(fileName) -> 70
-
             // Batch/cmd scripts: useful but below standard executables
             fileName.endsWith(".bat") || fileName.endsWith(".cmd") -> 40
+
+            // High priority: probable main executables
+            baseName.length >= 4 && !isSystemExecutable(fileName) -> 70
 
             // Medium priority: any non-system executable
             !isSystemExecutable(fileName) -> 50

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -33,6 +33,8 @@ import org.json.JSONObject
 import timber.log.Timber
 
 object ContainerUtils {
+    private val SCANNABLE_EXTENSIONS = listOf(".exe", ".bat", ".cmd")
+
     data class GpuInfo(
         val deviceId: Int,
         val vendorId: Int,
@@ -1163,7 +1165,7 @@ object ContainerUtils {
     }
 
     /**
-     * Scans the container's A: drive for all .exe files
+     * Scans the container's A: drive for all executable files (.exe, .bat, .cmd)
      */
     fun scanExecutablesInADrive(drives: String): List<String> {
         val executables = mutableListOf<String>()
@@ -1193,7 +1195,7 @@ object ContainerUtils {
                     if (file.isDirectory) {
                         if (FileUtils.isSymlink(file)) return@forEach
                         scanRecursive(file, baseDir, depth + 1, maxDepth)
-                    } else if (file.isFile && file.name.lowercase().endsWith(".exe")) {
+                    } else if (file.isFile && SCANNABLE_EXTENSIONS.any { ext -> file.name.lowercase().endsWith(ext) }) {
                         // Convert to relative Windows path format
                         val relativePath = baseDir.toURI().relativize(file.toURI()).path
                         executables.add(relativePath)
@@ -1251,6 +1253,9 @@ object ContainerUtils {
 
             // High priority: probable main executables
             baseName.length >= 4 && !isSystemExecutable(fileName) -> 70
+
+            // Batch/cmd scripts: useful but below standard executables
+            fileName.endsWith(".bat") || fileName.endsWith(".cmd") -> 40
 
             // Medium priority: any non-system executable
             !isSystemExecutable(fileName) -> 50

--- a/app/src/main/java/app/gamenative/utils/InstallScriptInterpreter.kt
+++ b/app/src/main/java/app/gamenative/utils/InstallScriptInterpreter.kt
@@ -1,0 +1,108 @@
+package app.gamenative.utils
+
+import `in`.dragonbra.javasteam.types.KeyValue
+import timber.log.Timber
+
+object InstallScriptInterpreter {
+    private const val TAG = "InstallScriptInterpreter"
+
+    fun buildAllCommands(kv: KeyValue): List<String> {
+        return buildRegistryCommands(kv) + buildRunProcessCommands(kv)
+    }
+
+    fun expandEnvVars(str: String, wineUser: String = "steamuser"): String {
+        var result = str
+        val replacements = mapOf(
+            "%INSTALLDIR%" to "A:\\",
+            "%ROOTDRIVE%" to "C",
+            "%APPDATA%" to "C:\\users\\$wineUser\\AppData\\Roaming",
+            "%USER_MYDOCS%" to "C:\\users\\$wineUser\\Documents",
+            "%COMMON_MYDOCS%" to "C:\\users\\Public\\Documents",
+            "%LOCALAPPDATA%" to "C:\\users\\$wineUser\\AppData\\Local",
+            "%WinDir%" to "C:\\windows",
+            "%STEAMPATH%" to "C:\\Program Files (x86)\\Steam",
+        )
+        for ((variable, value) in replacements) {
+            result = result.replace(variable, value, ignoreCase = true)
+        }
+        return result
+    }
+
+    fun buildRegistryCommands(kv: KeyValue): List<String> {
+        val registry = kv["Registry"]
+        if (registry.children.isEmpty()) return emptyList()
+
+        val commands = mutableListOf<String>()
+
+        for (pathEntry in registry.children) {
+            val regPath = pathEntry.name ?: continue
+
+            for (stringEntry in pathEntry["string"].children) {
+                val valueName = stringEntry.name ?: continue
+                val expandedValue = expandEnvVars(stringEntry.value ?: "")
+                commands.add(
+                    if (valueName == "(Default)") {
+                        "wine reg add \"$regPath\" /ve /t REG_SZ /d \"$expandedValue\" /f"
+                    } else {
+                        "wine reg add \"$regPath\" /v \"$valueName\" /t REG_SZ /d \"$expandedValue\" /f"
+                    }
+                )
+            }
+
+            for (dwordEntry in pathEntry["dword"].children) {
+                val valueName = dwordEntry.name ?: continue
+                val value = dwordEntry.value ?: "0"
+                commands.add(
+                    if (valueName == "(Default)") {
+                        "wine reg add \"$regPath\" /ve /t REG_DWORD /d $value /f"
+                    } else {
+                        "wine reg add \"$regPath\" /v \"$valueName\" /t REG_DWORD /d $value /f"
+                    }
+                )
+            }
+        }
+
+        return commands
+    }
+
+    fun buildRunProcessCommands(kv: KeyValue): List<String> {
+        val runProcess = kv["Run Process"]
+        if (runProcess.children.isEmpty()) return emptyList()
+
+        val commands = mutableListOf<String>()
+
+        for (entry in runProcess.children) {
+            val process = expandEnvVars(entry["process 1"].value ?: continue)
+            val command = expandEnvVars(entry["command 1"].value ?: "")
+            val hasRunKey = entry["HasRunKey"].value?.takeIf { it.isNotEmpty() }
+
+            if (hasRunKey != null) {
+                val lastSep = hasRunKey.lastIndexOf('\\')
+                val parentKey: String
+                val valueName: String
+                if (lastSep >= 0) {
+                    parentKey = hasRunKey.substring(0, lastSep)
+                    valueName = hasRunKey.substring(lastSep + 1)
+                } else {
+                    parentKey = hasRunKey
+                    valueName = ""
+                }
+
+                commands.add(
+                    if (valueName.isEmpty()) {
+                        "(wine reg query \"$parentKey\" /ve 2>nul | find \"0x\" >nul) || (\"$process\" $command && wine reg add \"$parentKey\" /ve /t REG_DWORD /d 1 /f)"
+                    } else {
+                        "(wine reg query \"$parentKey\" /v \"$valueName\" 2>nul | find \"0x\" >nul) || (\"$process\" $command && wine reg add \"$parentKey\" /v \"$valueName\" /t REG_DWORD /d 1 /f)"
+                    }
+                )
+            } else {
+                val cmdPart = if (command.isNotEmpty()) " $command" else ""
+                commands.add("\"$process\"$cmdPart")
+            }
+        }
+
+        return commands
+    }
+
+    fun buildFirewallCommands(kv: KeyValue): List<String> = emptyList()
+}

--- a/app/src/main/java/app/gamenative/utils/InstallScriptInterpreter.kt
+++ b/app/src/main/java/app/gamenative/utils/InstallScriptInterpreter.kt
@@ -4,7 +4,9 @@ import `in`.dragonbra.javasteam.types.KeyValue
 import timber.log.Timber
 
 object InstallScriptInterpreter {
-    private const val TAG = "InstallScriptInterpreter"
+
+    private fun shellEscape(s: String): String =
+        s.replace("\"", "\\\"").replace("$", "\\$").replace("`", "\\`")
 
     fun buildAllCommands(kv: KeyValue): List<String> {
         return buildRegistryCommands(kv) + buildRunProcessCommands(kv)
@@ -35,11 +37,11 @@ object InstallScriptInterpreter {
         val commands = mutableListOf<String>()
 
         for (pathEntry in registry.children) {
-            val regPath = pathEntry.name ?: continue
+            val regPath = shellEscape(pathEntry.name ?: continue)
 
             for (stringEntry in pathEntry["string"].children) {
-                val valueName = stringEntry.name ?: continue
-                val expandedValue = expandEnvVars(stringEntry.value ?: "")
+                val valueName = shellEscape(stringEntry.name ?: continue)
+                val expandedValue = shellEscape(expandEnvVars(stringEntry.value ?: ""))
                 commands.add(
                     if (valueName == "(Default)") {
                         "wine reg add \"$regPath\" /ve /t REG_SZ /d \"$expandedValue\" /f"
@@ -50,7 +52,7 @@ object InstallScriptInterpreter {
             }
 
             for (dwordEntry in pathEntry["dword"].children) {
-                val valueName = dwordEntry.name ?: continue
+                val valueName = shellEscape(dwordEntry.name ?: continue)
                 val value = dwordEntry.value ?: "0"
                 commands.add(
                     if (valueName == "(Default)") {
@@ -72,7 +74,7 @@ object InstallScriptInterpreter {
         val commands = mutableListOf<String>()
 
         for (entry in runProcess.children) {
-            val process = expandEnvVars(entry["process 1"].value ?: continue)
+            val process = shellEscape(expandEnvVars(entry["process 1"].value ?: continue))
             val command = expandEnvVars(entry["command 1"].value ?: "")
             val hasRunKey = entry["HasRunKey"].value?.takeIf { it.isNotEmpty() }
 
@@ -81,10 +83,10 @@ object InstallScriptInterpreter {
                 val parentKey: String
                 val valueName: String
                 if (lastSep >= 0) {
-                    parentKey = hasRunKey.substring(0, lastSep)
-                    valueName = hasRunKey.substring(lastSep + 1)
+                    parentKey = shellEscape(hasRunKey.substring(0, lastSep))
+                    valueName = shellEscape(hasRunKey.substring(lastSep + 1))
                 } else {
-                    parentKey = hasRunKey
+                    parentKey = shellEscape(hasRunKey)
                     valueName = ""
                 }
 

--- a/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/KeyValueUtils.kt
@@ -144,6 +144,7 @@ fun KeyValue.generateSteamApp(): SteamApp {
                     type = it["type"].value.orEmpty(),
                     configOS = OS.from(it["config"]["oslist"].value),
                     configArch = OSArch.from(it["config"]["osarch"].value),
+                    arguments = it["arguments"].value.orEmpty(),
                 )
             },
             steamControllerTemplateIndex = this["config"]["steamcontrollertemplateindex"].asInteger(),

--- a/app/src/main/java/app/gamenative/utils/MarkerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/MarkerUtils.kt
@@ -14,6 +14,7 @@ object MarkerUtils {
         Marker.OPENAL_INSTALLED,
         Marker.XNA_INSTALLED,
         Marker.UBISOFT_CONNECT_INSTALLED,
+        Marker.STEAM_INSTALL_SCRIPT_RUN,
     )
 
     fun hasMarker(dirPath: String, type: Marker): Boolean {

--- a/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
@@ -30,6 +30,7 @@ object PreInstallSteps {
         XnaFrameworkStep,
         GogScriptInterpreterStep,
         UbisoftConnectStep,
+        SteamInstallScriptStep,
     )
 
     private var stepsProvider: () -> List<PreInstallStep> = { steps }

--- a/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
@@ -29,8 +29,8 @@ object PreInstallSteps {
         OpenALStep,
         XnaFrameworkStep,
         GogScriptInterpreterStep,
-        UbisoftConnectStep,
         SteamInstallScriptStep,
+        UbisoftConnectStep,
     )
 
     private var stepsProvider: () -> List<PreInstallStep> = { steps }

--- a/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
@@ -29,8 +29,8 @@ object PreInstallSteps {
         OpenALStep,
         XnaFrameworkStep,
         GogScriptInterpreterStep,
-        SteamInstallScriptStep,
         UbisoftConnectStep,
+        SteamInstallScriptStep,
     )
 
     private var stepsProvider: () -> List<PreInstallStep> = { steps }

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/SteamInstallScriptStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/SteamInstallScriptStep.kt
@@ -1,0 +1,85 @@
+package app.gamenative.utils
+
+import app.gamenative.data.GameSource
+import app.gamenative.enums.Marker
+import com.winlator.container.Container
+import `in`.dragonbra.javasteam.enums.EDepotFileFlag
+import `in`.dragonbra.javasteam.types.DepotManifest
+import `in`.dragonbra.javasteam.types.KeyValue
+import timber.log.Timber
+import java.io.File
+
+object SteamInstallScriptStep : PreInstallStep {
+    private const val TAG = "SteamInstallScriptStep"
+    private const val DEPOT_DIR = ".DepotDownloader"
+
+    override val marker: Marker = Marker.STEAM_INSTALL_SCRIPT_RUN
+
+    override fun appliesTo(
+        container: Container,
+        gameSource: GameSource,
+        gameDirPath: String,
+    ): Boolean {
+        return gameSource == GameSource.STEAM &&
+            !MarkerUtils.hasMarker(gameDirPath, Marker.STEAM_INSTALL_SCRIPT_RUN)
+    }
+
+    override fun buildCommand(
+        container: Container,
+        appId: String,
+        gameSource: GameSource,
+        gameDir: File,
+        gameDirPath: String,
+    ): String? {
+        val scriptFiles = findInstallScriptFiles(gameDir)
+        if (scriptFiles.isEmpty()) {
+            Timber.tag(TAG).i("No install script files found for appId=%s", appId)
+            return null
+        }
+
+        val allCommands = mutableListOf<String>()
+        for (scriptFile in scriptFiles) {
+            try {
+                val content = scriptFile.readText()
+                val kv = KeyValue.loadFromString(content) ?: continue
+                allCommands.addAll(InstallScriptInterpreter.buildAllCommands(kv))
+            } catch (e: Exception) {
+                Timber.tag(TAG).w(e, "Failed to parse install script: %s", scriptFile.name)
+            }
+        }
+
+        return if (allCommands.isEmpty()) null else allCommands.joinToString(" & ")
+    }
+
+    private fun findInstallScriptFiles(gameDir: File): List<File> {
+        val depotDir = File(gameDir, DEPOT_DIR)
+        if (!depotDir.isDirectory) return emptyList()
+
+        val manifestFiles = depotDir.listFiles { _, name ->
+            name.endsWith(".manifest")
+        } ?: return emptyList()
+
+        val scriptFileNames = mutableSetOf<String>()
+
+        for (manifestFile in manifestFiles) {
+            try {
+                val manifest = DepotManifest.loadFromFile(manifestFile.absolutePath)
+                    ?: continue
+                manifest.files
+                    ?.filter { fileData ->
+                        fileData.flags?.contains(EDepotFileFlag.InstallScript) == true
+                    }
+                    ?.forEach { fileData ->
+                        scriptFileNames.add(fileData.fileName)
+                    }
+            } catch (e: Exception) {
+                Timber.tag(TAG).w(e, "Failed to load manifest: %s", manifestFile.name)
+            }
+        }
+
+        return scriptFileNames.mapNotNull { fileName ->
+            val hostPath = File(gameDir, fileName.replace('\\', '/'))
+            if (hostPath.isFile) hostPath else null
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/SteamInstallScriptStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/SteamInstallScriptStep.kt
@@ -2,6 +2,7 @@ package app.gamenative.utils
 
 import app.gamenative.data.GameSource
 import app.gamenative.enums.Marker
+import app.gamenative.service.SteamService
 import com.winlator.container.Container
 import `in`.dragonbra.javasteam.enums.EDepotFileFlag
 import `in`.dragonbra.javasteam.types.DepotManifest
@@ -31,7 +32,7 @@ object SteamInstallScriptStep : PreInstallStep {
         gameDir: File,
         gameDirPath: String,
     ): String? {
-        val scriptFiles = findInstallScriptFiles(gameDir)
+        val scriptFiles = findInstallScriptFiles(appId, gameDir)
         if (scriptFiles.isEmpty()) {
             Timber.tag(TAG).i("No install script files found for appId=%s", appId)
             return null
@@ -51,7 +52,21 @@ object SteamInstallScriptStep : PreInstallStep {
         return if (allCommands.isEmpty()) null else allCommands.joinToString(" & ")
     }
 
-    private fun findInstallScriptFiles(gameDir: File): List<File> {
+    private fun findInstallScriptFiles(appId: String, gameDir: File): List<File> {
+        val gameId = appId.toIntOrNull()
+        if (gameId != null) {
+            val steamApp = SteamService.getAppInfoOf(gameId)
+            if (steamApp?.installScriptOverride == true && steamApp.installScript.isNotEmpty()) {
+                Timber.tag(TAG).i("Using override install script: %s", steamApp.installScript)
+                val overrideFile = File(gameDir, steamApp.installScript.replace('\\', '/'))
+                return if (overrideFile.isFile) listOf(overrideFile) else emptyList()
+            }
+        }
+
+        return findInstallScriptFilesFromManifests(gameDir)
+    }
+
+    private fun findInstallScriptFilesFromManifests(gameDir: File): List<File> {
         val depotDir = File(gameDir, DEPOT_DIR)
         if (!depotDir.isDirectory) return emptyList()
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1106,6 +1106,8 @@
     <string name="container_config_vkd3d_version">VKD3D Version</string>
     <string name="container_config_executable_path">Executable Path</string>
     <string name="container_config_executable_path_placeholder">e.g., path\\to\\exe</string>
+    <string name="container_config_steam_launch_options">Steam Launch Options</string>
+    <string name="container_config_detected_files">Detected Files</string>
 
     <!-- Libraries Dialog -->
     <string name="libraries_title">Libraries Used</string>

--- a/app/src/test/java/app/gamenative/utils/InstallScriptInterpreterTest.kt
+++ b/app/src/test/java/app/gamenative/utils/InstallScriptInterpreterTest.kt
@@ -1,0 +1,349 @@
+package app.gamenative.utils
+
+import `in`.dragonbra.javasteam.types.KeyValue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class InstallScriptInterpreterTest {
+
+    // ── expandEnvVars ───────────────────────────────────────────────────
+
+    @Test
+    fun expandEnvVars_replacesAllKnownVariables() {
+        assertEquals("A:\\", InstallScriptInterpreter.expandEnvVars("%INSTALLDIR%"))
+        assertEquals("C", InstallScriptInterpreter.expandEnvVars("%ROOTDRIVE%"))
+        assertEquals(
+            "C:\\users\\steamuser\\AppData\\Roaming",
+            InstallScriptInterpreter.expandEnvVars("%APPDATA%"),
+        )
+        assertEquals(
+            "C:\\users\\steamuser\\Documents",
+            InstallScriptInterpreter.expandEnvVars("%USER_MYDOCS%"),
+        )
+        assertEquals(
+            "C:\\users\\Public\\Documents",
+            InstallScriptInterpreter.expandEnvVars("%COMMON_MYDOCS%"),
+        )
+        assertEquals(
+            "C:\\users\\steamuser\\AppData\\Local",
+            InstallScriptInterpreter.expandEnvVars("%LOCALAPPDATA%"),
+        )
+        assertEquals("C:\\windows", InstallScriptInterpreter.expandEnvVars("%WinDir%"))
+        assertEquals(
+            "C:\\Program Files (x86)\\Steam",
+            InstallScriptInterpreter.expandEnvVars("%STEAMPATH%"),
+        )
+    }
+
+    @Test
+    fun expandEnvVars_isCaseInsensitive() {
+        assertEquals("A:\\", InstallScriptInterpreter.expandEnvVars("%installdir%"))
+        assertEquals("A:\\", InstallScriptInterpreter.expandEnvVars("%INSTALLDIR%"))
+        assertEquals("A:\\", InstallScriptInterpreter.expandEnvVars("%InstallDir%"))
+    }
+
+    @Test
+    fun expandEnvVars_leavesUnknownVariablesAsIs() {
+        assertEquals("%UNKNOWN%", InstallScriptInterpreter.expandEnvVars("%UNKNOWN%"))
+        assertEquals(
+            "prefix_%NOPE%_suffix",
+            InstallScriptInterpreter.expandEnvVars("prefix_%NOPE%_suffix"),
+        )
+    }
+
+    // ── buildRegistryCommands ───────────────────────────────────────────
+
+    @Test
+    fun buildRegistryCommands_stringValuesProduceRegSzCommands() {
+        val kv = loadInstallScript(
+            """
+            "InstallScript"
+            {
+                "Registry"
+                {
+                    "HKLM\\Software\\TestApp"
+                    {
+                        "string"
+                        {
+                            "InstallPath"        "C:\\Games"
+                        }
+                    }
+                }
+            }
+            """,
+        )
+
+        val commands = InstallScriptInterpreter.buildRegistryCommands(kv)
+
+        assertEquals(1, commands.size)
+        assertEquals(
+            "wine reg add \"HKLM\\Software\\TestApp\" /v \"InstallPath\" /t REG_SZ /d \"C:\\Games\" /f",
+            commands[0],
+        )
+    }
+
+    @Test
+    fun buildRegistryCommands_dwordValuesProduceRegDwordCommands() {
+        val kv = loadInstallScript(
+            """
+            "InstallScript"
+            {
+                "Registry"
+                {
+                    "HKLM\\Software\\TestApp"
+                    {
+                        "dword"
+                        {
+                            "Version"        "42"
+                        }
+                    }
+                }
+            }
+            """,
+        )
+
+        val commands = InstallScriptInterpreter.buildRegistryCommands(kv)
+
+        assertEquals(1, commands.size)
+        assertEquals(
+            "wine reg add \"HKLM\\Software\\TestApp\" /v \"Version\" /t REG_DWORD /d 42 /f",
+            commands[0],
+        )
+    }
+
+    @Test
+    fun buildRegistryCommands_defaultValueNameUsesVeFlag() {
+        val kv = loadInstallScript(
+            """
+            "InstallScript"
+            {
+                "Registry"
+                {
+                    "HKLM\\Software\\TestApp"
+                    {
+                        "string"
+                        {
+                            "(Default)"        "myvalue"
+                        }
+                    }
+                }
+            }
+            """,
+        )
+
+        val commands = InstallScriptInterpreter.buildRegistryCommands(kv)
+
+        assertEquals(1, commands.size)
+        assertEquals(
+            "wine reg add \"HKLM\\Software\\TestApp\" /ve /t REG_SZ /d \"myvalue\" /f",
+            commands[0],
+        )
+    }
+
+    @Test
+    fun buildRegistryCommands_expandsEnvVarsInValues() {
+        val kv = loadInstallScript(
+            """
+            "InstallScript"
+            {
+                "Registry"
+                {
+                    "HKLM\\Software\\TestApp"
+                    {
+                        "string"
+                        {
+                            "Path"        "%INSTALLDIR%bin"
+                        }
+                    }
+                }
+            }
+            """,
+        )
+
+        val commands = InstallScriptInterpreter.buildRegistryCommands(kv)
+
+        assertEquals(1, commands.size)
+        assertEquals(
+            "wine reg add \"HKLM\\Software\\TestApp\" /v \"Path\" /t REG_SZ /d \"A:\\bin\" /f",
+            commands[0],
+        )
+    }
+
+    @Test
+    fun buildRegistryCommands_returnsEmptyListWhenRegistryBlockMissing() {
+        val kv = loadInstallScript(
+            """
+            "InstallScript"
+            {
+            }
+            """,
+        )
+
+        val commands = InstallScriptInterpreter.buildRegistryCommands(kv)
+
+        assertTrue(commands.isEmpty())
+    }
+
+    // ── buildRunProcessCommands ─────────────────────────────────────────
+
+    @Test
+    fun buildRunProcessCommands_withHasRunKeyGeneratesConditionalCommand() {
+        val kv = loadInstallScript(
+            """
+            "InstallScript"
+            {
+                "Run Process"
+                {
+                    "0"
+                    {
+                        "process 1"        "C:\\setup.exe"
+                        "command 1"        "/silent"
+                        "HasRunKey"        "HKLM\\Software\\MyApp\\Setup\\Installed"
+                    }
+                }
+            }
+            """,
+        )
+
+        val commands = InstallScriptInterpreter.buildRunProcessCommands(kv)
+
+        assertEquals(1, commands.size)
+        assertEquals(
+            "(wine reg query \"HKLM\\Software\\MyApp\\Setup\" /v \"Installed\" 2>nul | find \"0x\" >nul) || (\"C:\\setup.exe\" /silent && wine reg add \"HKLM\\Software\\MyApp\\Setup\" /v \"Installed\" /t REG_DWORD /d 1 /f)",
+            commands[0],
+        )
+    }
+
+    @Test
+    fun buildRunProcessCommands_withoutHasRunKeyGeneratesUnconditionalCommand() {
+        val kv = loadInstallScript(
+            """
+            "InstallScript"
+            {
+                "Run Process"
+                {
+                    "0"
+                    {
+                        "process 1"        "C:\\update.exe"
+                        "command 1"        ""
+                    }
+                }
+            }
+            """,
+        )
+
+        val commands = InstallScriptInterpreter.buildRunProcessCommands(kv)
+
+        assertEquals(1, commands.size)
+        assertEquals("\"C:\\update.exe\"", commands[0])
+    }
+
+    @Test
+    fun buildRunProcessCommands_expandsEnvVarsInProcessAndCommand() {
+        val kv = loadInstallScript(
+            """
+            "InstallScript"
+            {
+                "Run Process"
+                {
+                    "0"
+                    {
+                        "process 1"        "%INSTALLDIR%setup.exe"
+                        "command 1"        "/dir=%INSTALLDIR%"
+                    }
+                }
+            }
+            """,
+        )
+
+        val commands = InstallScriptInterpreter.buildRunProcessCommands(kv)
+
+        assertEquals(1, commands.size)
+        assertEquals("\"A:\\setup.exe\" /dir=A:\\", commands[0])
+    }
+
+    @Test
+    fun buildRunProcessCommands_returnsEmptyListWhenRunProcessBlockMissing() {
+        val kv = loadInstallScript(
+            """
+            "InstallScript"
+            {
+            }
+            """,
+        )
+
+        val commands = InstallScriptInterpreter.buildRunProcessCommands(kv)
+
+        assertTrue(commands.isEmpty())
+    }
+
+    // ── buildAllCommands ────────────────────────────────────────────────
+
+    @Test
+    fun buildAllCommands_registryCommandsAppearBeforeRunProcessCommands() {
+        val kv = loadInstallScript(
+            """
+            "InstallScript"
+            {
+                "Registry"
+                {
+                    "HKLM\\Software\\TestApp"
+                    {
+                        "string"
+                        {
+                            "InstallPath"        "C:\\Games"
+                        }
+                    }
+                }
+                "Run Process"
+                {
+                    "0"
+                    {
+                        "process 1"        "C:\\update.exe"
+                        "command 1"        ""
+                    }
+                }
+            }
+            """,
+        )
+
+        val commands = InstallScriptInterpreter.buildAllCommands(kv)
+
+        assertEquals(2, commands.size)
+        assertTrue(commands[0].contains("/t REG_SZ"))
+        assertEquals("\"C:\\update.exe\"", commands[1])
+    }
+
+    // ── buildFirewallCommands ───────────────────────────────────────────
+
+    @Test
+    fun buildFirewallCommands_alwaysReturnsEmptyList() {
+        val kv = loadInstallScript(
+            """
+            "InstallScript"
+            {
+                "Firewall"
+                {
+                    "MyApp"
+                    {
+                        "path"        "C:\\app.exe"
+                    }
+                }
+            }
+            """,
+        )
+
+        val commands = InstallScriptInterpreter.buildFirewallCommands(kv)
+
+        assertTrue(commands.isEmpty())
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private fun loadInstallScript(vdf: String): KeyValue =
+        KeyValue.loadFromString(vdf.trimIndent())!!
+}

--- a/app/src/test/java/app/gamenative/utils/preInstallSteps/SteamInstallScriptStepTest.kt
+++ b/app/src/test/java/app/gamenative/utils/preInstallSteps/SteamInstallScriptStepTest.kt
@@ -1,0 +1,57 @@
+package app.gamenative.utils
+
+import app.gamenative.data.GameSource
+import app.gamenative.enums.Marker
+import com.winlator.container.Container
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+@RunWith(RobolectricTestRunner::class)
+class SteamInstallScriptStepTest {
+    private lateinit var container: Container
+    private lateinit var gameDir: File
+
+    @Before
+    fun setUp() {
+        container = mockk(relaxed = true)
+        gameDir = createTempDirectory(prefix = "steam-installscript-test").toFile()
+    }
+
+    @Test
+    fun appliesTo_returnsTrue_forSteamWithoutMarker() {
+        assertTrue(SteamInstallScriptStep.appliesTo(container, GameSource.STEAM, gameDir.absolutePath))
+    }
+
+    @Test
+    fun appliesTo_returnsFalse_whenMarkerExists() {
+        MarkerUtils.addMarker(gameDir.absolutePath, Marker.STEAM_INSTALL_SCRIPT_RUN)
+        assertFalse(SteamInstallScriptStep.appliesTo(container, GameSource.STEAM, gameDir.absolutePath))
+    }
+
+    @Test
+    fun appliesTo_returnsFalse_forNonSteamSources() {
+        assertFalse(SteamInstallScriptStep.appliesTo(container, GameSource.GOG, gameDir.absolutePath))
+        assertFalse(SteamInstallScriptStep.appliesTo(container, GameSource.CUSTOM_GAME, gameDir.absolutePath))
+    }
+
+    @Test
+    fun buildCommand_returnsNull_whenNoDepotDir() {
+        val result = SteamInstallScriptStep.buildCommand(container, "12345", GameSource.STEAM, gameDir, gameDir.absolutePath)
+        assertNull(result)
+    }
+
+    @Test
+    fun buildCommand_returnsNull_whenNoManifestFiles() {
+        File(gameDir, ".DepotDownloader").mkdirs()
+        val result = SteamInstallScriptStep.buildCommand(container, "12345", GameSource.STEAM, gameDir, gameDir.absolutePath)
+        assertNull(result)
+    }
+}

--- a/app/src/test/java/app/gamenative/utils/preInstallSteps/SteamInstallScriptStepTest.kt
+++ b/app/src/test/java/app/gamenative/utils/preInstallSteps/SteamInstallScriptStepTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,6 +24,11 @@ class SteamInstallScriptStepTest {
     fun setUp() {
         container = mockk(relaxed = true)
         gameDir = createTempDirectory(prefix = "steam-installscript-test").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        gameDir.deleteRecursively()
     }
 
     @Test


### PR DESCRIPTION
## Description

Executes Steam InstallScript VDF files during container setup. Discovers install scripts from depot manifests via `EDepotFileFlag.InstallScript`, parses them with JavaSteam's `KeyValue`, then:
- Writes registry keys to Wine prefix (Phase 1, pre-Wine)
- Chains prerequisite installers after PreInstallSteps (Phase 2, via Wine)

Supports env var expansion, language-specific registry overrides, OS filtering, and `HasRunKey` tracking.

Tested with NFS Rivals — EA App installer ran successfully via chained Wine process.

## Recording

https://github.com/user-attachments/assets/32577160-e344-491a-9dfe-07ab4a3a7362

## Type of Change

- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist

- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Steam InstallScript VDFs during container setup to install prerequisites and write needed registry keys. Also add Steam launch entries to the executable picker so users can auto-fill the path and arguments.

- **New Features**
  - Detect install scripts from depot manifests (InstallScript flag) or an app override, parse them, then write Wine registry keys and chain prerequisite installers with HasRunKey checks. Use a marker to avoid reruns.
  - Add a “Steam Launch Options” section in the Executable Path dropdown. Selecting an entry fills the executable and its arguments.

- **Refactors**
  - Scan `.bat`/`.cmd` files and adjust scoring; build Wine commands that handle batch files and URI schemes.
  - Add `arguments` to `LaunchInfo` and fetch all launch infos via a suspend API off the main thread.
  - Run the Steam install script step after the Ubisoft Connect step in `PreInstallSteps`.

<sup>Written for commit 96473556050eb7e0ec122b325095080cbc9e4908. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1462?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Steam launch options in container configuration dialog
  * Enabled execution of Steam install scripts during pre-installation phase
  * Added support for batch and command script files in executable detection

* **Improvements**
  * Enhanced handling of different executable types (batch scripts, URLs, standard executables) in launch path construction
  * Expanded launch configuration to include executable arguments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utkarshdalal/GameNative/pull/1462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->