### PR TITLE
fix: Pause and resume PerformanceHudView with lifecycle

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1468,6 +1468,31 @@ fun XServerScreen(
         }
     }
 
+    DisposableEffect(lifecycleOwner, performanceHudView) {
+        val hud = performanceHudView
+        if (hud != null) {
+            val observer = LifecycleEventObserver { _, event ->
+                when (event) {
+                    Lifecycle.Event.ON_PAUSE -> {
+                        Timber.d("Pausing PerformanceHudView for lifecycle event: $event")
+                        hud.pause()
+                    }
+                    Lifecycle.Event.ON_RESUME -> {
+                        Timber.d("Resuming PerformanceHudView for lifecycle event: $event")
+                        hud.resume()
+                    }
+                    else -> Unit
+                }
+            }
+            lifecycleOwner.lifecycle.addObserver(observer)
+            onDispose {
+                lifecycleOwner.lifecycle.removeObserver(observer)
+            }
+        } else {
+            onDispose { }
+        }
+    }
+
     val isPortrait = container.isPortraitMode
     // var launchedView by rememberSaveable { mutableStateOf(false) }
     Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1471,6 +1471,12 @@ fun XServerScreen(
     DisposableEffect(lifecycleOwner, performanceHudView) {
         val hud = performanceHudView
         if (hud != null) {
+            if (lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+                hud.resume()
+            } else {
+                hud.pause()
+            }
+
             val observer = LifecycleEventObserver { _, event ->
                 when (event) {
                     Lifecycle.Event.ON_PAUSE -> {

--- a/app/src/main/java/app/gamenative/ui/widget/PerformanceHudView.kt
+++ b/app/src/main/java/app/gamenative/ui/widget/PerformanceHudView.kt
@@ -61,6 +61,7 @@ class PerformanceHudView(
     private var attachedMetricSignature: List<MetricSignature> = emptyList()
     private var appearance = appearanceFor(initialConfig.size)
     private var smoothedBatteryRuntimeHours: Double? = null
+    private var isPaused = false
 
     private val backgroundDrawable = GradientDrawable().apply {
         shape = GradientDrawable.RECTANGLE
@@ -166,9 +167,23 @@ class PerformanceHudView(
         refreshVisibleMetrics()
     }
 
+    fun pause() {
+        isPaused = true
+        stopUpdates()
+    }
+
+    fun resume() {
+        isPaused = false
+        if (isAttachedToWindow) {
+            startUpdates()
+        }
+    }
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        startUpdates()
+        if (!isPaused) {
+            startUpdates()
+        }
     }
 
     override fun onDetachedFromWindow() {
@@ -678,7 +693,7 @@ class PerformanceHudView(
             discoverPrioritizedCpuTempPaths(),
         )
         if (reading != null) {
-            Timber.v("[HUD] CPU temp: %d°C from %s", reading.celsius, reading.source)
+            Timber.d("[HUD] CPU temp: %d°C from %s", reading.celsius, reading.source)
         }
         return reading?.celsius
     }
@@ -690,7 +705,7 @@ class PerformanceHudView(
         ) + discoverPrioritizedGpuTempPaths()
         val reading = readTemperatureCWithSource(paths)
         if (reading != null) {
-            Timber.v("[HUD] GPU temp: %d°C from %s", reading.celsius, reading.source)
+            Timber.d("[HUD] GPU temp: %d°C from %s", reading.celsius, reading.source)
         }
         return reading?.celsius
     }

--- a/app/src/main/java/app/gamenative/ui/widget/PerformanceHudView.kt
+++ b/app/src/main/java/app/gamenative/ui/widget/PerformanceHudView.kt
@@ -168,14 +168,18 @@ class PerformanceHudView(
     }
 
     fun pause() {
-        isPaused = true
-        stopUpdates()
+        if (!isPaused) {
+            isPaused = true
+            stopUpdates()
+        }
     }
 
     fun resume() {
-        isPaused = false
-        if (isAttachedToWindow) {
-            startUpdates()
+        if (isPaused) {
+            isPaused = false
+            if (isAttachedToWindow) {
+                startUpdates()
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Integrates the PerformanceHudView with the screen's lifecycle to automatically pause its updates when the screen is in the background (ON_PAUSE) and resume them when it returns to the foreground (ON_RESUME).

This change conserves resources and prevents unnecessary activity when the application is not actively displayed.

## Recording
None

## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pause `PerformanceHudView` when the screen goes to the background and resume it on return to foreground to cut unnecessary updates and save resources.

- **Bug Fixes**
  - Hooked into the screen lifecycle with `DisposableEffect` and `LifecycleEventObserver` (pause on ON_PAUSE, resume on ON_RESUME) and synced the initial state with the current lifecycle.
  - Added `pause()`/`resume()` with an `isPaused` flag; guarded `startUpdates()` in `onAttachedToWindow`; removed the observer on dispose.
  - Raised CPU/GPU temperature logs from verbose to debug for better visibility.

<sup>Written for commit a54c8cd22b17c48045f48048b0cc7529090fe7ea. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1463?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Performance HUD now reliably pauses and resumes metric updates with the app lifecycle, reducing resource use when the app is inactive and avoiding unnecessary restarts when the HUD is not visible.
* **Chores**
  * Adjusted HUD logging verbosity for clearer diagnostics during performance monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utkarshdalal/GameNative/pull/1463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->