### PR TITLE
added support for USB external storage

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
@@ -451,36 +452,41 @@ fun SettingsGroupInterface(
         // All writable non-primary volumes (SD / USB).
         // getExternalFilesDirs misses USB OTG on most devices, so also enumerate
         // StorageManager.storageVolumes and synthesize the per-app files dir.
-        val dirs = remember {
-            val seen = mutableSetOf<String>()
-            val result = mutableListOf<File>()
+        // Runs off the composition thread because synthesizing the USB candidate
+        // may need mkdirs() on first plug-in.
+        val externalStorageFallbackLabel = stringResource(R.string.storage_external)
+        val dirs by produceState(initialValue = emptyList<File>(), ctx) {
+            value = withContext(Dispatchers.IO) {
+                val seen = mutableSetOf<String>()
+                val result = mutableListOf<File>()
 
-            fun tryAdd(dir: File?) {
-                if (dir == null) return
-                if (Environment.getExternalStorageState(dir) != Environment.MEDIA_MOUNTED) return
-                if (sm?.getStorageVolume(dir)?.isPrimary == true) return
-                if (seen.add(dir.absolutePath)) result += dir
-            }
-
-            ctx.getExternalFilesDirs(null)?.forEach { tryAdd(it) }
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                sm?.storageVolumes?.forEach { volume ->
-                    if (volume.isPrimary) return@forEach
-                    val volDir = volume.directory ?: return@forEach
-                    val candidate = File(volDir, "Android/data/${ctx.packageName}/files")
-                    if (!candidate.isDirectory) candidate.mkdirs()
-                    if (candidate.isDirectory) tryAdd(candidate)
+                fun tryAdd(dir: File?) {
+                    if (dir == null) return
+                    if (Environment.getExternalStorageState(dir) != Environment.MEDIA_MOUNTED) return
+                    if (sm?.getStorageVolume(dir)?.isPrimary == true) return
+                    if (seen.add(dir.absolutePath)) result += dir
                 }
-            }
 
-            result
+                ctx.getExternalFilesDirs(null)?.forEach { tryAdd(it) }
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    sm?.storageVolumes?.forEach { volume ->
+                        if (volume.isPrimary) return@forEach
+                        val volDir = volume.directory ?: return@forEach
+                        val candidate = File(volDir, "Android/data/${ctx.packageName}/files")
+                        if (!candidate.isDirectory) candidate.mkdirs()
+                        if (candidate.isDirectory) tryAdd(candidate)
+                    }
+                }
+
+                result
+            }
         }
 
         // Labels the user sees
         val labels = remember(dirs) {
             dirs.map { dir ->
-                sm?.getStorageVolume(dir)?.getDescription(ctx) ?: dir.name
+                sm?.getStorageVolume(dir)?.getDescription(ctx) ?: externalStorageFallbackLabel
             }
         }
         var useExternalStorage by rememberSaveable { mutableStateOf(PrefManager.useExternalStorage) }

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
@@ -1,8 +1,10 @@
 package app.gamenative.ui.screen.settings
 
 import android.content.res.Configuration
+import android.os.Build
 import android.os.Environment
 import android.os.storage.StorageManager
+import java.io.File
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -446,18 +448,37 @@ fun SettingsGroupInterface(
         val ctx = LocalContext.current
         val sm = ctx.getSystemService(StorageManager::class.java)
 
-        // All writable volumes: primary first, then every SD / USB
+        // All writable non-primary volumes (SD / USB).
+        // getExternalFilesDirs misses USB OTG on most devices, so also enumerate
+        // StorageManager.storageVolumes and synthesize the per-app files dir.
         val dirs = remember {
-            ctx.getExternalFilesDirs(null)
-                .filterNotNull()
-                .filter { Environment.getExternalStorageState(it) == Environment.MEDIA_MOUNTED }
-                .filter { sm.getStorageVolume(it)?.isPrimary != true }
+            val seen = mutableSetOf<String>()
+            val result = mutableListOf<File>()
+
+            fun tryAdd(dir: File?) {
+                if (dir == null) return
+                if (Environment.getExternalStorageState(dir) != Environment.MEDIA_MOUNTED) return
+                if (sm?.getStorageVolume(dir)?.isPrimary == true) return
+                if (seen.add(dir.absolutePath)) result += dir
+            }
+
+            ctx.getExternalFilesDirs(null)?.forEach { tryAdd(it) }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                sm?.storageVolumes?.forEach { volume ->
+                    if (volume.isPrimary) return@forEach
+                    val volDir = volume.directory ?: return@forEach
+                    tryAdd(File(volDir, "Android/data/${ctx.packageName}/files"))
+                }
+            }
+
+            result
         }
 
         // Labels the user sees
         val labels = remember(dirs) {
             dirs.map { dir ->
-                sm.getStorageVolume(dir)?.getDescription(ctx) ?: dir.name
+                sm?.getStorageVolume(dir)?.getDescription(ctx) ?: dir.name
             }
         }
         var useExternalStorage by rememberSaveable { mutableStateOf(PrefManager.useExternalStorage) }

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
@@ -468,7 +468,9 @@ fun SettingsGroupInterface(
                 sm?.storageVolumes?.forEach { volume ->
                     if (volume.isPrimary) return@forEach
                     val volDir = volume.directory ?: return@forEach
-                    tryAdd(File(volDir, "Android/data/${ctx.packageName}/files"))
+                    val candidate = File(volDir, "Android/data/${ctx.packageName}/files")
+                    if (!candidate.isDirectory) candidate.mkdirs()
+                    if (candidate.isDirectory) tryAdd(candidate)
                 }
             }
 


### PR DESCRIPTION
## Description
Added support for USB storage

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds USB external storage support in Settings. Users can now select USB OTG drives alongside SD cards, with more reliable, non-blocking detection across devices.

- **Bug Fixes**
  - Include USB OTG by enumerating `StorageManager.storageVolumes` (Android 11+) and creating the per‑app files dir when `getExternalFilesDirs` misses it; run discovery off the UI thread to avoid jank.
  - Show only mounted, non‑primary volumes; dedupe paths; null‑guard `StorageManager` and SDK checks; and default to a clear "External storage" label when the system has no description.

<sup>Written for commit d2ea0f06ebebbe20d26e847ef68e45e2cea2f972. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1476?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external storage detection in Settings so more devices and volumes are discovered.
  * Now includes newer Android storage volumes and exposes per-app external directories when available.
  * Loads storage options in the background and deduplicates entries for a cleaner list.
  * Automatically creates missing per-app directories and shows clearer, user-friendly labels for each choice.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utkarshdalal/GameNative/pull/1476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->