### PR TITLE
fix(): Add missing Unix lsteamclient.so check for Bionic Steam

### DIFF
--- a/app/src/main/java/app/gamenative/utils/launchdependencies/BionicSteamAssetsDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/BionicSteamAssetsDependency.kt
@@ -154,8 +154,11 @@ object BionicSteamAssetsDependency : LaunchDependency {
         if (lsteamclientArchive != null) {
             val dllSystem32 = system32Dll(container)
             val dllSyswow64 = syswow64Dll(container)
-            val dllsPresent = withContext(Dispatchers.IO) { dllSystem32.exists() && dllSyswow64.exists() }
-            if (!dllsPresent) {
+            val unixSo = lsteamclientUnixSo(context, container)
+            val allFilesPresent = withContext(Dispatchers.IO) {
+                dllSystem32.exists() && dllSyswow64.exists() && unixSo.exists()
+            }
+            if (!allFilesPresent) {
                 val archiveCache = File(filesDir, lsteamclientArchive)
                 if (!withContext(Dispatchers.IO) { archiveCache.exists() }) {
                     callbacks.setLoadingMessage("Downloading $lsteamclientArchive")

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/BionicSteamAssetsDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/BionicSteamAssetsDependency.kt
@@ -45,6 +45,14 @@ object BionicSteamAssetsDependency : LaunchDependency {
     private fun system32SrcArchDir(container: Container): String =
         if (container.wineVersion.contains("arm64ec")) "aarch64-windows" else "x86_64-windows"
 
+    private fun unixArchDir(container: Container): String =
+        if (container.wineVersion.contains("arm64ec")) "aarch64-unix" else "x86_64-unix"
+
+    private fun lsteamclientUnixSo(context: Context, container: Container): File {
+        val wineDir = wineInstallDir(context, container)
+        return File(wineDir, "lib/wine/${unixArchDir(container)}/lsteamclient.so")
+    }
+
     /**
      * Resolves the actual Wine/Proton install directory for the container.
      * imageFs.winePath is not initialized yet at dependency-install time
@@ -83,6 +91,7 @@ object BionicSteamAssetsDependency : LaunchDependency {
         if (!libsteamclientSo(imageFs).exists()) return false
         if (lsteamclientArchiveFor(container) != null) {
             if (!system32Dll(container).exists() || !syswow64Dll(container).exists()) return false
+            if (!lsteamclientUnixSo(context, container).exists()) return false
         }
         return true
     }


### PR DESCRIPTION
## Description
Ensures the Unix-specific `lsteamclient.so` is present in the Wine prefix's lib directory. This prevents Bionic Steam from being marked as installed when this crucial file for Wine environments is missing.

## Recording
NA

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Bionic Steam validation and install require the Unix `lsteamclient.so` in the Wine prefix (`lib/wine/<aarch64-unix|x86_64-unix>/lsteamclient.so`). If missing, the installer now downloads/extracts it from the archive, preventing false positives.

<sup>Written for commit b1259bf5c7703ec93229343d8f591c16a3884b66. Summary will update on new commits. <a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1477?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency validation to detect the host architecture (x86_64 vs aarch64) and ensure both Windows and Unix runtime libraries are present before launch.
  * Installation now auto-extracts or downloads missing components when any expected runtime artifact is absent, preventing incomplete launches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utkarshdalal/GameNative/pull/1477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->