### PR TITLE
feat(library): allow opening options panel from search bar

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -958,6 +958,7 @@ private fun LibraryScreenContent(
                         },
                         onSearchQuery = onSearchQuery,
                         onDismiss = { onIsSearching(false) },
+                        onOptionsClick = { onOptionsPanelToggle(true) },
                         modifier = Modifier
                             .align(Alignment.TopCenter)
                             .fillMaxWidth(),

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibrarySearchBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibrarySearchBar.kt
@@ -227,7 +227,6 @@ private fun SearchBarInput(
         // TODO: there must be a better way of doing this
         val textColor = MaterialTheme.colorScheme.onSurface
         val hintColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-        // val cursorColor = MaterialTheme.colorScheme.primary
         val placeholderText = stringResource(R.string.library_search_placeholder)
 
         AndroidView(

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibrarySearchBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibrarySearchBar.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -53,6 +54,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.widget.doAfterTextChanged
@@ -70,6 +72,7 @@ fun LibrarySearchBar(
     onScrollToTop: suspend () -> Unit,
     onSearchQuery: (String) -> Unit,
     onDismiss: () -> Unit,
+    onOptionsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
@@ -113,6 +116,7 @@ fun LibrarySearchBar(
                     onScrollToTop = onScrollToTop,
                     onSearchQuery = onSearchQuery,
                     onDismiss = onDismiss,
+                    onOptionsClick = onOptionsClick,
                 )
 
                 // Results count
@@ -139,6 +143,7 @@ private fun SearchBarInput(
     onScrollToTop: suspend () -> Unit,
     onSearchQuery: (String) -> Unit,
     onDismiss: () -> Unit,
+    onOptionsClick: () -> Unit, // Callback recibido
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
@@ -222,7 +227,7 @@ private fun SearchBarInput(
         // TODO: there must be a better way of doing this
         val textColor = MaterialTheme.colorScheme.onSurface
         val hintColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-        val cursorColor = MaterialTheme.colorScheme.primary
+        // val cursorColor = MaterialTheme.colorScheme.primary
         val placeholderText = stringResource(R.string.library_search_placeholder)
 
         AndroidView(
@@ -316,6 +321,22 @@ private fun SearchBarInput(
                 )
             }
         }
+
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                .clickable { onOptionsClick() },
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Tune,
+                contentDescription = stringResource(R.string.options),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
     }
 }
 
@@ -337,6 +358,7 @@ private fun Preview_LibrarySearchBar() {
                 onScrollToTop = { },
                 onSearchQuery = { },
                 onDismiss = { },
+                onOptionsClick = { },
             )
         }
     }
@@ -356,6 +378,7 @@ private fun Preview_LibrarySearchBar_Empty() {
                 onScrollToTop = { },
                 onSearchQuery = { },
                 onDismiss = { },
+                onOptionsClick = { },
             )
         }
     }


### PR DESCRIPTION
This pull request introduces a shortcut to access the library options and filters panel directly from the active search bar interface. 

### Why is this needed?
Previously, if a user had a restrictive filter active (such as "Installed" games) and searched for an uninstalled title, they had to exit the search bar, open the options panel, modify or clear the filter, re-trigger the search, and re-type their query. 

Adding an options button directly inside the search bar input simplifies this process, allowing users to adjust active filters or sorting criteria on the fly without losing their current search context.

### What changed?
*   **`LibrarySearchBar.kt`**: Added an `onOptionsClick` callback parameter to `LibrarySearchBar` and `SearchBarInput`. Integrated an icon button (`Icons.Default.Tune`) next to the clear button to trigger this action.
*   **`LibraryScreen.kt`**: Wired the new callback within `LibraryScreenContent` to toggle the options panel visibility (`onOptionsPanelToggle(true)`).
*   **Previews**: Updated preview parameters to support the modified signatures.

*Note: Since this addresses an internal issue, the specific tracker ID is not referenced. This implementation was prepared with the assistance of an AI tool.*

## Recording
https://github.com/user-attachments/assets/45e2fa06-ba4e-426e-b6a6-793100591942

https://github.com/user-attachments/assets/63376662-330a-4604-8994-559ee485713c

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (Usability enhancement)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The library search bar now shows a persistent options (tune) button; tapping it opens the options panel from the search overlay.
  * The search input UI was streamlined: the options control is always visible (replacing the previous clear/X control), improving access to search options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->