### PR TITLE
Fix: Game exe running in background after pause, child process spawn catch

### DIFF
--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -34,6 +34,7 @@ public abstract class ProcessHelper {
     /** Set true when a pause sweep is in progress; cleared by resumeAllWineProcesses() so the
      *  background verification thread does not re-stop processes that were already resumed. */
     private static volatile boolean pauseActive = false;
+    private static final Object pauseSignalLock = new Object();
 
     public static void suspendProcess(int pid) {
         Process.sendSignal(pid, SIGSTOP);
@@ -128,17 +129,22 @@ public abstract class ProcessHelper {
 
             // Retry any process whose signal was silently dropped (e.g. SELinux deny).
             for (String pid : pids) {
-                if (!pauseActive) return;
-                if (!isProcessStopped(Integer.parseInt(pid))) {
-                    suspendProcess(Integer.parseInt(pid));
+                synchronized (pauseSignalLock) {
+                    if (!pauseActive) return;
+                    int parsedPid = Integer.parseInt(pid);
+                    if (!isProcessStopped(parsedPid)) {
+                        suspendProcess(parsedPid);
+                    }
                 }
             }
 
             // Second sweep: stop any Wine processes that spawned after the first scan.
             for (String pid : listRunningWineProcesses()) {
-                if (!pauseActive) return;
-                if (!pidSet.contains(pid)) {
-                    suspendProcess(Integer.parseInt(pid));
+                synchronized (pauseSignalLock) {
+                    if (!pauseActive) return;
+                    if (!pidSet.contains(pid)) {
+                        suspendProcess(Integer.parseInt(pid));
+                    }
                 }
             }
         });
@@ -168,11 +174,13 @@ public abstract class ProcessHelper {
     }
 
     public static void resumeAllWineProcesses() {
-        // Clear the flag first so the background pause-verification thread bails out
-        // before it can re-stop any process that is about to receive SIGCONT.
-        pauseActive = false;
-        for (String process : listRunningWineProcesses()) {
-            resumeProcess(Integer.parseInt(process));
+        // Clear the flag and send SIGCONT atomically with the pause-signal lock so the
+        // background verifier thread cannot re-stop a process after we send SIGCONT.
+        synchronized (pauseSignalLock) {
+            pauseActive = false;
+            for (String process : listRunningWineProcesses()) {
+                resumeProcess(Integer.parseInt(process));
+            }
         }
     }
 

--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -8,6 +8,7 @@ import app.gamenative.BuildConfig;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,7 +16,10 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -26,6 +30,10 @@ public abstract class ProcessHelper {
     private static final byte SIGSTOP = 19;
     private static final byte SIGTERM = 15;
     private static final byte SIGKILL = 9;
+
+    /** Set true when a pause sweep is in progress; cleared by resumeAllWineProcesses() so the
+     *  background verification thread does not re-stop processes that were already resumed. */
+    private static volatile boolean pauseActive = false;
 
     public static void suspendProcess(int pid) {
         Process.sendSignal(pid, SIGSTOP);
@@ -99,12 +107,70 @@ public abstract class ProcessHelper {
     }
 
     public static void pauseAllWineProcesses() {
-        for (String process : listRunningWineProcesses()) {
-            suspendProcess(Integer.parseInt(process));
+        pauseActive = true;
+        final List<String> pids = listRunningWineProcesses();
+        final Set<String> pidSet = new HashSet<>(pids); // O(1) lookup in second sweep
+
+        // Send SIGSTOP immediately on the calling thread so processes stop as fast as possible.
+        for (String pid : pids) {
+            suspendProcess(Integer.parseInt(pid));
         }
+
+        // Verify + retry on a background thread — never block the caller (may be the main thread).
+        //noinspection resource — shutdown() is called after execute(); try-with-resources not available on Android Java 8
+        ExecutorService verifier = Executors.newSingleThreadExecutor();
+        verifier.execute(() -> {
+            // Give the kernel 50 ms to deliver SIGSTOP before reading /proc status.
+            try { Thread.sleep(50); } catch (InterruptedException ignored) {}
+
+            // Bail out if resumeAllWineProcesses() was called before we woke up.
+            if (!pauseActive) return;
+
+            // Retry any process whose signal was silently dropped (e.g. SELinux deny).
+            for (String pid : pids) {
+                if (!pauseActive) return;
+                if (!isProcessStopped(Integer.parseInt(pid))) {
+                    suspendProcess(Integer.parseInt(pid));
+                }
+            }
+
+            // Second sweep: stop any Wine processes that spawned after the first scan.
+            for (String pid : listRunningWineProcesses()) {
+                if (!pauseActive) return;
+                if (!pidSet.contains(pid)) {
+                    suspendProcess(Integer.parseInt(pid));
+                }
+            }
+        });
+        verifier.shutdown(); // no new tasks; existing task runs to completion
+    }
+
+    private static boolean isProcessStopped(int pid) {
+        try (BufferedReader br = new BufferedReader(
+                new InputStreamReader(new FileInputStream("/proc/" + pid + "/status")))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.startsWith("State:")) {
+                    // Extract the single state character after "State:" and optional whitespace.
+                    // 'T' = stopped (SIGSTOP), 't' = tracing stop — both mean suspended.
+                    String trimmed = line.substring("State:".length()).trim();
+                    char state = trimmed.isEmpty() ? 0 : trimmed.charAt(0);
+                    return state == 'T' || state == 't';
+                }
+            }
+        } catch (FileNotFoundException ignored) {
+            // Process already gone — counts as stopped.
+        } catch (IOException ignored) {
+            // Unreadable status (unlikely for same-UID process) — assume not stopped so retry fires.
+            return false;
+        }
+        return true;
     }
 
     public static void resumeAllWineProcesses() {
+        // Clear the flag first so the background pause-verification thread bails out
+        // before it can re-stop any process that is about to receive SIGCONT.
+        pauseActive = false;
         for (String process : listRunningWineProcesses()) {
             resumeProcess(Integer.parseInt(process));
         }


### PR DESCRIPTION
## Description
1. Verify + retry — 50 ms after the SIGSTOP sweep, read /proc/[pid]/status for each PID. If State: isn't T (stopped), send SIGSTOP again

2. Second sweep — re-scan /proc for any Wine processes that appeared since the first scan

3. isProcessStopped() — reads /proc/[pid]/status, looks for State: T or State: t. Returns true if the file is gone (process exited = effectively stopped)

Since onPause() is a main thread Activity lifecycle callback, Background thread (50ms later) to avoid blocking.

The background thread added to pauseAllWineProcesses() completes in ~100ms total (50ms sleep + a few /proc reads). It only touches Wine game PIDs.

Added a cancellation flag. If resumeAllWineProcesses() is called before the background thread wakes up.
The pauseActive = false is the signal that tells the background thread "a resume already happened, don't touch anything"

With the changes, tested on Android 15 Retroid G2:
- app.gamenative — 3.4% (Steam service ticking, normal)
- Every Wine/game process — 0% (stopped, not scheduled by kernel at all)
- No game process even appears in the top list

Before:
- game kept running in backgroud using over 500% cpu and heating up due to a child process spawn.
<img width="2596" height="570" alt="image" src="https://github.com/user-attachments/assets/b83a9be5-334f-4f38-958e-5a01054e50b2" />
Issue:
https://discord.com/channels/1378308569287622737/1471437588396118056/1510039304079020192

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Wine game processes after app pause by verifying SIGSTOP and catching new child PIDs, with synchronization to avoid races on resume. Prevents background CPU spikes and heating.

- **Bug Fixes**
  - Immediate SIGSTOP sweep; verify after 50 ms via `/proc/[pid]/status` and retry if not stopped.
  - Second sweep to pause Wine PIDs that spawned after the first scan.
  - Added `isProcessStopped()`, `pauseActive`, and `pauseSignalLock` to prevent re-stopping after resume; resume clears the flag and sends SIGCONT under the same lock.
  - Verification runs on a single-thread executor to keep onPause() non-blocking.

<sup>Written for commit 42360fd540ab8a6e84dc05b3cf68e3b460481412. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of pausing and resuming Wine processes: pause now reliably stops all matching processes and a background verification ensures newly started or stubborn processes are also paused, while resume avoids races that could re-stop processes during/after restore.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utkarshdalal/GameNative/pull/1491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->