### PR TITLE
Feat: custom games add user-supplied cover image support

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
@@ -76,33 +76,40 @@ class CustomGameAppScreen : BaseAppScreen() {
 
         // Check for all SteamGridDB images in the game folder
         // Hero view uses horizontal grid (grid_hero)
+        // A user-supplied "coverh"/"cover" image takes priority over SteamGridDB.
+        // coverh = horizontal cover
         val heroImageUrl = remember(gameFolderPath) {
             gameFolderPath?.let { path ->
                 val folder = File(path)
-                findSteamGridDBImage(folder, "grid_hero")
+                CustomGameScanner.findHeroCoverInFolder(folder)
+                    ?: findSteamGridDBImage(folder, "grid_hero")
             }
         }
 
         // Capsule view uses vertical grid (grid_capsule)
+        // A user-supplied "coverv"/"cover" image takes priority over SteamGridDB.
+        // coverv = vertical cover
         val capsuleUrl = remember(gameFolderPath) {
             gameFolderPath?.let { path ->
                 val folder = File(path)
-                findSteamGridDBImage(folder, "grid_capsule")
+                CustomGameScanner.findCapsuleCoverInFolder(folder)
+                    ?: findSteamGridDBImage(folder, "grid_capsule")
             }
         }
 
         // Header view uses heroes endpoint (hero, but not grid_hero)
+        // This is also a horizontal banner, so the user "coverh"/"cover" applies here too.
         val headerUrl = remember(gameFolderPath) {
             gameFolderPath?.let { path ->
                 val folder = File(path)
-                // Find hero image but exclude grid_hero
-                folder.listFiles()?.firstOrNull { file ->
-                    file.name.startsWith("steamgriddb_hero") &&
-                    !file.name.contains("grid") &&
-                    (file.name.endsWith(".png", ignoreCase = true) ||
-                     file.name.endsWith(".jpg", ignoreCase = true) ||
-                     file.name.endsWith(".webp", ignoreCase = true))
-                }?.let { Uri.fromFile(it).toString() }
+                CustomGameScanner.findHeroCoverInFolder(folder)
+                    ?: folder.listFiles()?.firstOrNull { file ->
+                        file.name.startsWith("steamgriddb_hero") &&
+                        !file.name.contains("grid") &&
+                        (file.name.endsWith(".png", ignoreCase = true) ||
+                         file.name.endsWith(".jpg", ignoreCase = true) ||
+                         file.name.endsWith(".webp", ignoreCase = true))
+                    }?.let { Uri.fromFile(it).toString() }
             }
         }
 

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryGridCard.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryGridCard.kt
@@ -436,10 +436,18 @@ internal fun getGridImageUrl(
         GameSource.CUSTOM_GAME -> {
             val primary = when (paneType) {
                 PaneType.GRID_CAPSULE ->
-                    findSteamGridDBImage("grid_capsule") ?: appInfo.capsuleImageUrl
+                    // Capsule (vertical): user "coverv"/"cover" wins over SteamGridDB capsule.
+                    CustomGameScanner.findCapsuleCoverForCustomGame(appInfo.appId)
+                        ?: findSteamGridDBImage("grid_capsule")
+                        ?: appInfo.capsuleImageUrl
                 PaneType.GRID_HERO ->
-                    findSteamGridDBImage("grid_hero") ?: appInfo.headerImageUrl
+                    // Hero (horizontal): user "coverh"/"cover" wins over SteamGridDB hero.
+                    CustomGameScanner.findHeroCoverForCustomGame(appInfo.appId)
+                        ?: findSteamGridDBImage("grid_hero")
+                        ?: appInfo.headerImageUrl
                 else -> {
+                    // Default/carousel banner is also a horizontal hero view.
+                    val heroCover = CustomGameScanner.findHeroCoverForCustomGame(appInfo.appId)
                     val gameFolderPath = CustomGameScanner.getFolderPathFromAppId(appInfo.appId)
                     val heroUrl = gameFolderPath?.let { path ->
                         val folder = File(path)
@@ -454,7 +462,7 @@ internal fun getGridImageUrl(
                         }
                         heroFile?.let { android.net.Uri.fromFile(it).toString() }
                     }
-                    heroUrl ?: appInfo.headerImageUrl
+                    heroCover ?: heroUrl ?: appInfo.headerImageUrl
                 }
             }
             GridImageUrls(primary = primary)

--- a/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
+++ b/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
@@ -224,6 +224,67 @@ object CustomGameScanner {
         return fromHeuristic
     }
 
+    /**
+     * Finds a user-supplied cover image for a Custom Game's CAPSULE (vertical box-art) view.
+     *
+     * Priority: "coverv" (capsule-specific) first, then the generic "cover".
+     * Only the game's MAIN folder is searched — child folders are intentionally ignored.
+     * Supported extensions, in preference order: png, jpg, jpeg, webp.
+     *
+     * @return a file:// URI string usable directly as an image URL, or null if none exists.
+     */
+    fun findCapsuleCoverForCustomGame(appId: String): String? {
+        val folderPath = getFolderPathFromAppId(appId) ?: return null
+        return findCapsuleCoverInFolder(File(folderPath))
+    }
+
+    /** Folder-based variant of [findCapsuleCoverForCustomGame]. */
+    fun findCapsuleCoverInFolder(folder: File): String? =
+        findCoverByBaseNames(folder, listOf("coverv", "cover"))
+
+    /**
+     * Finds a user-supplied cover image for a Custom Game's HERO (horizontal banner) view.
+     *
+     * Priority: "coverh" (hero-specific) first, then the generic "cover".
+     * Only the game's MAIN folder is searched — child folders are intentionally ignored.
+     * Supported extensions, in preference order: png, jpg, jpeg, webp.
+     *
+     * @return a file:// URI string usable directly as an image URL, or null if none exists.
+     */
+    fun findHeroCoverForCustomGame(appId: String): String? {
+        val folderPath = getFolderPathFromAppId(appId) ?: return null
+        return findHeroCoverInFolder(File(folderPath))
+    }
+
+    /** Folder-based variant of [findHeroCoverForCustomGame]. */
+    fun findHeroCoverInFolder(folder: File): String? =
+        findCoverByBaseNames(folder, listOf("coverh", "cover"))
+
+    /**
+     * Scans ONLY the top level of [folder] for a file whose name matches one of [baseNames]
+     * (case-insensitive) with a supported image extension. [baseNames] are tried in order, so
+     * earlier entries take priority (e.g. "coverv" before the generic "cover"). Within a single
+     * base name, extensions are preferred png > jpg/jpeg > webp.
+     *
+     * @return a file:// URI string, or null if no matching file exists.
+     */
+    private fun findCoverByBaseNames(folder: File, baseNames: List<String>): String? {
+        if (!folder.exists() || !folder.isDirectory) return null
+        val extensions = listOf("png", "jpg", "jpeg", "webp")
+        val files = folder.listFiles { f -> f.isFile } ?: return null
+        for (base in baseNames) {
+            val match = files.filter { file ->
+                extensions.any { ext -> file.name.equals("$base.$ext", ignoreCase = true) }
+            }.minByOrNull { file ->
+                // Rank by extension preference so e.g. cover.png wins over cover.jpg.
+                val ext = file.name.substringAfterLast('.', "").lowercase()
+                extensions.indexOf(ext).let { if (it == -1) Int.MAX_VALUE else it }
+            }
+            if (match != null) return Uri.fromFile(match).toString()
+        }
+        return null
+    }
+
     // Shared helper for .ico/.png heuristic
     private fun findNearbyImageIcon(folder: File, uniqueExeRel: String?): String? {
         fun File.icoFiles(): List<File> = this.listFiles { f ->


### PR DESCRIPTION
## Description
Add cover-art to custom games. User adds their own images.

User adds image to custom game folder:
"cover" - for both horizontal and vertical images
"coverh" - for horizontal images (Hero + background) 
"coverv" - for vertical images (Capsule + Carrousel)

How to use:
- Place image with extentions png, jpg, jpeg in main custom game folder.
- name it "cover.jpg" for example, it will auto add the image for both horizontal and vertical views.
- User can also specify if they want a certain image to only be used by horizonal view or vertical by naming the image "coverh" or "coverv" with any of the supported image extentions.


Flow goes:
"coverh" or "coverv" take prority
then "cover"
then steamdb (already in code)

## Recording
<img width="1368" height="764" alt="image" src="https://github.com/user-attachments/assets/9e526cc3-0cd2-4e44-8d1b-09b81df8fd03" />
<img width="1322" height="734" alt="image" src="https://github.com/user-attachments/assets/855b7b7f-f827-4ba0-8c10-e24a91216386" />
<img width="1360" height="756" alt="image" src="https://github.com/user-attachments/assets/bfaa3edf-9ebc-41c1-b895-6db5b8497b9f" />
<img width="1356" height="764" alt="image" src="https://github.com/user-attachments/assets/8588f11c-14ca-4c43-b0ae-244e79c66e3c" />


## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add user-supplied cover art for custom games, used across hero/header/capsule/carousel views. Users can drop images in the game’s folder, which take priority over SteamGridDB.

- **New Features**
  - Place files in the custom game’s main folder: coverh (horizontal), coverv (vertical), cover (both).
  - Horizontal views (hero/header/carousel) use coverh or cover; vertical (capsule) uses coverv or cover.
  - Priority: coverh/coverv > cover > SteamGridDB.
  - Supports png, jpg, jpeg, webp. Searches top-level of the folder only.

<sup>Written for commit a1a5ec4b616b62ee951f4ea929e06b04793f7701. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now supply custom cover images for custom games in both vertical (capsule) and horizontal (hero) formats. These custom covers take priority over default images across all game display views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->