### PR TITLE
Fix: Long exe game names not SIGSTOPed due to getting truncate

### DIFF
--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -602,23 +602,39 @@ public abstract class ProcessHelper {
                 return new File(proc, filename).isDirectory() && filename.matches("[0-9]+");
             }
         });
+        if (allPids == null) return filteredPids;
 
-        String procFile = BuildConfig.MODERN_ANDROID ? "/cmdline" : "/stat";
         for (int index = 0; index < allPids.length; index++){
-            String data = "";
-            try (
-                FileInputStream fr = new FileInputStream(proc + "/" + allPids[index] + procFile);
-                BufferedReader br = new BufferedReader(new InputStreamReader(fr));
-            ) {
-                String line = br.readLine();
-                if (line != null) data = line;
+            // Match on the full /cmdline. The comm in /stat (and /proc/<pid>/comm) is truncated
+            // to 15 chars, so a long exe name like "Dishonored_DO.exe" becomes "Dishonored_DO.e"
+            // and loses the ".exe" suffix — game would never be paused/stopped.
+            // /cmdline carries the full path and matches reliably on every
+            // Android version. It reads only the app's own child PIDs, so it is not affected by
+            // the Android 16 SELinux restrictions on global /proc/* files).
+            String data = readProcLine(proc + "/" + allPids[index] + "/cmdline");
+            // Legacy-only safety net: on the legacy flavor we historically read /stat, so keep a
+            // fallback for the rare empty-cmdline case (zombies/kernel threads). The modern
+            // (Android 16 / Play Store) flavor stays on /cmdline exclusively.
+            if (data.isEmpty() && !BuildConfig.MODERN_ANDROID) {
+                data = readProcLine(proc + "/" + allPids[index] + "/stat");
             }
-            catch (IOException e) {}
             for (String filter : filterList) {
-                if (data.contains(filter))
+                if (data.contains(filter)) {
                     filteredPids.add(allPids[index]);
+                    break; // a name containing both "wine" and "exe" must not be added twice
+                }
             }
         }
         return filteredPids;
+    }
+
+    /** Reads the first line of a /proc file, returning "" on any error. */
+    private static String readProcLine(String path) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(path)))) {
+            String line = br.readLine();
+            return line != null ? line : "";
+        } catch (IOException e) {
+            return "";
+        }
     }
 }

--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -602,39 +602,23 @@ public abstract class ProcessHelper {
                 return new File(proc, filename).isDirectory() && filename.matches("[0-9]+");
             }
         });
-        if (allPids == null) return filteredPids;
 
+        String procFile = "/cmdline";
         for (int index = 0; index < allPids.length; index++){
-            // Match on the full /cmdline. The comm in /stat (and /proc/<pid>/comm) is truncated
-            // to 15 chars, so a long exe name like "Dishonored_DO.exe" becomes "Dishonored_DO.e"
-            // and loses the ".exe" suffix — game would never be paused/stopped.
-            // /cmdline carries the full path and matches reliably on every
-            // Android version. It reads only the app's own child PIDs, so it is not affected by
-            // the Android 16 SELinux restrictions on global /proc/* files).
-            String data = readProcLine(proc + "/" + allPids[index] + "/cmdline");
-            // Legacy-only safety net: on the legacy flavor we historically read /stat, so keep a
-            // fallback for the rare empty-cmdline case (zombies/kernel threads). The modern
-            // (Android 16 / Play Store) flavor stays on /cmdline exclusively.
-            if (data.isEmpty() && !BuildConfig.MODERN_ANDROID) {
-                data = readProcLine(proc + "/" + allPids[index] + "/stat");
+            String data = "";
+            try (
+                FileInputStream fr = new FileInputStream(proc + "/" + allPids[index] + procFile);
+                BufferedReader br = new BufferedReader(new InputStreamReader(fr));
+            ) {
+                String line = br.readLine();
+                if (line != null) data = line;
             }
+            catch (IOException e) {}
             for (String filter : filterList) {
-                if (data.contains(filter)) {
+                if (data.contains(filter))
                     filteredPids.add(allPids[index]);
-                    break; // a name containing both "wine" and "exe" must not be added twice
-                }
             }
         }
         return filteredPids;
-    }
-
-    /** Reads the first line of a /proc file, returning "" on any error. */
-    private static String readProcLine(String path) {
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(path)))) {
-            String line = br.readLine();
-            return line != null ? line : "";
-        } catch (IOException e) {
-            return "";
-        }
     }
 }


### PR DESCRIPTION
## Description
Game exes longer than 15 chars were not being listed in ListRunningWineProcesses and therefore not part of the pause in ProcessHelper.java.

- the comm field in /stat (and /proc/<pid>/comm) is truncated to 15 chars (TASK_COMM_LEN)

SIGSTOP was not reading exe at the end of the proccess name and therefore not closing it when pause was active.

Fix:

- Reads the untruncated /cmdline, so A:\Dishonored_DO.exe matches exe → the game is included in the list and gets SIGSTOP on pause.

- ~~/stat fallback only when cmdline is empty (mid-exec edge case).~~
- ~~break prevents the old double-add when a name contains both wine and exe.~~
- ~~Since every pause/resume/terminate/kill path funnels through this one function, fixing it here corrects all of them with no other code touched.~~

**For a quick test, run when game is paused:**

`adb shell "ps -A -o PID,PPID,STAT,NAME | grep -iE 'app.gamenative|\.exe|wineserver|winedevice|winhandler|pulseaudio' | grep -iv grep"`


Confirmed all still working, no regressions.
tested on Retroid Pocket 5

## Recording
Before: 
<img width="1668" height="380" alt="image" src="https://github.com/user-attachments/assets/ff7e7cb5-555c-4bb0-b493-e8cb5dd25cac" />
Buhh...
If the game is beafy can also generate heat and consume a lot more battery.

**Now with this PR:**
<img width="1486" height="386" alt="image" src="https://github.com/user-attachments/assets/b13de0ed-3ba7-4c5e-885f-9657c900a765" />
YAY!! 
All processes terminated, pause is extremely low cost on the device.

## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes long .exe game processes not being paused/stopped by matching processes via full `/proc/<pid>/cmdline`. This makes pause/resume/terminate/kill reliable across games with long names.

- **Bug Fixes**
  - Always read `/proc/<pid>/cmdline`; removed BuildConfig-based `/stat` selection.
  - Prevent double-adds by breaking after the first filter match.
  - Add safe readProcLine() helper and handle null PID lists.

<sup>Written for commit 5569625db2d4c79d8aa7cdfffee9a4eba2243754. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Wine process detection reliability with improved fallback handling when reading process information and prevention of duplicate process entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->