### PR TITLE
Feat: Add more variable preset suggestions

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/EnvironmentTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/EnvironmentTab.kt
@@ -176,13 +176,28 @@ fun EnvironmentTabContent(state: ContainerConfigState) {
                                         onDismissRequest = { suggestionsExpanded = false },
                                     ) {
                                         selectedEnvVarInfo!!.possibleValues.forEach { suggestion ->
-                                            DropdownMenuItem(
-                                                text = { Text(suggestion) },
-                                                onClick = {
-                                                    envVarValue = suggestion
-                                                    suggestionsExpanded = false
-                                                },
-                                            )
+                                            // suggestion box headers
+                                            if (suggestion.startsWith("---")) {
+                                                DropdownMenuItem(
+                                                    text = {
+                                                        Text(
+                                                            text = suggestion.removePrefix("---"),
+                                                            style = androidx.compose.material3.MaterialTheme.typography.labelSmall,
+                                                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                                        )
+                                                    },
+                                                    onClick = {},
+                                                    enabled = false,
+                                                )
+                                            } else {
+                                                DropdownMenuItem(
+                                                    text = { Text(suggestion) },
+                                                    onClick = {
+                                                        envVarValue = suggestion
+                                                        suggestionsExpanded = false
+                                                    },
+                                                )
+                                            }
                                         }
                                     }
                                 }

--- a/app/src/main/java/app/gamenative/ui/component/settings/SettingsTextFieldWithSuggestions.kt
+++ b/app/src/main/java/app/gamenative/ui/component/settings/SettingsTextFieldWithSuggestions.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
 import app.gamenative.ui.component.NoExtractOutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -82,14 +83,30 @@ fun SettingsTextFieldWithSuggestions(
                         onDismissRequest = { suggestionsExpanded = false },
                     ) {
                         suggestions.forEach { suggestion ->
-                            DropdownMenuItem(
-                                text = { Text(suggestion) },
-                                onClick = {
-                                    onValueChange(suggestion)
-                                    suggestionsExpanded = false
-                                },
-                            )
-                        }
+                                            // suggestion box headers
+                                            if (suggestion.startsWith("---")) {
+                                                // Category header — greyed out, not clickable
+                                                DropdownMenuItem(
+                                                    text = {
+                                                        Text(
+                                                            text = suggestion.removePrefix("---"),
+                                                            style = MaterialTheme.typography.labelSmall,
+                                                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                                        )
+                                                    },
+                                                    onClick = {},
+                                                    enabled = false,
+                                                )
+                                            } else {
+                                                DropdownMenuItem(
+                                                    text = { Text(suggestion) },
+                                                    onClick = {
+                                                        onValueChange(suggestion)
+                                                        suggestionsExpanded = false
+                                                    },
+                                                )
+                                            }
+                                        }
                     }
                 }
             }

--- a/app/src/main/java/app/gamenative/ui/component/settings/SettingsTextFieldWithSuggestions.kt
+++ b/app/src/main/java/app/gamenative/ui/component/settings/SettingsTextFieldWithSuggestions.kt
@@ -106,7 +106,7 @@ fun SettingsTextFieldWithSuggestions(
                                                     },
                                                 )
                                             }
-                                        }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/winlator/core/envvars/EnvVarInfo.kt
+++ b/app/src/main/java/com/winlator/core/envvars/EnvVarInfo.kt
@@ -293,6 +293,10 @@ data class EnvVarInfo(
                     "xinput1_3=n,b;xinput1_4=n,b",
                     "xinput9_1_0=n,b;windows.gaming.input=n,b",
                     "xinput1_1=n,b;xinput1_2=n,b",
+                    // Category header: Network
+                    "---Network",
+                    "wininet=n,b",
+
                 ),
             ),
         )

--- a/app/src/main/java/com/winlator/core/envvars/EnvVarInfo.kt
+++ b/app/src/main/java/com/winlator/core/envvars/EnvVarInfo.kt
@@ -261,35 +261,38 @@ data class EnvVarInfo(
             "VKD3D_SHADER_CACHE_PATH" to EnvVarInfo(
                 identifier = "VKD3D_SHADER_CACHE_PATH",
             ),
+            "VKD3D_CONFIG" to EnvVarInfo(
+                identifier = "VKD3D_CONFIG",
+            ),
             "DXVK_CONFIG" to EnvVarInfo(
                 identifier = "DXVK_CONFIG",
             ),
-            "VKD3D_CONFIG" to EnvVarInfo(
-                identifier = "VKD3D_CONFIG",
+            "DXVK_DISABLE_TIMELINE_SEMAPHORES" to EnvVarInfo(
+                identifier = "DXVK_DISABLE_TIMELINE_SEMAPHORES",
+                selectionType = EnvVarSelectionType.TOGGLE,
+                possibleValues = listOf("0", "1")
             ),
             "MESA_VK_PRESENT_MODE" to EnvVarInfo(
                 identifier = "MESA_VK_PRESENT_MODE",
             ),
-            "DXVK_FILTER_DEVICE_NAME" to EnvVarInfo(
-                identifier = "DXVK_FILTER_DEVICE_NAME",
-                selectionType = EnvVarSelectionType.MULTI_SELECT,
-                possibleValues = listOf(
-                    "NVIDIA GeForce GTX 1080",
-                    "NVIDIA GeForce RTX 3060",
-                    "AMD Radeon RX 580",
-                    "Radeon HD 7900 Series",
-                ),
-            ),
             // Wine DLL overrides — user types freely or picks a common preset
-            // More common DLL overrides can be added in future. Only audio related for now
             "WINEDLLOVERRIDES" to EnvVarInfo(
                 identifier = "WINEDLLOVERRIDES",
                 selectionType = EnvVarSelectionType.SUGGESTIONS,
                 possibleValues = listOf(
+                    // Category header: Audio
+                    "---Audio",
                     "openal32=native,builtin",
                     "soft_oal=native",
                     "openal32=native,builtin;soft_oal=native",
                     "xaudio2_7=native,builtin",
+                    // Category header: Input
+                    "---Input",
+                    "dinput8=n,b",
+                    "dinput8=n,b;dinput=n,b",
+                    "xinput1_3=n,b;xinput1_4=n,b",
+                    "xinput9_1_0=n,b;windows.gaming.input=n,b",
+                    "xinput1_1=n,b;xinput1_2=n,b",
                 ),
             ),
         )

--- a/app/src/main/java/com/winlator/core/envvars/EnvVarInfo.kt
+++ b/app/src/main/java/com/winlator/core/envvars/EnvVarInfo.kt
@@ -1,5 +1,7 @@
 package com.winlator.core.envvars
 
+import org.intellij.lang.annotations.Identifier
+
 data class EnvVarInfo(
     val identifier: String,
     val selectionType: EnvVarSelectionType = EnvVarSelectionType.NONE,
@@ -258,15 +260,27 @@ data class EnvVarInfo(
             "VKD3D_THREAD_COUNT" to EnvVarInfo(
                 identifier = "VKD3D_THREAD_COUNT",
             ),
+            // Shader cache saves in a folder instead of pipeline
             "VKD3D_SHADER_CACHE_PATH" to EnvVarInfo(
                 identifier = "VKD3D_SHADER_CACHE_PATH",
             ),
+            // 0 to 16 values can be used to trade latency for smooth fps
+            "VKD3D_SWAPCHAIN_LATENCY_FRAMES" to EnvVarInfo(
+                identifier = "VKD3D_SWAPCHAIN_LATENCY_FRAMES",
+            ),
             "VKD3D_CONFIG" to EnvVarInfo(
                 identifier = "VKD3D_CONFIG",
+                selectionType = EnvVarSelectionType.SUGGESTIONS,
+                possibleValues = listOf(
+                    "no_upload_hvv,nodxr", //prevents free use of vram as memory, disables Ray Tracing
+                    "skip_application_workarounds", //disables x86 fixes that are mostly not in android
+                    "no_upload_hvv,nodxr,skip_application_workarounds", //combination of the above two
+                ),
             ),
             "DXVK_CONFIG" to EnvVarInfo(
                 identifier = "DXVK_CONFIG",
             ),
+            // New var for DXVK 2.5.x FPS regressions as per Leegao, ahead of new builds
             "DXVK_DISABLE_TIMELINE_SEMAPHORES" to EnvVarInfo(
                 identifier = "DXVK_DISABLE_TIMELINE_SEMAPHORES",
                 selectionType = EnvVarSelectionType.TOGGLE,
@@ -296,15 +310,22 @@ data class EnvVarInfo(
                     // Category header: Network
                     "---Network",
                     "wininet=n,b",
-
                 ),
             ),
-            // ONE UI BUG VARIABLE
+            // "ONE UI" BUG VARIABLE - seen in a lot of Samsung and A8xx
             "FD_DEV_FEATURES" to EnvVarInfo(
                 identifier = "FD_DEV_FEATURES",
                 selectionType = EnvVarSelectionType.SUGGESTIONS,
                 possibleValues = listOf(
                     "enable_tp_ubwc_flag_hint=1",
+                ),
+            ),
+            // Releases unused memory in background threads, per sec, reducing micro-stutters
+            "MALLOC_CONF" to EnvVarInfo(
+                identifier = "MALLOC_CONF",
+                selectionType = EnvVarSelectionType.SUGGESTIONS,
+                possibleValues = listOf(
+                    "background_thread:true,dirty_decay_ms:1000",
                 ),
             ),
         )

--- a/app/src/main/java/com/winlator/core/envvars/EnvVarInfo.kt
+++ b/app/src/main/java/com/winlator/core/envvars/EnvVarInfo.kt
@@ -299,6 +299,14 @@ data class EnvVarInfo(
 
                 ),
             ),
+            // ONE UI BUG VARIABLE
+            "FD_DEV_FEATURES" to EnvVarInfo(
+                identifier = "FD_DEV_FEATURES",
+                selectionType = EnvVarSelectionType.SUGGESTIONS,
+                possibleValues = listOf(
+                    "enable_tp_ubwc_flag_hint=1",
+                ),
+            ),
         )
     }
 }


### PR DESCRIPTION
## Description
More Environment Variables preset suggestions added to Add  "New Environment Variable" in Container Settings "Environment" tab to user to quick add when needed.

- SettingsTextFieldWithSuggestions.kt
Added MaterialTheme import
Header-aware logic: suggestions prefixed with --- render as a disabled, greyed-out label (category header); all others render as normal clickable items

- EnvironmentTab.kt
Applied the same header-aware logic to the suggestions dropdown in the "Add environment variable" dialog

- EnvVarInfo.kt
Expanded WINEDLLOVERRIDES's possibleValues with a new ---Input category header and four input-related DLL override presets (dinput8, xinput variants), followed by the ---Audio header and the audio presets already present, and ---Network
 Added DXVK_DISABLE_TIMELINE_SEMAPHORES
 Added FD_DEV_FEATURES with enable_tp_ubwc_flag_hint=1
Added MALLOC_CONF suggestion.
Shuffled order around

Deleted variable that does not work currently in GameNative

Tested on Retroid Pocket 5.

## Recording
<img width="1350" height="760" alt="image" src="https://github.com/user-attachments/assets/a64b5a99-7066-4ba0-9444-32d64850aba4" />

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds categorized suggestions to environment variable dropdowns and expands presets to speed up adding common values in Container Settings. Adds VKD3D and memory tuning presets plus new network/input options for `WINEDLLOVERRIDES`.

- **New Features**
  - Suggestions support category headers: items starting with '---' render as disabled headers in both the Environment dialog and settings fields.
  - Expanded `WINEDLLOVERRIDES` presets with Audio, Input, and Network options.
  - Added `VKD3D_CONFIG` presets, `VKD3D_SWAPCHAIN_LATENCY_FRAMES`, and `MALLOC_CONF` suggestion.
  - Added `DXVK_DISABLE_TIMELINE_SEMAPHORES` as a toggle (0/1).
  - Added `FD_DEV_FEATURES` with enable_tp_ubwc_flag_hint=1.

- **Refactors**
  - Removed `DXVK_FILTER_DEVICE_NAME` (unsupported in GameNative).
  - Minor UI cleanup and variable reordering.

<sup>Written for commit 940be313663d514125e78fc9fa1cf9ff63283105. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment variable suggestion dropdowns now show categorized preset options with non-selectable section headers for clearer organization and styling.
  * Expanded and reorganized preset suggestions for key environment variables, including additional grouped options and new toggle-style choices.
  * Settings fields now consistently display and apply structured suggestion lists across the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->