### PR TITLE
Fix Darkest Dungeon Workshop mod handling

### DIFF
--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -50,6 +50,9 @@ import timber.log.Timber
 import java.io.BufferedOutputStream
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.util.Comparator
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -270,6 +273,8 @@ object WorkshopManager {
     }
 
     private const val COMPLETE_MARKER = ".workshop_complete"
+    private const val MIN_SIZE_VALIDATION_BYTES = 8L * 1024L * 1024L
+    private const val SUSPICIOUS_SIZE_RATIO_DIVISOR = 20L
 
     /**
      * Filters items that need downloading. An item needs sync if:
@@ -283,6 +288,7 @@ object WorkshopManager {
         items: List<WorkshopItem>,
         workshopContentDir: File,
     ): List<WorkshopItem> {
+        cleanupGeneratedSteamSettingsInWorkshopContent(workshopContentDir)
         Timber.tag(TAG).d(
             "getItemsNeedingSync: checking ${items.size} items in $workshopContentDir " +
                 "(exists=${workshopContentDir.exists()})"
@@ -317,6 +323,14 @@ object WorkshopManager {
                         "dir=${itemDir.exists()}, marker=${completeMarker.exists()}, " +
                         "markerPath=${completeMarker.absolutePath}, " +
                         "partial=${partialDir.exists()}"
+                )
+                return@filter true
+            }
+
+            invalidWorkshopPayloadReason(itemDir, item)?.let { reason ->
+                invalidateWorkshopItemForRedownload(itemDir, partialDir, reason)
+                Timber.tag(TAG).w(
+                    "Item ${item.publishedFileId} '${item.title}' needs sync: $reason"
                 )
                 return@filter true
             }
@@ -1479,6 +1493,167 @@ object WorkshopManager {
         gameRootDir.walkTopDown().maxDepth(5)
             .any { it.isFile && it.name == "gameinfo.txt" && !it.absolutePath.contains("steam_settings") }
 
+    private fun pathKey(file: File): String = pathKey(file.toPath())
+
+    private fun pathKey(path: Path): String =
+        path.normalize().toAbsolutePath().toString()
+            .replace('\\', '/')
+            .trimEnd('/')
+            .lowercase()
+
+    private fun hasSteamSettingsSegment(path: String): Boolean =
+        path.endsWith("/steam_settings") || path.contains("/steam_settings/")
+
+    private fun isSameOrChildPath(path: String, parent: String): Boolean =
+        parent.isNotEmpty() && (path == parent || path.startsWith("$parent/"))
+
+    private fun isWorkshopContentPath(path: String): Boolean =
+        path.contains("/workshop/content/")
+
+    private fun isWorkshopPayloadFile(file: File): Boolean =
+        file.isFile &&
+            !file.name.startsWith(".") &&
+            !file.name.startsWith("preview.", ignoreCase = true) &&
+            !hasSteamSettingsSegment(pathKey(file))
+
+    private fun shouldEnterWorkshopPayloadDir(root: File, dir: File): Boolean =
+        dir == root || (!dir.name.startsWith(".") && !hasSteamSettingsSegment(pathKey(dir)))
+
+    private fun workshopPayloadFiles(itemDir: File): Sequence<File> =
+        itemDir.walkTopDown()
+            .onEnter { shouldEnterWorkshopPayloadDir(itemDir, it) }
+            .filter { isWorkshopPayloadFile(it) }
+
+    private fun workshopPayloadSize(itemDir: File): Long =
+        if (itemDir.isDirectory) workshopPayloadFiles(itemDir).sumOf { it.length() } else 0L
+
+    private fun invalidWorkshopPayloadReason(itemDir: File, item: WorkshopItem): String? {
+        val payloadSize = workshopPayloadSize(itemDir)
+        return when {
+            payloadSize <= 0L -> "no payload files outside generated metadata"
+            item.fileSizeBytes >= MIN_SIZE_VALIDATION_BYTES &&
+                payloadSize < item.fileSizeBytes / SUSPICIOUS_SIZE_RATIO_DIVISOR ->
+                "payload too small ($payloadSize bytes, expected about ${item.fileSizeBytes})"
+            else -> null
+        }
+    }
+
+    private fun invalidateWorkshopItemForRedownload(
+        itemDir: File,
+        partialDir: File,
+        reason: String,
+    ) {
+        Timber.tag(TAG).w("Invalidating workshop item ${itemDir.name}: $reason")
+        deleteDirectoryTreeNoFollow(itemDir)
+        deleteDirectoryTreeNoFollow(partialDir)
+    }
+
+    private fun deleteDirectoryTreeNoFollow(dir: File): Boolean {
+        if (!dir.exists()) return false
+        return try {
+            val stream = Files.walk(dir.toPath())
+            try {
+                stream.sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+            } finally {
+                stream.close()
+            }
+            true
+        } catch (e: Exception) {
+            Timber.tag(TAG).w(e, "Failed to delete directory tree: ${dir.absolutePath}")
+            false
+        }
+    }
+
+    private fun collectSteamSettingsDirs(root: File, maxDepth: Int): List<File> {
+        if (!root.isDirectory) return emptyList()
+        val dirs = mutableListOf<File>()
+        val stream = Files.walk(root.toPath(), maxDepth)
+        try {
+            stream.forEach { path ->
+                if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS) &&
+                    path.fileName?.toString() == "steam_settings"
+                ) {
+                    dirs += path.toFile()
+                }
+            }
+        } finally {
+            stream.close()
+        }
+        return dirs
+    }
+
+    private fun cleanupGeneratedSteamSettingsInWorkshopContent(workshopContentDir: File) {
+        val removed = removeSteamSettingsDirs(workshopContentDir, 12, ::isGeneratedSteamSettingsDir)
+        if (removed > 0) {
+            Timber.tag(TAG).i("Removed $removed generated steam_settings dir(s) from workshop content")
+        }
+    }
+
+    private fun removeSteamSettingsDirs(
+        root: File,
+        maxDepth: Int,
+        shouldRemove: (File) -> Boolean,
+    ): Int = collectSteamSettingsDirs(root, maxDepth)
+        .filter(shouldRemove)
+        .sortedByDescending { it.absolutePath.length }
+        .count { deleteDirectoryTreeNoFollow(it) }
+
+    private fun isGeneratedSteamSettingsDir(dir: File): Boolean =
+        File(dir, "mods.json").exists() ||
+            File(dir, "mods").exists() ||
+            File(dir, "mod_images").exists() ||
+            File(dir, "steam_appid.txt").exists() ||
+            File(dir, "configs.user.ini").exists() ||
+            File(dir, "configs.app.ini").exists()
+
+    private fun hasSteamApiSibling(settingsDir: File, dllNames: Set<String>): Boolean =
+        settingsDir.parentFile?.listFiles()?.any {
+            it.isFile && it.name.lowercase() in dllNames
+        } == true
+
+    private fun cleanupStaleGeneratedGameSteamSettings(
+        gameRootDir: File,
+        validSettingsDirPaths: Set<String>,
+        dllNames: Set<String>,
+    ) {
+        val removed = removeSteamSettingsDirs(gameRootDir, 10) {
+            pathKey(it) !in validSettingsDirPaths &&
+                !hasSteamApiSibling(it, dllNames) &&
+                isGeneratedSteamSettingsDir(it)
+        }
+        if (removed > 0) {
+            Timber.tag(TAG).i("Removed $removed stale generated game steam_settings dir(s)")
+        }
+    }
+
+    private fun shouldSkipDllDiscoveryPath(
+        file: File,
+        workshopContentPath: String,
+        workshopContentRealPath: String,
+    ): Boolean {
+        val currentPath = pathKey(file)
+        if (hasSteamSettingsSegment(currentPath) ||
+            isWorkshopContentPath(currentPath) ||
+            isSameOrChildPath(currentPath, workshopContentPath) ||
+            isSameOrChildPath(currentPath, workshopContentRealPath)
+        ) {
+            return true
+        }
+
+        if (!Files.isSymbolicLink(file.toPath())) return false
+
+        val target = runCatching { Files.readSymbolicLink(file.toPath()) }.getOrNull()
+            ?: return false
+        val resolved = if (target.isAbsolute) target else file.toPath().parent.resolve(target)
+        val targetPath = runCatching { resolved.toRealPath() }
+            .getOrElse { resolved.normalize().toAbsolutePath() }
+            .let { pathKey(it) }
+
+        return isWorkshopContentPath(targetPath) ||
+            isSameOrChildPath(targetPath, workshopContentPath) ||
+            isSameOrChildPath(targetPath, workshopContentRealPath)
+    }
+
     /**
      * Copies preview images from workshop item directories into a
      * `mod_images/<itemId>/` tree under [settingsDir] for gbe_fork.
@@ -1511,9 +1686,8 @@ object WorkshopManager {
             val entry = JSONObject()
             entry.put("title", item?.title ?: itemDir.name)
 
-            // Find the primary content file (first non-hidden file)
-            val contentFile = itemDir.listFiles()
-                ?.firstOrNull { it.isFile && !it.name.startsWith(".") }
+            // Find the primary content file from the filtered payload set.
+            val contentFile = workshopPayloadFiles(itemDir).firstOrNull()
             if (contentFile != null) {
                 entry.put("primary_filename", contentFile.name)
                 entry.put("primary_filesize", contentFile.length())
@@ -1521,9 +1695,7 @@ object WorkshopManager {
 
             // total_files_sizes: gbe_fork uses this for GetItemInstallInfo::punSizeOnDisk
             // Walk recursively to include subdirectory files (e.g. Terraria Content/)
-            val totalSize = itemDir.walkTopDown()
-                .filter { it.isFile && !it.name.startsWith(".") }
-                .sumOf { it.length() }
+            val totalSize = workshopPayloadSize(itemDir)
             entry.put("total_files_sizes", totalSize)
 
             // time_updated: gbe_fork uses this for GetItemInstallInfo::punTimeStamp
@@ -2072,6 +2244,7 @@ object WorkshopManager {
             Timber.tag(TAG).d("Workshop content dir doesn't exist yet, skipping symlink config")
             return
         }
+        cleanupGeneratedSteamSettingsInWorkshopContent(workshopContentDir)
         // Only include mod directories that have actual content
         // (not just .workshop_complete marker or .DepotDownloader metadata)
         // and that are still in the enabled items list (if provided).
@@ -2262,11 +2435,6 @@ object WorkshopManager {
         val unityModTargets by lazy { detectUnityModTargets(gameRootDir, winePrefix) }
         val modsJsonText by lazy { buildModsJson(modDirs, items).toString(2) }
 
-        // Starbound has mods/ (HIGH confidence) but workshop items use a
-        // _metadata format that doesn't work when symlinked into mods/.
-        // Force ISteamUGC path regardless of detection.
-        val forceStandardAppIds = setOf(211820,1468810) // Starbound,TaleofImmortal
-
         // When the game's binary contains ISteamUGC / GetItemInstallInfo
         // strings AND there's a HIGH-confidence mod directory, the game
         // likely uses the Steam Workshop API for content discovery — the
@@ -2289,7 +2457,7 @@ object WorkshopManager {
                 "Workshop compatibility override for $gameName: using Steam metadata only"
             )
             false
-        } else if (appId in forceStandardAppIds) {
+        } else if (appId in WorkshopOverrideIds.forceStandardAppIds) {
             stdSeenWithHighDir = true // treat like stdSeen so Phase 6 + cleanup runs
             Timber.tag(TAG).i("Force-Standard override for appId $appId ($gameName)")
             false
@@ -2345,11 +2513,23 @@ object WorkshopManager {
             steamRootDir?.let { File(it, "steam_settings") }
         val workshopAppIdText = workshopContentDir.name
         var configuredCount = 0
-        gameRootDir.walkTopDown().maxDepth(10).forEach { file ->
+        val workshopContentPath = pathKey(workshopContentDir)
+        val workshopContentRealPath = runCatching { pathKey(workshopContentDir.toPath().toRealPath()) }
+            .getOrElse { workshopContentPath }
+        val validSettingsDirPaths = mutableSetOf<String>()
+        gameRootDir.walkTopDown().maxDepth(10).onEnter { dir ->
+            !shouldSkipDllDiscoveryPath(
+                dir,
+                workshopContentPath,
+                workshopContentRealPath,
+            )
+        }.forEach { file ->
+            if (shouldSkipDllDiscoveryPath(file, workshopContentPath, workshopContentRealPath)) return@forEach
             if (!file.isFile) return@forEach
             if (file.name.lowercase() !in dllNames) return@forEach
 
             val settingsDir = file.parentFile?.let { File(it, "steam_settings") } ?: return@forEach
+            validSettingsDirPaths += pathKey(settingsDir)
             if (!settingsDir.exists()) {
                 settingsDir.mkdirs()
             }
@@ -2469,6 +2649,8 @@ object WorkshopManager {
                 Timber.tag(TAG).w(e, "Failed to create mod symlinks at ${modsDir.absolutePath}")
             }
         }
+
+        cleanupStaleGeneratedGameSteamSettings(gameRootDir, validSettingsDirPaths, dllNames)
 
         // Clean up any stale uninitialized steam_settings folders (mods-only)
         // created by older logic near DLL folders (e.g. bin/, bin/x64/).

--- a/app/src/main/java/app/gamenative/workshop/WorkshopOverrideIds.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopOverrideIds.kt
@@ -1,0 +1,13 @@
+package app.gamenative.workshop
+
+internal object WorkshopOverrideIds {
+    /**
+     * Games that should use the standard ISteamUGC/mods.json path even when
+     * mod directory detection finds a high-confidence filesystem mod folder.
+     */
+    val forceStandardAppIds = setOf(
+        211820, // Starbound
+        1468810, // Tale of Immortal
+        262060, // Darkest Dungeon
+    )
+}

--- a/app/src/main/java/app/gamenative/workshop/WorkshopOverrideIds.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopOverrideIds.kt
@@ -4,6 +4,9 @@ internal object WorkshopOverrideIds {
     /**
      * Games that should use the standard ISteamUGC/mods.json path even when
      * mod directory detection finds a high-confidence filesystem mod folder.
+     *
+     * Add an app ID here when the game has a mods/ or similar folder for local
+     * mods, but Workshop items are still discovered through Steam UGC metadata.
      */
     val forceStandardAppIds = setOf(
         211820, // Starbound


### PR DESCRIPTION
## Description
This is a requested bug fix from here: https://discord.com/channels/1378308569287622737/1506727093122240632

Fixes Darkest Dungeon workshop mods only partially appearing in-game on GameNative.

The game was being treated as a filesystem-managed mod title because it has a high-confidence `mods/` directory, which caused Workshop items to be symlinked instead of exposed through the standard ISteamUGC/gbe_fork Workshop metadata path. This made only a subset of subscribed Workshop mods appear in-game.

This change forces Darkest Dungeon (`262060`) through the standard Workshop path, prevents generated `steam_settings` and Workshop symlink trees from being rediscovered as game Steam API locations, excludes generated metadata from Workshop payload sizing, and invalidates stale completed downloads whose usable payload is missing or implausibly incomplete.

## Recording
I downloaded a mod that removes the circus icon in the bottom left corner just to show off mods working easily. Image here is before the mod, circus icon in the bottom left:
<img width="2520" height="1080" alt="Screenshot_20260601_222235_GameNative" src="https://github.com/user-attachments/assets/05e2f5fb-1ca0-4684-a62a-f6238451b5b5" />

Video showing the mod working (and other mods enabled and no crashing):
https://github.com/user-attachments/assets/59101681-004d-4731-a68d-44a2023f24d2



## Type of Change
- [X] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Darkest Dungeon (app 262060) Workshop mods only partially appearing by routing the game through standard Steam Workshop handling and tightening validation/cleanup. All subscribed Workshop mods now load correctly and broken or partial downloads are auto-repaired.

- **Bug Fixes**
  - Force 262060 to use the metadata-driven Workshop path via `WorkshopOverrideIds` (instead of filesystem mod detection).
  - Validate Workshop payload using only real mod files; if empty or implausibly small vs Steam metadata, delete item/partial dirs and re-sync.
  - Exclude `steam_settings`, hidden files, and preview images from payload scans; compute `primary_filename`, `primary_filesize`, and `total_files_sizes` from filtered files only.
  - Skip DLL discovery in `steam_settings`, anywhere under `/workshop/content/`, and symlinks pointing into it to avoid false Steam API locations.
  - Remove generated `steam_settings` from Workshop content and stale ones in the game tree; keep only dirs next to real Steam DLLs and write the correct `steam_appid.txt` beside each.

<sup>Written for commit 2db27e7550cb1d39bf2510949f4b0bcb07d84ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and automatic re-downloading of corrupted or incomplete workshop content.
  * Safer, symlink-aware removal of invalid or partial mod directories to avoid accidental data loss.
  * Enhanced cleanup of generated Steam settings to prevent stale configuration buildup.
  * More accurate mod metadata and total size calculations by enumerating actual payload files and excluding generated metadata and previews.

* **Chores**
  * Added explicit override list for specific games to ensure consistent mod metadata path selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->