### PR TITLE
Add Hold Mouse Button While Touching gesture option

### DIFF
--- a/app/src/main/java/app/gamenative/data/TouchGestureConfig.kt
+++ b/app/src/main/java/app/gamenative/data/TouchGestureConfig.kt
@@ -16,6 +16,8 @@ data class TouchGestureConfig(
     // 2. Drag (box selection) — customizable pan/drag action
     val dragEnabled: Boolean = true,
     val dragAction: String = PAN_LEFT_CLICK_DRAG,
+    val holdMouseButtonWhileTouchingEnabled: Boolean = false,
+    val holdMouseButtonWhileTouchingAction: String = ACTION_LEFT_CLICK,
 
     // 3. Long Press — customizable action, disabled by default
     val longPressEnabled: Boolean = false,
@@ -64,6 +66,7 @@ data class TouchGestureConfig(
 
     // 13. Gesture debug overlay text (Tap, 2F Drag, etc.)
     val showGestureDebugOverlay: Boolean = false,
+    val showCursorInTouchscreenMode: Boolean = false,
 
     // 14. Gesture threshold (px) for two-finger gesture lock-in
     val gestureThreshold: Int = DEFAULT_GESTURE_THRESHOLD,
@@ -77,6 +80,14 @@ data class TouchGestureConfig(
             put(KEY_TAP_ACTION, tapAction)
             put(KEY_DRAG_ENABLED, dragEnabled)
             put(KEY_DRAG_ACTION, dragAction)
+            put(
+                KEY_HOLD_MOUSE_BUTTON_WHILE_TOUCHING_ENABLED,
+                holdMouseButtonWhileTouchingEnabled,
+            )
+            put(
+                KEY_HOLD_MOUSE_BUTTON_WHILE_TOUCHING_ACTION,
+                holdMouseButtonWhileTouchingAction,
+            )
             put(KEY_LONG_PRESS_ENABLED, longPressEnabled)
             put(KEY_LONG_PRESS_ACTION, longPressAction)
             put(KEY_LONG_PRESS_MOUSE_BEHAVIOR, longPressMouseBehavior)
@@ -103,6 +114,7 @@ data class TouchGestureConfig(
             put(KEY_THREE_FINGER_HOLD_DELAY, threeFingerHoldDelay)
             put(KEY_SHOW_CLICK_HIGHLIGHT, showClickHighlight)
             put(KEY_SHOW_GESTURE_DEBUG_OVERLAY, showGestureDebugOverlay)
+            put(KEY_SHOW_CURSOR_IN_TOUCHSCREEN_MODE, showCursorInTouchscreenMode)
             put(KEY_GESTURE_THRESHOLD, gestureThreshold)
         }.toString()
     }
@@ -142,6 +154,10 @@ data class TouchGestureConfig(
         private const val KEY_TAP_ACTION = "tapAction"
         private const val KEY_DRAG_ENABLED = "dragEnabled"
         private const val KEY_DRAG_ACTION = "dragAction"
+        private const val KEY_HOLD_MOUSE_BUTTON_WHILE_TOUCHING_ENABLED =
+            "holdMouseButtonWhileTouchingEnabled"
+        private const val KEY_HOLD_MOUSE_BUTTON_WHILE_TOUCHING_ACTION =
+            "holdMouseButtonWhileTouchingAction"
         private const val KEY_LONG_PRESS_ENABLED = "longPressEnabled"
         private const val KEY_LONG_PRESS_ACTION = "longPressAction"
         private const val KEY_LONG_PRESS_MOUSE_BEHAVIOR = "longPressMouseBehavior"
@@ -168,6 +184,7 @@ data class TouchGestureConfig(
         private const val KEY_THREE_FINGER_HOLD_DELAY = "threeFingerHoldDelay"
         private const val KEY_SHOW_CLICK_HIGHLIGHT = "showClickHighlight"
         private const val KEY_SHOW_GESTURE_DEBUG_OVERLAY = "showGestureDebugOverlay"
+        private const val KEY_SHOW_CURSOR_IN_TOUCHSCREEN_MODE = "showCursorInTouchscreenMode"
         private const val KEY_GESTURE_THRESHOLD = "gestureThreshold"
 
         /**
@@ -194,6 +211,14 @@ data class TouchGestureConfig(
                     tapAction = obj.optString(KEY_TAP_ACTION, ACTION_LEFT_CLICK),
                     dragEnabled = obj.optBoolean(KEY_DRAG_ENABLED, true),
                     dragAction = obj.optString(KEY_DRAG_ACTION, PAN_LEFT_CLICK_DRAG),
+                    holdMouseButtonWhileTouchingEnabled = obj.optBoolean(
+                        KEY_HOLD_MOUSE_BUTTON_WHILE_TOUCHING_ENABLED,
+                        false,
+                    ),
+                    holdMouseButtonWhileTouchingAction = obj.optString(
+                        KEY_HOLD_MOUSE_BUTTON_WHILE_TOUCHING_ACTION,
+                        ACTION_LEFT_CLICK,
+                    ),
                     longPressEnabled = obj.optBoolean(KEY_LONG_PRESS_ENABLED, false),
                     longPressAction = obj.optString(KEY_LONG_PRESS_ACTION, ACTION_RIGHT_CLICK),
                     longPressMouseBehavior = normalizeMouseBehavior(
@@ -226,6 +251,7 @@ data class TouchGestureConfig(
                     threeFingerHoldDelay = obj.optInt(KEY_THREE_FINGER_HOLD_DELAY, DEFAULT_DELAY_MS),
                     showClickHighlight = obj.optBoolean(KEY_SHOW_CLICK_HIGHLIGHT, false),
                     showGestureDebugOverlay = obj.optBoolean(KEY_SHOW_GESTURE_DEBUG_OVERLAY, false),
+                    showCursorInTouchscreenMode = obj.optBoolean(KEY_SHOW_CURSOR_IN_TOUCHSCREEN_MODE, false),
                     gestureThreshold = obj.optInt(KEY_GESTURE_THRESHOLD, DEFAULT_GESTURE_THRESHOLD),
                 )
             } catch (_: Exception) {

--- a/app/src/main/java/app/gamenative/ui/component/dialog/TouchGestureSettingsDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/TouchGestureSettingsDialog.kt
@@ -131,6 +131,22 @@ fun TouchGestureSettingsDialog(
                     )
                 }
 
+                GestureRow(
+                    title = stringResource(R.string.gesture_hold_mouse_button_while_touching),
+                    subtitle = tapHoldActionLabel(config.holdMouseButtonWhileTouchingAction),
+                    enabled = config.holdMouseButtonWhileTouchingEnabled,
+                    onEnabledChange = {
+                        config = config.copy(holdMouseButtonWhileTouchingEnabled = it)
+                    },
+                ) {
+                    MouseButtonActionPicker(
+                        currentAction = config.holdMouseButtonWhileTouchingAction,
+                        onActionSelected = {
+                            config = config.copy(holdMouseButtonWhileTouchingAction = it)
+                        },
+                    )
+                }
+
                 // ── Double-Tap (fixed action, customisable delay) ────────
                 GestureRow(
                     title = stringResource(R.string.gesture_double_tap),
@@ -352,6 +368,14 @@ fun TouchGestureSettingsDialog(
                     subtitle = { Text(stringResource(R.string.gesture_show_debug_overlay_subtitle)) },
                     state = config.showGestureDebugOverlay,
                     onCheckedChange = { config = config.copy(showGestureDebugOverlay = it) },
+                )
+
+                SettingsSwitch(
+                    colors = settingsTileColorsAlt(),
+                    title = { Text(stringResource(R.string.gesture_show_cursor_touchscreen_mode)) },
+                    subtitle = { Text(stringResource(R.string.gesture_show_cursor_touchscreen_mode_subtitle)) },
+                    state = config.showCursorInTouchscreenMode,
+                    onCheckedChange = { config = config.copy(showCursorInTouchscreenMode = it) },
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
@@ -691,6 +715,23 @@ private fun TapHoldActionPicker(
             },
         )
     }
+}
+
+@Composable
+private fun MouseButtonActionPicker(
+    currentAction: String,
+    onActionSelected: (String) -> Unit,
+) {
+    val actions = listOf(ACTION_LEFT_CLICK, ACTION_RIGHT_CLICK, ACTION_MIDDLE_CLICK)
+    SettingsListDropdown(
+        colors = settingsTileColors(),
+        title = { Text(stringResource(R.string.gesture_mouse_button_label)) },
+        value = actions.indexOf(currentAction).coerceAtLeast(0),
+        items = actions.map { tapHoldActionLabel(it) },
+        onItemSelected = { index ->
+            onActionSelected(actions[index])
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -438,6 +438,13 @@ fun XServerScreen(
     var currentGestureConfig by remember {
         mutableStateOf(app.gamenative.data.TouchGestureConfig.fromJson(container.getGestureConfig()))
     }
+    fun shouldShowMouseCursor(): Boolean {
+        return !container.isDisableMouseInput &&
+            (!container.isTouchscreenMode || currentGestureConfig.showCursorInTouchscreenMode)
+    }
+    fun applyMouseCursorVisibility() {
+        xServerView?.renderer?.setCursorVisible(shouldShowMouseCursor())
+    }
     val clickHighlightPoints = remember { mutableStateListOf<app.gamenative.ui.component.HighlightPoint>() }
     var debugGestureName by remember { mutableStateOf("") }
     var debugGestureKey by remember { mutableIntStateOf(0) }
@@ -1024,10 +1031,10 @@ fun XServerScreen(
                 container.setDisableMouseInput(newValue)
                 container.saveData()
                 PluviaApp.touchpadView?.setTouchscreenMouseDisabled(newValue)
-                if (!newValue && !container.isTouchscreenMode) {
-                    xServerView?.renderer?.setCursorVisible(true)
-                } else if (newValue) {
+                if (newValue) {
                     xServerView?.renderer?.setCursorVisible(false)
+                } else {
+                    applyMouseCursorVisibility()
                 }
                 true
             }
@@ -1127,13 +1134,9 @@ fun XServerScreen(
                         areControlsVisible = false
                     }
 
-                    // Hide cursor in touchscreen mode
-                    xServerView?.renderer?.setCursorVisible(false)
+                    applyMouseCursorVisibility()
                 } else {
-                    // Restore cursor if mouse input is allowed
-                    if (!container.isDisableMouseInput) {
-                        xServerView?.renderer?.setCursorVisible(true)
-                    }
+                    applyMouseCursorVisibility()
 
                     // Re-evaluate whether to show on-screen controls
                     // (same logic as scanForExternalDevices startup path)
@@ -1837,7 +1840,7 @@ fun XServerScreen(
 
                         override fun onUpdateWindowContent(window: Window) {
                             if (!xServerState.value.winStarted && window.isApplicationWindow()) {
-                                if (!container.isDisableMouseInput && !container.isTouchscreenMode) renderer?.setCursorVisible(true)
+                                if (shouldShowMouseCursor()) renderer?.setCursorVisible(true)
                                 xServerState.value.winStarted = true
                             }
                             if (frameRatingWindowId == -1 && window.isApplicationWindow()) {
@@ -2576,6 +2579,7 @@ fun XServerScreen(
                 container.setGestureConfig(newConfig.toJson())
                 container.saveData()
                 PluviaApp.touchpadView?.setGestureConfig(newConfig)
+                applyMouseCursorVisibility()
                 showTouchGestureDialog = false
             },
         )

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -84,6 +84,8 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     // Drag tracking (box selection)
     private boolean isDragging;
     private boolean dragButtonPressed;
+    private boolean holdMouseButtonTouchActive;
+    private String holdMouseButtonTouchAction;
 
     // Two-finger tracking
     private boolean twoFingerDragging;
@@ -727,6 +729,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     private void handleTsDown(MotionEvent event, int actionIndex) {
         flushPendingTapRelease();
         flushPendingHoldClickRelease();
+        finishHoldMouseButtonTouch();
 
         float[] pt = XForm.transformPoint(xform, event.getX(actionIndex), event.getY(actionIndex));
         int x = (int) pt[0];
@@ -736,6 +739,8 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         doubleTapDetected = false;
         isDragging = false;
         dragButtonPressed = false;
+        holdMouseButtonTouchActive = false;
+        holdMouseButtonTouchAction = null;
         movedBeyondTapThreshold = false;
         multiFingerGestureUsed = false;
         twoFingerDragging = false;
@@ -758,6 +763,11 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
         // Move cursor to touch point
         moveCursorTo(x, y);
+
+        if (gestureConfig.getHoldMouseButtonWhileTouchingEnabled()) {
+            startHoldMouseButtonTouch(event.getX(actionIndex), event.getY(actionIndex));
+            return;
+        }
 
         // Double-tap detection (fixed action: double left click)
         if (gestureConfig.getDoubleTapEnabled()) {
@@ -808,6 +818,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
             longPressActionHeld = releaseHoldAction(longPressActionHeld, gestureConfig.getLongPressAction());
             longPressTriggered = false;
         }
+        finishHoldMouseButtonTouch();
         cancelLongPressTimer();
         cancelDrag();
 
@@ -858,6 +869,11 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         float[] pt = XForm.transformPoint(xform, event.getX(pointerIndex), event.getY(pointerIndex));
         int x = (int) pt[0];
         int y = (int) pt[1];
+
+        if (holdMouseButtonTouchActive) {
+            moveCursorTo(x, y);
+            return;
+        }
 
         // If long press already triggered, ignore movement (right-click already sent)
         if (longPressTriggered) return;
@@ -1090,6 +1106,11 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         cancelLongPressTimer();
         stopGestureRefresh();
 
+        if (holdMouseButtonTouchActive) {
+            finishHoldMouseButtonTouch();
+            return;
+        }
+
         if (longPressTriggered) {
             // Release the long-press action
             longPressActionHeld = releaseHoldAction(longPressActionHeld, gestureConfig.getLongPressAction());
@@ -1173,11 +1194,8 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         // fold a rapid re-tap into a single down-up pair.  If we cancel
         // before that runnable fires, the previously-injected tap press
         // would leak.  Flush it synchronously.
-        if (delayedPress != null) {
-            removeCallbacks(delayedPress);
-            delayedPress = null;
-            injectRelease(gestureConfig.getTapAction());
-        }
+        flushPendingTapRelease();
+        finishHoldMouseButtonTouch();
         if (dragButtonPressed) {
             releasePanKeys();
             releaseAllDragButtons();
@@ -1206,6 +1224,8 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         threeFingerGestureMode = THREE_FINGER_GESTURE_NONE;
         longPressTriggered = false;
         longPressActionHeld = twoFingerHoldActionHeld = threeFingerHoldActionHeld = false;
+        holdMouseButtonTouchActive = false;
+        holdMouseButtonTouchAction = null;
         multiFingerGestureUsed = false;
         movedBeyondTapThreshold = false;
         doubleTapDetected = false;
@@ -1367,7 +1387,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
             // If there's a new single tap within 'CLICK_DELAYED_TIME' ms
             // Immediately release the previous down click
             removeCallbacks(delayedPress);
-            injectRelease(TouchGestureConfig.ACTION_LEFT_CLICK);
+            injectRelease(gestureConfig.getTapAction());
             delayedPress = null;
         }
     }
@@ -1380,6 +1400,32 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
             pendingHoldClickReleaseAction = null;
             injectRelease(action);
         }
+    }
+
+    private void startHoldMouseButtonTouch(float viewX, float viewY) {
+        String action = getHoldMouseButtonTouchAction();
+        if (!injectClick(action)) return;
+        holdMouseButtonTouchAction = action;
+        holdMouseButtonTouchActive = true;
+        notifyHighlight(viewX, viewY);
+        notifyGesture("Hold Mouse Button", true);
+    }
+
+    private void finishHoldMouseButtonTouch() {
+        if (!holdMouseButtonTouchActive) return;
+        stopGestureRefresh();
+        injectRelease(holdMouseButtonTouchAction);
+        holdMouseButtonTouchActive = false;
+        holdMouseButtonTouchAction = null;
+    }
+
+    private String getHoldMouseButtonTouchAction() {
+        String action = gestureConfig.getHoldMouseButtonWhileTouchingAction();
+        if (TouchGestureConfig.ACTION_RIGHT_CLICK.equals(action)
+                || TouchGestureConfig.ACTION_MIDDLE_CLICK.equals(action)) {
+            return action;
+        }
+        return TouchGestureConfig.ACTION_LEFT_CLICK;
     }
 
     private void cancelLongPressTimer() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -774,6 +774,8 @@
     <string name="gesture_tap_subtitle">Left Click</string>
     <string name="gesture_drag">Drag Finger</string>
     <string name="gesture_drag_subtitle">Drag Left Click (Box Selection)</string>
+    <string name="gesture_hold_mouse_button_while_touching">Hold Mouse Button While Touching</string>
+    <string name="gesture_mouse_button_label">Mouse Button</string>
     <string name="gesture_long_press">Long Press</string>
     <string name="gesture_long_press_delay">Long Press Delay (ms)</string>
     <string name="gesture_double_tap">Double-Tap</string>
@@ -817,6 +819,8 @@
     <string name="gesture_show_click_highlight_subtitle">Show a circle at tap location</string>
     <string name="gesture_show_debug_overlay">Show Gesture Debug Overlay</string>
     <string name="gesture_show_debug_overlay_subtitle">Show temporary gesture labels at top center</string>
+    <string name="gesture_show_cursor_touchscreen_mode">Show Cursor in Touchscreen Mode</string>
+    <string name="gesture_show_cursor_touchscreen_mode_subtitle">Keep the mouse cursor visible while touchscreen gestures are active</string>
 
     <string name="external_display_input">External Display Input</string>
     <string name="external_display_input_subtitle">Choose how a connected presentation display should behave</string>

--- a/app/src/test/java/app/gamenative/data/TouchGestureConfigTest.kt
+++ b/app/src/test/java/app/gamenative/data/TouchGestureConfigTest.kt
@@ -1,0 +1,49 @@
+package app.gamenative.data
+
+import app.gamenative.data.TouchGestureConfig.Companion.ACTION_RIGHT_CLICK
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TouchGestureConfigTest {
+    @Test
+    fun `new touch options default off for older configs`() {
+        val config = TouchGestureConfig.fromJson("""{"tapEnabled":false}""")
+
+        assertFalse(config.holdMouseButtonWhileTouchingEnabled)
+        assertFalse(config.showCursorInTouchscreenMode)
+        assertEquals(TouchGestureConfig.ACTION_LEFT_CLICK, config.holdMouseButtonWhileTouchingAction)
+    }
+
+    @Test
+    fun `new touch options are written to json`() {
+        val config = TouchGestureConfig(
+            holdMouseButtonWhileTouchingEnabled = true,
+            holdMouseButtonWhileTouchingAction = ACTION_RIGHT_CLICK,
+            showCursorInTouchscreenMode = true,
+        )
+
+        val json = JSONObject(config.toJson())
+
+        assertTrue(json.getBoolean("holdMouseButtonWhileTouchingEnabled"))
+        assertEquals(ACTION_RIGHT_CLICK, json.getString("holdMouseButtonWhileTouchingAction"))
+        assertTrue(json.getBoolean("showCursorInTouchscreenMode"))
+    }
+
+    @Test
+    fun `new touch options round trip from json`() {
+        val expected = TouchGestureConfig(
+            holdMouseButtonWhileTouchingEnabled = true,
+            holdMouseButtonWhileTouchingAction = ACTION_RIGHT_CLICK,
+            showCursorInTouchscreenMode = true,
+        )
+
+        val actual = TouchGestureConfig.fromJson(expected.toJson())
+
+        assertTrue(actual.holdMouseButtonWhileTouchingEnabled)
+        assertEquals(ACTION_RIGHT_CLICK, actual.holdMouseButtonWhileTouchingAction)
+        assertTrue(actual.showCursorInTouchscreenMode)
+    }
+}


### PR DESCRIPTION
﻿## Description
This is a requested feature from here:
https://discord.com/channels/1378308569287622737/1510234216795869345

Also fixes the issue here: https://discord.com/channels/1378308569287622737/1510980477769617408

> "i want to be able to long press my click as soon as i touch the screen, and without lifting my finger also dragging the cursor sometime afterwards. i want a function that my finger just acts as a direct mouse click input no matter where and how i touch."

Adds a new touchscreen gesture setting named "Hold Mouse Button While Touching". When enabled, a one-finger touchscreen press immediately holds the configured mouse button, finger movement continues moving the cursor while that button remains held, and lifting or cancelling the touch releases the same button. This option takes over single-finger touchscreen input when users explicitly enable it, so tap, drag, and long-press gestures are bypassed for that touch sequence to avoid conflicts.

This also adds an optional "Show Cursor in Touchscreen Mode" setting, which has been requested by multiple users, so users can keep the cursor visible while using touchscreen gestures.

## Recording

https://github.com/user-attachments/assets/a8c1725f-cc86-42e7-8b00-db4684ac95d0

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [X] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt‑in “Hold Mouse Button While Touching” gesture that holds a chosen mouse button for a single‑finger touch and releases on lift/cancel. Also adds an option to keep the cursor visible in touchscreen mode, with smarter visibility updates that respect “Disable Mouse Input”.

- New Features
  - Hold Mouse Button While Touching: on touch down, press and hold the selected button; move to drag; release on lift/cancel. Left/right/middle selectable. Default off. Overrides other single‑finger gestures while active.
  - Show Cursor in Touchscreen Mode: optional toggle to keep the cursor visible. Visibility updates when switching input modes, toggling “Disable Mouse Input”, or saving gesture settings, and still respects “Disable Mouse Input”.
  - Persistence and tests: new fields stored in `TouchGestureConfig`. Defaults off for existing configs. Unit tests cover defaults and JSON round‑trip.

- Bug Fixes
  - Pending tap release now uses the configured tap action instead of hard‑coded left click, preventing stuck buttons on cancel.

<sup>Written for commit 35620dc50789cf449b2feb2dcfc5fb12f16b25e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "hold mouse button while touching" gesture with configurable mouse-button action (left/right/middle).
  * Added "show cursor in touchscreen mode" toggle and updated cursor visibility to honor per-gesture settings.
  * Settings UI updated with controls for the new options and corresponding user-facing labels.

* **Tests**
  * Added tests ensuring new touch options default off for older configs, are written to JSON, and round-trip correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->