### PR TITLE
fix: steamautocloud remotecache value

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -1352,7 +1352,7 @@ object SteamAutoCloud {
             // Build VDF structure using KeyValue
             val root = KeyValue(appId.toString())
             root.children.add(KeyValue("ChangeNumber", changeNumber.toString()))
-            root.children.add(KeyValue("OSType", EOSType.WinUnknown.ordinal.toString())) // 0 = Windows
+            root.children.add(KeyValue("OSType", EOSType.WinUnknown.code().toString())) // 0 = Windows
 
             // Create an entry for each file using the filename as the key
             // Sort files by their cloud path for consistent ordering

--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -1352,7 +1352,7 @@ object SteamAutoCloud {
             // Build VDF structure using KeyValue
             val root = KeyValue(appId.toString())
             root.children.add(KeyValue("ChangeNumber", changeNumber.toString()))
-            root.children.add(KeyValue("OSType", EOSType.WinUnknown.toString())) // 0 = Windows
+            root.children.add(KeyValue("OSType", EOSType.WinUnknown.ordinal.toString())) // 0 = Windows
 
             // Create an entry for each file using the filename as the key
             // Sort files by their cloud path for consistent ordering


### PR DESCRIPTION
## Description
Incorrect value was written to `OSType` in `remotecache.vdf`

## Recording
NA

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Write OSType as a numeric code in remotecache.vdf for Steam Auto Cloud so Steam parses the cache correctly. Use EOSType.code() (0 for Windows) instead of the enum name.

<sup>Written for commit ffc825f7392d527b2fd4783fc24fad8af4ae2de0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed serialization of operating system type in Steam remote cache files so the OS is stored as the numeric code string, improving compatibility with Steam cache parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->