### PR TITLE
fix: Adjust defaults for FEXCORE, BOX64 and Proton

### DIFF
--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -46,7 +46,7 @@ object ContainerUtils {
         // Override default driver and DXVK version based on Turnip capability
         if (GPUInformation.isTurnipCapable(context)) {
             DefaultVersion.VARIANT = Container.BIONIC
-            DefaultVersion.WINE_VERSION = "proton-9.0-arm64ec"
+            DefaultVersion.WINE_VERSION = "proton-10.0-4-arm64ec-1"
             DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
             DefaultVersion.DXVK = if (GPUInformation.isAdreno6xx(context)) "1.11.1-sarek" else "2.4.1-gplasync"
             DefaultVersion.VKD3D = "2.14.1"
@@ -55,7 +55,7 @@ object ContainerUtils {
             DefaultVersion.ASYNC_CACHE = "1"
         } else if (GPUInformation.isAdreno8Elite(context)) {
             DefaultVersion.VARIANT = Container.BIONIC
-            DefaultVersion.WINE_VERSION = "proton-9.0-arm64ec"
+            DefaultVersion.WINE_VERSION = "proton-10.0-4-arm64ec-1"
             DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
             DefaultVersion.DXVK = "2.4.1-gplasync"
             DefaultVersion.VKD3D = "2.14.1"
@@ -64,7 +64,7 @@ object ContainerUtils {
             DefaultVersion.ASYNC_CACHE = "1"
         } else {
             DefaultVersion.VARIANT = Container.BIONIC
-            DefaultVersion.WINE_VERSION = "proton-9.0-arm64ec"
+            DefaultVersion.WINE_VERSION = "proton-10.0-4-arm64ec-1"
             DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
             DefaultVersion.DXVK = "async-1.10.3"
             DefaultVersion.VKD3D = "2.14.1"

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -46,7 +46,7 @@ object ContainerUtils {
         // Override default driver and DXVK version based on Turnip capability
         if (GPUInformation.isTurnipCapable(context)) {
             DefaultVersion.VARIANT = Container.BIONIC
-            DefaultVersion.WINE_VERSION = "proton-10.0-4-arm64ec-1"
+            DefaultVersion.WINE_VERSION = "proton-10.0-arm64ec-2"
             DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
             DefaultVersion.DXVK = if (GPUInformation.isAdreno6xx(context)) "1.11.1-sarek" else "2.4.1-gplasync"
             DefaultVersion.VKD3D = "2.14.1"
@@ -55,7 +55,7 @@ object ContainerUtils {
             DefaultVersion.ASYNC_CACHE = "1"
         } else if (GPUInformation.isAdreno8Elite(context)) {
             DefaultVersion.VARIANT = Container.BIONIC
-            DefaultVersion.WINE_VERSION = "proton-10.0-4-arm64ec-1"
+            DefaultVersion.WINE_VERSION = "proton-10.0-arm64ec-2"
             DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
             DefaultVersion.DXVK = "2.4.1-gplasync"
             DefaultVersion.VKD3D = "2.14.1"
@@ -64,7 +64,7 @@ object ContainerUtils {
             DefaultVersion.ASYNC_CACHE = "1"
         } else {
             DefaultVersion.VARIANT = Container.BIONIC
-            DefaultVersion.WINE_VERSION = "proton-10.0-4-arm64ec-1"
+            DefaultVersion.WINE_VERSION = "proton-10.0-arm64ec-2"
             DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
             DefaultVersion.DXVK = "async-1.10.3"
             DefaultVersion.VKD3D = "2.14.1"

--- a/app/src/main/java/com/winlator/core/DefaultVersion.java
+++ b/app/src/main/java/com/winlator/core/DefaultVersion.java
@@ -7,8 +7,8 @@ import com.winlator.container.Container;
 public abstract class DefaultVersion {
 
     public static final String BOX86 = "0.3.2";
-    public static final String BOX64 = "0.3.6";
-    public static final String FEXCORE = "2603";
+    public static final String BOX64 = "0.4.2";
+    public static final String FEXCORE = "2605";
     public static String WRAPPER = "System";
     public static final String TURNIP = "25.2.0";
     public static final String ZINK = "22.2.5";


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

Updated the defaults for FEXCORE, Box64 and Proton:

**Fexcore**: 2603 -> 2605
**Box64**: 0.3.6 -> 0.4.2
**Proton**: proton-9.0-arm64ec -> proton-10.0-4-arm64ec-1

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update default versions for `FEXCORE`, `Box64`, and Proton to improve compatibility on Turnip-capable and Adreno devices. Proton now defaults to the latest ARM64EC v10 build across all GPU paths.

- **Dependencies**
  - `FEXCORE`: 2603 → 2605
  - `Box64`: 0.3.6 → 0.4.2
  - Proton default set to `proton-10.0-arm64ec-2` in `ContainerUtils` for Turnip-capable, Adreno 8 Elite, and fallback paths

<sup>Written for commit 1b6b4877a43c6cd684f79c7830be0e2c4a7f50cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated bundled runtimes for better ARM64 support and stability: newer Proton build for Turnip-capable devices, Box64 emulator bumped, and FEXCore advanced—improves compatibility and performance on supported devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->