### PR TITLE
Updated messaging for builds to tell people to use legacy build

### DIFF
--- a/.github/workflows/app-release-signed.yml
+++ b/.github/workflows/app-release-signed.yml
@@ -161,5 +161,5 @@ jobs:
           --arg legacy "$LEGACY_URL" \
           --arg modern "$MODERN_URL" \
           --arg changes "$CHANGELOG" \
-          '{content: "**New Android build**\nDownload: \($legacy)\nModern (Android 11+ — built for the latest Android, so **no security warning** about an outdated target. No D drive access and no custom game support; glibc not supported, external storage location moved.): \($modern)\n\nChanges:\n\($changes)"}')
+          '{content: "**New Android build**\nStandard Build (Recommended): \($legacy)\nPlay Store Build (Android 11+ — built for the latest Android, so **no security warning** about an outdated target. No D drive access and no custom game support; glibc not supported, external storage location moved.): \($modern)\n\nChanges:\n\($changes)"}')
         curl -H 'Content-Type: application/json' -d "$payload" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -162,8 +162,8 @@ jobs:
           append_body: true
           body: |
             ## Downloads
-            - **`gamenative-${{ github.ref_name }}.apk`** — Legacy build (Android 8–14). Recommended for most users.
-            - **`gamenative-${{ github.ref_name }}-modern.apk`** — Modern build (Android 11+). Built for the latest Android, so **no security warning** about an outdated target. No D drive access and no custom game support; glibc not supported, external storage location moved.
+            - **`gamenative-${{ github.ref_name }}.apk`** — Standard build (Android 8–14). Recommended for most users.
+            - **`gamenative-${{ github.ref_name }}-modern.apk`** — Play Store build (Android 11+). Built for the latest Android, so **no security warning** about an outdated target. No D drive access and no custom game support; glibc not supported, external storage location moved.
           files: |
             gamenative-${{ github.ref_name }}.apk
             gamenative-${{ github.ref_name }}-modern.apk


### PR DESCRIPTION
## Description
People were getting confused by the modern build, downloading it and then complaining that things like custom games were removed.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated release messaging to recommend the Standard build and clearly label the Play Store build with its limitations, reducing confusion about missing features like custom games.

- **Refactors**
  - Updated `.github/workflows/app-release-signed.yml` to rename “Legacy” → “Standard (Recommended)” and “Modern” → “Play Store” in the Discord release message, with explicit limitations (Android 11+, no custom games, no D drive access, glibc not supported, external storage moved).
  - Updated `.github/workflows/tagged-release.yml` to apply the same labels and notes in the GitHub Releases download section.

<sup>Written for commit 2ab883955253c9f264e4e246a26eead7a5a620c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release notification labels for build artifacts, renaming legacy build references to "Standard Build (Recommended)" in GitHub Actions workflows and release communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->