### PR TITLE
Fix: Adding custom games from USB OTG drives silently fails

### DIFF
--- a/app/src/main/java/app/gamenative/ui/components/CustomGameFolderPicker.kt
+++ b/app/src/main/java/app/gamenative/ui/components/CustomGameFolderPicker.kt
@@ -19,7 +19,7 @@ import app.gamenative.utils.CustomGameScanner
  * Converts a document tree URI to a file path.
  * Returns null if conversion fails.
  */
-fun getPathFromTreeUri(uri: Uri?): String? {
+fun getPathFromTreeUri(context: Context, uri: Uri?): String? {
     if (uri == null) return null
 
     return try {
@@ -41,16 +41,30 @@ fun getPathFromTreeUri(uri: Uri?): String? {
                 if (parts.size == 2) {
                     val volumeId = parts[0]
                     val path = parts[1]
-                    val possiblePath = if (path.isEmpty()) {
-                        "/storage/$volumeId"
+                    // Resolve the real mount point for this volume. SD cards typically live at
+                    // /storage/<uuid>, but USB OTG drives on some devices (e.g. Samsung) are only
+                    // mounted at the path reported by StorageVolume.getDirectory()
+                    // (e.g. /mnt/media_rw/<uuid>), with no /storage view at all.
+                    val defaultRoot = "/storage/$volumeId"
+                    val volumeRoot = if (java.io.File(defaultRoot).exists()) {
+                        defaultRoot
                     } else {
-                        "/storage/$volumeId/$path"
+                        val sm = context.getSystemService(android.os.storage.StorageManager::class.java)
+                        val volume = sm?.storageVolumes?.firstOrNull {
+                            it.uuid?.equals(volumeId, ignoreCase = true) == true
+                        }
+                        val resolved = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                            volume?.directory?.absolutePath
+                        } else {
+                            null
+                        }
+                        resolved ?: defaultRoot
                     }
-                    val file = java.io.File(possiblePath)
-                    if (file.exists() || file.parentFile?.exists() == true) {
-                        return possiblePath
+                    return if (path.isEmpty()) {
+                        volumeRoot
+                    } else {
+                        "$volumeRoot/$path"
                     }
-                    return possiblePath
                 }
             }
 
@@ -127,7 +141,7 @@ fun rememberCustomGameFolderPicker(
             return@rememberLauncherForActivityResult
         }
 
-        val path = getPathFromTreeUri(uri)
+        val path = getPathFromTreeUri(context, uri)
         if (path != null) {
             onPathSelected(path)
         } else {

--- a/app/src/main/java/app/gamenative/ui/components/CustomGameFolderPicker.kt
+++ b/app/src/main/java/app/gamenative/ui/components/CustomGameFolderPicker.kt
@@ -16,8 +16,48 @@ import app.gamenative.R
 import app.gamenative.utils.CustomGameScanner
 
 /**
- * Converts a document tree URI to a file path.
- * Returns null if conversion fails.
+ * Resolves the filesystem root of a storage volume identified by the volume id
+ * from a document tree URI (e.g. "6A1F-93F0").
+ *
+ * SD cards typically live at /storage/<uuid>, but USB OTG drives on some devices
+ * (e.g. Samsung) are only mounted at the path reported by
+ * [android.os.storage.StorageVolume.getDirectory] (such as /mnt/media_rw/<uuid>),
+ * with no /storage view at all.
+ *
+ * @param context Used to query [android.os.storage.StorageManager] for mounted volumes.
+ * @param volumeId The volume id portion of a tree document id (the part before ":").
+ * @return The volume's mount point. Prefers /storage/<volumeId> when it exists,
+ *         otherwise the directory reported by StorageManager, falling back to
+ *         /storage/<volumeId> when the volume cannot be resolved.
+ */
+private fun resolveVolumeRoot(context: Context, volumeId: String): String {
+    val defaultRoot = "/storage/$volumeId"
+    if (java.io.File(defaultRoot).exists()) {
+        return defaultRoot
+    }
+    val sm = context.getSystemService(android.os.storage.StorageManager::class.java)
+    val volume = sm?.storageVolumes?.firstOrNull {
+        it.uuid?.equals(volumeId, ignoreCase = true) == true
+    }
+    val resolved = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        volume?.directory?.absolutePath
+    } else {
+        null
+    }
+    return resolved ?: defaultRoot
+}
+
+/**
+ * Converts a document tree URI (from e.g. [ActivityResultContracts.OpenDocumentTree])
+ * to a raw filesystem path.
+ *
+ * Handles the primary volume ("primary:" document ids) as well as secondary volumes
+ * such as SD cards and USB OTG drives, whose mount point is resolved via
+ * [resolveVolumeRoot].
+ *
+ * @param context Used to resolve secondary volume mount points.
+ * @param uri The tree URI returned by the document picker, or null.
+ * @return The resolved filesystem path, or null if [uri] is null or conversion fails.
  */
 fun getPathFromTreeUri(context: Context, uri: Uri?): String? {
     if (uri == null) return null
@@ -41,25 +81,7 @@ fun getPathFromTreeUri(context: Context, uri: Uri?): String? {
                 if (parts.size == 2) {
                     val volumeId = parts[0]
                     val path = parts[1]
-                    // Resolve the real mount point for this volume. SD cards typically live at
-                    // /storage/<uuid>, but USB OTG drives on some devices (e.g. Samsung) are only
-                    // mounted at the path reported by StorageVolume.getDirectory()
-                    // (e.g. /mnt/media_rw/<uuid>), with no /storage view at all.
-                    val defaultRoot = "/storage/$volumeId"
-                    val volumeRoot = if (java.io.File(defaultRoot).exists()) {
-                        defaultRoot
-                    } else {
-                        val sm = context.getSystemService(android.os.storage.StorageManager::class.java)
-                        val volume = sm?.storageVolumes?.firstOrNull {
-                            it.uuid?.equals(volumeId, ignoreCase = true) == true
-                        }
-                        val resolved = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                            volume?.directory?.absolutePath
-                        } else {
-                            null
-                        }
-                        resolved ?: defaultRoot
-                    }
+                    val volumeRoot = resolveVolumeRoot(context, volumeId)
                     return if (path.isEmpty()) {
                         volumeRoot
                     } else {


### PR DESCRIPTION
## Description
Adding a custom game from a USB OTG drive silently failed: `getPathFromTreeUri` hardcodes `/storage/<uuid>` when converting the picked document tree to a file path, but USB OTG drives on some devices (verified on a Samsung Galaxy Z Fold6, Android 16) are only mounted at the path reported by `StorageVolume.getDirectory()` — e.g. `/mnt/media_rw/<uuid>` — with no `/storage/<uuid>` view at all. The resolved path never existed (`stat` → `ENOENT`), so `CustomGameScanner.createLibraryItemFromFolder` rejected the folder even with **All files access** granted.

The fix resolves the volume root via `StorageManager` by matching the volume UUID from the tree document ID, preferring `/storage/<uuid>` when it exists (SD cards) and falling back to `StorageVolume.getDirectory()` (USB OTG). Verified end-to-end on the affected device: a GOG game folder on a USB drive now adds and shows up in the library.

Diagnostics captured during testing on the affected device:
```
path: /storage/6A1F-93F0/Games/GOG/Blood West
Os.stat errno=2 (ENOENT)
isExternalStorageManager=true
volume uuid=6A1F-93F0 state=mounted removable=true primary=false dir=/mnt/media_rw/6A1F-93F0 desc=SANZANG
```

Two adjacent pre-existing issues noticed while debugging (not addressed here, happy to file separately):
- On the `modern` flavor, the custom-game flow forwards users to the system **All files access** page, but the toggle there is permanently greyed out since the flavor doesn't declare `MANAGE_EXTERNAL_STORAGE` — a dead end. Only `legacy` can complete this flow.
- When the selected folder fails validation, `LibraryViewModel.addCustomGameFolder` only logs and returns — the user gets no feedback.

## Recording
https://www.youtube.com/shorts/mAWQXeKYIus

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom-game folder import from USB OTG drives by resolving the correct storage volume root instead of hardcoding `/storage/<uuid>`. Users can now add games from OTG drives mounted only under `/mnt/media_rw/<uuid>` (e.g., Samsung devices).

- **Bug Fixes**
  - Resolve volume root via `StorageManager` by matching the volume UUID; prefer `/storage/<uuid>` if it exists, else use `StorageVolume.getDirectory()`, then append the picked path.
  - Update `getPathFromTreeUri` to accept `Context` and pass it from the folder picker.

- **Refactors**
  - Extract volume root resolution into a documented `resolveVolumeRoot` helper.

<sup>Written for commit 5b449e357164df9dd5985283abe7653aca41c079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the custom game folder picker when accessing folders on secondary or non-primary storage volumes.
  * Better handling of various device storage layouts to reduce failed folder selections and improve path resolution across Android devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->