### PR TITLE
fix(workshop): preserve zip payload extensions

### DIFF
--- a/app/src/main/java/app/gamenative/workshop/WorkshopItem.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopItem.kt
@@ -19,7 +19,7 @@ data class WorkshopItem(
     companion object {
         /** File extensions recognised as valid workshop content (used to skip magic-byte detection). */
         val KNOWN_EXTENSIONS = setOf(
-            "gma", "vpk", "bsp", "zip", "rar", "7z",
+            "gma", "vpk", "bsp", "zip", "rar", "7z", "jar", "gro",
             "bsa", "esp", "esm", "ckm", "pak", "bin",
             "txt", "cfg", "lua", "mdl", "vmt", "vtf",
             "wav", "mp3", "ogg", "png", "jpg", "jpeg",

--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -81,6 +81,13 @@ object WorkshopManager {
      */
     private val SKIP_ZIP_EXTRACTION_APP_IDS = setOf(
         1942280, // Brotato
+        646570,  // Slay the Spire - Workshop items include Java/JAR payloads
+        564310,  // Serious Sam Fusion 2017 - .gro files are ZIP payloads read by the game
+    )
+
+    private val ZIP_PAYLOAD_EXTENSIONS_BY_APP_ID = mapOf(
+        646570 to setOf("jar"),
+        564310 to setOf("gro"),
     )
 
     /**
@@ -514,6 +521,31 @@ object WorkshopManager {
 
         if (extractedCount > 0) {
             Timber.tag(TAG).i("Extracted $extractedCount CKM files into BSA/ESP")
+        }
+    }
+
+    private fun restoreZipPayloadNames(workshopContentDir: File) {
+        val extensions = ZIP_PAYLOAD_EXTENSIONS_BY_APP_ID[workshopContentDir.name.toIntOrNull()] ?: return
+        var restoredCount = 0
+
+        workshopContentDir.listFiles()?.forEach { itemDir ->
+            if (!itemDir.isDirectory) return@forEach
+            itemDir.listFiles()?.forEach { file ->
+                if (!file.isFile || file.name.startsWith(".")) return@forEach
+                val lowerName = file.name.lowercase()
+                if (extensions.none { lowerName.endsWith(".$it.zip") }) return@forEach
+
+                val restored = File(file.parentFile, file.name.dropLast(4))
+                if (restored.exists()) return@forEach
+                if (file.renameTo(restored)) {
+                    restoredCount++
+                    Timber.tag(TAG).i("Restored ZIP payload name: ${file.name} -> ${restored.name} in ${itemDir.name}")
+                }
+            }
+        }
+
+        if (restoredCount > 0) {
+            Timber.tag(TAG).i("Restored $restoredCount ZIP payload filename(s)")
         }
     }
 
@@ -3541,6 +3573,7 @@ object WorkshopManager {
         }
         onStatus?.invoke("Extracting archives…")
         extractCkmFiles(workshopContentDir)
+        restoreZipPayloadNames(workshopContentDir)
         extractZipMods(workshopContentDir)
         decompressLzmaFiles(workshopContentDir) { completed, total ->
             onStatus?.invoke("Decompressing ($completed/$total)…")

--- a/app/src/test/java/app/gamenative/workshop/WorkshopManagerTest.kt
+++ b/app/src/test/java/app/gamenative/workshop/WorkshopManagerTest.kt
@@ -11,6 +11,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlinx.coroutines.runBlocking
 import kotlin.io.path.createTempDirectory
 
 class WorkshopManagerTest {
@@ -58,6 +61,15 @@ class WorkshopManagerTest {
         val file = File(dir, fileName)
         file.parentFile?.mkdirs()
         file.writeText("content")
+    }
+
+    private fun writeZipPayload(file: File, entryName: String = "inside.txt") {
+        file.parentFile?.mkdirs()
+        ZipOutputStream(file.outputStream()).use { zip ->
+            zip.putNextEntry(ZipEntry(entryName))
+            zip.write("content".toByteArray())
+            zip.closeEntry()
+        }
     }
 
     private fun useSteamWorkshopContentDir(appId: Int = 331470) {
@@ -570,5 +582,70 @@ class WorkshopManagerTest {
         WorkshopManager.fixItemFileNames(items, workshopContentDir)
 
         assertTrue(File(dir, "my_mod.vpk").exists())
+    }
+
+    @Test
+    fun fixFileExtensions_preservesKnownZipContainerPayloadExtensions() {
+        val dir = File(workshopContentDir, "111").apply { mkdirs() }
+        val jarFile = File(dir, "mod.jar")
+        val groFile = File(dir, "mod.gro")
+        writeZipPayload(jarFile)
+        writeZipPayload(groFile)
+
+        WorkshopManager.fixFileExtensions(workshopContentDir)
+
+        assertTrue(jarFile.exists())
+        assertTrue(groFile.exists())
+        assertFalse(File(dir, "mod.jar.zip").exists())
+        assertFalse(File(dir, "mod.gro.zip").exists())
+    }
+
+    @Test
+    fun runPostProcessing_restoresZipPayloadNamesBeforeExtraction() = runBlocking {
+        useSteamWorkshopContentDir(646570)
+        val slayDir = File(workshopContentDir, "111").apply { mkdirs() }
+        writeZipPayload(File(slayDir, "mod.jar.zip"))
+
+        WorkshopManager.runPostProcessing(
+            downloadedItems = null,
+            allItems = emptyList(),
+            workshopContentDir = workshopContentDir,
+        )
+
+        assertTrue(File(slayDir, "mod.jar").exists())
+        assertFalse(File(slayDir, "mod.jar.zip").exists())
+        assertFalse(File(slayDir, "inside.txt").exists())
+        assertFalse(File(slayDir, ".zip_extracted").exists())
+
+        useSteamWorkshopContentDir(564310)
+        val seriousSamDir = File(workshopContentDir, "222").apply { mkdirs() }
+        writeZipPayload(File(seriousSamDir, "mod.gro.zip"))
+
+        WorkshopManager.runPostProcessing(
+            downloadedItems = null,
+            allItems = emptyList(),
+            workshopContentDir = workshopContentDir,
+        )
+
+        assertTrue(File(seriousSamDir, "mod.gro").exists())
+        assertFalse(File(seriousSamDir, "mod.gro.zip").exists())
+        assertFalse(File(seriousSamDir, "inside.txt").exists())
+        assertFalse(File(seriousSamDir, ".zip_extracted").exists())
+    }
+
+    @Test
+    fun extractZipMods_skipsZipExtractionForZipPayloadGames() {
+        listOf(646570, 564310).forEachIndexed { index, appId ->
+            useSteamWorkshopContentDir(appId)
+            val itemDir = File(workshopContentDir, (300 + index).toString()).apply { mkdirs() }
+            val zipFile = File(itemDir, "payload.zip")
+            writeZipPayload(zipFile)
+
+            WorkshopManager.extractZipMods(workshopContentDir)
+
+            assertTrue(zipFile.exists())
+            assertFalse(File(itemDir, "inside.txt").exists())
+            assertFalse(File(itemDir, ".zip_extracted").exists())
+        }
     }
 }


### PR DESCRIPTION
﻿## Description
This PR fixes a workshop bug where jar and gro files are being renamed with .zip at the end of their file name then extracted. 

Known games being affected: Slay the Spire and Serious Sam Fusion 2017.

## Recording
Not much to show, but the screenshot below shows a jar file from a workshop mod is not being renamed with .zip at the end nor is it being extracted like it used to.

<img width="2184" height="1968" alt="Screenshot_20260604_230327_GameNative" src="https://github.com/user-attachments/assets/e21c12c1-cfc0-4f75-b978-5a1703ef3b6f" />


## Type of Change
- [X] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `.gro` file extension as a recognized workshop content type
  * Enhanced workshop content post-processing to preserve zip payloads for specific games that require them to remain in zip format rather than being automatically extracted

* **Tests**
  * Added comprehensive test coverage validating zip payload preservation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->