### PR TITLE
feat: Add QAM display brightness control

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -72,11 +73,13 @@ import app.gamenative.ui.util.adaptivePanelWidth
 import app.gamenative.ui.util.applyScreenEffectsConfig
 import app.gamenative.ui.util.loadScreenEffectsConfig
 import app.gamenative.ui.util.persistScreenEffectsConfig
+import app.gamenative.utils.BrightnessManager
 import com.winlator.container.Container
 import com.winlator.renderer.GLRenderer
 import com.winlator.renderer.VulkanRenderer
 import kotlinx.coroutines.delay
 import kotlin.math.abs
+import kotlin.math.roundToInt
 
 private const val SCREEN_EFFECT_PERCENT_STEP = 5f
 private const val SCREEN_EFFECT_GAMMA_STEP = 0.1f
@@ -145,6 +148,43 @@ private val GL_BASIC_MODES = listOf(
     ScreenEffectsConfig.SCALING_MODE_FILL,
     ScreenEffectsConfig.SCALING_MODE_STRETCH,
 )
+
+@Composable
+private fun DisplayBrightnessRow(
+    focusRequester: FocusRequester? = null,
+) {
+    val context = LocalContext.current
+    val activity = remember(context) { BrightnessManager.findActivity(context) }
+    var displayBrightness by remember(activity) {
+        mutableFloatStateOf(activity?.let(BrightnessManager::readDisplayBrightness) ?: 0.5f)
+    }
+
+    fun setDisplayBrightness(value: Float) {
+        val next = BrightnessManager.snapDisplayBrightness(value)
+        displayBrightness = next
+        activity?.let { BrightnessManager.applyDisplayBrightness(it, next) }
+    }
+
+    ScreenEffectAdjustmentRow(
+        title = stringResource(R.string.display_brightness),
+        valueText = stringResource(
+            R.string.performance_hud_percentage_value,
+            (displayBrightness * 100f).roundToInt(),
+        ),
+        progress = normalizedProgress(
+            displayBrightness,
+            BrightnessManager.DISPLAY_BRIGHTNESS_MIN,
+            BrightnessManager.DISPLAY_BRIGHTNESS_MAX,
+        ),
+        onDecrease = {
+            setDisplayBrightness(displayBrightness - BrightnessManager.DISPLAY_BRIGHTNESS_STEP)
+        },
+        onIncrease = {
+            setDisplayBrightness(displayBrightness + BrightnessManager.DISPLAY_BRIGHTNESS_STEP)
+        },
+        focusRequester = focusRequester,
+    )
+}
 
 @Composable
 fun GLScreenEffectsTabContent(
@@ -236,11 +276,14 @@ fun GLScreenEffectsTabContent(
             .focusGroup()
             .padding(vertical = 12.dp),
     ) {
+        DisplayBrightnessRow(focusRequester = firstItemFocusRequester)
+
+        Spacer(modifier = Modifier.height(20.dp))
+
         ScreenEffectRadioRow(
             title = stringResource(scalingModeLabelRes(ScreenEffectsConfig.SCALING_MODE_NONE)),
             selected = scalingMode == ScreenEffectsConfig.SCALING_MODE_NONE,
             onSelect = { scalingMode = ScreenEffectsConfig.SCALING_MODE_NONE },
-            focusRequester = firstItemFocusRequester,
         )
 
         Spacer(modifier = Modifier.height(20.dp))
@@ -471,11 +514,14 @@ fun ScreenEffectsTabContent(
             .focusGroup()
             .padding(vertical = 12.dp),
     ) {
+        DisplayBrightnessRow(focusRequester = firstItemFocusRequester)
+
+        Spacer(modifier = Modifier.height(20.dp))
+
         ScreenEffectRadioRow(
             title = stringResource(scalingModeLabelRes(ScreenEffectsConfig.SCALING_MODE_NONE)),
             selected = scalingMode == ScreenEffectsConfig.SCALING_MODE_NONE,
             onSelect = { scalingMode = ScreenEffectsConfig.SCALING_MODE_NONE },
-            focusRequester = firstItemFocusRequester,
         )
 
         Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
@@ -155,14 +155,16 @@ private fun DisplayBrightnessRow(
 ) {
     val context = LocalContext.current
     val activity = remember(context) { BrightnessManager.findActivity(context) }
+    // Without an Activity there is no window brightness target to control.
+    if (activity == null) return
     var displayBrightness by remember(activity) {
-        mutableFloatStateOf(activity?.let(BrightnessManager::readDisplayBrightness) ?: 0.5f)
+        mutableFloatStateOf(BrightnessManager.readDisplayBrightness(activity))
     }
 
     fun setDisplayBrightness(value: Float) {
         val next = BrightnessManager.snapDisplayBrightness(value)
         displayBrightness = next
-        activity?.let { BrightnessManager.applyDisplayBrightness(it, next) }
+        BrightnessManager.applyDisplayBrightness(activity, next)
     }
 
     ScreenEffectAdjustmentRow(

--- a/app/src/main/java/app/gamenative/utils/BrightnessManager.kt
+++ b/app/src/main/java/app/gamenative/utils/BrightnessManager.kt
@@ -54,6 +54,7 @@ class BrightnessManager(private val activity: Activity, private val targetBright
                 .coerceIn(DISPLAY_BRIGHTNESS_MIN, DISPLAY_BRIGHTNESS_MAX)
         }
 
+        @MainThread
         fun readDisplayBrightness(activity: Activity): Float {
             val windowBrightness = activity.window.attributes.screenBrightness
             if (windowBrightness in DISPLAY_BRIGHTNESS_MIN..DISPLAY_BRIGHTNESS_MAX) {

--- a/app/src/main/java/app/gamenative/utils/BrightnessManager.kt
+++ b/app/src/main/java/app/gamenative/utils/BrightnessManager.kt
@@ -1,7 +1,11 @@
 package app.gamenative.utils
 
 import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.provider.Settings
 import androidx.annotation.MainThread
+import kotlin.math.roundToInt
 
 class BrightnessManager(private val activity: Activity, private val targetBrightness: Float) {
     private var savedBrightness: Float = UNSET_BRIGHTNESS
@@ -31,5 +35,46 @@ class BrightnessManager(private val activity: Activity, private val targetBright
 
     companion object {
         private const val UNSET_BRIGHTNESS = -1f
+        const val DISPLAY_BRIGHTNESS_STEP = 0.05f
+        const val DISPLAY_BRIGHTNESS_MIN = 0.05f
+        const val DISPLAY_BRIGHTNESS_MAX = 1f
+
+        tailrec fun findActivity(context: Context): Activity? {
+            return when (context) {
+                is Activity -> context
+                is ContextWrapper -> findActivity(context.baseContext)
+                else -> null
+            }
+        }
+
+        fun snapDisplayBrightness(value: Float): Float {
+            return (value / DISPLAY_BRIGHTNESS_STEP)
+                .roundToInt()
+                .times(DISPLAY_BRIGHTNESS_STEP)
+                .coerceIn(DISPLAY_BRIGHTNESS_MIN, DISPLAY_BRIGHTNESS_MAX)
+        }
+
+        fun readDisplayBrightness(activity: Activity): Float {
+            val windowBrightness = activity.window.attributes.screenBrightness
+            if (windowBrightness in DISPLAY_BRIGHTNESS_MIN..DISPLAY_BRIGHTNESS_MAX) {
+                return snapDisplayBrightness(windowBrightness)
+            }
+
+            val systemBrightness = runCatching {
+                Settings.System.getInt(
+                    activity.contentResolver,
+                    Settings.System.SCREEN_BRIGHTNESS,
+                ) / 255f
+            }.getOrDefault(0.5f)
+
+            return snapDisplayBrightness(systemBrightness)
+        }
+
+        @MainThread
+        fun applyDisplayBrightness(activity: Activity, value: Float) {
+            val params = activity.window.attributes
+            params.screenBrightness = value.coerceIn(DISPLAY_BRIGHTNESS_MIN, DISPLAY_BRIGHTNESS_MAX)
+            activity.window.attributes = params
+        }
     }
 }

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -209,6 +209,7 @@
     <string name="open_navigation_menu">Åbn navigationsmenu</string>
     <string name="quick_menu_title">Hurtig menu</string>
     <string name="quick_menu_back">Tilbage</string>
+    <string name="display_brightness">Skærmens lysstyrke</string>
     <string name="screen_effects">Skærmeffekter</string>
     <string name="screen_effects_live_preview">Ændringer anvendes straks på det aktuelle spil.</string>
     <string name="screen_effects_color_adjustments">Farvejusteringer</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -272,6 +272,7 @@
     <string name="open_navigation_menu">Navigationsmenü öffnen</string>
     <string name="quick_menu_title">Schnellmenü</string>
     <string name="quick_menu_back">Zurück</string>
+    <string name="display_brightness">Displayhelligkeit</string>
     <string name="screen_effects">Bildschirmeffekte</string>
     <string name="screen_effects_live_preview">Änderungen werden sofort auf das aktuelle Spiel angewendet.</string>
     <string name="screen_effects_color_adjustments">Farbkorrekturen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -294,6 +294,7 @@
     <string name="open_navigation_menu">Abrir menú de navegación</string>
     <string name="quick_menu_title">Menú rápido</string>
     <string name="quick_menu_back">Atrás</string>
+    <string name="display_brightness">Brillo de pantalla</string>
     <string name="screen_effects">Efectos de pantalla</string>
     <string name="screen_effects_live_preview">Los cambios se aplican al instante al juego actual.</string>
     <string name="screen_effects_color_adjustments">Ajustes de color</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -279,6 +279,7 @@
     <string name="open_navigation_menu">Ouvrir le menu de navigation</string>
     <string name="quick_menu_title">Menu rapide</string>
     <string name="quick_menu_back">Retour</string>
+    <string name="display_brightness">Luminosité de l’écran</string>
     <string name="screen_effects">Effets d’écran</string>
     <string name="screen_effects_live_preview">Les modifications s’appliquent instantanément au jeu en cours.</string>
     <string name="screen_effects_color_adjustments">Réglages des couleurs</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -283,6 +283,7 @@
     <string name="open_navigation_menu">Apri Menu Navigazione</string>
     <string name="quick_menu_title">Menu rapido</string>
     <string name="quick_menu_back">Indietro</string>
+    <string name="display_brightness">Luminosità display</string>
     <string name="screen_effects">Effetti schermo</string>
     <string name="screen_effects_live_preview">Le modifiche si applicano istantaneamente al gioco corrente.</string>
     <string name="screen_effects_color_adjustments">Regolazioni colore</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -240,6 +240,7 @@
     <string name="open_navigation_menu">ナビゲーションメニューを開く</string>
     <string name="quick_menu_title">クイックメニュー</string>
     <string name="quick_menu_back">戻る</string>
+    <string name="display_brightness">ディスプレイの明るさ</string>
     <string name="screen_effects">画面効果</string>
     <string name="screen_effects_live_preview">変更は現在のゲームに即座に適用されます。</string>
     <string name="screen_effects_scaling">スケーリング</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -292,6 +292,7 @@
     <string name="open_navigation_menu">탐색 메뉴 열기</string>
     <string name="quick_menu_title">빠른 메뉴</string>
     <string name="quick_menu_back">뒤로</string>
+    <string name="display_brightness">디스플레이 밝기</string>
     <string name="screen_effects">화면 효과</string>
     <string name="screen_effects_live_preview">변경 사항이 현재 게임에 즉시 적용됩니다.</string>
     <string name="screen_effects_color_adjustments">색상 조정</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -291,6 +291,7 @@
     <string name="open_navigation_menu">Otwórz menu nawigacji</string>
     <string name="quick_menu_title">Menu szybkie</string>
     <string name="quick_menu_back">Wstecz</string>
+    <string name="display_brightness">Jasność ekranu</string>
     <string name="screen_effects">Efekty ekranu</string>
     <string name="screen_effects_live_preview">Zmiany są natychmiast stosowane do bieżącej gry.</string>
     <string name="screen_effects_color_adjustments">Regulacja kolorów</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -209,6 +209,7 @@
     <string name="open_navigation_menu">Abrir Menu de Navegação</string>
     <string name="quick_menu_title">Menu rápido</string>
     <string name="quick_menu_back">Voltar</string>
+    <string name="display_brightness">Brilho da tela</string>
     <string name="screen_effects">Efeitos de tela</string>
     <string name="screen_effects_live_preview">As alterações são aplicadas instantaneamente ao jogo atual.</string>
     <string name="screen_effects_color_adjustments">Ajustes de cor</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -281,6 +281,7 @@
     <string name="open_navigation_menu">Deschide meniul de navigare</string>
     <string name="quick_menu_title">Meniu rapid</string>
     <string name="quick_menu_back">Înapoi</string>
+    <string name="display_brightness">Luminozitatea ecranului</string>
     <string name="screen_effects">Efecte de ecran</string>
     <string name="screen_effects_live_preview">Modificările se aplică instantaneu jocului curent.</string>
     <string name="screen_effects_color_adjustments">Ajustări de culoare</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -854,6 +854,7 @@ https://gamenative.app
     <string name="properties">Свойства</string>
     <string name="quick_menu_back">Назад</string>
     <string name="quick_menu_title">Быстрое меню</string>
+    <string name="display_brightness">Яркость дисплея</string>
     <string name="screen_effects">Эффекты экрана</string>
     <string name="screen_effects_live_preview">Изменения мгновенно применяются к текущей игре.</string>
     <string name="screen_effects_color_adjustments">Настройка цвета</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -278,6 +278,7 @@
     <string name="open_navigation_menu">Відкрити меню навігації</string>
     <string name="quick_menu_title">Швидке меню</string>
     <string name="quick_menu_back">Назад</string>
+    <string name="display_brightness">Яскравість дисплея</string>
     <string name="screen_effects">Ефекти екрана</string>
     <string name="screen_effects_live_preview">Зміни миттєво застосовуються до поточної гри.</string>
     <string name="screen_effects_color_adjustments">Налаштування кольору</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -277,6 +277,7 @@
     <string name="open_navigation_menu">打开导航菜单</string>
     <string name="quick_menu_title">快捷菜单</string>
     <string name="quick_menu_back">返回</string>
+    <string name="display_brightness">显示亮度</string>
     <string name="screen_effects">屏幕效果</string>
     <string name="screen_effects_live_preview">更改会立即应用到当前游戏。</string>
     <string name="screen_effects_color_adjustments">颜色调整</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -277,6 +277,7 @@
     <string name="open_navigation_menu">開啟導航選單</string>
     <string name="quick_menu_title">快捷選單</string>
     <string name="quick_menu_back">返回</string>
+    <string name="display_brightness">顯示亮度</string>
     <string name="screen_effects">螢幕效果</string>
     <string name="screen_effects_live_preview">變更會立即套用到目前遊戲。</string>
     <string name="screen_effects_color_adjustments">色彩調整</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,6 +241,7 @@
     <string name="open_navigation_menu">Open Navigation Menu</string>
     <string name="quick_menu_title">Quick Menu</string>
     <string name="quick_menu_back">Back</string>
+    <string name="display_brightness">Display brightness</string>
     <string name="screen_effects">Screen Effects</string>
     <string name="screen_effects_live_preview">Changes apply instantly to the current game.</string>
     <string name="screen_effects_scaling">Scaling</string>


### PR DESCRIPTION
## Description
Adds a transient Display brightness slider to QAM screen effects for adjusting the current app window brightness.

prevents the annoying android paradigm of swiping multiple times to show status bar then pull notification shade then expand shade then finally move brightness slider, this way it can be controller driven and done in very few presses. 

## Recording

<img width="960" height="544" alt="gamenative-qam-brightness" src="https://github.com/user-attachments/assets/e8971ac7-acfd-49a2-a697-7decdef9c154" />


## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a display brightness slider to the QAM Screen Effects panel to adjust the current app window’s brightness in real time. Values snap to 5% steps (5%–100%) and only affect the active window, not system brightness.

- **New Features**
  - New “Display brightness” row at the top of Screen Effects in both tab variants; first focusable item for quick access.
  - Reads the initial value from the window; falls back to the system setting if needed.
  - Applies per-window changes via `BrightnessManager` with 5% snapping, safe Activity detection, and clamping.
  - Adds the `display_brightness` string with translations across supported locales.

<sup>Written for commit 0b7c54ebb92b6678e6f16ced7d4025f93a170550. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display brightness control added to the Screen Effects settings panel for direct in-app adjustment.
  * Brightness slider positioned at the top of the effects menu for faster access and initial focus.
  * Localized UI text for the brightness control added across 16+ languages for broader language support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->