### PR TITLE
Fix keyboard Esc quick menu shortcut

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/KeyboardEscMenuHandler.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/KeyboardEscMenuHandler.kt
@@ -1,0 +1,108 @@
+package app.gamenative.ui.screen.xserver
+
+import android.os.SystemClock
+import android.view.KeyEvent
+import com.winlator.xserver.Keyboard
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private const val KEYBOARD_ESC_MENU_HOLD_MS = 2_000L
+
+internal class KeyboardEscMenuHandler(
+    private val scope: CoroutineScope,
+) {
+    private var menuJob: Job? = null
+    private var menuTriggered = false
+
+    fun isEscOrBack(event: KeyEvent): Boolean =
+        event.keyCode == KeyEvent.KEYCODE_ESCAPE || event.keyCode == KeyEvent.KEYCODE_BACK
+
+    fun cancel() {
+        menuJob?.cancel()
+        menuJob = null
+    }
+
+    fun handleOverlayEscOrBack(event: KeyEvent, keyboard: Keyboard?) {
+        if (event.action == KeyEvent.ACTION_UP && menuJob != null && !menuTriggered) {
+            dispatchEscToGame(event, keyboard)
+        }
+        cancel()
+        menuTriggered = false
+    }
+
+    fun handleGameEscOrBack(
+        event: KeyEvent,
+        keyboard: Keyboard?,
+        canOpenMenu: () -> Boolean,
+        openMenu: () -> Unit,
+    ): Boolean {
+        return when (event.action) {
+            KeyEvent.ACTION_DOWN -> {
+                if (event.repeatCount == 0) {
+                    menuTriggered = false
+                    cancel()
+                    menuJob = scope.launch {
+                        delay(KEYBOARD_ESC_MENU_HOLD_MS)
+                        if (canOpenMenu()) {
+                            menuTriggered = true
+                            menuJob = null
+                            dispatchEscToGame(event.asEscEvent(action = KeyEvent.ACTION_UP), keyboard)
+                            openMenu()
+                        }
+                    }
+                }
+                dispatchEscToGame(event, keyboard) || event.keyCode == KeyEvent.KEYCODE_BACK
+            }
+            KeyEvent.ACTION_UP -> {
+                val shouldReleaseGameEsc = menuJob != null && !menuTriggered
+                val shouldConsume = menuJob != null ||
+                    menuTriggered ||
+                    event.keyCode == KeyEvent.KEYCODE_BACK
+
+                cancel()
+                if (shouldReleaseGameEsc) {
+                    dispatchEscToGame(event, keyboard) || event.keyCode == KeyEvent.KEYCODE_BACK
+                } else {
+                    menuTriggered = false
+                    shouldConsume
+                }
+            }
+            else -> dispatchEscToGame(event, keyboard) || event.keyCode == KeyEvent.KEYCODE_BACK
+        }
+    }
+
+    private fun dispatchEscToGame(event: KeyEvent, keyboard: Keyboard?): Boolean {
+        val gameEscEvent = event.asEscEvent()
+        val targetKeyboard = keyboard ?: return false
+        return if (gameEscEvent.device?.isVirtual == true) {
+            targetKeyboard.onVirtualKeyEvent(gameEscEvent)
+        } else {
+            targetKeyboard.onKeyEvent(gameEscEvent)
+        }
+    }
+
+    private fun KeyEvent.asEscEvent(
+        action: Int = this.action,
+        repeatCount: Int = this.repeatCount,
+    ): KeyEvent {
+        if (keyCode == KeyEvent.KEYCODE_ESCAPE && action == this.action && repeatCount == this.repeatCount) {
+            return this
+        }
+
+        val eventTime = if (action == this.action) eventTime else SystemClock.uptimeMillis()
+        return KeyEvent(
+            downTime,
+            eventTime,
+            action,
+            KeyEvent.KEYCODE_ESCAPE,
+            repeatCount,
+            metaState,
+            deviceId,
+            scanCode,
+            flags,
+            source,
+        )
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -406,6 +406,7 @@ fun XServerScreen(
     var win32AppWorkarounds: Win32AppWorkarounds? by remember { mutableStateOf(null) }
     var physicalControllerHandler: PhysicalControllerHandler? by remember { mutableStateOf(null) }
     var exitWatchJob: Job? by remember { mutableStateOf(null) }
+    val keyboardEscMenuHandler = remember(scope) { KeyboardEscMenuHandler(scope) }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -413,6 +414,7 @@ fun XServerScreen(
             physicalControllerHandler = null
             exitWatchJob?.cancel()
             exitWatchJob = null
+            keyboardEscMenuHandler.cancel()
         }
     }
     var isKeyboardVisible = false
@@ -1293,6 +1295,7 @@ fun XServerScreen(
         }
         val onKeyEvent: (AndroidEvent.KeyEvent) -> Boolean = {
             val isKeyboard = Keyboard.isKeyboardDevice(it.event.device)
+            val isPhysicalKeyboard = isKeyboard && it.event.device?.isVirtual != true
             val isGamepad = ExternalController.isGameController(it.event.device)
             val waitingForManualResume =
                 manualResumeMode &&
@@ -1314,11 +1317,16 @@ fun XServerScreen(
                     else -> false
                 }
             } else if ((showElementEditor || keepPausedForEditor || showQuickMenu || isEditMode) && (isGamepad || isKeyboard)) {
-                val escPressed = isKeyboard && !keepPausedForEditor && it.event.keyCode == KeyEvent.KEYCODE_ESCAPE &&
-                        it.event.action == KeyEvent.ACTION_DOWN &&
-                        it.event.repeatCount == 0
-                if (escPressed) {
-                    (context as? ComponentActivity)?.onBackPressedDispatcher?.onBackPressed()
+                val escOrBackPressed = !keepPausedForEditor &&
+                    (
+                        isKeyboard && it.event.keyCode == KeyEvent.KEYCODE_ESCAPE ||
+                            isPhysicalKeyboard && it.event.keyCode == KeyEvent.KEYCODE_BACK
+                        )
+                if (escOrBackPressed) {
+                    keyboardEscMenuHandler.handleOverlayEscOrBack(it.event, keyboard)
+                    if (it.event.action == KeyEvent.ACTION_DOWN && it.event.repeatCount == 0) {
+                        (context as? ComponentActivity)?.onBackPressedDispatcher?.onBackPressed()
+                    }
                     true
                 } else {
                     // Let Compose focus system handle keyboard and gamepad navigation/selection while menu is visible.
@@ -1335,13 +1343,22 @@ fun XServerScreen(
                 }
                 if (!handled && isKeyboard) {
                     val isShiftEscPressed = it.event.keyCode == KeyEvent.KEYCODE_ESCAPE &&
-                            it.event.isShiftPressed &&
-                            it.event.action == KeyEvent.ACTION_DOWN &&
-                            it.event.repeatCount == 0
+                        it.event.isShiftPressed &&
+                        it.event.action == KeyEvent.ACTION_DOWN &&
+                        it.event.repeatCount == 0
                     if (isShiftEscPressed &&
                         !showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode) {
+                        keyboardEscMenuHandler.cancel()
                         gameBack()
                         handled = true
+                    } else if (isPhysicalKeyboard && keyboardEscMenuHandler.isEscOrBack(it.event) &&
+                        !showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode) {
+                        handled = keyboardEscMenuHandler.handleGameEscOrBack(
+                            event = it.event,
+                            keyboard = keyboard,
+                            canOpenMenu = { !showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode },
+                            openMenu = gameBack,
+                        )
                     } else {
                         if (it.event.device?.isVirtual == true) {
                             handled = keyboard?.onVirtualKeyEvent(it.event) == true

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1325,7 +1325,11 @@ fun XServerScreen(
                 if (escOrBackPressed) {
                     keyboardEscMenuHandler.handleOverlayEscOrBack(it.event, keyboard)
                     if (it.event.action == KeyEvent.ACTION_DOWN && it.event.repeatCount == 0) {
-                        (context as? ComponentActivity)?.onBackPressedDispatcher?.onBackPressed()
+                        if (BuildConfig.MODERN_ANDROID) {
+                            (context as? ComponentActivity)?.onBackPressedDispatcher?.onBackPressed()
+                        } else {
+                            gameBack()
+                        }
                     }
                     true
                 } else {


### PR DESCRIPTION
## Description
Fixes a physical keyboard Escape handling issue reported here: https://discord.com/channels/1378308569287622737/1511935659038740641

Previously, pressing Esc on a physical/Bluetooth keyboard could open the GameNative quick/side menu instead of sending Esc to the game. This caused games that use Esc for pause menus or in-game menus to miss the input.

This PR changes physical keyboard handling so a quick Esc press is forwarded to the game as Esc. Physical keyboard Back key events are also treated as in-game Esc, covering keyboards that report Esc as Android Back. Holding Esc/Back for 2 seconds opens the GameNative quick/side menu.

## Recording
N/A I dont have a bluetooth keyboard to test with.

## Type of Change
- [X] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes physical keyboard Esc/Back so a quick press goes to the game, and a 2s hold opens the quick/side menu. Also fixes overlay dismissal on legacy builds so Esc/Back closes overlays instead of opening the menu.

- **Bug Fixes**
  - Added `KeyboardEscMenuHandler` to time the 2s hold and forward Esc to the game (sends key-up before opening the menu).
  - Updated `XServerScreen`: physical Esc/Back acts as in-game Esc; correct routing for physical vs virtual via `Keyboard.onKeyEvent`/`onVirtualKeyEvent`; `Shift+Esc` behavior unchanged.
  - Overlays: Esc/Back dismisses overlays using `onBackPressedDispatcher` on modern builds and `gameBack()` on legacy; pending menu jobs canceled on dispose.

<sup>Written for commit e4b648b2b6417c47aa3ec6e630113ded4d7dff1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hold ESC/BACK for 2s to open the in-game menu.
  * Improved detection and routing for physical vs virtual keyboards.
  * Better behavior when overlays/editors/menus are visible (physical BACK treated like ESC).
  * Shift+ESC now reliably cancels pending menu actions before triggering back.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->