### PR TITLE
Fix shooter mode touch-side joystick routing

### DIFF
--- a/app/src/main/java/com/winlator/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/widget/InputControlsView.java
@@ -658,6 +658,59 @@ public class InputControlsView extends View {
         drawDynamicJoystick(canvas, joystickCenterX, joystickCenterY, joystickCurrentX, joystickCurrentY, joystickSizeMultiplier);
     }
 
+    private boolean isLeftSideTouch(float x) {
+        return x < getWidth() / 2f;
+    }
+
+    private boolean shouldUseRightJoystickLook() {
+        ControlElement smElement = getShooterModeElement();
+        return (smElement != null && "gamepad_right_stick".equals(smElement.getShooterLookType()))
+                || (containerShooterModeRuntime && smElement == null);
+    }
+
+    private boolean startShooterJoystickPointer(int pointerId, float x, float y) {
+        if (joystickPointerId != -1) return false;
+
+        joystickPointerId = pointerId;
+        joystickCenterX = x;
+        joystickCenterY = y;
+        joystickCurrentX = x;
+        joystickCurrentY = y;
+        invalidate();
+        return true;
+    }
+
+    private boolean startRightJoystickPointer(int pointerId, float x, float y) {
+        if (rightJoystickPointerId != -1) return false;
+
+        rightJoystickPointerId = pointerId;
+        rightJoystickCenterX = x;
+        rightJoystickCenterY = y;
+        rightJoystickCurrentX = x;
+        rightJoystickCurrentY = y;
+        invalidate();
+        return true;
+    }
+
+    private boolean startShooterLookPointer(int pointerId, float x, float y, ControlElement fireElement) {
+        if (lookPointerId != -1) return false;
+
+        lookPointerId = pointerId;
+        lookLastX = x;
+        lookLastY = y;
+        lookAccumX = 0;
+        lookAccumY = 0;
+        lookFireElement = fireElement;
+        return true;
+    }
+
+    private boolean startRightSideShooterPointer(int pointerId, float x, float y, ControlElement fireElement) {
+        if (shouldUseRightJoystickLook()) {
+            return startRightJoystickPointer(pointerId, x, y);
+        }
+        return startShooterLookPointer(pointerId, x, y, fireElement);
+    }
+
     private boolean handleShooterTouchDown(int pointerId, float x, float y) {
         boolean handled = false;
 
@@ -688,68 +741,17 @@ public class InputControlsView extends View {
                 performHapticFeedback(android.view.HapticFeedbackConstants.VIRTUAL_KEY);
                 handled = true;
                 if (element.getType() == ControlElement.Type.BUTTON) {
-                    // Also track this pointer for look-around so the user can
-                    // press any button and still look/aim with the same finger.
-                    ControlElement smElement = getShooterModeElement();
-                    boolean useRightStick = (smElement != null && "gamepad_right_stick".equals(smElement.getShooterLookType()))
-                                         || (containerShooterModeRuntime && smElement == null);
-                    if (useRightStick) {
-                        if (rightJoystickPointerId == -1) {
-                            rightJoystickPointerId = pointerId;
-                            rightJoystickCenterX = x;
-                            rightJoystickCenterY = y;
-                            rightJoystickCurrentX = x;
-                            rightJoystickCurrentY = y;
-                        }
-                    } else {
-                        if (lookPointerId == -1) {
-                            lookPointerId = pointerId;
-                            lookLastX = x;
-                            lookLastY = y;
-                            lookAccumX = 0;
-                            lookAccumY = 0;
-                            lookFireElement = element;
-                        }
-                    }
+                    if (isLeftSideTouch(x)) startShooterJoystickPointer(pointerId, x, y);
+                    else startRightSideShooterPointer(pointerId, x, y, element);
                 }
                 break;
             }
         }
         if (!handled) {
-            int screenMidX = getWidth() / 2;
-            if (x < screenMidX && joystickPointerId == -1) {
-                // Left side: spawn dynamic joystick
-                joystickPointerId = pointerId;
-                joystickCenterX = x;
-                joystickCenterY = y;
-                joystickCurrentX = x;
-                joystickCurrentY = y;
-                handled = true;
-                invalidate();
-            } else if (x >= screenMidX) {
-                // Right side: check look type
-                ControlElement smElement = getShooterModeElement();
-                boolean useRightStick = (smElement != null && "gamepad_right_stick".equals(smElement.getShooterLookType()))
-                                     || (containerShooterModeRuntime && smElement == null);
-                if (useRightStick && rightJoystickPointerId == -1) {
-                    // Right side: spawn dynamic right joystick
-                    rightJoystickPointerId = pointerId;
-                    rightJoystickCenterX = x;
-                    rightJoystickCenterY = y;
-                    rightJoystickCurrentX = x;
-                    rightJoystickCurrentY = y;
-                    handled = true;
-                    invalidate();
-                } else if (!useRightStick && lookPointerId == -1) {
-                    // Right side: mouse look
-                    lookPointerId = pointerId;
-                    lookLastX = x;
-                    lookLastY = y;
-                    lookAccumX = 0;
-                    lookAccumY = 0;
-                    lookFireElement = null;
-                    handled = true;
-                }
+            if (isLeftSideTouch(x)) {
+                handled = startShooterJoystickPointer(pointerId, x, y);
+            } else {
+                handled = startRightSideShooterPointer(pointerId, x, y, null);
             }
         }
         return handled;


### PR DESCRIPTION
## Description

This is a bug fix for the issue reported here: https://discord.com/channels/1378308569287622737/1512611200784138240

Currently in shooter mode when you press a button on the left side then drag your finger around, it creates the right joystick. This fix makes it so if you press a button on the left side then drag your finger around it creates the left joystick appropriately.

## Recording

https://github.com/user-attachments/assets/f351797e-0ef3-4137-86bf-5d37156a50d3

## Type of Change
- [X] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal touch control initialization for shooter mode to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->