### PR TITLE
Add relative touchscreen drag movement option

### DIFF
--- a/app/src/main/java/app/gamenative/data/TouchGestureConfig.kt
+++ b/app/src/main/java/app/gamenative/data/TouchGestureConfig.kt
@@ -70,6 +70,9 @@ data class TouchGestureConfig(
 
     // 14. Gesture threshold (px) for two-finger gesture lock-in
     val gestureThreshold: Int = DEFAULT_GESTURE_THRESHOLD,
+
+    // 15. Movement mode used by mouse-button drag gestures
+    val mouseDragMovementMode: String = MOUSE_DRAG_MOVEMENT_DIRECT,
 ) {
 
     // ── Serialisation ────────────────────────────────────────────────────
@@ -116,6 +119,7 @@ data class TouchGestureConfig(
             put(KEY_SHOW_GESTURE_DEBUG_OVERLAY, showGestureDebugOverlay)
             put(KEY_SHOW_CURSOR_IN_TOUCHSCREEN_MODE, showCursorInTouchscreenMode)
             put(KEY_GESTURE_THRESHOLD, gestureThreshold)
+            put(KEY_MOUSE_DRAG_MOVEMENT_MODE, mouseDragMovementMode)
         }.toString()
     }
 
@@ -132,6 +136,9 @@ data class TouchGestureConfig(
 
         const val MOUSE_BEHAVIOR_HOLD = "hold"
         const val MOUSE_BEHAVIOR_CLICK = "click"
+
+        const val MOUSE_DRAG_MOVEMENT_DIRECT = "direct"
+        const val MOUSE_DRAG_MOVEMENT_RELATIVE = "relative"
 
         // ── Special actions ──────────────────────────────────────────────
         const val ACTION_SHOW_KEYBOARD = "show_keyboard"
@@ -186,6 +193,7 @@ data class TouchGestureConfig(
         private const val KEY_SHOW_GESTURE_DEBUG_OVERLAY = "showGestureDebugOverlay"
         private const val KEY_SHOW_CURSOR_IN_TOUCHSCREEN_MODE = "showCursorInTouchscreenMode"
         private const val KEY_GESTURE_THRESHOLD = "gestureThreshold"
+        private const val KEY_MOUSE_DRAG_MOVEMENT_MODE = "mouseDragMovementMode"
 
         /**
          * Compatibility-safe defaults for existing (pre-overhaul) configs.
@@ -253,6 +261,9 @@ data class TouchGestureConfig(
                     showGestureDebugOverlay = obj.optBoolean(KEY_SHOW_GESTURE_DEBUG_OVERLAY, false),
                     showCursorInTouchscreenMode = obj.optBoolean(KEY_SHOW_CURSOR_IN_TOUCHSCREEN_MODE, false),
                     gestureThreshold = obj.optInt(KEY_GESTURE_THRESHOLD, DEFAULT_GESTURE_THRESHOLD),
+                    mouseDragMovementMode = normalizeMouseDragMovementMode(
+                        obj.optString(KEY_MOUSE_DRAG_MOVEMENT_MODE, MOUSE_DRAG_MOVEMENT_DIRECT),
+                    ),
                 )
             } catch (_: Exception) {
                 compatibilityDefaults()
@@ -270,6 +281,14 @@ data class TouchGestureConfig(
             return if (value == MOUSE_BEHAVIOR_CLICK) MOUSE_BEHAVIOR_CLICK else MOUSE_BEHAVIOR_HOLD
         }
 
+        fun normalizeMouseDragMovementMode(mode: String?): String {
+            return if (mode == MOUSE_DRAG_MOVEMENT_RELATIVE) {
+                MOUSE_DRAG_MOVEMENT_RELATIVE
+            } else {
+                MOUSE_DRAG_MOVEMENT_DIRECT
+            }
+        }
+
         /** Ordered list of pan/camera-drag actions. */
         val PAN_ACTIONS = listOf(
             PAN_ARROW_KEYS,
@@ -277,6 +296,11 @@ data class TouchGestureConfig(
             PAN_MIDDLE_MOUSE,
             PAN_LEFT_CLICK_DRAG,
             PAN_RIGHT_CLICK_DRAG,
+        )
+
+        val MOUSE_DRAG_MOVEMENT_MODES = listOf(
+            MOUSE_DRAG_MOVEMENT_DIRECT,
+            MOUSE_DRAG_MOVEMENT_RELATIVE,
         )
 
         /** Ordered list of zoom/pinch actions. */

--- a/app/src/main/java/app/gamenative/ui/component/dialog/TouchGestureSettingsDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/TouchGestureSettingsDialog.kt
@@ -33,6 +33,9 @@ import app.gamenative.data.TouchGestureConfig.Companion.ACTION_RIGHT_CLICK
 import app.gamenative.data.TouchGestureConfig.Companion.ACTION_SHOW_KEYBOARD
 import app.gamenative.data.TouchGestureConfig.Companion.MOUSE_BEHAVIOR_CLICK
 import app.gamenative.data.TouchGestureConfig.Companion.MOUSE_BEHAVIOR_HOLD
+import app.gamenative.data.TouchGestureConfig.Companion.MOUSE_DRAG_MOVEMENT_DIRECT
+import app.gamenative.data.TouchGestureConfig.Companion.MOUSE_DRAG_MOVEMENT_MODES
+import app.gamenative.data.TouchGestureConfig.Companion.MOUSE_DRAG_MOVEMENT_RELATIVE
 import app.gamenative.data.TouchGestureConfig.Companion.PAN_ACTIONS
 import app.gamenative.data.TouchGestureConfig.Companion.PAN_ARROW_KEYS
 import app.gamenative.data.TouchGestureConfig.Companion.PAN_LEFT_CLICK_DRAG
@@ -353,6 +356,19 @@ fun TouchGestureSettingsDialog(
                     onValueChange = { config = config.copy(gestureThreshold = it) },
                 )
 
+                SettingsListDropdown(
+                    colors = settingsTileColorsAlt(),
+                    title = { Text(stringResource(R.string.gesture_mouse_drag_movement)) },
+                    subtitle = { Text(stringResource(R.string.gesture_mouse_drag_movement_subtitle)) },
+                    value = MOUSE_DRAG_MOVEMENT_MODES
+                        .indexOf(config.mouseDragMovementMode)
+                        .coerceAtLeast(0),
+                    items = MOUSE_DRAG_MOVEMENT_MODES.map { mouseDragMovementModeLabel(it) },
+                    onItemSelected = { index ->
+                        config = config.copy(mouseDragMovementMode = MOUSE_DRAG_MOVEMENT_MODES[index])
+                    },
+                )
+
                 // ── Show Click Highlight ─────────────────────────────────
                 SettingsSwitch(
                     colors = settingsTileColorsAlt(),
@@ -587,6 +603,13 @@ private fun zoomActionLabel(action: String): String = when (action) {
     ZOOM_PLUS_MINUS -> stringResource(R.string.gesture_zoom_plus_minus)
     ZOOM_PAGE_UP_DOWN -> stringResource(R.string.gesture_zoom_page_up_down)
     else -> action
+}
+
+@Composable
+private fun mouseDragMovementModeLabel(mode: String): String = when (mode) {
+    MOUSE_DRAG_MOVEMENT_RELATIVE -> stringResource(R.string.gesture_mouse_drag_movement_relative)
+    MOUSE_DRAG_MOVEMENT_DIRECT -> stringResource(R.string.gesture_mouse_drag_movement_direct)
+    else -> mode
 }
 
 // ── Categorized action picker for tap/hold gestures ─────────────────────

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -1067,10 +1067,8 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
             String twoFingerDragAction = gestureConfig.getTwoFingerDragAction();
             if (isClickDragAction(twoFingerDragAction)) {
                 if (useRelativeMouseDragMovement()) {
-                    if (Math.abs(dx) > 3f || Math.abs(dy) > 3f) {
-                        twoFingerDragging = true;
-                        performClickDragWithRelativeMovement(dx, dy, twoFingerDragAction);
-                    }
+                    twoFingerDragging = true;
+                    performClickDragWithRelativeMovement(dx, dy, twoFingerDragAction);
                 } else {
                     twoFingerDragging = true;
                     performClickDragAt(midX, midY, twoFingerDragAction);
@@ -1361,14 +1359,12 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         }
 
         if (threeFingerGestureMode == THREE_FINGER_GESTURE_PAN) {
-            // #3: Minimum drag distance — require 3px of per-frame movement to emit pan events
+            // #3: Minimum drag distance - require 3px of per-frame movement for non-click pan actions
             String threeFingerDragAction = gestureConfig.getThreeFingerDragAction();
             if (isClickDragAction(threeFingerDragAction)) {
                 if (useRelativeMouseDragMovement()) {
-                    if (Math.abs(dx) > 3f || Math.abs(dy) > 3f) {
-                        threeFingerDragging = true;
-                        performClickDragWithRelativeMovement(dx, dy, threeFingerDragAction);
-                    }
+                    threeFingerDragging = true;
+                    performClickDragWithRelativeMovement(dx, dy, threeFingerDragAction);
                 } else {
                     threeFingerDragging = true;
                     performClickDragAt(midX, midY, threeFingerDragAction);

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -871,7 +871,15 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         int y = (int) pt[1];
 
         if (holdMouseButtonTouchActive) {
-            moveCursorTo(x, y);
+            float rawX = event.getX(pointerIndex);
+            float rawY = event.getY(pointerIndex);
+            if (useRelativeMouseDragMovement()) {
+                moveCursorByRelativeDelta(rawX - singleFingerLastRawX, rawY - singleFingerLastRawY);
+            } else {
+                moveCursorTo(x, y);
+            }
+            singleFingerLastRawX = rawX;
+            singleFingerLastRawY = rawY;
             return;
         }
 
@@ -903,7 +911,11 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
             // (or is a no-op for the key-pan variants, which press per
             // direction on their next move frame).
             if (isClickDragAction(dragAction)) {
-                performClickDragAt(event.getX(pointerIndex), event.getY(pointerIndex), dragAction);
+                if (useRelativeMouseDragMovement()) {
+                    pressClickDragButton(buttonForClickDragAction(dragAction));
+                } else {
+                    performClickDragAt(event.getX(pointerIndex), event.getY(pointerIndex), dragAction);
+                }
             } else {
                 performPanAction(0f, 0f, dragAction);
             }
@@ -914,7 +926,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
         if (isDragging) {
             String dragAction = gestureConfig.getDragAction();
-            if (isClickDragAction(dragAction)) {
+            if (isClickDragAction(dragAction) && !useRelativeMouseDragMovement()) {
                 moveCursorTo(x, y);
                 return;
             }
@@ -925,7 +937,11 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
             float dy = rawY - singleFingerLastRawY;
             singleFingerLastRawX = rawX;
             singleFingerLastRawY = rawY;
-            performPanAction(dx, dy, dragAction);
+            if (isClickDragAction(dragAction)) {
+                performClickDragWithRelativeMovement(dx, dy, dragAction);
+            } else {
+                performPanAction(dx, dy, dragAction);
+            }
             return;
         }
 
@@ -1050,8 +1066,15 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         if (twoFingerGestureMode == TWO_FINGER_GESTURE_PAN) {
             String twoFingerDragAction = gestureConfig.getTwoFingerDragAction();
             if (isClickDragAction(twoFingerDragAction)) {
-                twoFingerDragging = true;
-                performClickDragAt(midX, midY, twoFingerDragAction);
+                if (useRelativeMouseDragMovement()) {
+                    if (Math.abs(dx) > 3f || Math.abs(dy) > 3f) {
+                        twoFingerDragging = true;
+                        performClickDragWithRelativeMovement(dx, dy, twoFingerDragAction);
+                    }
+                } else {
+                    twoFingerDragging = true;
+                    performClickDragAt(midX, midY, twoFingerDragAction);
+                }
             } else if (Math.abs(dx) > 3f || Math.abs(dy) > 3f) {
                 twoFingerDragging = true;
                 performPanAction(dx, dy, twoFingerDragAction);
@@ -1341,8 +1364,15 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
             // #3: Minimum drag distance — require 3px of per-frame movement to emit pan events
             String threeFingerDragAction = gestureConfig.getThreeFingerDragAction();
             if (isClickDragAction(threeFingerDragAction)) {
-                threeFingerDragging = true;
-                performClickDragAt(midX, midY, threeFingerDragAction);
+                if (useRelativeMouseDragMovement()) {
+                    if (Math.abs(dx) > 3f || Math.abs(dy) > 3f) {
+                        threeFingerDragging = true;
+                        performClickDragWithRelativeMovement(dx, dy, threeFingerDragAction);
+                    }
+                } else {
+                    threeFingerDragging = true;
+                    performClickDragAt(midX, midY, threeFingerDragAction);
+                }
             } else if (Math.abs(dx) > 3f || Math.abs(dy) > 3f) {
                 threeFingerDragging = true;
                 performPanAction(dx, dy, threeFingerDragAction);
@@ -1629,10 +1659,17 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
                 || TouchGestureConfig.PAN_RIGHT_CLICK_DRAG.equals(action);
     }
 
-    private void performClickDragAt(float rawX, float rawY, String action) {
-        Pointer.Button button = TouchGestureConfig.PAN_RIGHT_CLICK_DRAG.equals(action)
+    private boolean useRelativeMouseDragMovement() {
+        return TouchGestureConfig.MOUSE_DRAG_MOVEMENT_RELATIVE.equals(gestureConfig.getMouseDragMovementMode());
+    }
+
+    private Pointer.Button buttonForClickDragAction(String action) {
+        return TouchGestureConfig.PAN_RIGHT_CLICK_DRAG.equals(action)
                 ? Pointer.Button.BUTTON_RIGHT : Pointer.Button.BUTTON_LEFT;
-        pressClickDragButton(button);
+    }
+
+    private void performClickDragAt(float rawX, float rawY, String action) {
+        pressClickDragButton(buttonForClickDragAction(action));
         float[] pt = XForm.transformPoint(xform, rawX, rawY);
         moveCursorTo((int) pt[0], (int) pt[1]);
     }
@@ -1650,6 +1687,11 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         moveCursorByDelta(dx, dy);
     }
 
+    private void performClickDragWithRelativeMovement(float dx, float dy, String action) {
+        pressClickDragButton(buttonForClickDragAction(action));
+        moveCursorByRelativeDelta(dx, dy);
+    }
+
     private void pressClickDragButton(Pointer.Button button) {
         if (button == Pointer.Button.BUTTON_LEFT && !leftClickDragButtonDown) {
             xServer.injectPointerButtonPress(Pointer.Button.BUTTON_LEFT);
@@ -1657,6 +1699,18 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         } else if (button == Pointer.Button.BUTTON_RIGHT && !rightClickDragButtonDown) {
             xServer.injectPointerButtonPress(Pointer.Button.BUTTON_RIGHT);
             rightClickDragButtonDown = true;
+        }
+    }
+
+    private void moveCursorByRelativeDelta(float dx, float dy) {
+        float[] ptOrigin = XForm.transformPoint(xform, 0, 0);
+        float[] ptDelta  = XForm.transformPoint(xform, dx, dy);
+        int mx = (int) (ptDelta[0] - ptOrigin[0]);
+        int my = (int) (ptDelta[1] - ptOrigin[1]);
+        if (xServer.isRelativeMouseMovement()) {
+            xServer.getWinHandler().mouseEvent(MouseEventFlags.MOVE, mx, my, 0);
+        } else {
+            xServer.injectPointerMoveDelta(mx, my);
         }
     }
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -600,6 +600,10 @@
     <string name="gesture_three_finger_hold_delay">Forsinkelse for hold med tre fingre (ms)</string>
     <string name="gesture_threshold">Gestus-tærskel (px)</string>
     <string name="gesture_threshold_subtitle">Bevægelse, der kræves for at låse gestustypen (lavere = mere responsiv)</string>
+    <string name="gesture_mouse_drag_movement">Musebevægelse ved træk</string>
+    <string name="gesture_mouse_drag_movement_subtitle">Direkte virker for de fleste spil. Brug Relativ, hvis træk giver kamera- eller markørproblemer</string>
+    <string name="gesture_mouse_drag_movement_direct">Direkte</string>
+    <string name="gesture_mouse_drag_movement_relative">Relativ</string>
     <string name="gesture_show_click_highlight">Vis klikfremhævning</string>
     <string name="gesture_show_click_highlight_subtitle">Vis en cirkel ved trykplacering</string>
     <string name="gesture_show_debug_overlay">Vis fejlfindings-overlay for gestus</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -749,6 +749,10 @@
     <string name="gesture_three_finger_hold_delay">Verzögerung für Halten mit drei Fingern (ms)</string>
     <string name="gesture_threshold">Gestenschwelle (px)</string>
     <string name="gesture_threshold_subtitle">Bewegung zum Sperren des Gestentyps (niedriger = reaktionsschneller)</string>
+    <string name="gesture_mouse_drag_movement">Mausbewegung beim Ziehen</string>
+    <string name="gesture_mouse_drag_movement_subtitle">Direkt funktioniert für die meisten Spiele. Verwende Relativ, wenn Ziehen Kamera- oder Cursorprobleme verursacht</string>
+    <string name="gesture_mouse_drag_movement_direct">Direkt</string>
+    <string name="gesture_mouse_drag_movement_relative">Relativ</string>
     <string name="gesture_show_click_highlight">Klickhervorhebung anzeigen</string>
     <string name="gesture_show_click_highlight_subtitle">Kreis an Tipp-Position anzeigen</string>
     <string name="gesture_show_debug_overlay">Gesten-Debug-Overlay anzeigen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -824,6 +824,10 @@
     <string name="gesture_three_finger_hold_delay">Retardo de mantener con tres dedos (ms)</string>
     <string name="gesture_threshold">Umbral de gesto (px)</string>
     <string name="gesture_threshold_subtitle">Movimiento necesario para bloquear el tipo de gesto (menor = más sensible)</string>
+    <string name="gesture_mouse_drag_movement">Movimiento del ratón al arrastrar</string>
+    <string name="gesture_mouse_drag_movement_subtitle">Directo funciona en la mayoría de juegos. Usa Relativo si arrastrar causa problemas de cámara o cursor</string>
+    <string name="gesture_mouse_drag_movement_direct">Directo</string>
+    <string name="gesture_mouse_drag_movement_relative">Relativo</string>
     <string name="gesture_show_click_highlight">Mostrar resaltado de clic</string>
     <string name="gesture_show_click_highlight_subtitle">Mostrar un círculo en la ubicación del toque</string>
     <string name="gesture_show_debug_overlay">Mostrar superposición de depuración de gestos</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -775,6 +775,10 @@
     <string name="gesture_three_finger_hold_delay">Délai du maintien à trois doigts (ms)</string>
     <string name="gesture_threshold">Seuil du geste (px)</string>
     <string name="gesture_threshold_subtitle">Mouvement requis pour verrouiller le type de geste (plus bas = plus réactif)</string>
+    <string name="gesture_mouse_drag_movement">Mouvement de la souris lors du glissement</string>
+    <string name="gesture_mouse_drag_movement_subtitle">Direct fonctionne pour la plupart des jeux. Utilisez Relatif si le glissement provoque des problèmes de caméra ou de curseur</string>
+    <string name="gesture_mouse_drag_movement_direct">Direct</string>
+    <string name="gesture_mouse_drag_movement_relative">Relatif</string>
     <string name="gesture_show_click_highlight">Afficher la mise en évidence du clic</string>
     <string name="gesture_show_click_highlight_subtitle">Afficher un cercle à l\'emplacement du toucher</string>
     <string name="gesture_show_debug_overlay">Afficher la superposition de débogage des gestes</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -779,6 +779,10 @@
     <string name="gesture_three_finger_hold_delay">Ritardo pressione con tre dita (ms)</string>
     <string name="gesture_threshold">Soglia gesto (px)</string>
     <string name="gesture_threshold_subtitle">Movimento necessario per bloccare il tipo di gesto (più basso = più reattivo)</string>
+    <string name="gesture_mouse_drag_movement">Movimento del mouse durante il trascinamento</string>
+    <string name="gesture_mouse_drag_movement_subtitle">Diretto funziona con la maggior parte dei giochi. Usa Relativo se il trascinamento causa problemi alla visuale o al cursore</string>
+    <string name="gesture_mouse_drag_movement_direct">Diretto</string>
+    <string name="gesture_mouse_drag_movement_relative">Relativo</string>
     <string name="gesture_show_click_highlight">Mostra evidenziazione clic</string>
     <string name="gesture_show_click_highlight_subtitle">Mostra un cerchio nella posizione del tocco</string>
     <string name="gesture_show_debug_overlay">Mostra overlay debug gesture</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -795,6 +795,10 @@
     <string name="gesture_three_finger_hold_delay">3 本指ホールド遅延 (ミリ秒)</string>
     <string name="gesture_threshold">ジェスチャーのしきい値 (px)</string>
     <string name="gesture_threshold_subtitle">ジェスチャ タイプをロックするために必要な動作 (低い = 応答性が高い)</string>
+    <string name="gesture_mouse_drag_movement">ドラッグ時のマウス移動</string>
+    <string name="gesture_mouse_drag_movement_subtitle">ほとんどのゲームではダイレクトが動作します。ドラッグでカメラやカーソルに問題が出る場合は相対を使用してください</string>
+    <string name="gesture_mouse_drag_movement_direct">ダイレクト</string>
+    <string name="gesture_mouse_drag_movement_relative">相対</string>
     <string name="gesture_show_click_highlight">クリックハイライトを表示</string>
     <string name="gesture_show_click_highlight_subtitle">タップした位置に円を表示</string>
     <string name="gesture_show_debug_overlay">ジェスチャ デバッグ オーバーレイを表示</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -789,6 +789,10 @@
     <string name="gesture_three_finger_hold_delay">세 손가락 길게 누르기 지연 (ms)</string>
     <string name="gesture_threshold">제스처 임계값 (px)</string>
     <string name="gesture_threshold_subtitle">제스처 유형을 고정하는 데 필요한 이동 거리 (낮을수록 더 반응이 빠름)</string>
+    <string name="gesture_mouse_drag_movement">드래그 시 마우스 이동</string>
+    <string name="gesture_mouse_drag_movement_subtitle">대부분의 게임에서는 직접 모드가 작동합니다. 드래그 시 카메라나 커서 문제가 있으면 상대 모드를 사용하세요</string>
+    <string name="gesture_mouse_drag_movement_direct">직접</string>
+    <string name="gesture_mouse_drag_movement_relative">상대</string>
     <string name="gesture_show_click_highlight">클릭 강조 표시</string>
     <string name="gesture_show_click_highlight_subtitle">탭 위치에 원 표시</string>
     <string name="gesture_show_debug_overlay">제스처 디버그 오버레이 표시</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -788,6 +788,10 @@
     <string name="gesture_three_finger_hold_delay">Opóźnienie przytrzymania trzema palcami (ms)</string>
     <string name="gesture_threshold">Próg gestu (px)</string>
     <string name="gesture_threshold_subtitle">Ruch wymagany do zablokowania typu gestu (niższy = większa responsywność)</string>
+    <string name="gesture_mouse_drag_movement">Ruch myszy podczas przeciągania</string>
+    <string name="gesture_mouse_drag_movement_subtitle">Bezpośredni działa w większości gier. Użyj względnego, jeśli przeciąganie powoduje problemy z kamerą lub kursorem</string>
+    <string name="gesture_mouse_drag_movement_direct">Bezpośredni</string>
+    <string name="gesture_mouse_drag_movement_relative">Względny</string>
     <string name="gesture_show_click_highlight">Pokaż podświetlenie kliknięcia</string>
     <string name="gesture_show_click_highlight_subtitle">Pokaż okrąg w miejscu stuknięcia</string>
     <string name="gesture_show_debug_overlay">Pokaż nakładkę debugowania gestów</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -600,6 +600,10 @@
     <string name="gesture_three_finger_hold_delay">Atraso ao segurar com três dedos (ms)</string>
     <string name="gesture_threshold">Limite do gesto (px)</string>
     <string name="gesture_threshold_subtitle">Movimento necessário para travar o tipo de gesto (menor = mais responsivo)</string>
+    <string name="gesture_mouse_drag_movement">Movimento do mouse ao arrastar</string>
+    <string name="gesture_mouse_drag_movement_subtitle">Direto funciona na maioria dos jogos. Use Relativo se arrastar causar problemas na câmera ou no cursor</string>
+    <string name="gesture_mouse_drag_movement_direct">Direto</string>
+    <string name="gesture_mouse_drag_movement_relative">Relativo</string>
     <string name="gesture_show_click_highlight">Mostrar destaque de clique</string>
     <string name="gesture_show_click_highlight_subtitle">Mostrar um círculo no local do toque</string>
     <string name="gesture_show_debug_overlay">Mostrar sobreposição de depuração de gestos</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -780,6 +780,10 @@
     <string name="gesture_three_finger_hold_delay">Întârziere menținere cu trei degete (ms)</string>
     <string name="gesture_threshold">Prag gest (px)</string>
     <string name="gesture_threshold_subtitle">Mișcare necesară pentru a bloca tipul de gest (mai mic = mai receptiv)</string>
+    <string name="gesture_mouse_drag_movement">Mișcarea mouse-ului la glisare</string>
+    <string name="gesture_mouse_drag_movement_subtitle">Direct funcționează în majoritatea jocurilor. Folosește Relativ dacă glisarea provoacă probleme cu camera sau cursorul</string>
+    <string name="gesture_mouse_drag_movement_direct">Direct</string>
+    <string name="gesture_mouse_drag_movement_relative">Relativ</string>
     <string name="gesture_show_click_highlight">Afișează evidențierea clicului</string>
     <string name="gesture_show_click_highlight_subtitle">Afișează un cerc la locația atingerii</string>
     <string name="gesture_show_debug_overlay">Afișează suprapunerea de depanare a gesturilor</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -475,6 +475,10 @@
     <string name="gesture_three_finger_hold_delay">Задержка удержания тремя пальцами (мс)</string>
     <string name="gesture_threshold">Порог жеста (px)</string>
     <string name="gesture_threshold_subtitle">Движение, необходимое для фиксации типа жеста (меньше = быстрее отклик)</string>
+    <string name="gesture_mouse_drag_movement">Движение мыши при перетаскивании</string>
+    <string name="gesture_mouse_drag_movement_subtitle">Прямой режим подходит для большинства игр. Используйте относительный, если перетаскивание вызывает проблемы с камерой или курсором</string>
+    <string name="gesture_mouse_drag_movement_direct">Прямой</string>
+    <string name="gesture_mouse_drag_movement_relative">Относительный</string>
     <string name="gesture_show_click_highlight">Показывать подсветку клика</string>
     <string name="gesture_show_click_highlight_subtitle">Показывать круг в месте касания</string>
     <string name="gesture_show_debug_overlay">Показывать отладочный оверлей жестов</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -774,6 +774,10 @@
     <string name="gesture_three_finger_hold_delay">Затримка утримання трьома пальцями (мс)</string>
     <string name="gesture_threshold">Поріг жесту (px)</string>
     <string name="gesture_threshold_subtitle">Рух, потрібний для фіксації типу жесту (нижче = вища чутливість)</string>
+    <string name="gesture_mouse_drag_movement">Рух миші під час перетягування</string>
+    <string name="gesture_mouse_drag_movement_subtitle">Прямий режим працює в більшості ігор. Використовуйте відносний, якщо перетягування спричиняє проблеми з камерою або курсором</string>
+    <string name="gesture_mouse_drag_movement_direct">Прямий</string>
+    <string name="gesture_mouse_drag_movement_relative">Відносний</string>
     <string name="gesture_show_click_highlight">Показувати підсвічування кліку</string>
     <string name="gesture_show_click_highlight_subtitle">Показувати коло в місці торкання</string>
     <string name="gesture_show_debug_overlay">Показувати оверлей налагодження жестів</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -770,6 +770,10 @@
     <string name="gesture_three_finger_hold_delay">三指长按延迟 (ms)</string>
     <string name="gesture_threshold">手势阈值 (px)</string>
     <string name="gesture_threshold_subtitle">锁定手势类型所需的移动距离（越低越灵敏）</string>
+    <string name="gesture_mouse_drag_movement">拖动时的鼠标移动</string>
+    <string name="gesture_mouse_drag_movement_subtitle">直接模式适用于大多数游戏。如果拖动导致镜头或光标问题，请使用相对模式</string>
+    <string name="gesture_mouse_drag_movement_direct">直接</string>
+    <string name="gesture_mouse_drag_movement_relative">相对</string>
     <string name="gesture_show_click_highlight">显示点击高亮</string>
     <string name="gesture_show_click_highlight_subtitle">在点击位置显示圆圈</string>
     <string name="gesture_show_debug_overlay">显示手势调试叠加层</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -772,6 +772,10 @@
     <string name="gesture_three_finger_hold_delay">三指長按延遲 (ms)</string>
     <string name="gesture_threshold">手勢閾值 (px)</string>
     <string name="gesture_threshold_subtitle">鎖定手勢類型所需的移動距離（越低越靈敏）</string>
+    <string name="gesture_mouse_drag_movement">拖曳時的滑鼠移動</string>
+    <string name="gesture_mouse_drag_movement_subtitle">直接模式適用於大多數遊戲。如果拖曳造成鏡頭或游標問題，請使用相對模式</string>
+    <string name="gesture_mouse_drag_movement_direct">直接</string>
+    <string name="gesture_mouse_drag_movement_relative">相對</string>
     <string name="gesture_show_click_highlight">顯示點擊高亮</string>
     <string name="gesture_show_click_highlight_subtitle">在點擊位置顯示圓圈</string>
     <string name="gesture_show_debug_overlay">顯示手勢除錯疊加層</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -815,6 +815,10 @@
     <string name="gesture_three_finger_hold_delay">Three-Finger Hold Delay (ms)</string>
     <string name="gesture_threshold">Gesture Threshold (px)</string>
     <string name="gesture_threshold_subtitle">Movement needed to lock gesture type (lower = more responsive)</string>
+    <string name="gesture_mouse_drag_movement">Mouse Drag Movement</string>
+    <string name="gesture_mouse_drag_movement_subtitle">Direct works for most games. Use Relative if dragging causes camera or cursor issues</string>
+    <string name="gesture_mouse_drag_movement_direct">Direct</string>
+    <string name="gesture_mouse_drag_movement_relative">Relative</string>
     <string name="gesture_show_click_highlight">Show Click Highlight</string>
     <string name="gesture_show_click_highlight_subtitle">Show a circle at tap location</string>
     <string name="gesture_show_debug_overlay">Show Gesture Debug Overlay</string>


### PR DESCRIPTION
﻿## Description

This should fix the issue reported here: https://www.reddit.com/r/EmulationOnAndroid/comments/1tymqfj/comment/oqaugej/

Adds a Touch Gesture Settings > Other > Mouse Drag Movement option with two options.
1. "Direct" which is the default/current behavior to preserve existing touchscreen drag behavior.
2. "Relative" which is for mouse-button drag gestures in games that recenter or warp the cursor.

The setting affects drag finger, 2F Drag, 3F Drag and the new Hold Mouse Button While Touching gesture as well.

Also adds translations for these changes.

## Recording

https://github.com/user-attachments/assets/7d6e33bf-cbf2-4518-b623-180af1413de7

## Type of Change
- [X] Bug fix
- [ ] Performance / stability improvement
- [X] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Mouse Drag Movement setting with Direct (default) and Relative modes for touchscreen mouse-button drags, and fixes the multi-finger relative click-drag threshold. This resolves camera/cursor issues in games that recenter or warp the cursor.

- **New Features**
  - New setting in Touch Gesture Settings > Other: Mouse Drag Movement (Direct default, Relative).
  - Relative sends deltas while holding the mouse button; Direct keeps absolute movement.
  - Applies to single-, two-, and three-finger drags and Hold Mouse Button While Touching.
  - Added translations for the new labels.

<sup>Written for commit 8607abac4b9bc004c02524781433164c98c845c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable mouse-drag movement mode in touch gesture settings, letting users choose between Direct and Relative drag behavior for different game types.
  * Exposed the new option in the gesture settings UI so users can select their preferred drag mode.
  * Added localized UI text for this setting across 16+ languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->