### PR TITLE
fix: put bionic steam stop in background to avoid ANR

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3967,10 +3967,15 @@ private fun exit(
     // down so the next launch can stand up a fresh pipe / user instead of
     // inheriting the previous session's half-dead state.
     if (container.isLaunchBionicSteam) {
-        try {
-            SteamBootstrap.stop()
-        } catch (e: Exception) {
-            Timber.e(e, "SteamBootstrap.stop() failed during exit")
+        // Launch async to avoid ANR if nativeShutdown() takes >5s
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                Timber.d("SteamBootstrap stopping...")
+                SteamBootstrap.stop()
+                Timber.d("SteamBootstrap stopped successfully")
+            } catch (e: Exception) {
+                Timber.e(e, "SteamBootstrap.stop() failed during exit")
+            }
         }
     }
 


### PR DESCRIPTION
## Description
fix: put bionic steam stop in background to avoid ANR

## Recording
None

## Type of Change
- [ ] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `SteamBootstrap.stop()` for Bionic Steam exits in a background `CoroutineScope(Dispatchers.IO)` to prevent ANR during app exit. Adds debug logs for start/success and keeps error logging via `Timber`.

<sup>Written for commit 2739113591813f0d48766bcd6a3b9c67a615e077. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown responsiveness by preventing the exit process from blocking the UI thread. Error handling and logging during shutdown remain intact to ensure reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->