### PR TITLE
Fix - Loading hang at Handling DRM by using wineserver -k

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -4064,11 +4064,14 @@ private fun unpackExecutableFile(
     if (needsUnpacking || containerVariantChanged){
         try {
             PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Installing Mono..."))
-            val monoCmd = "wine msiexec /i Z:\\opt\\mono-gecko-offline\\wine-mono-11.0.0-x86.msi && wineserver -k"
+            // Note: && is NOT interpreted by ProcessBuilder (no shell), so wineserver -k must
+            // be a separate execShellCommand call after the wine process exits.
+            val monoCmd = "wine msiexec /i Z:\\opt\\mono-gecko-offline\\wine-mono-11.0.0-x86.msi"
             Timber.i("Install mono command $monoCmd")
             val monoOutput = guestProgramLauncherComponent.execShellCommand(monoCmd)
             output.append(monoOutput)
             Timber.i("Result of mono command " + output)
+            guestProgramLauncherComponent.execShellCommand("wineserver -k")
         } catch (e: Exception) {
             Timber.e("Error during mono installation: $e")
         }
@@ -4102,6 +4105,8 @@ private fun unpackExecutableFile(
                                 val genCmd = "wine z:\\generate_interfaces_file.exe A:\\" + relDllPath.replace('/', '\\')
                                 Timber.i("Running generate_interfaces_file $genCmd")
                                 val genOutput = guestProgramLauncherComponent.execShellCommand(genCmd)
+                                // Note: && is NOT interpreted by ProcessBuilder (no shell) — run wineserver -k separately.
+                                guestProgramLauncherComponent.execShellCommand("wineserver -k")
 
                                 val origSteamInterfaces = File("${imageFs.wineprefix}/dosdevices/z:/steam_interfaces.txt")
                                 if (origSteamInterfaces.exists()) {
@@ -4169,6 +4174,7 @@ private fun unpackExecutableFile(
 
                         val slCmd = "wine z:\\tmp\\steamless_wrapper.bat"
                         val slOutput = guestProgramLauncherComponent.execShellCommand(slCmd)
+                        guestProgramLauncherComponent.execShellCommand("wineserver -k")
                         output.append(slOutput)
                         Timber.i("Finished processing executable. Result: $output")
                     } catch (e: Exception) {

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -4104,9 +4104,18 @@ private fun unpackExecutableFile(
                             if (origDll.exists()) {
                                 val genCmd = "wine z:\\generate_interfaces_file.exe A:\\" + relDllPath.replace('/', '\\')
                                 Timber.i("Running generate_interfaces_file $genCmd")
-                                val genOutput = guestProgramLauncherComponent.execShellCommand(genCmd)
-                                // Note: && is NOT interpreted by ProcessBuilder (no shell) — run wineserver -k separately.
-                                guestProgramLauncherComponent.execShellCommand("wineserver -k")
+                                var genOutput = ""
+                                try {
+                                    genOutput = guestProgramLauncherComponent.execShellCommand(genCmd)
+                                } finally {
+                                    // Kill wineserver to flush registry state written by
+                                    // generate_interfaces_file.exe before reading its output file.
+                                    try {
+                                        guestProgramLauncherComponent.execShellCommand("wineserver -k")
+                                    } catch (_: Exception) {
+                                        // cleanup failure — don't propagate
+                                    }
+                                }
 
                                 val origSteamInterfaces = File("${imageFs.wineprefix}/dosdevices/z:/steam_interfaces.txt")
                                 if (origSteamInterfaces.exists()) {
@@ -4174,13 +4183,19 @@ private fun unpackExecutableFile(
 
                         val slCmd = "wine z:\\tmp\\steamless_wrapper.bat"
                         val slOutput = guestProgramLauncherComponent.execShellCommand(slCmd)
-                        guestProgramLauncherComponent.execShellCommand("wineserver -k")
                         output.append(slOutput)
                         Timber.i("Finished processing executable. Result: $output")
                     } catch (e: Exception) {
                         Timber.e(e, "Error running Steamless on $executablePath")
                         output.append("Error processing $executablePath: ${e.message}\n")
                     } finally {
+                        // Kill wineserver after each Steamless run to ensure clean state for
+                        // the next iteration and prevent stale wineserver processes accumulating.
+                        try {
+                            guestProgramLauncherComponent.execShellCommand("wineserver -k")
+                        } catch (_: Exception) {
+                            // cleanup failure — don't propagate
+                        }
                         batchFile?.delete()
                     }
 


### PR DESCRIPTION
## Description
Kill stale wineserver left over that could cause loading hangs in Handling DRM.

After mono, it now calls execShellCommand("wineserver -k") which:
- Tells wineserver to shut down
- Blocks (via execWithOutput.waitFor()) until wineserver has finished all pending MSI registry work and fully exited
- Only then does generate_interfaces_file.exe start, with a clean, idle wineserver and no registry contention

Safe to use, as when wineserver shuts down, all registry changes (user.reg, system.reg) are written to disk in the Wine prefix. Shutting it down doesn't lose data.

With wineserver -k:
Registry flushes complete before the next command starts Result: Clean, fast, sequential execution

Confirmed loading and working with no stalls in Retroid Pocker G2

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loading hangs during DRM handling by cleanly shutting down the Wine server between steps. Adds explicit `wineserver -k` calls to flush MSI/registry state and prevent contention.

- **Bug Fixes**
  - Run `wineserver -k` via `execShellCommand` after `wine msiexec`, after `generate_interfaces_file.exe` (before reading `steam_interfaces.txt`), and after each Steamless wrapper run.
  - Place shutdowns in `finally` blocks with best-effort try/catch to guarantee cleanup without breaking flow.
  - Use separate calls because `ProcessBuilder` doesn't interpret `&&`; ensures each step completes before the next.

<sup>Written for commit bcf978589758fcc30494ce643ac9dab723a625e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced executable unpacking with improved command execution sequencing and process management to ensure more reliable installation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->