### PR TITLE
fix(): Fixed AppData subfolder detection bug to fix Disco Eslysium save path resolution

### DIFF
--- a/app/src/main/java/app/gamenative/service/epic/EpicCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicCloudSavesManager.kt
@@ -1262,10 +1262,16 @@ object EpicCloudSavesManager {
             }
         }
 
-        // resolve against on-disk casing to avoid creating duplicate dirs (e.g. locallow vs LocalLow)
-        // supersedes PR #701
-        val joinedPath = normalizedParts.joinToString("/")
-        val resolved = FileUtils.resolveCaseInsensitive(File("/"), joinedPath)
+        // Resolve against on-disk casing to avoid creating duplicate dirs (e.g. locallow vs LocalLow).
+        val joinedPath = "/${canonicalizeAppDataSegments(normalizedParts).joinToString("/")}"
+        val trustedRoots = buildList {
+            add(usersPath)
+            add(File(winePrefix))
+            if (installDir.isNotEmpty()) {
+                add(File(installDir))
+            }
+        }
+        val resolved = resolveAbsolutePathCaseInsensitive(joinedPath, trustedRoots)
         // guard against path traversal escaping the wine prefix
         val absPath = resolved.absolutePath
         val withinPrefix = absPath.startsWith("$winePrefix/") || absPath == winePrefix ||
@@ -1321,6 +1327,51 @@ object EpicCloudSavesManager {
         Timber.tag("Epic").d("[Cloud Saves]   Resolved: ${actualPath.absolutePath}")
 
         return actualPath
+    }
+
+    internal fun resolveAbsolutePathCaseInsensitive(
+        path: String,
+        trustedRoots: List<File> = emptyList(),
+    ): File {
+        val normalizedPath = path.replace('\\', '/')
+        trustedRoots.firstNotNullOfOrNull { root ->
+            val rootPath = root.absolutePath.replace('\\', '/').trimEnd('/')
+            if (normalizedPath == rootPath || normalizedPath.startsWith("$rootPath/")) {
+                val relativePath = normalizedPath.removePrefix(rootPath).trimStart('/')
+                FileUtils.resolveCaseInsensitive(root, relativePath)
+            } else {
+                null
+            }
+        }?.let { return it }
+
+        val pathFile = File(normalizedPath)
+        val rootPath = pathFile.toPath().root?.toString()?.replace('\\', '/')
+        val base = when {
+            pathFile.isAbsolute && rootPath != null -> File(rootPath)
+            normalizedPath.startsWith("/") -> File("/")
+            else -> File("")
+        }
+        val relativePath = when {
+            pathFile.isAbsolute && rootPath != null -> normalizedPath.removePrefix(rootPath).trimStart('/')
+            else -> normalizedPath.trimStart('/')
+        }
+        return FileUtils.resolveCaseInsensitive(base, relativePath)
+    }
+
+    // Fixes issue where saves were being lost due to inconsistencies in lower-case sub-folders in AppData
+    internal fun canonicalizeAppDataSegments(segments: List<String>): List<String> {
+        return segments.mapIndexed { index, segment ->
+            if (index > 0 && segments[index - 1].equals("AppData", ignoreCase = true)) {
+                when (segment.lowercase()) {
+                    "local" -> "Local"
+                    "locallow" -> "LocalLow"
+                    "roaming" -> "Roaming"
+                    else -> segment
+                }
+            } else {
+                segment
+            }
+        }
     }
 
     private fun getSyncTimestamp(context: Context, appId: Int): String? {

--- a/app/src/test/java/app/gamenative/service/epic/EpicCloudSavesTest.kt
+++ b/app/src/test/java/app/gamenative/service/epic/EpicCloudSavesTest.kt
@@ -9,13 +9,16 @@ import app.gamenative.service.epic.manifest.EpicManifest
 import app.gamenative.service.epic.manifest.FileManifest
 import app.gamenative.service.epic.manifest.FileManifestList
 import app.gamenative.service.epic.manifest.ManifestMeta
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
+import org.junit.rules.TemporaryFolder
 
 /**
  * Tests for Epic Cloud Saves manifest & chunk correctness.
@@ -25,6 +28,9 @@ import java.nio.ByteOrder
  * and verified manually.
  */
 class EpicCloudSavesTest {
+
+    @get:Rule
+    val tmpDir = TemporaryFolder()
 
     // -------------------------------------------------------------------------
     // Rolling hash — test vectors produced by Legendary's get_hash()
@@ -74,6 +80,35 @@ class EpicCloudSavesTest {
     // -------------------------------------------------------------------------
     // CustomFields — read/write round-trip must be symmetric and include version byte
     // -------------------------------------------------------------------------
+
+    @Test
+    fun `absolute cloud save path resolves LocalLow using on-disk casing`() {
+        val wineUserDir = tmpDir.newFolder("prefix", "drive_c", "users", "xuser")
+        val saveDir = File(wineUserDir, "AppData/LocalLow/ZAUM Studio/Disco Elysium/SaveGames").apply {
+            mkdirs()
+        }
+
+        val metadataPath = File(wineUserDir, "AppData/locallow/ZAUM Studio/Disco Elysium/SaveGames")
+            .absolutePath
+            .replace('\\', '/')
+
+        val resolved = EpicCloudSavesManager.resolveAbsolutePathCaseInsensitive(
+            metadataPath,
+            trustedRoots = listOf(wineUserDir),
+        )
+
+        assertEquals(saveDir.absolutePath, resolved.absolutePath)
+        assertTrue(resolved.exists())
+    }
+
+    @Test
+    fun `AppData child segments are canonicalized before creating save paths`() {
+        val segments = listOf("data", "prefix", "AppData", "locallow", "ZAUM Studio")
+
+        val canonicalized = EpicCloudSavesManager.canonicalizeAppDataSegments(segments)
+
+        assertEquals(listOf("data", "prefix", "AppData", "LocalLow", "ZAUM Studio"), canonicalized)
+    }
 
     @Test
     fun `CustomFields round-trips through write then read`() {


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

AppData subfolders weren't be capitlized correctly and thus were being missed out by Epic's CloudSavesManager.

This was seen in Disco Elysium where saves weren't being uploaded or downloaded correctly as it couldn't detect the folder:

Here's what the fix now gives:



**Uploading:**
```
06-09 13:22:23.905  6332  8738 I Epic    : [Cloud Saves] Found 2 files to package
06-09 13:22:23.905  6332  8738 D Epic    : [Cloud Saves] Processing file: WHIRLING-IN-RAGS, DAY 1, 08-06(6_9_2026 9-36-35 AM).jpg (46829 bytes)
06-09 13:22:23.908  6332  8738 D Epic    : [Cloud Saves] Processing file: WHIRLING-IN-RAGS, DAY 1, 08-06(6_9_2026 9-36-35 AM).ntwtf.zip (879648 bytes)
06-09 13:22:23.990  6332  8738 D Epic    : [Cloud Saves] Finalized chunk #0: 923edbcd-6fee95ce-bdc08cb7-181e2643 groupNum=81 (870634 bytes)
06-09 13:22:23.991  6332  8738 I Epic    : [Cloud Saves] Packaged 2 files into 1 chunks
06-09 13:22:23.991  6332  8738 D Epic    : [Cloud Saves] Requesting write links for 2 files
06-09 13:22:23.991  6332  8738 D Epic    : [Cloud Saves] Requesting write link for: ChunksV4/81/AEA94C6F932CB580_923EDBCD6FEE95CEBDC08CB7181E2643.chunk
06-09 13:22:23.991  6332  8738 D Epic    : [Cloud Saves] Requesting write link for: manifests/2026.06.09-13.22.23.manifest
06-09 13:22:23.991  6332  8738 D Epic    : [Cloud Saves] Request body: {"files":["ChunksV4\/81\/AEA94C6F932CB580_923EDBCD6FEE95CEBDC08CB7181E2643.chunk","manifests\/2026.06.09-13.22.23.manifest"]}
06-09 13:22:24.139  6332  8738 D Epic    : [Cloud Saves] Response code: 200
06-09 13:22:24.139  6332  8738 I Epic    : [Cloud Saves] Received 2 write links
06-09 13:22:24.140  6332  8738 D Epic    : [Cloud Saves] Uploading chunk: ChunksV4/81/AEA94C6F932CB580_923EDBCD6FEE95CEBDC08CB7181E2643.chunk (870634 bytes)
06-09 13:22:25.573  6332  8738 I Epic    : [Cloud Saves] Uploaded chunk: ChunksV4/81/AEA94C6F932CB580_923EDBCD6FEE95CEBDC08CB7181E2643.chunk (870634 bytes)
06-09 13:22:25.573  6332  8738 D Epic    : [Cloud Saves] Uploading manifest: manifests/2026.06.09-13.22.23.manifest (430 bytes)
06-09 13:22:25.697  6332  8738 I Epic    : [Cloud Saves] Uploaded manifest: manifests/2026.06.09-13.22.23.manifest (430 bytes)
06-09 13:22:25.698  6332  8738 I Epic    : [Cloud Saves] Upload complete: 1 chunks uploaded
```


**Downloading:**
```
06-09 13:25:04.668  6332  8753 D Epic    : [Cloud Saves] Scanning path: /data/user/0/app.gamenative/files/imagefs/home/xuser-EPIC_362/.wine/drive_c/users/xuser/AppData/LocalLow/ZAUM Studio/Disco Elysium/SaveGames
06-09 13:25:04.668  6332  8753 D Epic    : [Cloud Saves] Path exists: true
06-09 13:25:04.668  6332  8753 D Epic    : [Cloud Saves] Total items in path: 2
06-09 13:25:04.668  6332  8753 D Epic    : [Cloud Saves]   FILE: WHIRLING-IN-RAGS, DAY 1, 08-06(6_9_2026 9-36-35 AM).jpg (46829 bytes)
06-09 13:25:04.668  6332  8753 D Epic    : [Cloud Saves]   FILE: WHIRLING-IN-RAGS, DAY 1, 08-06(6_9_2026 9-36-35 AM).ntwtf.zip (879648 bytes)

06-09 13:25:04.668  6332  8753 D Epic    : [Cloud Saves] Reconstructing file: WHIRLING-IN-RAGS, DAY 1, 08-06(6_9_2026 9-36-35 AM).jpg
06-09 13:25:04.669  6332  8753 I Epic    : [Cloud Saves] Reconstructed: WHIRLING-IN-RAGS, DAY 1, 08-06(6_9_2026 9-36-35 AM).jpg (46829 bytes)
06-09 13:25:04.669  6332  8753 D Epic    : [Cloud Saves] Reconstructing file: WHIRLING-IN-RAGS, DAY 1, 08-06(6_9_2026 9-36-35 AM).ntwtf.zip
06-09 13:25:04.670  6332  8753 I Epic    : [Cloud Saves] Reconstructed: WHIRLING-IN-RAGS, DAY 1, 08-06(6_9_2026 9-36-35 AM).ntwtf.zip (879648 bytes)
06-09 13:25:04.670  6332  8753 I Epic    : [Cloud Saves] Download complete: 2 files reconstructed
06-09 13:25:04.670  6332  8753 I Epic    : [Cloud Saves] Sync completed successfully
```


This is based on my testing with both unit tests & uploading & downloading saves back and forth between 2 devices.



Changes 
## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AppData casing resolution so Epic Cloud Saves correctly detects Disco Elysium save paths. Saves now upload and download reliably.

- **Bug Fixes**
  - Canonicalize AppData child segments to `Local`, `LocalLow`, and `Roaming`.
  - Resolve absolute paths case-insensitively within trusted roots to match on-disk casing and avoid duplicate directories.
  - Added unit tests for `LocalLow` path resolution and AppData canonicalization.

<sup>Written for commit 08c8d8de0ff3a1148e2f83a853c5f3aa42553d63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Epic cloud save directory resolution to handle system path variations more reliably, ensuring saves are consistently stored in the correct location regardless of configuration differences.

* **Tests**
  * Added test coverage to validate cloud save path resolution and verify proper system directory naming and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->