### PR TITLE
Allow ad-hoc signed builds of fork PRs by number

### DIFF
--- a/.github/workflows/adhoc-signed-build.yml
+++ b/.github/workflows/adhoc-signed-build.yml
@@ -2,6 +2,11 @@ name: Ad-hoc Signed Build
 
 on:
   workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to build (leave blank to build the selected branch)"
+        required: false
+        default: ''
 
 jobs:
   build:
@@ -11,6 +16,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Check out PR head (fork-aware)
+      if: ${{ inputs.pr != '' }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh pr checkout ${{ inputs.pr }}
+    - name: Compute artifact suffix
+      id: meta
+      run: |
+        if [ -n "${{ inputs.pr }}" ]; then
+          echo "suffix=pr-${{ inputs.pr }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "suffix=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+        fi
     - name: set up Java 17
       uses: actions/setup-java@v4
       with:
@@ -120,11 +138,11 @@ jobs:
     - name: Upload Legacy APK
       uses: actions/upload-artifact@v4
       with:
-        name: adhoc-signed-${{ github.ref_name }}
+        name: adhoc-signed-${{ steps.meta.outputs.suffix }}
         path: ${{ github.workspace }}/universal.apk
 
     - name: Upload Modern APK
       uses: actions/upload-artifact@v4
       with:
-        name: adhoc-signed-modern-${{ github.ref_name }}
+        name: adhoc-signed-modern-${{ steps.meta.outputs.suffix }}
         path: ${{ github.workspace }}/universal-modern.apk


### PR DESCRIPTION
## What

Adds an optional `pr` input to the **Ad-hoc Signed Build** workflow (`.github/workflows/adhoc-signed-build.yml`).

- Leave `pr` blank → behaves exactly as before (builds the selected branch).
- Provide a PR number → a fork-aware `gh pr checkout <number>` pulls that PR's head before building, so it works for PRs from forks too.
- Artifact names now use `pr-<number>` for PR builds (branch name otherwise) to avoid collisions.

## Why

Lets trusted-but-non-collaborator devs get a signed build of their fork PR without granting repo write access. They can't trigger `workflow_dispatch` themselves (that needs write access), so the maintainer dispatches with the PR number. The existing `if: github.actor == 'utkarshdalal'` gate is unchanged — only the maintainer can run it.

## Reviewer note

This checks out and builds the PR author's code with the signing keystore present in the environment. Only dispatch for PRs whose contents you've reviewed and trust — a malicious build step could read the signing secrets.

## How to run

Actions → "Ad-hoc Signed Build" → Run workflow → enter the PR number, or:

```
gh workflow run "Ad-hoc Signed Build" -f pr=<number>
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables maintainer-triggered ad-hoc signed builds for fork PRs by PR number. Branch builds are unchanged and artifacts are uniquely named to avoid collisions.

- **New Features**
  - Adds optional `pr` input to `.github/workflows/adhoc-signed-build.yml`.
  - When set, checks out the PR head with `gh pr checkout <number>` using `${{ github.token }}` (fork-aware).
  - Applies a computed artifact suffix (`pr-<number>` or branch name) to upload steps.
  - Existing actor gate remains; only the maintainer can run this workflow.

<sup>Written for commit 708a0b849645fdbf82713b623400f9385bdbe2d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow to support manual selection of specific pull requests for building
  * Improved artifact naming with pull-request-specific identifiers for better organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->