### PR TITLE
fix: Show "Opening container" on loading screen when opening a container instead of saying "Launching Game"

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -902,8 +902,6 @@ fun PluviaMain(
                     isOffline = viewModel.isOffline.value,
                     bootToContainer = state.bootToContainer,
                 )
-                    bootToContainer = state.bootToContainer,
-                )
             }
             onDismissClick = {
                 setMessageDialogState(MessageDialogState(false))

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -807,6 +807,7 @@ fun PluviaMain(
                     setLoadingMessage = viewModel::setLoadingDialogMessage,
                     setMessageDialogState = setMessageDialogState,
                     onSuccess = viewModel::launchApp,
+                    bootToContainer = state.bootToContainer,
                 )
                 msgDialogState = MessageDialogState(false)
             }
@@ -820,6 +821,7 @@ fun PluviaMain(
                     setLoadingMessage = viewModel::setLoadingDialogMessage,
                     setMessageDialogState = setMessageDialogState,
                     onSuccess = viewModel::launchApp,
+                    bootToContainer = state.bootToContainer,
                 )
                 msgDialogState = MessageDialogState(false)
             }
@@ -900,6 +902,8 @@ fun PluviaMain(
                     isOffline = viewModel.isOffline.value,
                     bootToContainer = state.bootToContainer,
                 )
+                    bootToContainer = state.bootToContainer,
+                )
             }
             onDismissClick = {
                 setMessageDialogState(MessageDialogState(false))
@@ -946,6 +950,8 @@ fun PluviaMain(
                         setMessageDialogState = setMessageDialogState,
                         onSuccess = viewModel::launchApp,
                         isOffline = viewModel.isOffline.value,
+                        bootToContainer = state.bootToContainer,
+                )
                     )
                 }
             }
@@ -1437,12 +1443,13 @@ fun PluviaMain(
                 } */
 
                 /** Game Screen **/
-                composable(route = PluviaScreen.XServer.route) {
+                    composable(route = PluviaScreen.XServer.route) {
                     val xServerIsOffline by viewModel.isOffline.collectAsStateWithLifecycle()
+                    val currentState = viewModel.state.value
                     XServerScreen(
-                        appId = state.launchedAppId,
-                        bootToContainer = state.bootToContainer,
-                        testGraphics = state.testGraphics,
+                        appId = currentState.launchedAppId,
+                        bootToContainer = currentState.bootToContainer,
+                        testGraphics = currentState.testGraphics,
                         isOffline = xServerIsOffline,
                         registerBackAction = { cb ->
                             Timber.d("registerBackAction called: $cb")

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -949,7 +949,6 @@ fun PluviaMain(
                         onSuccess = viewModel::launchApp,
                         isOffline = viewModel.isOffline.value,
                         bootToContainer = state.bootToContainer,
-                )
                     )
                 }
             }

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -453,9 +453,10 @@ class MainViewModel @Inject constructor(
             _state.update {
                     it.copy(
                         showBootingSplash = true,
-                        bootingSplashText = if (it.bootToContainer) "Opening container..." else "Launching game...",
-                    )
-            }
+                        bootingSplashText = if (it.bootToContainer) context.getString(R.string.booting_splash_opening_container) else context.getString(
+                            R.string.booting_splash_launching_game),
+                )
+        }
              PluviaApp.events.emit(AndroidEvent.SetAllowedOrientation(PrefManager.allowedOrientation))
 
             val apiJob = viewModelScope.async(Dispatchers.IO) {

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -449,15 +449,10 @@ class MainViewModel @Inject constructor(
          fun launchApp(context: Context, appId: String) {
         // Show booting splash before launching the app
         viewModelScope.launch {
-            // Show the booting splash with a neutral default text.
-            // The text ("Launching game..." / "Opening container...")
-            // is set later by setupXEnvironment in XServerScreen based on the actual
-            // bootToContainer parameter, so there is no flicker  when the two
-            // sources disagree.
-            _state.update {
+                       _state.update {
                 it.copy(
                     showBootingSplash = true,
-                    bootingSplashText = "Booting...",
+                    bootingSplashText = if (it.bootToContainer) "Opening container..." else "Launching game...",
                 )
             }
              PluviaApp.events.emit(AndroidEvent.SetAllowedOrientation(PrefManager.allowedOrientation))

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -5,6 +5,7 @@ import android.os.Process
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.gamenative.R
 import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
 import app.gamenative.data.GameProcessInfo

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -447,11 +447,19 @@ class MainViewModel @Inject constructor(
     }
 
          fun launchApp(context: Context, appId: String) {
-         // Show booting splash before launching the app
-         viewModelScope.launch {
-             setShowBootingSplash(true)
-+            // Set the correct splash text immediately so it doesn't flash stale text from a previous session
-+            setBootingSplashText(if (_state.value.bootToContainer) "Opening container..." else "Launching game...")
+        // Show booting splash before launching the app
+        viewModelScope.launch {
+            // Show the booting splash with a neutral default text.
+            // The text ("Launching game..." / "Opening container...")
+            // is set later by setupXEnvironment in XServerScreen based on the actual
+            // bootToContainer parameter, so there is no flicker  when the two
+            // sources disagree.
+            _state.update {
+                it.copy(
+                    showBootingSplash = true,
+                    bootingSplashText = "Booting...",
+                )
+            }
              PluviaApp.events.emit(AndroidEvent.SetAllowedOrientation(PrefManager.allowedOrientation))
 
             val apiJob = viewModelScope.async(Dispatchers.IO) {

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -446,11 +446,13 @@ class MainViewModel @Inject constructor(
         _state.update { it.copy(testGraphics = value) }
     }
 
-    fun launchApp(context: Context, appId: String) {
-        // Show booting splash before launching the app
-        viewModelScope.launch {
-            setShowBootingSplash(true)
-            PluviaApp.events.emit(AndroidEvent.SetAllowedOrientation(PrefManager.allowedOrientation))
+         fun launchApp(context: Context, appId: String) {
+         // Show booting splash before launching the app
+         viewModelScope.launch {
+             setShowBootingSplash(true)
++            // Set the correct splash text immediately so it doesn't flash stale text from a previous session
++            setBootingSplashText(if (_state.value.bootToContainer) "Opening container..." else "Launching game...")
+             PluviaApp.events.emit(AndroidEvent.SetAllowedOrientation(PrefManager.allowedOrientation))
 
             val apiJob = viewModelScope.async(Dispatchers.IO) {
                 val container = ContainerUtils.getOrCreateContainer(context, appId)

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -446,14 +446,14 @@ class MainViewModel @Inject constructor(
         _state.update { it.copy(testGraphics = value) }
     }
 
-         fun launchApp(context: Context, appId: String) {
+    fun launchApp(context: Context, appId: String) {
         // Show booting splash before launching the app
         viewModelScope.launch {
-                       _state.update {
-                it.copy(
-                    showBootingSplash = true,
-                    bootingSplashText = if (it.bootToContainer) "Opening container..." else "Launching game...",
-                )
+            _state.update {
+                    it.copy(
+                        showBootingSplash = true,
+                        bootingSplashText = if (it.bootToContainer) "Opening container..." else "Launching game...",
+                    )
             }
              PluviaApp.events.emit(AndroidEvent.SetAllowedOrientation(PrefManager.allowedOrientation))
 

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XAudioUtils.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XAudioUtils.kt
@@ -1,6 +1,7 @@
 package app.gamenative.ui.screen.xserver
 
 import android.content.Context
+import app.gamenative.R
 import app.gamenative.PluviaApp
 import app.gamenative.data.GameSource
 import app.gamenative.events.AndroidEvent
@@ -24,7 +25,11 @@ object XAudioUtils {
     /**
      * Replace DLLs from DirectX Redistributable
      */
-    fun replaceXAudioDllsFromRedistributable(context: Context, guestProgramLauncherComponent: GuestProgramLauncherComponent, appId: String) {
+    fun replaceXAudioDllsFromRedistributable(
+        context: Context,
+        guestProgramLauncherComponent: GuestProgramLauncherComponent,
+        appId: String
+    ) {
         val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
         val appDirPath = try {
             when (gameSource) {
@@ -134,7 +139,7 @@ object XAudioUtils {
                 return
             }
 
-            PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Extracting XAudio DLLs..."))
+            PluviaApp.events.emit(AndroidEvent.SetBootingSplashText(context.getString(R.string.booting_splash_extracting_xaudio_dlls)))
 
             val batFile = File(tempDir, "extract_dx_audio_dlls.bat")
             val batContent = buildCabarcBatchScript(

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3239,14 +3239,20 @@ private fun setupXEnvironment(
                 containerVariantChanged = containerVariantChanged,
                 onError = onGameLaunchError
             )
-    if (preInstallCommands.isNotEmpty()) {
-                PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Installing prerequisites..."))
-            } else if (bootToContainer) {
-                PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Opening container..."))
-            } else {
-                PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Launching game..."))
-            }
-        }
+        guestProgramLauncherComponent.setPreUnpack {
+            unpackExecutableFile(
+            context = context,
+            needsUnpacking = container.isNeedsUnpacking,
+            container = container,
+            appId = appId,
+            appLaunchInfo = appLaunchInfo,
+            guestProgramLauncherComponent = guestProgramLauncherComponent,
+            containerVariantChanged = containerVariantChanged,
+            onError = onGameLaunchError
+        )
+    
+}
+
 
         val enableGstreamer = container.isGstreamerWorkaround()
 

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3349,12 +3349,12 @@ private fun setupXEnvironment(
             val nextRemaining = remaining.drop(1)
             if (nextRemaining.isEmpty()) {
                 if (bootToContainer) {
-                    PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Opening container..."))
+                    PluviaApp.events.emit(AndroidEvent.SetBootingSplashText(context.getString(R.string.booting_splash_opening_container)))
                 } else {
-                    PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Launching game..."))
+                    PluviaApp.events.emit(AndroidEvent.SetBootingSplashText(context.getString(R.string.booting_splash_launching_game)))
                 }
             } else {
-                PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Installing prerequisites..."))
+               PluviaApp.events.emit(AndroidEvent.SetBootingSplashText(context.getString(R.string.booting_splash_installing_prerequisites)))
             }
             chainPreInstallSteps(nextRemaining)
             guestProgramLauncherComponent.start()

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3239,8 +3239,10 @@ private fun setupXEnvironment(
                 containerVariantChanged = containerVariantChanged,
                 onError = onGameLaunchError
             )
-            if (preInstallCommands.isNotEmpty()) {
+    if (preInstallCommands.isNotEmpty()) {
                 PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Installing prerequisites..."))
+            } else if (bootToContainer) {
+                PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Opening container..."))
             } else {
                 PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Launching game..."))
             }
@@ -3340,7 +3342,11 @@ private fun setupXEnvironment(
             }
             val nextRemaining = remaining.drop(1)
             if (nextRemaining.isEmpty()) {
-                PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Launching game..."))
+                if (bootToContainer) {
+                    PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Opening container..."))
+                } else {
+                    PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Launching game..."))
+                }
             } else {
                 PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Installing prerequisites..."))
             }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -4132,7 +4132,7 @@ private fun unpackExecutableFile(
         val rootDir: File = imageFs.getRootDir()
 
         try {
-            PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Handling DRM..."))
+            PluviaApp.events.emit(AndroidEvent.SetBootingSplashText(context.getString(R.string.booting_splash_handling_drm)))
             // a:/.../GameDir/orig_dll_path.txt  (same dir as the EXE inside A:)
             val origTxtFile  = File("${imageFs.wineprefix}/dosdevices/a:/orig_dll_path.txt")
 
@@ -4196,10 +4196,18 @@ private fun unpackExecutableFile(
             if (exePaths.isEmpty()) {
                 Timber.w("No executable path set, skipping Steamless")
             } else {
-                PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Handling DRM..."))
+               PluviaApp.events.emit(AndroidEvent.SetBootingSplashText(context.getString(R.string.booting_splash_handling_drm)))
                 for ((index, executablePath) in exePaths.withIndex()) {
                     if (exePaths.size > 1) {
-                        PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Handling DRM (${index + 1}/${exePaths.size})"))
+                        PluviaApp.events.emit(
+                            AndroidEvent.SetBootingSplashText(
+                                context.getString(
+                                    R.string.booting_splash_handling_drm_progress,
+                                    index + 1,
+                                    exePaths.size
+                                )
+                            )
+                        )
                     }
                     var batchFile: File? = null
                     try {


### PR DESCRIPTION
## Description
Previously when opening a container for any game would give a loading screen saying "Launching game" which doesn't correspond to what is actually happening, this changes the loading screen to instead say "Opening container" ONLY when the "Open Container" option is pressed, this has no effect on any other loading screen.

## Recording
[Screen_Recording_20260609_220114_GameNative.zip](https://github.com/user-attachments/files/28777801/Screen_Recording_20260609_220114_GameNative.zip)


## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [✅ ] Other (requires prior approval)

## Checklist
- [✅ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ✅] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [✅ ] I have attached a recording of the change.
- [✅ ] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show “Opening container…” when using Open Container and set the correct splash text immediately to prevent flicker. Dialog/setup flows preserve the right message, use `R.string`, and remove a duplicate `bootToContainer` parameter.

- **Bug Fixes**
  - MainViewModel.launchApp: sets `showBootingSplash` and `bootingSplashText` immediately via `R.string` based on `bootToContainer`.
  - PluviaMain: passes `bootToContainer` through all dialog retries, reads the latest ViewModel state for XServerScreen to avoid reversion after prompts, and removes a duplicate `bootToContainer` param.
  - XServerScreen: adds a pre-unpack hook; uses `R.string` for prerequisites, DRM, and per-executable DRM progress; restores the correct message instead of a neutral “Booting…”.
  - XAudioUtils: uses `R.string` for “Extracting XAudio DLLs…”.

<sup>Written for commit 45be9a49ad553c4a35ab1e720886be98d1cfb9bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial boot-splash display so the correct message shows immediately on app start, matching the selected **“boot to container”** mode.
  * Refined boot-splash messaging across pre-install and launch steps to reliably switch between **“Opening container...”** and **“Launching game...”**.
  * Localized DRM and XAudio DLL extraction boot-splash text, including per-executable DRM progress updates.
  * Preserved **“boot to container”** selection through dialog-driven launch flows and ensured the XServer screen reflects the latest state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->