### PR TITLE
Return empty defaults when ImageFs metadata files exist but are empty

### DIFF
--- a/app/src/main/java/app/gamenative/utils/ContainerMigrator.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerMigrator.kt
@@ -44,7 +44,7 @@ object ContainerMigrator {
         val versionFile = File(imageFs.configDir, ".container_migration_version")
         return if (versionFile.exists()) {
             try {
-                FileUtils.readLines(versionFile)[0].toInt()
+                FileUtils.readFirstLine(versionFile)?.trim()?.toInt() ?: 0
             } catch (e: Exception) {
                 Timber.e(e, "Failed to read container migration version")
                 0

--- a/app/src/main/java/com/winlator/core/FileUtils.java
+++ b/app/src/main/java/com/winlator/core/FileUtils.java
@@ -250,6 +250,23 @@ public abstract class FileUtils {
         }
     }
 
+    /**
+     * Reads and returns the first line of {@code file} as UTF-8 text, or {@code null} if the file
+     * is empty or cannot be read. The caller is responsible for any trimming or blank checks.
+     * @param file The file to read.
+     * @return The first line, or {@code null} if the file is empty or unreadable.
+     */
+    public static String readFirstLine(File file) {
+        if (file == null) return null;
+        try (FileInputStream fis = new FileInputStream(file)) {
+            return new BufferedReader(new InputStreamReader(fis, StandardCharsets.UTF_8)).readLine();
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
     public static ArrayList<String> readLines(File file) {
         ArrayList<String> lines = new ArrayList<>();
         try (FileInputStream fis = new FileInputStream(file)) {

--- a/app/src/main/java/com/winlator/xenvironment/ImageFs.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFs.java
@@ -34,7 +34,11 @@ public class ImageFs {
         wineprefix = rootDir + WINEPREFIX;
     }
 
-    /** Shared Proton directory; opt/<version> in each variant symlinks here. */
+    /**
+     * Returns (and creates if absent) the shared Proton directory in app storage.
+     * @param context Application context used to resolve the files directory.
+     * @return The shared Proton directory ({@code imagefs_shared/proton}).
+     */
     public static File getSharedProtonDir(Context context) {
         File sharedProtonDir = new File(context.getFilesDir(), "imagefs_shared/proton");
         if (!sharedProtonDir.exists()) {
@@ -43,6 +47,11 @@ public class ImageFs {
         return sharedProtonDir;
     }
 
+    /**
+     * Returns the singleton {@link ImageFs} rooted at {@code context.getFilesDir()/imagefs}.
+     * @param context Application context used to resolve the files directory.
+     * @return The singleton {@link ImageFs} instance.
+     */
     public static ImageFs find(Context context) {
         ImageFs local = INSTANCE;
         if (local != null) return local;
@@ -54,27 +63,60 @@ public class ImageFs {
         }
     }
 
+    /**
+     * Returns a new {@link ImageFs} rooted at the given directory; does not use the singleton.
+     * @param rootDir The root directory for the image filesystem.
+     * @return A new {@link ImageFs} instance.
+     */
     public static ImageFs find(File rootDir) {
         return new ImageFs(rootDir);
     }
 
+    /**
+     * Returns the root directory of this image filesystem.
+     * @return The root {@link File} directory.
+     */
     public File getRootDir() {
         return rootDir;
     }
 
+    /**
+     * Returns {@code true} if the root directory exists and contains a version file.
+     * @return True if this image filesystem appears to be a valid installation.
+     */
     public boolean isValid() {
         return rootDir.isDirectory() && getImgVersionFile().exists();
     }
 
+    /**
+     * Returns the image version stored in {@code .img_version}, or {@code 0} if the file is
+     * absent, empty, whitespace-only, or contains non-numeric content.
+     * @return The parsed version number, or {@code 0} as a safe default.
+     */
     public int getVersion() {
         File imgVersionFile = getImgVersionFile();
-        return imgVersionFile.exists() ? Integer.parseInt(FileUtils.readLines(imgVersionFile).get(0)) : 0;
+        if (!imgVersionFile.exists()) return 0;
+        String line = FileUtils.readFirstLine(imgVersionFile);
+        if (line == null || line.isBlank()) return 0;
+        try {
+            return Integer.parseInt(line.trim());
+        } catch (NumberFormatException ignored) {
+            return 0;
+        }
     }
 
+    /**
+     * Returns {@link #getVersion()} formatted as a one-decimal-place string (e.g. {@code "26.0"}).
+     * @return The version as a formatted string.
+     */
     public String getFormattedVersion() {
         return String.format(Locale.ENGLISH, "%.1f", (float)getVersion());
     }
 
+    /**
+     * Writes {@code version} to {@code .img_version}, creating the config directory if needed.
+     * @param version The version number to persist.
+     */
     public void createImgVersionFile(int version) {
         getConfigDir().mkdirs();
         File file = getImgVersionFile();
@@ -87,11 +129,22 @@ public class ImageFs {
         }
     }
 
+    /**
+     * Returns the filesystem variant stored in {@code .variant} (e.g. {@code "glibc"}), or
+     * {@code ""} if the file is absent, empty, or whitespace-only.
+     * @return The variant string, or {@code ""} as a safe default.
+     */
     public String getVariant() {
         File variantFile = getVariantFile();
-        return variantFile.exists() ? FileUtils.readLines(variantFile).get(0) : "";
+        if (!variantFile.exists()) return "";
+        String line = FileUtils.readFirstLine(variantFile);
+        return (line == null || line.isBlank()) ? "" : line.trim();
     }
 
+    /**
+     * Writes {@code variant} to {@code .variant}, creating the config directory if needed.
+     * @param variant The variant string to persist (e.g. {@code "glibc"}).
+     */
     public void createVariantFile(String variant) {
         getConfigDir().mkdirs();
         File file = getVariantFile();
@@ -104,11 +157,22 @@ public class ImageFs {
         }
     }
 
+    /**
+     * Returns the CPU architecture stored in {@code .arch} (e.g. {@code "arm64"}), or {@code ""}
+     * if the file is absent, empty, or whitespace-only.
+     * @return The architecture string, or {@code ""} as a safe default.
+     */
     public String getArch() {
         File archFile = getArchFile();
-        return archFile.exists() ? FileUtils.readLines(archFile).get(0) : "";
+        if (!archFile.exists()) return "";
+        String line = FileUtils.readFirstLine(archFile);
+        return (line == null || line.isBlank()) ? "" : line.trim();
     }
 
+    /**
+     * Writes {@code arch} to {@code .arch}, creating the config directory if needed.
+     * @param arch The architecture string to persist (e.g. {@code "arm64"}).
+     */
     public void createArchFile(String arch) {
         getConfigDir().mkdirs();
         File file = getArchFile();
@@ -121,76 +185,153 @@ public class ImageFs {
         }
     }
 
+    /**
+     * Returns the path to the Wine installation used by this image.
+     * @return The Wine installation path.
+     */
     public String getWinePath() {
         return winePath;
     }
 
+    /**
+     * Overrides the Wine installation path for this image.
+     * @param winePath The new Wine installation path.
+     */
     public void setWinePath(String winePath) {
         this.winePath = winePath;
     }
 
+    /**
+     * Returns the {@code .winlator} config directory inside the image root.
+     * @return The config directory.
+     */
     public File getConfigDir() {
         return new File(rootDir, ".winlator");
     }
 
+    /**
+     * Returns the {@code .img_version} metadata file.
+     * @return The version metadata file.
+     */
     public File getImgVersionFile() {
         return new File(getConfigDir(), ".img_version");
     }
 
+    /**
+     * Returns the {@code .variant} metadata file.
+     * @return The variant metadata file.
+     */
     public File getVariantFile() {
         return new File(getConfigDir(), ".variant");
     }
 
+    /**
+     * Returns the {@code .arch} metadata file.
+     * @return The architecture metadata file.
+     */
     public File getArchFile() {
         return new File(getConfigDir(), ".arch");
     }
 
+    /**
+     * Returns the directory where the active Wine build is installed ({@code /opt/installed-wine}).
+     * @return The installed Wine directory.
+     */
     public File getInstalledWineDir() {
         return new File(rootDir, "/opt/installed-wine");
     }
 
+    /**
+     * Returns the {@code /tmp} directory inside the image.
+     * @return The temporary directory.
+     */
     public File getTmpDir() {
         return new File(rootDir, "/tmp");
     }
 
+    /**
+     * Returns the {@code /usr/lib} directory inside the image.
+     * @return The lib directory.
+     */
     public File getLibDir() { return new File(rootDir, "/usr/lib"); }
 
+    /**
+     * Returns the {@code /usr/bin} directory inside the image.
+     * @return The bin directory.
+     */
     public File getBinDir() { return new File(rootDir, "/usr/bin"); }
 
+    /**
+     * Returns the {@code /usr/share} directory inside the image.
+     * @return The share directory.
+     */
     public File getShareDir() {
         return new File(rootDir, "/usr/share");
     }
 
+    /**
+     * Returns the 32-bit glibc library directory ({@code /usr/lib/arm-linux-gnueabihf}).
+     * @return The 32-bit glibc directory.
+     */
     public File getGlibc32Dir() {
         return new File(rootDir, "/usr/lib/arm-linux-gnueabihf");
     }
 
+    /**
+     * Returns the 64-bit glibc library directory ({@code /usr/lib}).
+     * @return The 64-bit glibc directory.
+     */
     public File getGlibc64Dir() {
         return new File(rootDir, "/usr/lib");
     }
 
+    /**
+     * Returns the 32-bit library directory ({@code /usr/lib/arm-linux-gnueabihf}).
+     * @return The 32-bit library directory.
+     */
     public File getLib32Dir() {
         return new File(rootDir, "/usr/lib/arm-linux-gnueabihf");
     }
 
+    /**
+     * Returns the 64-bit library directory ({@code /usr/lib}).
+     * @return The 64-bit library directory.
+     */
     public File getLib64Dir() {
         return new File(rootDir, "/usr/lib");
     }
 
+    /**
+     * Returns the {@code /storage} directory inside the image.
+     * @return The storage directory.
+     */
     public File getStorageDir() {
         return new File(rootDir, "/storage");
     }
 
+    /**
+     * Returns the parent of the image root (equivalent to {@code context.getFilesDir()}).
+     * @return The parent directory of the image root.
+     */
     public File getFilesDir() {
         return rootDir.getParentFile();
     }
 
+    /**
+     * Returns the absolute path of the image root directory.
+     * @return The root directory path.
+     */
     @NonNull
     @Override
     public String toString() {
         return rootDir.getPath();
     }
 
+    /**
+     * Returns (and creates if absent) the shared {@code imagefs_shared} directory in app storage.
+     * @param context Application context used to resolve the files directory.
+     * @return The shared imagefs directory.
+     */
     public static File getImageFsSharedDir(Context context) {
         File sharedDir = new File(context.getFilesDir(), "imagefs_shared");
         if (!sharedDir.exists()) {

--- a/app/src/main/java/com/winlator/xenvironment/ImageFs.java
+++ b/app/src/main/java/com/winlator/xenvironment/ImageFs.java
@@ -34,11 +34,7 @@ public class ImageFs {
         wineprefix = rootDir + WINEPREFIX;
     }
 
-    /**
-     * Returns (and creates if absent) the shared Proton directory in app storage.
-     * @param context Application context used to resolve the files directory.
-     * @return The shared Proton directory ({@code imagefs_shared/proton}).
-     */
+    /** Shared Proton directory; opt/<version> in each variant symlinks here. */
     public static File getSharedProtonDir(Context context) {
         File sharedProtonDir = new File(context.getFilesDir(), "imagefs_shared/proton");
         if (!sharedProtonDir.exists()) {
@@ -47,11 +43,6 @@ public class ImageFs {
         return sharedProtonDir;
     }
 
-    /**
-     * Returns the singleton {@link ImageFs} rooted at {@code context.getFilesDir()/imagefs}.
-     * @param context Application context used to resolve the files directory.
-     * @return The singleton {@link ImageFs} instance.
-     */
     public static ImageFs find(Context context) {
         ImageFs local = INSTANCE;
         if (local != null) return local;
@@ -63,27 +54,14 @@ public class ImageFs {
         }
     }
 
-    /**
-     * Returns a new {@link ImageFs} rooted at the given directory; does not use the singleton.
-     * @param rootDir The root directory for the image filesystem.
-     * @return A new {@link ImageFs} instance.
-     */
     public static ImageFs find(File rootDir) {
         return new ImageFs(rootDir);
     }
 
-    /**
-     * Returns the root directory of this image filesystem.
-     * @return The root {@link File} directory.
-     */
     public File getRootDir() {
         return rootDir;
     }
 
-    /**
-     * Returns {@code true} if the root directory exists and contains a version file.
-     * @return True if this image filesystem appears to be a valid installation.
-     */
     public boolean isValid() {
         return rootDir.isDirectory() && getImgVersionFile().exists();
     }
@@ -105,18 +83,10 @@ public class ImageFs {
         }
     }
 
-    /**
-     * Returns {@link #getVersion()} formatted as a one-decimal-place string (e.g. {@code "26.0"}).
-     * @return The version as a formatted string.
-     */
     public String getFormattedVersion() {
         return String.format(Locale.ENGLISH, "%.1f", (float)getVersion());
     }
 
-    /**
-     * Writes {@code version} to {@code .img_version}, creating the config directory if needed.
-     * @param version The version number to persist.
-     */
     public void createImgVersionFile(int version) {
         getConfigDir().mkdirs();
         File file = getImgVersionFile();
@@ -141,10 +111,6 @@ public class ImageFs {
         return (line == null || line.isBlank()) ? "" : line.trim();
     }
 
-    /**
-     * Writes {@code variant} to {@code .variant}, creating the config directory if needed.
-     * @param variant The variant string to persist (e.g. {@code "glibc"}).
-     */
     public void createVariantFile(String variant) {
         getConfigDir().mkdirs();
         File file = getVariantFile();
@@ -157,181 +123,72 @@ public class ImageFs {
         }
     }
 
-    /**
-     * Returns the CPU architecture stored in {@code .arch} (e.g. {@code "arm64"}), or {@code ""}
-     * if the file is absent, empty, or whitespace-only.
-     * @return The architecture string, or {@code ""} as a safe default.
-     */
-    public String getArch() {
-        File archFile = getArchFile();
-        if (!archFile.exists()) return "";
-        String line = FileUtils.readFirstLine(archFile);
-        return (line == null || line.isBlank()) ? "" : line.trim();
-    }
-
-    /**
-     * Writes {@code arch} to {@code .arch}, creating the config directory if needed.
-     * @param arch The architecture string to persist (e.g. {@code "arm64"}).
-     */
-    public void createArchFile(String arch) {
-        getConfigDir().mkdirs();
-        File file = getArchFile();
-        try {
-            file.createNewFile();
-            FileUtils.writeString(file, arch);
-        }
-        catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    /**
-     * Returns the path to the Wine installation used by this image.
-     * @return The Wine installation path.
-     */
     public String getWinePath() {
         return winePath;
     }
 
-    /**
-     * Overrides the Wine installation path for this image.
-     * @param winePath The new Wine installation path.
-     */
     public void setWinePath(String winePath) {
         this.winePath = winePath;
     }
 
-    /**
-     * Returns the {@code .winlator} config directory inside the image root.
-     * @return The config directory.
-     */
     public File getConfigDir() {
         return new File(rootDir, ".winlator");
     }
 
-    /**
-     * Returns the {@code .img_version} metadata file.
-     * @return The version metadata file.
-     */
     public File getImgVersionFile() {
         return new File(getConfigDir(), ".img_version");
     }
 
-    /**
-     * Returns the {@code .variant} metadata file.
-     * @return The variant metadata file.
-     */
     public File getVariantFile() {
         return new File(getConfigDir(), ".variant");
     }
 
-    /**
-     * Returns the {@code .arch} metadata file.
-     * @return The architecture metadata file.
-     */
-    public File getArchFile() {
-        return new File(getConfigDir(), ".arch");
-    }
-
-    /**
-     * Returns the directory where the active Wine build is installed ({@code /opt/installed-wine}).
-     * @return The installed Wine directory.
-     */
     public File getInstalledWineDir() {
         return new File(rootDir, "/opt/installed-wine");
     }
 
-    /**
-     * Returns the {@code /tmp} directory inside the image.
-     * @return The temporary directory.
-     */
     public File getTmpDir() {
         return new File(rootDir, "/tmp");
     }
 
-    /**
-     * Returns the {@code /usr/lib} directory inside the image.
-     * @return The lib directory.
-     */
     public File getLibDir() { return new File(rootDir, "/usr/lib"); }
 
-    /**
-     * Returns the {@code /usr/bin} directory inside the image.
-     * @return The bin directory.
-     */
     public File getBinDir() { return new File(rootDir, "/usr/bin"); }
 
-    /**
-     * Returns the {@code /usr/share} directory inside the image.
-     * @return The share directory.
-     */
     public File getShareDir() {
         return new File(rootDir, "/usr/share");
     }
 
-    /**
-     * Returns the 32-bit glibc library directory ({@code /usr/lib/arm-linux-gnueabihf}).
-     * @return The 32-bit glibc directory.
-     */
     public File getGlibc32Dir() {
         return new File(rootDir, "/usr/lib/arm-linux-gnueabihf");
     }
 
-    /**
-     * Returns the 64-bit glibc library directory ({@code /usr/lib}).
-     * @return The 64-bit glibc directory.
-     */
     public File getGlibc64Dir() {
         return new File(rootDir, "/usr/lib");
     }
 
-    /**
-     * Returns the 32-bit library directory ({@code /usr/lib/arm-linux-gnueabihf}).
-     * @return The 32-bit library directory.
-     */
     public File getLib32Dir() {
         return new File(rootDir, "/usr/lib/arm-linux-gnueabihf");
     }
 
-    /**
-     * Returns the 64-bit library directory ({@code /usr/lib}).
-     * @return The 64-bit library directory.
-     */
     public File getLib64Dir() {
         return new File(rootDir, "/usr/lib");
     }
 
-    /**
-     * Returns the {@code /storage} directory inside the image.
-     * @return The storage directory.
-     */
     public File getStorageDir() {
         return new File(rootDir, "/storage");
     }
 
-    /**
-     * Returns the parent of the image root (equivalent to {@code context.getFilesDir()}).
-     * @return The parent directory of the image root.
-     */
     public File getFilesDir() {
         return rootDir.getParentFile();
     }
 
-    /**
-     * Returns the absolute path of the image root directory.
-     * @return The root directory path.
-     */
     @NonNull
     @Override
     public String toString() {
         return rootDir.getPath();
     }
 
-    /**
-     * Returns (and creates if absent) the shared {@code imagefs_shared} directory in app storage.
-     * @param context Application context used to resolve the files directory.
-     * @return The shared imagefs directory.
-     */
     public static File getImageFsSharedDir(Context context) {
         File sharedDir = new File(context.getFilesDir(), "imagefs_shared");
         if (!sharedDir.exists()) {

--- a/app/src/test/java/com/winlator/core/FileUtilsTest.kt
+++ b/app/src/test/java/com/winlator/core/FileUtilsTest.kt
@@ -1,0 +1,44 @@
+package com.winlator.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class FileUtilsTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    // ── readFirstLine ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `readFirstLine returns null when file does not exist`() {
+        val missing = tmp.root.resolve("missing.txt")
+        assertNull(FileUtils.readFirstLine(missing))
+    }
+
+    @Test
+    fun `readFirstLine returns null when file is empty`() {
+        val file = tmp.newFile("empty.txt")
+        assertNull(FileUtils.readFirstLine(file))
+    }
+
+    @Test
+    fun `readFirstLine returns the single line`() {
+        val file = tmp.newFile("single.txt").also { it.writeText("hello") }
+        assertEquals("hello", FileUtils.readFirstLine(file))
+    }
+
+    @Test
+    fun `readFirstLine returns only the first line of a multi-line file`() {
+        val file = tmp.newFile("multi.txt").also { it.writeText("first\nsecond\nthird") }
+        assertEquals("first", FileUtils.readFirstLine(file))
+    }
+
+    @Test
+    fun `readFirstLine preserves leading and trailing whitespace`() {
+        val file = tmp.newFile("padded.txt").also { it.writeText("  42  \nsecond") }
+        assertEquals("  42  ", FileUtils.readFirstLine(file))
+    }
+}

--- a/app/src/test/java/com/winlator/xenvironment/ImageFsTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFsTest.kt
@@ -87,35 +87,6 @@ class ImageFsTest {
         assertEquals("glibc", imageFs().variant)
     }
 
-    // ── getArch ───────────────────────────────────────────────────────────────
-
-    @Test
-    fun `getArch returns empty string when file is absent`() {
-        assertEquals("", imageFs().arch)
-    }
-
-    @Test
-    fun `getArch returns empty string when file exists but is empty`() {
-        configDir().also { it.mkdirs() }
-        File(configDir(), ".arch").createNewFile()
-
-        assertEquals("", imageFs().arch)
-    }
-
-    @Test
-    fun `getArch returns empty string when file contains only whitespace`() {
-        configDir().also { it.mkdirs() }
-        File(configDir(), ".arch").writeText("   ")
-
-        assertEquals("", imageFs().arch)
-    }
-
-    @Test
-    fun `getArch returns stored value`() {
-        imageFs().createArchFile("arm64")
-        assertEquals("arm64", imageFs().arch)
-    }
-
     // ── getVersion ────────────────────────────────────────────────────────────
 
     @Test

--- a/app/src/test/java/com/winlator/xenvironment/ImageFsTest.kt
+++ b/app/src/test/java/com/winlator/xenvironment/ImageFsTest.kt
@@ -5,7 +5,9 @@ import java.io.File
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -14,10 +16,18 @@ class ImageFsTest {
     private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
     private val sharedDir = File(context.filesDir, "imagefs_shared")
 
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun imageFs(): ImageFs = ImageFs.find(tmp.root)
+    private fun configDir(): File = File(tmp.root, ".winlator")
+
     @After
     fun tearDown() {
         sharedDir.deleteRecursively()
     }
+
+    // ── shared dir ────────────────────────────────────────────────────────────
 
     @Test
     fun getImageFsSharedDir_createsAndReturnsSharedDirectory() {
@@ -46,5 +56,100 @@ class ImageFsTest {
         val expected = File(sharedRoot, "proton")
 
         assertEquals(expected.absolutePath, sharedProton.absolutePath)
+    }
+
+    // ── getVariant ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `getVariant returns empty string when file is absent`() {
+        assertEquals("", imageFs().variant)
+    }
+
+    @Test
+    fun `getVariant returns empty string when file exists but is empty`() {
+        configDir().also { it.mkdirs() }
+        File(configDir(), ".variant").createNewFile()
+
+        assertEquals("", imageFs().variant)
+    }
+
+    @Test
+    fun `getVariant returns empty string when file contains only whitespace`() {
+        configDir().also { it.mkdirs() }
+        File(configDir(), ".variant").writeText("   ")
+
+        assertEquals("", imageFs().variant)
+    }
+
+    @Test
+    fun `getVariant returns stored value`() {
+        imageFs().createVariantFile("glibc")
+        assertEquals("glibc", imageFs().variant)
+    }
+
+    // ── getArch ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `getArch returns empty string when file is absent`() {
+        assertEquals("", imageFs().arch)
+    }
+
+    @Test
+    fun `getArch returns empty string when file exists but is empty`() {
+        configDir().also { it.mkdirs() }
+        File(configDir(), ".arch").createNewFile()
+
+        assertEquals("", imageFs().arch)
+    }
+
+    @Test
+    fun `getArch returns empty string when file contains only whitespace`() {
+        configDir().also { it.mkdirs() }
+        File(configDir(), ".arch").writeText("   ")
+
+        assertEquals("", imageFs().arch)
+    }
+
+    @Test
+    fun `getArch returns stored value`() {
+        imageFs().createArchFile("arm64")
+        assertEquals("arm64", imageFs().arch)
+    }
+
+    // ── getVersion ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `getVersion returns 0 when file is absent`() {
+        assertEquals(0, imageFs().version)
+    }
+
+    @Test
+    fun `getVersion returns 0 when file exists but is empty`() {
+        configDir().also { it.mkdirs() }
+        File(configDir(), ".img_version").createNewFile()
+
+        assertEquals(0, imageFs().version)
+    }
+
+    @Test
+    fun `getVersion returns 0 when file contains only whitespace`() {
+        configDir().also { it.mkdirs() }
+        File(configDir(), ".img_version").writeText("   ")
+
+        assertEquals(0, imageFs().version)
+    }
+
+    @Test
+    fun `getVersion returns 0 when file contains non-numeric content`() {
+        configDir().also { it.mkdirs() }
+        File(configDir(), ".img_version").writeText("corrupted")
+
+        assertEquals(0, imageFs().version)
+    }
+
+    @Test
+    fun `getVersion returns stored value`() {
+        imageFs().createImgVersionFile(26)
+        assertEquals(26, imageFs().version)
     }
 }


### PR DESCRIPTION
## Description
`ImageFs.getVariant()`, `getArch()`, and `getVersion()` called `.get(0)` on the result of `readLines()` after only checking file existence. A zero-byte `.variant` file (caused by interrupted install) crashed the app on every game launch with `IndexOutOfBoundsException`. Empty files now return the same defaults as missing files, triggering a clean re-install of the base image.

## Recording
N/A — crash fix, no visual change.

## Type of Change
- [x] Bug fix

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return safe defaults when `ImageFs` metadata files are empty, whitespace-only, or invalid to prevent crashes and trigger a clean re-install. Also adds a null-safe `FileUtils.readFirstLine()`, hardens container migration version parsing, and removes unused arch APIs.

- **Bug Fixes**
  - `getVariant()` and `getVersion()` now use `readFirstLine()`, trim values, treat empty/whitespace as missing, and return `0` on non-numeric version.
  - `ContainerMigrator` reads the first line, trims, and defaults to `0` for empty/missing `.container_migration_version`; tests added for `ImageFs` and `FileUtils` covering missing, empty, whitespace-only, multi-line, and non-numeric cases.

- **Refactors**
  - Removed `getArch`, `createArchFile`, and `getArchFile` from `ImageFs`.
  - Expanded Javadoc in `ImageFs` and `FileUtils`.

<sup>Written for commit ac2c577ecfe376bb66875c00229ec2fd4d811cd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer handling of small configuration/metadata files: missing, empty, or whitespace-only values now yield safe defaults (version → 0; variant/arch → empty string). Non-numeric version content falls back to 0 to avoid errors.

* **Tests**
  * New and expanded tests verifying behavior for missing, empty, whitespace-only, multi-line, and non-numeric file contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->