### PR TITLE
fix: allow scrcpy motion event to move mouse

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -458,6 +458,7 @@ fun XServerScreen(
     var keepPausedForEditor by remember { mutableStateOf(false) }
     var hasPhysicalKeyboard by remember { mutableStateOf(false) }
     var hasPhysicalMouse by remember { mutableStateOf(false) }
+    var usingScreenMirror by remember { mutableStateOf(false) }
     var hasInternalTouchpad by remember { mutableStateOf(false) }
     var hasUpdatedScreenGamepad by remember { mutableStateOf(false) }
     var isPerformanceHudEnabled by remember { mutableStateOf(PrefManager.showFps) }
@@ -825,10 +826,7 @@ fun XServerScreen(
     }
 
     val tryCapturePointer: () -> Boolean = {
-        // Only recapture when we have a physical mouse plugged in (or internal touchpad),
-        // no menus are open and we're not in Touchscreen mode
-        if ((hasPhysicalMouse || hasInternalTouchpad) &&
-            !showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode &&
+        if (!showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode &&
             !container.isTouchscreenMode) {
             PluviaApp.touchpadView?.postDelayed({
                 val view = PluviaApp.touchpadView
@@ -861,7 +859,8 @@ fun XServerScreen(
         controllerManager.scanForDevices()
         hasPhysicalController = controllerManager.getDetectedDevices().isNotEmpty()
 
-        if (!hasInternalTouchpad && !hasPhysicalMouse && !hasPhysicalKeyboard && !hasPhysicalController &&
+        if (!usingScreenMirror &&
+            !hasInternalTouchpad && !hasPhysicalMouse && !hasPhysicalKeyboard && !hasPhysicalController &&
             !container.isTouchscreenMode) {
             val manager = PluviaApp.inputControlsManager
             val profiles = manager?.getProfiles(false) ?: listOf()
@@ -1412,6 +1411,11 @@ fun XServerScreen(
                         }
                         tryCapturePointer()
                     }
+                }
+                val event = it.event
+                val device = event?.device
+                if (!usingScreenMirror && device?.name == "scrcpy") {
+                    usingScreenMirror = true
                 }
                 handled
             }


### PR DESCRIPTION
## Description
device name from motion events is read to detect scrcpy events
allow it to be captured and operated as the container mouse

scrcpy needs to use `--mouse=uhid` argument to work

fix small regression caused by moving to always relative mouse mode
https://discord.com/channels/1378308569287622737/1496292801581682829

## Recording

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables container mouse control from `scrcpy` by detecting `scrcpy` motion events and capturing the pointer without requiring a physical mouse. Also fixes a regression from always-relative mouse mode that blocked remote mirroring input.

- **Bug Fixes**
  - Detects the `scrcpy` input device by name from motion events and treats it as a mouse.
  - Allows pointer capture when not in menus/edit mode, even with no physical mouse/touchpad; suppresses “no input devices” logic when screen mirroring is active.

- **Migration**
  - Launch `scrcpy` with `--mouse=uhid` so its input device is created and motion events are captured.

<sup>Written for commit 4fa3e9991213f4ca5ed20bf2bacb5ecf244faf56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of screen-mirroring sessions by disabling automatic pointer re-capture and on-screen controls when mirroring is active, preventing conflicts with mirrored input sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->