### PR TITLE
Add 1.12.0-sarek-dyasync to DXWrapper in manifest.json

### DIFF
--- a/app/src/main/assets/dxwrapper_download.json
+++ b/app/src/main/assets/dxwrapper_download.json
@@ -38,6 +38,11 @@
       "url": "https://downloads.gamenative.app/dxwrapper/dxvk-1.11.1-sarek.tzst"
     },
     {
+      "id": "dxvk-1.12.0-sarek",
+      "name": "dxvk-1.12.0-sarek.wcp",
+      "url": "https://downloads.gamenative.app/dxwrapper/dxvk-sarek-dyasync-1.12.0.wcp"
+    },
+    {
       "id": "dxvk-2.4.1",
       "name": "dxvk-2.4.1.tzst",
       "url": "https://downloads.gamenative.app/dxwrapper/dxvk-2.4.1.tzst"

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": 1,
   "updatedAt": "2026-06-10",
   "items": {
     "driver": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-06-10",
+  "updatedAt": "2026-01-26",
   "items": {
     "driver": [
       {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": 1,
-  "updatedAt": "2026-01-26",
+  "version": "2",
+  "updatedAt": "2026-06-10",
   "items": {
     "driver": [
       {
@@ -689,7 +689,8 @@
         "url": "https://github.com/Arihany/WinlatorWCPHub/releases/download/DXVK/dxvk-1.10.3.wcp",
         "variant": "bionic"
       },
-      { "id": "1.12.0-sarek-dyasync",
+      {
+        "id": "1.12.0-sarek-dyasync",
         "name": "DXVK 1.12.0-sarek",
         "url": "https://downloads.gamenative.app/dxwrapper/dxvk-sarek-dyasync-1.12.0.wcp",
         "variant": "bionic"

--- a/manifest.json
+++ b/manifest.json
@@ -688,6 +688,11 @@
         "name": "DXVK 1.10.3",
         "url": "https://github.com/Arihany/WinlatorWCPHub/releases/download/DXVK/dxvk-1.10.3.wcp",
         "variant": "bionic"
+      },
+      { "id": "1.12.0-sarek-dyasync",
+        "name": "DXVK 1.12.0-sarek",
+        "url": "https://downloads.gamenative.app/dxwrapper/dxvk-sarek-dyasync-1.12.0.wcp",
+        "variant": "bionic"
       }
     ],
     "proton": [

--- a/manifest.json
+++ b/manifest.json
@@ -688,12 +688,6 @@
         "name": "DXVK 1.10.3",
         "url": "https://github.com/Arihany/WinlatorWCPHub/releases/download/DXVK/dxvk-1.10.3.wcp",
         "variant": "bionic"
-      },
-      {
-        "id": "1.12.0-sarek-dyasync",
-        "name": "DXVK 1.12.0-sarek",
-        "url": "https://downloads.gamenative.app/dxwrapper/dxvk-sarek-dyasync-1.12.0.wcp",
-        "variant": "bionic"
       }
     ],
     "proton": [


### PR DESCRIPTION
## Description
Add 1.12.0-sarek-dyasync to manifest.json

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ x This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added DXVK 1.12.0-sarek-dyasync to the DXWrapper downloads manifest so users can install the bionic `.wcp` build.

New entry: id `dxvk-1.12.0-sarek`, name "dxvk-1.12.0-sarek.wcp", URL https://downloads.gamenative.app/dxwrapper/dxvk-sarek-dyasync-1.12.0.wcp

<sup>Written for commit 791d6ae7b2806902845c6eabffa24ecaa1083595. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated manifest timestamp to reflect the latest publish date.
  * Replaced the DXVK entry with version 1.12.0-sarek-dyasync and refreshed its download reference while keeping the bionic variant.
  * Added a new download component for DXVK 1.12.0-sarek so installers can retrieve the corresponding .wcp artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->