### PR TITLE
Added gamefix for subnautica 2

### DIFF
--- a/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
@@ -39,6 +39,7 @@ object GameFixesRegistry {
         STEAM_Fix_413420,
         STEAM_Fix_752580,
         STEAM_Fix_1637320,
+        STEAM_Fix_1962700,
         STEAM_Fix_2868840,
         STEAM_Fix_3373660,
         STEAM_Fix_990080,

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_1962700.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_1962700.kt
@@ -1,0 +1,35 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+import com.winlator.xenvironment.ImageFs
+
+private val SUBNAUTICA2_ENGINE_INI = """
+[SectionsToSave]
+bCanSaveAllSections=true
++Section=CurrentIniVersion
+
+[/Script/Engine.RendererSettings]
+r.Nanite=0
+r.DynamicGlobalIlluminationMethod=0
+r.ReflectionMethod=0
+r.ShadowQuality=0
+r.Shadow.CSM.MaxCascades=1
+r.Shadow.Virtual.Enable=0
+r.VolumetricFog=0
+r.GPUCrashDebugging=0
+r.BufferPool.FreeUnusedVariables=1
+r.D3D12.ZeroBufferAllocations=1
+
+[/Script/WindowsTargetPlatform.WindowsTargetSettings]
+r.D3D12.GlobalViewHeapSize=500000
+r.D3D12.LocalViewHeapSize=16384
+r.D3D12.MaxGraphicsResourceViewHeapSize=500000
+d3d12.MaxDescriptorHeaps=4096
+""".trimIndent() + "\n"
+
+val STEAM_Fix_1962700: KeyedGameFix = KeyedPrefixFileFix(
+    gameSource = GameSource.STEAM,
+    gameId = "1962700",
+    driveCRelativePath = "users/${ImageFs.USER}/AppData/Local/Subnautica2/Saved/Config/Windows/Engine.ini",
+    content = SUBNAUTICA2_ENGINE_INI,
+)

--- a/app/src/main/java/app/gamenative/gamefixes/types/PrefixFileFix.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/types/PrefixFileFix.kt
@@ -1,0 +1,51 @@
+package app.gamenative.gamefixes
+
+import android.content.Context
+import app.gamenative.data.GameSource
+import com.winlator.container.Container
+import java.io.File
+import java.nio.charset.StandardCharsets
+import timber.log.Timber
+
+/**
+ * Writes a fixed file (creating parent directories) at a path relative to the
+ * container's `drive_c/` on every launch.
+ *
+ * Used for games that need a config dropped into the prefix (e.g. an Unreal
+ * Engine `Engine.ini` under AppData) before they will run acceptably. The file
+ * is only rewritten when its contents differ from [content].
+ */
+class PrefixFileFix(
+    private val driveCRelativePath: String,
+    private val content: String,
+) : GameFix {
+    override fun apply(
+        context: Context,
+        gameId: String,
+        installPath: String,
+        installPathWindows: String,
+        container: Container,
+    ): Boolean {
+        val target = File(container.rootDir, ".wine/drive_c/$driveCRelativePath")
+        return runCatching {
+            val existing = if (target.isFile) target.readText(StandardCharsets.UTF_8) else null
+            if (existing == content) {
+                return false
+            }
+            target.parentFile?.mkdirs()
+            target.writeText(content, StandardCharsets.UTF_8)
+            Timber.tag("GameFixes").i("Wrote '${target.absolutePath}' for game $gameId")
+            true
+        }.getOrElse { error ->
+            Timber.tag("GameFixes").w(error, "Failed to write '${target.absolutePath}' for game $gameId")
+            false
+        }
+    }
+}
+
+class KeyedPrefixFileFix(
+    override val gameSource: GameSource,
+    override val gameId: String,
+    driveCRelativePath: String,
+    content: String,
+) : KeyedGameFix, GameFix by PrefixFileFix(driveCRelativePath, content)

--- a/app/src/test/java/app/gamenative/gamefixes/types/PrefixFileFixTest.kt
+++ b/app/src/test/java/app/gamenative/gamefixes/types/PrefixFileFixTest.kt
@@ -1,0 +1,126 @@
+package app.gamenative.gamefixes
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.winlator.container.Container
+import com.winlator.xenvironment.ImageFs
+import io.mockk.every
+import io.mockk.mockk
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PrefixFileFixTest {
+
+    private lateinit var context: Context
+    private lateinit var tempDir: File
+    private lateinit var container: Container
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        tempDir = Files.createTempDirectory("prefix_file_fix_test_").toFile()
+        container = mockk(relaxed = true)
+        every { container.rootDir } returns tempDir
+    }
+
+    @After
+    fun tearDown() {
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun apply_createsMissingDirectoriesAndWritesContent() {
+        val fix = PrefixFileFix(
+            driveCRelativePath = "users/xuser/AppData/Local/Subnautica2/Saved/Config/Windows/Engine.ini",
+            content = "[Section]\nKey=Value\n",
+        )
+
+        val changed = fix.apply(
+            context = context,
+            gameId = "1962700",
+            installPath = tempDir.absolutePath,
+            installPathWindows = "A:\\",
+            container = container,
+        )
+
+        assertTrue(changed)
+        val target = File(
+            tempDir,
+            ".wine/drive_c/users/xuser/AppData/Local/Subnautica2/Saved/Config/Windows/Engine.ini",
+        )
+        assertEquals("[Section]\nKey=Value\n", target.readText(StandardCharsets.UTF_8))
+    }
+
+    @Test
+    fun apply_returnsFalse_whenContentAlreadyMatches() {
+        val relativePath = "users/xuser/AppData/Local/Game/Engine.ini"
+        val content = "[Section]\nKey=Value\n"
+        val target = File(tempDir, ".wine/drive_c/$relativePath")
+        target.parentFile?.mkdirs()
+        target.writeText(content, StandardCharsets.UTF_8)
+
+        val fix = PrefixFileFix(driveCRelativePath = relativePath, content = content)
+
+        val changed = fix.apply(
+            context = context,
+            gameId = "1962700",
+            installPath = tempDir.absolutePath,
+            installPathWindows = "A:\\",
+            container = container,
+        )
+
+        assertFalse(changed)
+    }
+
+    @Test
+    fun apply_overwritesDifferingContent() {
+        val relativePath = "users/xuser/AppData/Local/Game/Engine.ini"
+        val target = File(tempDir, ".wine/drive_c/$relativePath")
+        target.parentFile?.mkdirs()
+        target.writeText("old\n", StandardCharsets.UTF_8)
+
+        val fix = PrefixFileFix(driveCRelativePath = relativePath, content = "new\n")
+
+        val changed = fix.apply(
+            context = context,
+            gameId = "1962700",
+            installPath = tempDir.absolutePath,
+            installPathWindows = "A:\\",
+            container = container,
+        )
+
+        assertTrue(changed)
+        assertEquals("new\n", target.readText(StandardCharsets.UTF_8))
+    }
+
+    @Test
+    fun steamFix1962700_writesEngineIniToSubnauticaConfigPath() {
+        val changed = STEAM_Fix_1962700.apply(
+            context = context,
+            gameId = "1962700",
+            installPath = tempDir.absolutePath,
+            installPathWindows = "A:\\",
+            container = container,
+        )
+
+        assertTrue(changed)
+        val target = File(
+            tempDir,
+            ".wine/drive_c/users/${ImageFs.USER}/AppData/Local/Subnautica2/Saved/Config/Windows/Engine.ini",
+        )
+        val written = target.readText(StandardCharsets.UTF_8)
+        assertTrue(written.contains("[/Script/Engine.RendererSettings]"))
+        assertTrue(written.contains("r.Nanite=0"))
+        assertTrue(written.contains("d3d12.MaxDescriptorHeaps=4096"))
+    }
+}


### PR DESCRIPTION
## Description
Subnautica needs file added

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Subnautica 2 (Steam 1962700) gamefix that writes an Engine.ini into the Wine prefix to improve stability and performance. Also introduces a reusable file-based fix for dropping config files into `drive_c` on launch.

- New Features
  - New `PrefixFileFix`/`KeyedPrefixFileFix`: writes files under `drive_c` on launch; no-op if unchanged.
  - Subnautica 2 (`1962700`) fix: writes `Engine.ini` to `users/${ImageFs.USER}/AppData/Local/Subnautica2/Saved/Config/Windows/Engine.ini` with renderer/D3D12 tweaks (e.g., `r.Nanite=0`, `d3d12.MaxDescriptorHeaps=4096`).
  - Registered in `GameFixesRegistry` and covered by tests (write, no-op, overwrite, correct path/content).

<sup>Written for commit cd997bd452f146268ced2a72021cc897294e482d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Subnautica 2 (Steam) game fix with optimized graphics and memory heap configuration.
  * Introduced file-based game fix system for applying configuration modifications to games.

* **Tests**
  * Added comprehensive test coverage for the new file modification functionality and Subnautica 2 fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->