### PR TITLE
fix: dxwrappers and graphic drivers downloader handling on custom content files

### DIFF
--- a/app/src/main/java/app/gamenative/utils/downloader/DXWrapperDownloader.kt
+++ b/app/src/main/java/app/gamenative/utils/downloader/DXWrapperDownloader.kt
@@ -50,8 +50,8 @@ object DXWrapperDownloader {
     ): File? = withContext(Dispatchers.IO) {
         // Validate component exists in manifest first (for both legacy and modern variants)
         val manifest = loadDXWrapperManifest(context)
-        manifest.components.find { it.id == componentId }
-            ?: throw Exception("DXWrapper $componentId not found in $DXWRAPPER_MANIFEST_FILE")
+        val component = manifest.components.find { it.id == componentId }
+            ?: return@withContext null
 
         // Legacy variant: use bundled assets
         if (!BuildConfig.MODERN_ANDROID) {
@@ -61,7 +61,7 @@ object DXWrapperDownloader {
 
         // Modern variant: download from server
         // Check if already downloaded and cached
-        val destFile = File(context.filesDir, "$DXWRAPPER_CACHE_DIR/$componentId.tzst")
+        val destFile = File(context.filesDir, "$DXWRAPPER_CACHE_DIR/${component.name}")
         if (destFile.exists() && destFile.length() > 0) {
             Timber.d("Using cached dxwrapper: $componentId at ${destFile.absolutePath}")
             return@withContext destFile
@@ -74,7 +74,7 @@ object DXWrapperDownloader {
 
         try {
             SteamService.fetchFileWithFallback(
-                fileName = "dxwrapper/$componentId.tzst",
+                fileName = "dxwrapper/${component.name}",
                 dest = destFile,
                 context = context,
                 onProgress = onProgress

--- a/app/src/main/java/app/gamenative/utils/downloader/GraphicsDriverDownloader.kt
+++ b/app/src/main/java/app/gamenative/utils/downloader/GraphicsDriverDownloader.kt
@@ -51,7 +51,7 @@ object GraphicsDriverDownloader {
         // Validate component exists in manifest first (for both legacy and modern variants)
         val manifest = loadGraphicsDriverManifest(context)
         val component = manifest.components.find { it.id == componentId }
-            ?: throw Exception("Graphics driver $componentId not found in $GRAPHICS_DRIVER_MANIFEST_FILE")
+            ?: return@withContext null
 
         // Legacy variant: use bundled assets
         if (!BuildConfig.MODERN_ANDROID) {

--- a/app/src/test/java/app/gamenative/utils/downloader/DXWrapperDownloaderTest.kt
+++ b/app/src/test/java/app/gamenative/utils/downloader/DXWrapperDownloaderTest.kt
@@ -208,9 +208,15 @@ class DXWrapperDownloaderTest {
     fun testCachedComponentReuse() = runBlocking {
         val componentId = "vkd3d-2.6"
 
+        // Load manifest to get component name
+        val manifestJson = context.assets.open(DXWrapperDownloader.DXWRAPPER_MANIFEST_FILE).bufferedReader().use { it.readText() }
+        val manifest = Json { ignoreUnknownKeys = true }
+            .decodeFromString<DXWrapperDownloader.DXWrapperManifest>(manifestJson)
+        val component = manifest.components.find { it.id == componentId }!!
+
         // Create a mock cached file
         cacheDir.mkdirs()
-        val cachedFile = File(cacheDir, "$componentId.tzst")
+        val cachedFile = File(cacheDir, component.name)
         cachedFile.writeText("mock cached content")
 
         val retrievedFile = DXWrapperDownloader.ensureDXWrapperAvailable(
@@ -228,19 +234,16 @@ class DXWrapperDownloaderTest {
     }
 
     @Test
-    fun testInvalidComponentThrowsException() = runBlocking {
-        try {
-            DXWrapperDownloader.ensureDXWrapperAvailable(
-                context,
-                "nonexistent_dxvk_xyz"
-            )
-            throw AssertionError("Should have thrown exception for invalid component")
-        } catch (e: Exception) {
-            assertTrue(
-                "Exception message should mention component not found",
-                e.message?.contains("not found") == true
-            )
-        }
+    fun testInvalidComponentReturnsNull() = runBlocking {
+        val result = DXWrapperDownloader.ensureDXWrapperAvailable(
+            context,
+            "nonexistent_dxvk_xyz"
+        )
+        assertEquals(
+            "Invalid component should return null",
+            null,
+            result
+        )
     }
 
     @Test

--- a/app/src/test/java/app/gamenative/utils/downloader/GraphicsDriverDownloaderTest.kt
+++ b/app/src/test/java/app/gamenative/utils/downloader/GraphicsDriverDownloaderTest.kt
@@ -251,9 +251,15 @@ class GraphicsDriverDownloaderTest {
     fun testCachedComponentReuse() = runBlocking {
         val componentId = "vortek-2.1"
 
+        // Load manifest to get component name
+        val manifestJson = context.assets.open(GraphicsDriverDownloader.GRAPHICS_DRIVER_MANIFEST_FILE).bufferedReader().use { it.readText() }
+        val manifest = Json { ignoreUnknownKeys = true }
+            .decodeFromString<GraphicsDriverDownloader.GraphicsDriverManifest>(manifestJson)
+        val component = manifest.components.find { it.id == componentId }!!
+
         // Create a mock cached file
         cacheDir.mkdirs()
-        val cachedFile = File(cacheDir, "$componentId.tzst")
+        val cachedFile = File(cacheDir, component.name)
         cachedFile.writeText("mock cached content")
 
         val retrievedFile = GraphicsDriverDownloader.ensureGraphicsDriverAvailable(
@@ -271,19 +277,16 @@ class GraphicsDriverDownloaderTest {
     }
 
     @Test
-    fun testInvalidComponentThrowsException() = runBlocking {
-        try {
-            GraphicsDriverDownloader.ensureGraphicsDriverAvailable(
-                context,
-                "nonexistent_driver_xyz"
-            )
-            throw AssertionError("Should have thrown exception for invalid component")
-        } catch (e: Exception) {
-            assertTrue(
-                "Exception message should mention component not found",
-                e.message?.contains("not found") == true
-            )
-        }
+    fun testInvalidComponentReturnsNull() = runBlocking {
+        val result = GraphicsDriverDownloader.ensureGraphicsDriverAvailable(
+            context,
+            "nonexistent_driver_xyz"
+        )
+        assertEquals(
+            "Invalid component should return null",
+            null,
+            result
+        )
     }
 
     @Test


### PR DESCRIPTION
## Description
fix: dxwrappers and graphic drivers downloader handling on custom content files

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes downloader handling for DX wrappers and graphics drivers when using custom-named content files. Uses manifest-provided file names and returns null for unknown components to avoid crashes and improve cache reuse.

- **Bug Fixes**
  - `DXWrapperDownloader`: use `component.name` from the manifest for cache paths and remote fetch (`dxwrapper/${component.name}`).
  - `DXWrapperDownloader` and `GraphicsDriverDownloader`: return null when a component is missing from the manifest (no exception).

- **Migration**
  - Update call sites to handle a null return from `ensureDXWrapperAvailable` and `ensureGraphicsDriverAvailable`.

<sup>Written for commit 5293cedff6ae7a8a02d96b85cc4325ffe222931c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced error handling for missing graphics driver and DX wrapper components. The app now responds gracefully instead of throwing errors when components are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->