### PR TITLE
Quest improvements

### DIFF
--- a/.github/workflows/adhoc-signed-build.yml
+++ b/.github/workflows/adhoc-signed-build.yml
@@ -87,12 +87,13 @@ jobs:
         yes | "$SDKMANAGER" --install "build-tools;34.0.0"
 
     - name: Build with Gradle
-      run: ./gradlew :app:bundleLegacyRelease :app:bundleModernRelease
+      run: ./gradlew :app:bundleLegacyRelease :app:bundleModernRelease :app:bundleLegacyXrRelease
 
     - name: Stage bundles
       run: |
         cp app/build/outputs/bundle/legacyRelease/app-legacy-release.aab app-release.aab
         cp app/build/outputs/bundle/modernRelease/app-modern-release.aab app-modern-release.aab
+        cp app/build/outputs/bundle/legacyXrRelease/app-legacyXr-release.aab app-legacy-xr-release.aab
 
     - name: Extract APKs from Bundles
       run: |
@@ -100,6 +101,8 @@ jobs:
         unzip -o app-release.apks universal.apk
         java -jar tools/bundletool-all-1.17.2.jar build-apks --bundle=app-modern-release.aab --output=app-modern-release.apks --mode=universal
         unzip -p app-modern-release.apks universal.apk > universal-modern.apk
+        java -jar tools/bundletool-all-1.17.2.jar build-apks --bundle=app-legacy-xr-release.aab --output=app-legacy-xr-release.apks --mode=universal
+        unzip -p app-legacy-xr-release.apks universal.apk > universal-legacy-xr.apk
 
     - name: Copy lineage file
       run: |
@@ -119,7 +122,7 @@ jobs:
         if [ ! -d "$BUILD_TOOLS_DIR" ]; then
           BUILD_TOOLS_DIR="${ANDROID_SDK_ROOT}/build-tools/34.0.0"
         fi
-        for apk in universal.apk universal-modern.apk; do
+        for apk in universal.apk universal-modern.apk universal-legacy-xr.apk; do
           "${BUILD_TOOLS_DIR}/apksigner" sign \
             --lineage app/keystores/prod-debug.lineage \
             --ks app/keystores/keystore \
@@ -146,3 +149,9 @@ jobs:
       with:
         name: adhoc-signed-modern-${{ steps.meta.outputs.suffix }}
         path: ${{ github.workspace }}/universal-modern.apk
+
+    - name: Upload Legacy XR APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: adhoc-signed-legacy-xr-${{ steps.meta.outputs.suffix }}
+        path: ${{ github.workspace }}/universal-legacy-xr.apk

--- a/.github/workflows/app-release-signed.yml
+++ b/.github/workflows/app-release-signed.yml
@@ -76,12 +76,13 @@ jobs:
         yes | "$SDKMANAGER" --install "build-tools;34.0.0"
 
     - name: Build with Gradle
-      run: ./gradlew :app:bundleLegacyRelease :app:bundleModernRelease
+      run: ./gradlew :app:bundleLegacyRelease :app:bundleModernRelease :app:bundleLegacyXrRelease
 
     - name: Stage bundles
       run: |
         cp app/build/outputs/bundle/legacyRelease/app-legacy-release.aab app-release.aab
         cp app/build/outputs/bundle/modernRelease/app-modern-release.aab app-modern-release.aab
+        cp app/build/outputs/bundle/legacyXrRelease/app-legacyXr-release.aab app-legacy-xr-release.aab
 
     - name: Extract APKs from Bundles
       run: |
@@ -89,6 +90,8 @@ jobs:
         unzip -o app-release.apks universal.apk
         java -jar tools/bundletool-all-1.17.2.jar build-apks --bundle=app-modern-release.aab --output=app-modern-release.apks --mode=universal
         unzip -p app-modern-release.apks universal.apk > universal-modern.apk
+        java -jar tools/bundletool-all-1.17.2.jar build-apks --bundle=app-legacy-xr-release.aab --output=app-legacy-xr-release.apks --mode=universal
+        unzip -p app-legacy-xr-release.apks universal.apk > universal-legacy-xr.apk
 
     - name: Copy lineage file
       run: |
@@ -108,7 +111,7 @@ jobs:
         if [ ! -d "$BUILD_TOOLS_DIR" ]; then
           BUILD_TOOLS_DIR="${ANDROID_SDK_ROOT}/build-tools/34.0.0"
         fi
-        for apk in universal.apk universal-modern.apk; do
+        for apk in universal.apk universal-modern.apk universal-legacy-xr.apk; do
           "${BUILD_TOOLS_DIR}/apksigner" sign \
             --lineage app/keystores/prod-debug.lineage \
             --ks app/keystores/keystore \
@@ -136,6 +139,12 @@ jobs:
         name: app-release-signed-modern
         path: ${{ github.workspace }}/universal-modern.apk
 
+    - name: Upload Legacy XR APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-release-signed-legacy-xr
+        path: ${{ github.workspace }}/universal-legacy-xr.apk
+
     - name: Build changelog text
       id: changelog
       run: |
@@ -155,11 +164,13 @@ jobs:
         CHANGELOG: ${{ steps.changelog.outputs.log }}
         LEGACY_URL: https://nightly.link/utkarshdalal/GameNative/actions/runs/${{ github.run_id }}/app-release-signed.zip
         MODERN_URL: https://nightly.link/utkarshdalal/GameNative/actions/runs/${{ github.run_id }}/app-release-signed-modern.zip
+        LEGACY_XR_URL: https://nightly.link/utkarshdalal/GameNative/actions/runs/${{ github.run_id }}/app-release-signed-legacy-xr.zip
       run: |
         # jq -n handles JSON escaping (newlines, quotes, etc.) for us.
         payload=$(jq -n \
           --arg legacy "$LEGACY_URL" \
           --arg modern "$MODERN_URL" \
+          --arg legacyXr "$LEGACY_XR_URL" \
           --arg changes "$CHANGELOG" \
-          '{content: "**New Android build**\nStandard Build (Recommended): \($legacy)\nPlay Store Build (Android 11+ — built for the latest Android, so **no security warning** about an outdated target. No D drive access and no custom game support; glibc not supported, external storage location moved.): \($modern)\n\nChanges:\n\($changes)"}')
+          '{content: "**New Android build**\nStandard Build (Recommended): \($legacy)\nPlay Store Build (Android 11+ — built for the latest Android, so **no security warning** about an outdated target. No D drive access and no custom game support; glibc not supported, external storage location moved.): \($modern)\nQuest/VR Build (sideload only — legacy storage with all-files access and D drive support, forced landscape): \($legacyXr)\n\nChanges:\n\($changes)"}')
         curl -H 'Content-Type: application/json' -d "$payload" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -73,12 +73,13 @@ jobs:
           yes | "$SDKMANAGER" --install "build-tools;34.0.0"
 
       - name: Build with Gradle
-        run: ./gradlew :app:bundleLegacyRelease :app:bundleModernRelease
+        run: ./gradlew :app:bundleLegacyRelease :app:bundleModernRelease :app:bundleLegacyXrRelease
 
       - name: Stage bundles
         run: |
           cp app/build/outputs/bundle/legacyRelease/app-legacy-release.aab app-release.aab
           cp app/build/outputs/bundle/modernRelease/app-modern-release.aab app-modern-release.aab
+          cp app/build/outputs/bundle/legacyXrRelease/app-legacyXr-release.aab app-legacy-xr-release.aab
 
       - name: Extract APKs from Bundles
         run: |
@@ -92,6 +93,11 @@ jobs:
             --output=app-modern-release.apks \
             --mode=universal
           unzip -p app-modern-release.apks universal.apk > universal-modern.apk
+          java -jar tools/bundletool-all-1.17.2.jar build-apks \
+            --bundle=app-legacy-xr-release.aab \
+            --output=app-legacy-xr-release.apks \
+            --mode=universal
+          unzip -p app-legacy-xr-release.apks universal.apk > universal-legacy-xr.apk
 
       - name: Copy lineage file
         run: |
@@ -111,7 +117,7 @@ jobs:
           if [ ! -d "$BUILD_TOOLS_DIR" ]; then
             BUILD_TOOLS_DIR="${ANDROID_SDK_ROOT}/build-tools/34.0.0"
           fi
-          for apk in universal.apk universal-modern.apk; do
+          for apk in universal.apk universal-modern.apk universal-legacy-xr.apk; do
             "${BUILD_TOOLS_DIR}/apksigner" sign \
               --lineage app/keystores/prod-debug.lineage \
               --ks app/keystores/keystore \
@@ -134,6 +140,7 @@ jobs:
           path: |
             universal.apk
             universal-modern.apk
+            universal-legacy-xr.apk
 
   release:
     needs: build
@@ -151,6 +158,7 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           mv universal.apk "gamenative-$TAG.apk"
           mv universal-modern.apk "gamenative-$TAG-modern.apk"
+          mv universal-legacy-xr.apk "gamenative-$TAG-legacy-xr.apk"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -164,8 +172,10 @@ jobs:
             ## Downloads
             - **`gamenative-${{ github.ref_name }}.apk`** — Standard build (Android 8–14). Recommended for most users.
             - **`gamenative-${{ github.ref_name }}-modern.apk`** — Play Store build (Android 11+). Built for the latest Android, so **no security warning** about an outdated target. No D drive access and no custom game support; glibc not supported, external storage location moved.
+            - **`gamenative-${{ github.ref_name }}-legacy-xr.apk`** — Quest/VR sideload build. Legacy storage with all-files access and D drive support, forced landscape. Sideload only (not for the store).
           files: |
             gamenative-${{ github.ref_name }}.apk
             gamenative-${{ github.ref_name }}-modern.apk
+            gamenative-${{ github.ref_name }}-legacy-xr.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -119,6 +119,15 @@ android {
             buildConfigField("boolean", "MODERN_ANDROID", "false")
             buildConfigField("String", "PRELOAD_BIONIC_SO", "\"libredirect-bionic.so\"")
         }
+        create("legacyXr") {
+            dimension = "androidApi"
+            targetSdk = 28
+            ndk.abiFilters += listOf("arm64-v8a", "armeabi-v7a")
+            buildConfigField("boolean", "MODERN_ANDROID", "false")
+            buildConfigField("String", "PRELOAD_BIONIC_SO", "\"libredirect-bionic.so\"")
+            buildConfigField("boolean", "XR_BUILD", "true")
+            manifestPlaceholders["screenOrientation"] = "landscape"
+        }
         create("modern") {
             dimension = "androidApi"
             minSdk = 29
@@ -212,6 +221,15 @@ android {
         getByName("legacy") {
             assets {
                 srcDirs("src/legacy/assets", "src/main/assets")
+            }
+        }
+        getByName("legacyXr") {
+            manifest.srcFile("src/legacy/AndroidManifest.xml")
+            assets {
+                srcDirs("src/legacy/assets", "src/main/assets")
+            }
+            jniLibs {
+                srcDirs("src/legacy/jniLibs")
             }
         }
         getByName("modern") {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,9 @@ android {
 
         minSdk = 26
 
+        manifestPlaceholders["screenOrientation"] = "unspecified"
+        buildConfigField("boolean", "XR_BUILD", "false")
+
         versionCode = 14
         versionName = "1.0.0"
 
@@ -123,6 +126,16 @@ android {
             ndk.abiFilters += listOf("arm64-v8a")
             buildConfigField("boolean", "MODERN_ANDROID", "true")
             buildConfigField("String", "PRELOAD_BIONIC_SO", "\"libredirect-bionic-wx.so\"")
+        }
+        create("modernXr") {
+            dimension = "androidApi"
+            minSdk = 29
+            targetSdk = 36
+            ndk.abiFilters += listOf("arm64-v8a")
+            buildConfigField("boolean", "MODERN_ANDROID", "true")
+            buildConfigField("String", "PRELOAD_BIONIC_SO", "\"libredirect-bionic-wx.so\"")
+            buildConfigField("boolean", "XR_BUILD", "true")
+            manifestPlaceholders["screenOrientation"] = "landscape"
         }
     }
 
@@ -204,6 +217,14 @@ android {
         getByName("modern") {
             assets {
                 srcDirs("src/modern/assets", "src/main/assets")
+            }
+        }
+        getByName("modernXr") {
+            assets {
+                srcDirs("src/modern/assets", "src/main/assets")
+            }
+            jniLibs {
+                srcDirs("src/modern/jniLibs")
             }
         }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
+            android:screenOrientation="${screenOrientation}"
             android:windowSoftInputMode="adjustResize"
             android:configChanges="orientation|screenSize|keyboard|keyboardHidden|navigation"
             android:theme="@style/Theme.Pluvia">

--- a/app/src/main/java/app/gamenative/MainActivity.kt
+++ b/app/src/main/java/app/gamenative/MainActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.graphics.Color.TRANSPARENT
 import android.os.Build
@@ -64,6 +65,12 @@ class MainActivity : ComponentActivity() {
 
         private var currentOrientationChangeValue: Int = 0
         private var availableOrientations: EnumSet<Orientation> = EnumSet.of(Orientation.UNSPECIFIED)
+
+        fun isHeadset(context: Context): Boolean =
+            context.packageManager.hasSystemFeature("android.hardware.vr.headtracking") ||
+                Build.MANUFACTURER.equals("Oculus", true) ||
+                Build.MANUFACTURER.equals("Meta", true) ||
+                Build.MANUFACTURER.equals("Pico", true)
 
         // Store pending launch request to be processed after UI is ready
         @Volatile
@@ -145,6 +152,18 @@ class MainActivity : ComponentActivity() {
             navigationBarStyle = SystemBarStyle.dark(TRANSPARENT),
         )
         super.onCreate(savedInstanceState)
+
+        if (isHeadset(this)) {
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+            android.view.InputDevice.getDeviceIds().forEach { id ->
+                val d = android.view.InputDevice.getDevice(id) ?: return@forEach
+                val axes = d.motionRanges.joinToString(",") { mr -> "axis=${mr.axis}(min=${mr.min},max=${mr.max})" }
+                Timber.tag("HeadsetInput").i(
+                    "id=$id name='${d.name}' sources=0x%08x vendor=0x%04x product=0x%04x isGamepad=%b axes=[$axes]",
+                    d.sources, d.vendorId, d.productId, d.sources and android.view.InputDevice.SOURCE_GAMEPAD == android.view.InputDevice.SOURCE_GAMEPAD
+                )
+            }
+        }
 
         // stale keepAlive from a prior crash/swipe — no container is actually running
         if (SteamService.keepAlive && PluviaApp.xEnvironment == null) {
@@ -580,6 +599,12 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun setOrientationTo(orientation: Int, conformTo: EnumSet<Orientation>) {
+        if (isHeadset(this)) {
+            if (requestedOrientation != ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE) {
+                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+            }
+            return
+        }
         // Log.d("MainActivity$index", "Setting orientation to conform")
 
         // reverse direction of orientation

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -242,7 +242,9 @@ private fun rememberContainerConfigDialogStaticData(): ContainerConfigDialogStat
         glibcWineEntriesBase = stringArrayResource(R.array.glibc_wine_entries).toList(),
         emulatorEntries = stringArrayResource(R.array.emulator_entries).toList(),
         bionicGraphicsDrivers = stringArrayResource(R.array.bionic_graphics_driver_entries).toList(),
-        baseWrapperVersions = stringArrayResource(R.array.wrapper_graphics_driver_version_entries).toList(),
+        baseWrapperVersions = ManifestComponentHelper.bundledGraphicsDriverBase(
+            stringArrayResource(R.array.wrapper_graphics_driver_version_entries).toList(),
+        ),
         languages = listOf(
             "arabic", "bulgarian", "schinese", "tchinese", "czech", "danish", "dutch", "english",
             "finnish", "french", "german", "greek", "hungarian", "italian", "japanese", "koreana",

--- a/app/src/main/java/app/gamenative/ui/enums/LibraryTab.kt
+++ b/app/src/main/java/app/gamenative/ui/enums/LibraryTab.kt
@@ -1,6 +1,7 @@
 package app.gamenative.ui.enums
 
 import androidx.annotation.StringRes
+import app.gamenative.BuildConfig
 import app.gamenative.R
 
 enum class LibraryTab(
@@ -68,16 +69,23 @@ enum class LibraryTab(
     );
 
     companion object {
+        /**
+         * Tabs shown in the UI. Custom (LOCAL) games rely on all-files access, which only the
+         * legacy storage flavors have, so the tab is hidden on modern (scoped-storage) builds.
+         */
+        val visibleEntries: List<LibraryTab>
+            get() = if (BuildConfig.MODERN_ANDROID) entries.filter { it != LOCAL } else entries
+
         fun LibraryTab.next(): LibraryTab {
-            val values = entries
-            val nextIndex = (ordinal + 1) % values.size
-            return values[nextIndex]
+            val values = visibleEntries
+            val index = values.indexOf(this).coerceAtLeast(0)
+            return values[(index + 1) % values.size]
         }
 
         fun LibraryTab.previous(): LibraryTab {
-            val values = entries
-            val prevIndex = if (ordinal == 0) values.size - 1 else ordinal - 1
-            return values[prevIndex]
+            val values = visibleEntries
+            val index = values.indexOf(this).coerceAtLeast(0)
+            return values[if (index == 0) values.size - 1 else index - 1]
         }
     }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -66,6 +66,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import app.gamenative.BuildConfig
 import app.gamenative.PrefManager
 import app.gamenative.PluviaApp
 import app.gamenative.R
@@ -821,7 +822,7 @@ private fun LibraryScreenContent(
 
                         // X button - add custom game
                         KeyEvent.KEYCODE_BUTTON_X -> {
-                            if (selectedAppId == null && !state.isSearching && !state.isOptionsPanelOpen && !isSystemMenuOpen) {
+                            if (!BuildConfig.MODERN_ANDROID && selectedAppId == null && !state.isSearching && !state.isOptionsPanelOpen && !isSystemMenuOpen) {
                                 onAddCustomGameClick()
                                 true
                             } else {
@@ -1049,12 +1050,17 @@ private fun LibraryScreenContent(
                         labelResId = R.string.search,
                         onClick = { onIsSearching(true) },
                     ),
-                    GamepadAction(
-                        button = GamepadButton.X,
-                        labelResId = R.string.action_add_game,
-                        onClick = onAddCustomGameClick,
-                    ),
-                )
+                ) + if (!BuildConfig.MODERN_ANDROID) {
+                    listOf(
+                        GamepadAction(
+                            button = GamepadButton.X,
+                            labelResId = R.string.action_add_game,
+                            onClick = onAddCustomGameClick,
+                        ),
+                    )
+                } else {
+                    emptyList()
+                }
             }
 
             GamepadActionBar(

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryTabBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryTabBar.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import app.gamenative.BuildConfig
 import app.gamenative.R
 import app.gamenative.ui.enums.LibraryTab
 import app.gamenative.ui.theme.PluviaTheme
@@ -133,7 +134,7 @@ private fun CompactLibraryTabBar(
     onNextTab: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val tabs = LibraryTab.entries
+    val tabs = LibraryTab.visibleEntries
     val currentIndex = tabs.indexOf(currentTab)
     val scrollState = rememberScrollState()
     val tabPositions = remember { mutableStateMapOf<Int, Float>() }
@@ -277,11 +278,13 @@ private fun CompactLibraryTabBar(
                 contentDescription = stringResource(R.string.search),
                 onClick = onSearchClick,
             )
-            CompactIconButton(
-                icon = Icons.Default.Add,
-                contentDescription = stringResource(R.string.action_add_game),
-                onClick = onAddGameClick,
-            )
+            if (!BuildConfig.MODERN_ANDROID) {
+                CompactIconButton(
+                    icon = Icons.Default.Add,
+                    contentDescription = stringResource(R.string.action_add_game),
+                    onClick = onAddGameClick,
+                )
+            }
             CompactIconButton(
                 icon = Icons.Default.Menu,
                 contentDescription = stringResource(R.string.menu),
@@ -371,7 +374,7 @@ private fun ExpandedLibraryTabBar(
     onNextTab: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val tabs = LibraryTab.entries
+    val tabs = LibraryTab.visibleEntries
     val currentIndex = tabs.indexOf(currentTab)
     val scrollState = rememberScrollState()
 
@@ -513,11 +516,13 @@ private fun ExpandedLibraryTabBar(
                 onClick = onSearchClick,
             )
 
-            IconActionButton(
-                icon = Icons.Default.Add,
-                contentDescription = stringResource(R.string.action_add_game),
-                onClick = onAddGameClick,
-            )
+            if (!BuildConfig.MODERN_ANDROID) {
+                IconActionButton(
+                    icon = Icons.Default.Add,
+                    contentDescription = stringResource(R.string.action_add_game),
+                    onClick = onAddGameClick,
+                )
+            }
 
             IconActionButton(
                 icon = Icons.Default.Menu,

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
+import app.gamenative.BuildConfig
 import app.gamenative.R
 import app.gamenative.PrefManager
 import app.gamenative.enums.AppTheme
@@ -360,16 +361,18 @@ fun SettingsGroupInterface(
             },
         )
 
-        val anyFrontendSyncConfigured by FrontendSyncManager.anyConfigured.collectAsState()
-        SettingsMenuLink(
-            colors = settingsTileColorsAlt(),
-            title = { Text(text = stringResource(R.string.settings_interface_frontend_sync_title)) },
-            subtitle = { Text(text = stringResource(R.string.settings_interface_frontend_sync_subtitle)) },
-            action = if (anyFrontendSyncConfigured) {
-                { FrontendSyncResyncButton() }
-            } else null,
-            onClick = { showFrontendSyncDialog = true },
-        )
+        if (!BuildConfig.MODERN_ANDROID) {
+            val anyFrontendSyncConfigured by FrontendSyncManager.anyConfigured.collectAsState()
+            SettingsMenuLink(
+                colors = settingsTileColorsAlt(),
+                title = { Text(text = stringResource(R.string.settings_interface_frontend_sync_title)) },
+                subtitle = { Text(text = stringResource(R.string.settings_interface_frontend_sync_subtitle)) },
+                action = if (anyFrontendSyncConfigured) {
+                    { FrontendSyncResyncButton() }
+                } else null,
+                onClick = { showFrontendSyncDialog = true },
+            )
+        }
 
         // Language selection
         SettingsMenuLink(

--- a/app/src/main/java/app/gamenative/utils/BestConfigService.kt
+++ b/app/src/main/java/app/gamenative/utils/BestConfigService.kt
@@ -10,7 +10,6 @@ import com.winlator.container.Container
 import com.winlator.container.ContainerData
 import com.winlator.core.DefaultVersion
 import com.winlator.contents.ContentProfile
-import com.winlator.core.GPUBlackist
 import com.winlator.core.GPUInformation
 import com.winlator.fexcore.FEXCorePresetManager
 import com.winlator.core.KeyValueSet
@@ -189,15 +188,6 @@ object BestConfigService {
             filtered.remove("executablePath")
         }
 
-        if (config.toString().contains("turnip", ignoreCase = true) && GPUBlackist.isTurnipBlacklisted()) {
-            if (matchType == "exact_gpu_match" || matchType == "gpu_family_match" || matchType == "fallback_match") {
-                filtered.remove("graphicsDriver")
-                filtered.remove("graphicsDriverVersion")
-                filtered.remove("graphicsDriverConfig")
-                return JsonObject(filtered)
-            }
-        }
-
         if (matchType == "exact_gpu_match" || matchType == "gpu_family_match") {
             // Apply all fields
             return JsonObject(filtered)
@@ -240,8 +230,7 @@ object BestConfigService {
         }
 
         if (GPUInformation.isAdreno8EliteGen5(context) &&
-            !matched.matches(Regex(".*adreno.*\\b8(4[0-9]|5[0-9])\\b.*")) &&
-            !GPUBlackist.isTurnipBlacklisted()
+            !matched.matches(Regex(".*adreno.*\\b8(4[0-9]|5[0-9])\\b.*"))
         ) {
             val kvs = KeyValueSet(filteredJson.optString("graphicsDriverConfig", ""))
             kvs.put("version", "Turnip Adreno Driver T26 (@Mr_Purple_666)")
@@ -357,7 +346,9 @@ object BestConfigService {
             manifestWine + manifestProton,
         )
         val availableDrivers = ManifestComponentHelper.buildAvailableVersions(
-            context.resources.getStringArray(R.array.wrapper_graphics_driver_version_entries).toList(),
+            ManifestComponentHelper.bundledGraphicsDriverBase(
+                context.resources.getStringArray(R.array.wrapper_graphics_driver_version_entries).toList(),
+            ),
             installed.installedDrivers,
             manifestDrivers,
         )
@@ -530,7 +521,9 @@ object BestConfigService {
         val baseFexcore = context.resources.getStringArray(R.array.fexcore_version_entries).toList()
         val baseWineBionic = context.resources.getStringArray(R.array.bionic_wine_entries).toList()
         val baseWineGlibc = context.resources.getStringArray(R.array.glibc_wine_entries).toList()
-        val baseDrivers = context.resources.getStringArray(R.array.wrapper_graphics_driver_version_entries).toList()
+        val baseDrivers = ManifestComponentHelper.bundledGraphicsDriverBase(
+            context.resources.getStringArray(R.array.wrapper_graphics_driver_version_entries).toList(),
+        )
 
         val locallyAvailableDxvk = ManifestComponentHelper.buildAvailableVersions(
             base = baseDxvk,

--- a/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
+++ b/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
@@ -1,6 +1,7 @@
 package app.gamenative.utils
 
 import android.content.Context
+import app.gamenative.BuildConfig
 import com.winlator.contents.AdrenotoolsManager
 import com.winlator.contents.ContentProfile
 import com.winlator.contents.ContentsManager
@@ -135,6 +136,14 @@ object ManifestComponentHelper {
             installed = installed.installed,
             installedDrivers = installed.installedDrivers,
         )
+    }
+
+    fun bundledGraphicsDriverBase(resourceEntries: List<String>): List<String> {
+        return if (BuildConfig.MODERN_ANDROID) {
+            resourceEntries.filter { it.equals("System", ignoreCase = true) }
+        } else {
+            resourceEntries
+        }
     }
 
     fun buildAvailableVersions(base: List<String>, installed: List<String>, manifest: List<ManifestEntry>, ): List<String> {

--- a/app/src/test/java/app/gamenative/utils/BestConfigServiceTest.kt
+++ b/app/src/test/java/app/gamenative/utils/BestConfigServiceTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
+import java.io.File
 import org.junit.Assert.*
 import org.junit.Assume.assumeFalse
 import org.junit.Before
@@ -74,6 +75,16 @@ class BestConfigServiceTest {
 
         // Initialize PrefManager
         PrefManager.init(context)
+
+        val workingDir = File(System.getProperty("user.dir"))
+        val manifestFile = listOf(
+            File(workingDir, "manifest.json"),
+            File(workingDir.parentFile, "manifest.json"),
+        ).firstOrNull { it.exists() }
+        if (manifestFile != null) {
+            PrefManager.componentManifestJson = manifestFile.readText()
+            PrefManager.componentManifestFetchedAt = System.currentTimeMillis()
+        }
     }
 
     /**

--- a/app/src/test/java/app/gamenative/utils/ManifestIdCorrelationTest.kt
+++ b/app/src/test/java/app/gamenative/utils/ManifestIdCorrelationTest.kt
@@ -56,6 +56,7 @@ class ManifestIdCorrelationTest {
 
     private suspend fun verifyDriverEntry(entry: ManifestEntry) {
         val manager = AdrenotoolsManager(context)
+        val driverRoot = File(context.filesDir, "contents/adrenotools")
         var installedId: String? = null
         try {
             println("Driver download/install id=${entry.id} name=${entry.name} url=${entry.url}")
@@ -65,12 +66,15 @@ class ManifestIdCorrelationTest {
                 "Driver install failed for ${entry.id}: ${result.message}",
                 result.success,
             )
-            val installed = manager.enumarateInstalledDrivers()
-            println("Driver installed IDs: $installed")
-            installedId = installed.firstOrNull { it.equals(entry.id, ignoreCase = true) }
+            val installedDirs = driverRoot.listFiles()
+                ?.filter { it.isDirectory && File(it, "meta.json").exists() }
+                ?.map { it.name }
+                .orEmpty()
+            println("Driver installed dirs: $installedDirs")
+            installedId = installedDirs.firstOrNull { it.equals(entry.id, ignoreCase = true) }
             println("Driver match id=${entry.id} matched=${installedId != null}")
             assertTrue(
-                "Driver ID mismatch for ${entry.id}. Installed: $installed",
+                "Driver ID mismatch for ${entry.id}. Installed: $installedDirs",
                 installedId != null,
             )
         } finally {

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,66 @@
   "items": {
     "driver": [
       {
+        "id": "turnip26.0.0_R8",
+        "name": "turnip26.0.0_R8",
+        "url": "https://downloads.gamenative.app/drivers/turnip26.0.0_R8.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "turnip26.0.0_R4",
+        "name": "turnip26.0.0_R4",
+        "url": "https://downloads.gamenative.app/drivers/turnip26.0.0_R4.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "turnip25.3.0_R11",
+        "name": "turnip25.3.0_R11",
+        "url": "https://downloads.gamenative.app/drivers/turnip25.3.0_R11.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "turnip25.3.0_R6_Gmem",
+        "name": "turnip25.3.0_R6_Gmem",
+        "url": "https://downloads.gamenative.app/drivers/turnip25.3.0_R6_Gmem.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "turnip25.3.0_R3_Gmem",
+        "name": "turnip25.3.0_R3_Gmem",
+        "url": "https://downloads.gamenative.app/drivers/turnip25.3.0_R3_Gmem.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "turnip25.3.0_R3_Auto",
+        "name": "turnip25.3.0_R3_Auto",
+        "url": "https://downloads.gamenative.app/drivers/turnip25.3.0_R3_Auto.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "turnip25.1.0",
+        "name": "turnip25.1.0",
+        "url": "https://downloads.gamenative.app/drivers/turnip25.1.0.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "Turnip_Gen8_V25",
+        "name": "Turnip_Gen8_V25",
+        "url": "https://downloads.gamenative.app/drivers/Turnip_Gen8_V25.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "v762",
+        "name": "v762",
+        "url": "https://downloads.gamenative.app/drivers/v762.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "v805",
+        "name": "v805",
+        "url": "https://downloads.gamenative.app/drivers/v805.zip",
+        "variant": "bionic"
+      },
+      {
         "id": "Turnip v26.2.0 R4",
         "name": "Turnip_v26.2.0_R4",
         "url": "https://downloads.gamenative.app/drivers/Turnio_v26.2.0_R4.zip",

--- a/ubuntufs/build.gradle.kts
+++ b/ubuntufs/build.gradle.kts
@@ -19,6 +19,9 @@ android {
         create("modern") {
             dimension = "androidApi"
         }
+        create("modernXr") {
+            dimension = "androidApi"
+        }
     }
 
     buildTypes {

--- a/ubuntufs/build.gradle.kts
+++ b/ubuntufs/build.gradle.kts
@@ -16,6 +16,9 @@ android {
         create("legacy") {
             dimension = "androidApi"
         }
+        create("legacyXr") {
+            dimension = "androidApi"
+        }
         create("modern") {
             dimension = "androidApi"
         }


### PR DESCRIPTION
## Description
Made an XR modern and legacy build, handle the driver, and fix using drivers in the modern build

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Quest/VR build variants with forced landscape and legacy storage, and fixes driver selection on modern builds. CI now ships a `legacy-xr` APK and the UI hides custom-game features on scoped-storage builds.

- **New Features**
  - New flavors: `legacyXr` (API 28, all-files access, landscape) and `modernXr`; `MainActivity` detects headsets (Oculus/Meta/Pico/`android.hardware.vr.headtracking`) and forces landscape.
  - CI/CD builds, signs, and uploads a `legacy-xr` universal APK in adhoc, release, and tagged workflows; added link in Discord and Release assets.
  - Modern builds gate custom-game features: hide LOCAL tab, Add Game (icon and gamepad X), and Frontend Sync; tab navigation respects visible tabs.

- **Bug Fixes**
  - Modern build driver dropdown shows valid choices only; base list limited to “System” via `bundledGraphicsDriverBase`, and available versions merge bundled/installed/manifest.
  - Removed client-side Turnip blacklist (now server-side) and refined best-config for Adreno Gen 8 devices.
  - Tests updated: driver install correlation checks directory IDs; `BestConfigServiceTest` loads `manifest.json` to ensure consistent driver availability.

<sup>Written for commit 456f1b25095027511e7363636ba8692181989106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added legacy XR and modern XR build variants.
  * Enhanced VR headset detection to force landscape orientation on supported headsets.
  * Added additional Turnip driver variants to the driver list.
* **Bug Fixes**
  * Improved wrapper/graphics-driver version handling for more reliable driver/config selection.
* **Chores**
  * Updated release pipelines to build, sign, and publish a legacy XR APK artifact.
  * Updated UI behavior for modern builds (hiding specific tabs/actions and the Frontend sync tile).
  * Improved test logic for installed driver ID correlation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->