### PR TITLE
fix: adreno tools extraction on modern build variant

### DIFF
--- a/app/src/main/java/com/winlator/contents/AdrenotoolsManager.java
+++ b/app/src/main/java/com/winlator/contents/AdrenotoolsManager.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 
 import android.content.Context;
 import android.util.Log;
+import app.gamenative.BuildConfig;
 import com.winlator.container.Container;
 import com.winlator.container.Shortcut;
 import com.winlator.container.ContainerManager;
@@ -29,14 +30,19 @@ import org.json.JSONObject;
 
 public class AdrenotoolsManager {
 
+    private static final String GRAPHICS_DRIVER_CACHE_DIR = "assets/graphics_driver";
     private File adrenotoolsContentDir;
+    private File graphicsDriverCacheDir;
     private Context mContext;
 
     public AdrenotoolsManager(Context context) {
         this.mContext = context;
         this.adrenotoolsContentDir = new File(mContext.getFilesDir(), "contents/adrenotools");
+        this.graphicsDriverCacheDir = new File(mContext.getFilesDir(), GRAPHICS_DRIVER_CACHE_DIR);
         if (!adrenotoolsContentDir.exists())
             adrenotoolsContentDir.mkdirs();
+        if (!graphicsDriverCacheDir.exists())
+            graphicsDriverCacheDir.mkdirs();
     }
 
     public String getLibraryName(String adrenoToolsDriverId) {
@@ -102,15 +108,22 @@ public class AdrenotoolsManager {
     public ArrayList<String> enumarateInstalledDrivers() {
         ArrayList<String> driversList = new ArrayList<>();
 
-        for (File f : adrenotoolsContentDir.listFiles()) {
-            boolean fromResources = isFromResources("graphics_driver/adrenotools-" + f.getName() + ".tzst");
-            if (!fromResources && new File(f, "meta.json").exists())
-                driversList.add(f.getName());
+        File[] files = adrenotoolsContentDir.listFiles();
+        if (files != null) {
+            for (File f : files) {
+                boolean fromResources = isFromResources("graphics_driver/adrenotools-" + f.getName() + ".tzst");
+                if (!fromResources && new File(f, "meta.json").exists())
+                    driversList.add(f.getName());
+            }
         }
         return driversList;
     }
 
     private boolean isFromResources(String driver) {
+        if (BuildConfig.MODERN_ANDROID) {
+            return false;
+        }
+
         AssetManager am = mContext.getResources().getAssets();
         InputStream is = null;
         boolean isFromResources = true;
@@ -127,16 +140,28 @@ public class AdrenotoolsManager {
     }
 
     private boolean extractDriverFromResources(String adrenotoolsDriverId) {
-        String src = "graphics_driver/adrenotools-" + adrenotoolsDriverId + ".tzst";
-        boolean hasExtracted;
-
+        String fileName = "adrenotools-" + adrenotoolsDriverId + ".tzst";
         File dst = new File(adrenotoolsContentDir, adrenotoolsDriverId);
+
         if (dst.exists())
             dst.delete();
-
         dst.mkdirs();
-        Log.d("AdrenotoolsManager", "Extracting " + src + " to " + dst.getAbsolutePath());
-        hasExtracted = TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, mContext, src, dst);
+
+        boolean hasExtracted = false;
+
+        if (BuildConfig.MODERN_ANDROID) {
+            File cachedDriver = new File(graphicsDriverCacheDir, fileName);
+            if (cachedDriver.exists() && cachedDriver.length() > 0) {
+                Log.d("AdrenotoolsManager", "Extracting from cached driver: " + cachedDriver.getAbsolutePath() + " to " + dst.getAbsolutePath());
+                hasExtracted = TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, cachedDriver, dst);
+            } else {
+                Log.w("AdrenotoolsManager", "Cached driver not found: " + fileName + ". Driver needs to be downloaded first.");
+            }
+        } else {
+            String src = "graphics_driver/" + fileName;
+            Log.d("AdrenotoolsManager", "Extracting from bundled assets: " + src + " to " + dst.getAbsolutePath());
+            hasExtracted = TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, mContext, src, dst);
+        }
 
         if (!hasExtracted)
             dst.delete();
@@ -186,24 +211,36 @@ public class AdrenotoolsManager {
     }
 
     public void setDriverById(EnvVars envVars, ImageFs imagefs, String adrenotoolsDriverId) {
-        if (extractDriverFromResources(adrenotoolsDriverId) || enumarateInstalledDrivers().contains(adrenotoolsDriverId)) {
-            String driverPath = adrenotoolsContentDir.getAbsolutePath() + "/" + adrenotoolsDriverId + "/";
-            if (!getLibraryName(adrenotoolsDriverId).equals("")) {
-                envVars.put("ADRENOTOOLS_DRIVER_PATH", driverPath);
-                envVars.put("ADRENOTOOLS_HOOKS_PATH", imagefs.getLibDir());
-                envVars.put("ADRENOTOOLS_DRIVER_NAME", getLibraryName(adrenotoolsDriverId));
-                if (adrenotoolsDriverId.contains("v762") && GPUInformation.getVersion(mContext).contains("512.530")) {
-                    Log.d("AdrenotoolsManager", "Patching v762 driver for stock v530");
-                    FileUtils.writeToBinaryFile(driverPath + "notadreno_utils.so", 0x2680, 3);
-                } else if (adrenotoolsDriverId.contains("v762") && GPUInformation.getVersion(mContext).contains("512.502")) {
-                    Log.d("AdrenotoolsManager", "Patching v762 driver for stock v502");
-                    FileUtils.writeToBinaryFile(driverPath + "notadreno_utils.so", 0x2680, 2);
+        File driverDir = new File(adrenotoolsContentDir, adrenotoolsDriverId);
+        boolean driverExists = driverDir.exists() && new File(driverDir, "meta.json").exists();
+
+        if (!driverExists) {
+            boolean extracted = extractDriverFromResources(adrenotoolsDriverId);
+            if (!extracted && !enumarateInstalledDrivers().contains(adrenotoolsDriverId)) {
+                if (adrenotoolsDriverId != null && !adrenotoolsDriverId.isEmpty()
+                        && !adrenotoolsDriverId.equalsIgnoreCase("System")) {
+                    Log.w("AdrenotoolsManager", "Driver not found: " + adrenotoolsDriverId
+                        + " - Falling back to System driver");
                 }
+                return;
             }
-        } else if (adrenotoolsDriverId != null && !adrenotoolsDriverId.isEmpty()
-                && !adrenotoolsDriverId.equalsIgnoreCase("System")) {
-            Log.w("AdrenotoolsManager", "Driver not found: " + adrenotoolsDriverId
-                + " - Falling back to System driver");
+        }
+
+        String driverPath = adrenotoolsContentDir.getAbsolutePath() + "/" + adrenotoolsDriverId + "/";
+        String libraryName = getLibraryName(adrenotoolsDriverId);
+
+        if (!libraryName.equals("")) {
+            envVars.put("ADRENOTOOLS_DRIVER_PATH", driverPath);
+            envVars.put("ADRENOTOOLS_HOOKS_PATH", imagefs.getLibDir());
+            envVars.put("ADRENOTOOLS_DRIVER_NAME", libraryName);
+
+            if (adrenotoolsDriverId.contains("v762") && GPUInformation.getVersion(mContext).contains("512.530")) {
+                Log.d("AdrenotoolsManager", "Patching v762 driver for stock v530");
+                FileUtils.writeToBinaryFile(driverPath + "notadreno_utils.so", 0x2680, 3);
+            } else if (adrenotoolsDriverId.contains("v762") && GPUInformation.getVersion(mContext).contains("512.502")) {
+                Log.d("AdrenotoolsManager", "Patching v762 driver for stock v502");
+                FileUtils.writeToBinaryFile(driverPath + "notadreno_utils.so", 0x2680, 2);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Refactors AdrenoTools driver handling to support extraction from a dedicated cache directory for `MODERN_ANDROID` builds, enabling external driver downloads. Improves driver selection logic and fallback behavior.

Fix the error in modern variant:
```
2026-06-13 20:43:36.301 AdrenotoolsManager                  app.gamenative                       D  Extracting graphics_driver/adrenotools-turnip26.0.0_R8.tzst to /data/user/0/app.gamenative/files/contents/adrenotools/turnip26.0.0_R8
2026-06-13 20:43:36.302 AdrenotoolsManager                  app.gamenative                       W  Driver not found: turnip26.0.0_R8 - Falling back to System driver
```

## Recording
None

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AdrenoTools driver extraction on the modern Android build by loading drivers from a cached directory instead of bundled assets. Prevents false “Driver not found” fallbacks and enables external driver downloads.

- **Bug Fixes**
  - Extract from `files/assets/graphics_driver` when `BuildConfig.MODERN_ANDROID` is true (warn if cache is missing); use bundled assets otherwise.
  - Skip asset lookups in modern builds (`isFromResources` returns false) and create content/cache directories on init.
  - Safer driver selection: require `meta.json`, try extraction if missing, set env vars only when a valid library is found; handle `listFiles()` nulls and log a clear fallback.

<sup>Written for commit a35b0f90de902ce6914fd064b7d56629cec0a7e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added modern Android graphics driver extraction with improved local caching.

* **Bug Fixes**
  * Improved robustness when enumerating installed drivers (handles empty directory results safely).
  * Enhanced driver installation flow with clearer handling when cached assets are missing or extraction fails.
  * Improved fallback behavior to the system driver when a requested driver isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->