### PR TITLE
Fixed usb storage not being detected

### DIFF
--- a/app/src/main/java/app/gamenative/service/DownloadService.kt
+++ b/app/src/main/java/app/gamenative/service/DownloadService.kt
@@ -37,10 +37,9 @@ object DownloadService {
         baseExternalAppDirPath = extFiles?.parentFile?.path ?: ""
 
         val sm = context.getSystemService(android.os.storage.StorageManager::class.java)
-        externalVolumePaths = context.getExternalFilesDirs(null)
-            .filterNotNull()
+        externalVolumePaths = StorageUtils.getAllExternalFilesDirs(context)
             .filter { Environment.getExternalStorageState(it) == Environment.MEDIA_MOUNTED }
-            .filter { sm.getStorageVolume(it)?.isPrimary != true }
+            .filter { sm?.getStorageVolume(it)?.isPrimary != true }
             .map { it.absolutePath }
     }
 

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
@@ -1,7 +1,6 @@
 package app.gamenative.ui.screen.settings
 
 import android.content.res.Configuration
-import android.os.Build
 import android.os.Environment
 import android.os.storage.StorageManager
 import java.io.File
@@ -97,6 +96,7 @@ import app.gamenative.ui.screen.auth.GOGOAuthActivity
 import app.gamenative.ui.screen.auth.AmazonOAuthActivity
 import app.gamenative.service.amazon.AmazonAuthManager
 import app.gamenative.utils.PlatformOAuthHandlers
+import app.gamenative.utils.StorageUtils
 import app.gamenative.data.GameSource
 import app.gamenative.sync.FrontendSyncManager
 import app.gamenative.ui.util.PlatformAuthUiHelpers
@@ -499,36 +499,16 @@ fun SettingsGroupInterface(
         val sm = ctx.getSystemService(StorageManager::class.java)
 
         // All writable non-primary volumes (SD / USB).
-        // getExternalFilesDirs misses USB OTG on most devices, so also enumerate
-        // StorageManager.storageVolumes and synthesize the per-app files dir.
+        // getExternalFilesDirs misses USB OTG on most devices, so StorageUtils also
+        // enumerates StorageManager.storageVolumes and synthesizes the per-app files dir.
         // Runs off the composition thread because synthesizing the USB candidate
         // may need mkdirs() on first plug-in.
         val externalStorageFallbackLabel = stringResource(R.string.storage_external)
         val dirs by produceState(initialValue = emptyList<File>(), ctx) {
             value = withContext(Dispatchers.IO) {
-                val seen = mutableSetOf<String>()
-                val result = mutableListOf<File>()
-
-                fun tryAdd(dir: File?) {
-                    if (dir == null) return
-                    if (Environment.getExternalStorageState(dir) != Environment.MEDIA_MOUNTED) return
-                    if (sm?.getStorageVolume(dir)?.isPrimary == true) return
-                    if (seen.add(dir.absolutePath)) result += dir
-                }
-
-                ctx.getExternalFilesDirs(null)?.forEach { tryAdd(it) }
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    sm?.storageVolumes?.forEach { volume ->
-                        if (volume.isPrimary) return@forEach
-                        val volDir = volume.directory ?: return@forEach
-                        val candidate = File(volDir, "Android/data/${ctx.packageName}/files")
-                        if (!candidate.isDirectory) candidate.mkdirs()
-                        if (candidate.isDirectory) tryAdd(candidate)
-                    }
-                }
-
-                result
+                StorageUtils.getAllExternalFilesDirs(ctx)
+                    .filter { Environment.getExternalStorageState(it) == Environment.MEDIA_MOUNTED }
+                    .filter { sm?.getStorageVolume(it)?.isPrimary != true }
             }
         }
 

--- a/app/src/main/java/app/gamenative/utils/StorageUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/StorageUtils.kt
@@ -1,6 +1,10 @@
 package app.gamenative.utils
 
+import android.content.Context
+import android.os.Build
+import android.os.Environment
 import android.os.StatFs
+import android.os.storage.StorageManager
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
@@ -74,6 +78,56 @@ object StorageUtils {
         )
 
         return result
+    }
+
+    /**
+     * Gets all app-specific external files directories, using StorageManager as a fallback
+     * for cases where context.getExternalFilesDirs(null) might return null or incomplete results
+     * (e.g. USB OTG drives, which most devices omit from getExternalFilesDirs).
+     */
+    fun getAllExternalFilesDirs(context: Context): List<File> {
+        val result = mutableSetOf<File>()
+
+        // 1. Primary source: Standard Android API
+        try {
+            context.getExternalFilesDirs(null)?.filterNotNull()?.let {
+                result.addAll(it)
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error calling getExternalFilesDirs")
+        }
+
+        // 2. Fallback: Iterate through all storage volumes using StorageManager
+        val sm = context.getSystemService(Context.STORAGE_SERVICE) as? StorageManager
+        if (sm != null) {
+            try {
+                for (volume in sm.storageVolumes) {
+                    if (volume.state != Environment.MEDIA_MOUNTED) continue
+
+                    val volumeDir = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        volume.directory
+                    } else {
+                        // Use reflection for older APIs (26-29) if getExternalFilesDirs missed it
+                        try {
+                            val getPath = volume.javaClass.getMethod("getPath")
+                            (getPath.invoke(volume) as? String)?.let { File(it) }
+                        } catch (re: Exception) {
+                            null
+                        }
+                    } ?: continue
+
+                    // The app-specific dedicated directory is /Android/data/<package_name>/files
+                    val appFilesDir = File(volumeDir, "Android/data/${context.packageName}/files")
+                    if (!result.contains(appFilesDir) && (appFilesDir.exists() || appFilesDir.mkdirs())) {
+                        result.add(appFilesDir)
+                    }
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error iterating storage volumes in fallback")
+            }
+        }
+
+        return result.toList()
     }
 
     suspend fun moveDirectory(


### PR DESCRIPTION
## Description
USB storage not detected, esp on older Android versions

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes USB/OTG storage not being detected, especially on older Android versions, so users can select and download to USB/SD volumes reliably.

- **Bug Fixes**
  - Added `StorageUtils.getAllExternalFilesDirs(...)` that merges `getExternalFilesDirs(null)` with `StorageManager` volumes (includes pre-R via reflection) and creates the per-app `Android/data/.../files` dir when needed.
  - Updated `DownloadService` and the Settings storage picker to use the new helper, filter to mounted volumes, and exclude the primary volume.
  - Added a null-safe check for `StorageManager.getStorageVolume(...)` to avoid crashes on some devices.

<sup>Written for commit 4aad04978bd022b55972bc39caf7fb98bed9670a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved external storage volume discovery to enhance compatibility across Android versions
  * Enhanced reliability of storage detection in settings and download functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->