### PR TITLE
Fix Slay the Spire workshop mod launching

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -102,6 +102,7 @@ import app.gamenative.utils.UpdateInfo
 import app.gamenative.utils.UpdateInstaller
 import app.gamenative.utils.LaunchDependencies
 import app.gamenative.workshop.WorkshopManager
+import app.gamenative.workshop.compatibility.SlayTheSpireModTheSpireCompatibility
 import com.google.android.play.core.splitcompat.SplitCompat
 import com.winlator.container.Container
 import com.winlator.container.ContainerData
@@ -1899,6 +1900,15 @@ fun preLaunchApp(
                     Timber.tag("Workshop").w(
                         "Steam not connected/logged in or offline, skipping workshop sync for appId=$gameId"
                     )
+                    if (gameId == SlayTheSpireModTheSpireCompatibility.APP_ID) {
+                        setLoadingMessage(context.getString(R.string.workshop_processing))
+                        setLoadingProgress(-1f)
+                        WorkshopManager.configureLocalWorkshopContentForEnabledIds(
+                            context = context,
+                            appId = gameId,
+                            enabledIds = enabledWorkshopIds,
+                        )
+                    }
                 } else {
                 // If a background download is still running from the save
                 // handler, wait for it to finish so its markers are on disk
@@ -2027,6 +2037,13 @@ fun preLaunchApp(
                 } // else (isLoggedIn)
             } catch (e: Exception) {
                 Timber.tag("Workshop").e(e, "Workshop mod sync failed, continuing without mods")
+            }
+        } else if (
+            SteamService.isAppInstalled(gameId) &&
+            gameId == SlayTheSpireModTheSpireCompatibility.APP_ID
+        ) {
+            withContext(Dispatchers.IO) {
+                WorkshopManager.cleanupDisabledWorkshopArtifactsForApp(context, gameId)
             }
         }
 

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -2039,8 +2039,8 @@ fun preLaunchApp(
                 Timber.tag("Workshop").e(e, "Workshop mod sync failed, continuing without mods")
             }
         } else if (
-            SteamService.isAppInstalled(gameId) &&
-            gameId == SlayTheSpireModTheSpireCompatibility.APP_ID
+            gameId == SlayTheSpireModTheSpireCompatibility.APP_ID &&
+            File(SteamService.getAppDirPath(gameId)).isDirectory
         ) {
             withContext(Dispatchers.IO) {
                 WorkshopManager.cleanupDisabledWorkshopArtifactsForApp(context, gameId)

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -300,7 +300,7 @@ object SteamUtils {
         val container = ContainerUtils.getContainer(context, appId)
         val steamRootDir = File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam")
 
-        if (MarkerUtils.hasMarker(appDirPath, Marker.STEAM_COLDCLIENT_USED) && File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/steamclient_loader_x64.dll").exists()) {
+        if (MarkerUtils.hasMarker(appDirPath, Marker.STEAM_COLDCLIENT_USED) && File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/steamclient_loader_x64.exe").exists()) {
             return
         }
         MarkerUtils.removeMarker(appDirPath, Marker.STEAM_DLL_REPLACED)

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -424,7 +424,8 @@ object SteamUtils {
         val sanitizedExecutablePath = sanitizeColdClientArgumentText(executablePath)
         val sanitizedExeCommandLine = sanitizeColdClientArgumentText(exeCommandLine)
         val sanitizedExeRunDirOverride = exeRunDirOverride?.let(::sanitizeColdClientArgumentText)
-        val exePath = "steamapps\\common\\$gameName\\${sanitizedExecutablePath.replace("/", "\\")}"
+        val exeBaseDir = sanitizedExeRunDirOverride ?: "steamapps\\common\\$gameName"
+        val exePath = "$exeBaseDir\\${sanitizedExecutablePath.replace("/", "\\")}"
         val exeRunDir = sanitizedExeRunDirOverride
             ?: if (workingDir.isNullOrEmpty()) exePath.substringBeforeLast("\\") else ""
 
@@ -460,7 +461,6 @@ object SteamUtils {
 
     internal fun resolveColdClientLaunchConfig(
         steamAppId: Int,
-        gameName: String,
         executablePath: String,
         exeCommandLine: String,
         gameRootDir: File,
@@ -469,7 +469,6 @@ object SteamUtils {
         val sanitizedExeCommandLine = sanitizeColdClientArgumentText(exeCommandLine)
         if (steamAppId == SlayTheSpireModTheSpireCompatibility.APP_ID) {
             SlayTheSpireModTheSpireCompatibility.resolveLaunchConfig(
-                gameName = gameName,
                 gameRootDir = gameRootDir,
                 fallbackCommandLine = sanitizedExeCommandLine,
             )?.let { slayLaunchConfig ->
@@ -504,7 +503,6 @@ object SteamUtils {
             ?: File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam")
         val launchConfig = resolveColdClientLaunchConfig(
             steamAppId = steamAppId,
-            gameName = gameName,
             executablePath = container.executablePath,
             exeCommandLine = container.execArgs,
             gameRootDir = File(SteamService.getAppDirPath(steamAppId)),

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -423,8 +423,9 @@ object SteamUtils {
     ): String {
         val sanitizedExecutablePath = sanitizeColdClientArgumentText(executablePath)
         val sanitizedExeCommandLine = sanitizeColdClientArgumentText(exeCommandLine)
+        val sanitizedExeRunDirOverride = exeRunDirOverride?.let(::sanitizeColdClientArgumentText)
         val exePath = "steamapps\\common\\$gameName\\${sanitizedExecutablePath.replace("/", "\\")}"
-        val exeRunDir = exeRunDirOverride
+        val exeRunDir = sanitizedExeRunDirOverride
             ?: if (workingDir.isNullOrEmpty()) exePath.substringBeforeLast("\\") else ""
 
         // Only include DllsToInjectFolder if unpackFiles is enabled
@@ -474,9 +475,11 @@ object SteamUtils {
             )?.let { slayLaunchConfig ->
                 Timber.i("Using Slay the Spire ModTheSpire Workshop launch")
                 return ColdClientLaunchConfig(
-                    executablePath = slayLaunchConfig.executablePath,
-                    exeCommandLine = slayLaunchConfig.exeCommandLine,
-                    exeRunDirOverride = slayLaunchConfig.exeRunDirOverride,
+                    executablePath = sanitizeColdClientArgumentText(slayLaunchConfig.executablePath),
+                    exeCommandLine = sanitizeColdClientArgumentText(slayLaunchConfig.exeCommandLine),
+                    exeRunDirOverride = sanitizeColdClientArgumentText(
+                        slayLaunchConfig.exeRunDirOverride
+                    ),
                 )
             }
         }

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -17,6 +17,7 @@ import app.gamenative.service.SteamService
 import app.gamenative.service.SteamService.Companion.getAppDirName
 import app.gamenative.service.SteamService.Companion.getAppInfoOf
 import app.gamenative.ui.component.TIMEOUT_SHOW_OFFLINE_OPTION_SECONDS
+import app.gamenative.workshop.compatibility.SlayTheSpireModTheSpireCompatibility
 import com.winlator.container.Container
 import com.winlator.core.TarCompressorUtils
 import com.winlator.core.WineRegistryEditor
@@ -48,6 +49,11 @@ import java.util.concurrent.TimeUnit
 import kotlin.io.path.setLastModifiedTime
 
 object SteamUtils {
+    internal data class ColdClientLaunchConfig(
+        val executablePath: String,
+        val exeCommandLine: String,
+        val exeRunDirOverride: String? = null,
+    )
 
     /**
      * True when a stored Steam session exists (offline-launch gate).
@@ -292,8 +298,14 @@ object SteamUtils {
         val steamAppId = ContainerUtils.extractGameIdFromContainerId(appId)
         val appDirPath = SteamService.getAppDirPath(steamAppId)
         val container = ContainerUtils.getContainer(context, appId)
+        val steamRootDir = File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam")
+        val shouldRefreshColdClient = shouldRefreshColdClient(
+            steamAppId = steamAppId,
+            steamRootDir = steamRootDir,
+            gameRootDir = File(appDirPath),
+        )
 
-        if (MarkerUtils.hasMarker(appDirPath, Marker.STEAM_COLDCLIENT_USED) && File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/steamclient_loader_x64.dll").exists()) {
+        if (!shouldRefreshColdClient && MarkerUtils.hasMarker(appDirPath, Marker.STEAM_COLDCLIENT_USED) && File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/steamclient_loader_x64.dll").exists()) {
             return
         }
         MarkerUtils.removeMarker(appDirPath, Marker.STEAM_DLL_REPLACED)
@@ -321,7 +333,7 @@ object SteamUtils {
 
         // Get ticket and pass to ensureSteamSettings
         val ticketBase64 = SteamService.instance?.getEncryptedAppTicketBase64(steamAppId)
-        val path = File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/steamclient.dll").toPath()
+        val path = File(steamRootDir, "steamclient.dll").toPath()
         ensureSteamSettings(context, path, appId, ticketBase64, isOffline)
         generateAchievementsFile(path, appId)
 
@@ -330,6 +342,19 @@ object SteamUtils {
 
         MarkerUtils.addMarker(appDirPath, Marker.STEAM_COLDCLIENT_USED)
     }
+
+    private fun shouldRefreshColdClient(
+        steamAppId: Int,
+        steamRootDir: File,
+        gameRootDir: File,
+    ): Boolean =
+        when {
+            steamAppId == SlayTheSpireModTheSpireCompatibility.APP_ID ->
+                SlayTheSpireModTheSpireCompatibility
+                    .shouldRefreshColdClient(steamRootDir, gameRootDir)
+
+            else -> false
+        }
 
     fun steamClientFiles() : Array<String> {
         return arrayOf(
@@ -394,9 +419,13 @@ object SteamUtils {
         steamAppId: Int,
         workingDir: String?,
         isUnpackFiles: Boolean,
+        exeRunDirOverride: String? = null,
     ): String {
-        val exePath = "steamapps\\common\\$gameName\\${executablePath.replace("/", "\\")}"
-        val exeRunDir = if (workingDir.isNullOrEmpty()) exePath.substringBeforeLast("\\") else ""
+        val sanitizedExecutablePath = sanitizeColdClientArgumentText(executablePath)
+        val sanitizedExeCommandLine = sanitizeColdClientArgumentText(exeCommandLine)
+        val exePath = "steamapps\\common\\$gameName\\${sanitizedExecutablePath.replace("/", "\\")}"
+        val exeRunDir = exeRunDirOverride
+            ?: if (workingDir.isNullOrEmpty()) exePath.substringBeforeLast("\\") else ""
 
         // Only include DllsToInjectFolder if unpackFiles is enabled
         val injectionSection = if (isUnpackFiles) {
@@ -417,7 +446,7 @@ object SteamUtils {
 
                 Exe=$exePath
                 ExeRunDir=$exeRunDir
-                ExeCommandLine=$exeCommandLine
+                ExeCommandLine=$sanitizedExeCommandLine
                 AppId=$steamAppId
 
                 # path to the steamclient dlls, both must be set, absolute paths or relative to the loader directory
@@ -428,19 +457,65 @@ object SteamUtils {
             """.trimIndent()
     }
 
+    internal fun resolveColdClientLaunchConfig(
+        steamAppId: Int,
+        gameName: String,
+        executablePath: String,
+        exeCommandLine: String,
+        gameRootDir: File,
+    ): ColdClientLaunchConfig {
+        val sanitizedExecutablePath = sanitizeColdClientArgumentText(executablePath)
+        val sanitizedExeCommandLine = sanitizeColdClientArgumentText(exeCommandLine)
+        if (steamAppId == SlayTheSpireModTheSpireCompatibility.APP_ID) {
+            SlayTheSpireModTheSpireCompatibility.resolveLaunchConfig(
+                gameName = gameName,
+                gameRootDir = gameRootDir,
+                fallbackCommandLine = sanitizedExeCommandLine,
+            )?.let { slayLaunchConfig ->
+                Timber.i("Using Slay the Spire ModTheSpire Workshop launch")
+                return ColdClientLaunchConfig(
+                    executablePath = slayLaunchConfig.executablePath,
+                    exeCommandLine = slayLaunchConfig.exeCommandLine,
+                    exeRunDirOverride = slayLaunchConfig.exeRunDirOverride,
+                )
+            }
+        }
+
+        return ColdClientLaunchConfig(
+            executablePath = sanitizedExecutablePath,
+            exeCommandLine = sanitizedExeCommandLine,
+        )
+    }
+
+    private fun sanitizeColdClientArgumentText(value: String): String =
+        value.filter { char ->
+            !Character.isISOControl(char) &&
+                Character.getType(char) != Character.FORMAT.toInt()
+        }.trim()
+
     internal fun writeColdClientIni(steamAppId: Int, container: Container, launchInfo: LaunchInfo? = null) {
         val gameName = getAppDirName(getAppInfoOf(steamAppId))
         val workingDir = launchInfo?.workingDir
         val iniFile = File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/ColdClientLoader.ini")
+        val steamRootDir = iniFile.parentFile
+            ?: File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam")
+        val launchConfig = resolveColdClientLaunchConfig(
+            steamAppId = steamAppId,
+            gameName = gameName,
+            executablePath = container.executablePath,
+            exeCommandLine = container.execArgs,
+            gameRootDir = File(SteamService.getAppDirPath(steamAppId)),
+        )
         iniFile.parentFile?.mkdirs()
         iniFile.writeText(
             generateColdClientIni(
                 gameName = gameName,
-                executablePath = container.executablePath,
-                exeCommandLine = container.execArgs,
+                executablePath = launchConfig.executablePath,
+                exeCommandLine = launchConfig.exeCommandLine,
                 steamAppId = steamAppId,
                 workingDir = workingDir,
                 isUnpackFiles = container.isUnpackFiles,
+                exeRunDirOverride = launchConfig.exeRunDirOverride,
             )
         )
     }

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -299,13 +299,8 @@ object SteamUtils {
         val appDirPath = SteamService.getAppDirPath(steamAppId)
         val container = ContainerUtils.getContainer(context, appId)
         val steamRootDir = File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam")
-        val shouldRefreshColdClient = shouldRefreshColdClient(
-            steamAppId = steamAppId,
-            steamRootDir = steamRootDir,
-            gameRootDir = File(appDirPath),
-        )
 
-        if (!shouldRefreshColdClient && MarkerUtils.hasMarker(appDirPath, Marker.STEAM_COLDCLIENT_USED) && File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/steamclient_loader_x64.dll").exists()) {
+        if (MarkerUtils.hasMarker(appDirPath, Marker.STEAM_COLDCLIENT_USED) && File(container.getRootDir(), ".wine/drive_c/Program Files (x86)/Steam/steamclient_loader_x64.dll").exists()) {
             return
         }
         MarkerUtils.removeMarker(appDirPath, Marker.STEAM_DLL_REPLACED)
@@ -342,19 +337,6 @@ object SteamUtils {
 
         MarkerUtils.addMarker(appDirPath, Marker.STEAM_COLDCLIENT_USED)
     }
-
-    private fun shouldRefreshColdClient(
-        steamAppId: Int,
-        steamRootDir: File,
-        gameRootDir: File,
-    ): Boolean =
-        when {
-            steamAppId == SlayTheSpireModTheSpireCompatibility.APP_ID ->
-                SlayTheSpireModTheSpireCompatibility
-                    .shouldRefreshColdClient(steamRootDir, gameRootDir)
-
-            else -> false
-        }
 
     fun steamClientFiles() : Array<String> {
         return arrayOf(

--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import app.gamenative.utils.Net
+import app.gamenative.workshop.compatibility.SlayTheSpireModTheSpireCompatibility
 import app.gamenative.workshop.compatibility.WorkshopCompatibilityOverride
 import app.gamenative.workshop.compatibility.WorkshopCompatibilityRegistry
 import app.gamenative.workshop.compatibility.WorkshopExposureMode
@@ -79,14 +80,15 @@ object WorkshopManager {
      * item directories. Our extractZipMods skips these to avoid deleting
      * the archive before the game can process it.
      */
+    private const val SLAY_THE_SPIRE_HEADLESS_LAUNCHER_JAR_BASE64 = "UEsDBAoAAAgAAG+AzlwAAAAAAAAAAAAAAAAJAAQATUVUQS1JTkYv/soAAFBLAwQUAAgICABvgM5cAAAAAAAAAAAAAAAAFAAAAE1FVEEtSU5GL01BTklGRVNULk1G803My0xLLS7RDUstKs7Mz7NSMNQz4OVyLkpNLElN0XWqtFIwAoroGRooaLgm52QWFKcqOKbkF5RkluZq8nLxcgEAUEsHCAUEhGxCAAAAQQAAAFBLAwQKAAAIAABvgM5cAAAAAAAAAAAAAAAABAAAAGNvbS9QSwMECgAACAAAb4DOXAAAAAAAAAAAAAAAAA8AAABjb20vZXZhY2lwYXRlZC9QSwMECgAACAAAb4DOXAAAAAAAAAAAAAAAABkAAABjb20vZXZhY2lwYXRlZC9jYXJkY3Jhd2wvUEsDBAoAAAgAAG+AzlwAAAAAAAAAAAAAAAAlAAAAY29tL2V2YWNpcGF0ZWQvY2FyZGNyYXdsL21vZHRoZXNwaXJlL1BLAwQUAAgICABvgM5cAAAAAAAAAAAAAAAATQAAAGNvbS9ldmFjaXBhdGVkL2NhcmRjcmF3bC9tb2R0aGVzcGlyZS9HYW1lTmF0aXZlTGF1bmNoZXIkVGVlT3V0cHV0U3RyZWFtLmNsYXNznZJNTxNRFIbfW1qmDCPl+6OAoqL2Ax1NNC4kLiRKmjSwgLBxdZle0zHTmWY+ij9FXagLdaEuxGhNXPAD/FHG95ZCYISNi5lz7jnnfc7NOff3n18HAO7ipokMBgxkLeQwKFB8LjvSdgP7ievFKtxM4nYSb8Whki2BwVXXd+OHAnOl+lHdyYoH5Z0h5DFkwLQwDEtg3QlatupIx23LWDVsR4YNJ5R7nt0KGnFTRW03VPa6bKkNGbsdVZeJ7zRVuLytVKp3pJzAbwhMn91aNx6xUNBdB4IkNjGGcQMTFiYxJTB5lkggtxe6sRLIlmrlHS2Z0fWzAkbp6aNaP1a0MI8FFj/zkqhJfEnH8yjq5CULS72k4wURSfY5ozlvYOy9FjQoLNRdX20krV0VbstdjxHz8QtHtWM38CMD1wUmjhC1zeMMq7aCJHQU90XJzL+jvKVVAlbN91W45skoUsRVBe7/52541dR2cJvTyPA9CYzrvdPL9b7LjFyhV9WPjHa4Uv0JUVn5AWO/V36V/5Fe6iXLX8HEa0a5MQq08A6tBo9VvuPCfBejtIa2afkb3uAtRvEOyzxlmbvWA832QfcYy9JOaVB1YbGLaY069NKw97zHB4o/noLxDfRhNk+CtqBhXcxpEk0a8wkGPtP/cgqzdIxZ6WOsSheLh4yLacZX6vY5028nGBncoJ9BCWVak7E8KqQV/wJQSwcIe2q6fhICAADWAwAAUEsDBBQACAgIAG+AzlwAAAAAAAAAAAAAAAA9AAAAY29tL2V2YWNpcGF0ZWQvY2FyZGNyYXdsL21vZHRoZXNwaXJlL0dhbWVOYXRpdmVMYXVuY2hlci5jbGFzc51YCXhU13X+j2Z5o9FFkgcLGBAgA0bSSEIYbNlItoyQRiA0krBGIEvGlh8zD+mh0bzxmzdg0jghsdM2S+NsXULSJqELWRzHmHgkTE3TNo3rxE2TtumSbum+702buo7JOW9GaBv4cADx3rvn3rP855z/3quvvvHiFQB3Ui6IMng0eBV88BOqT+gn9daUnp5sHTp2wkg4BP+9Ztp0OgmehsYjQQRQriGoUCHT705YM63GST1hZnTHSLYmdDuZsPVTqdYZK+lMGdmMaRut+/UZY1B3zJNGTM+lE1OGTag001lHT6Vi1mSvmTLKsQqVGqoUqnHLEjfip7OOMcPWrRw7UxNzJabVesg2007csQ19piOA1YSGBTN1A1ZyZMqIi/W6VNFmHduzHTM9GUQN1mhYq7AOYcLqEhoJWka+Umk22RBb5I3Dw5MdBSA2KNRiIyNUMEFY0/BQqbkaNs+bcQUjU7Z1Sj+WMoLYhNsUtgiUVZmCeT0xPWLrCZatwjaF27Gd4DUeNzl4b0OfKGsgqHmfBbsAIoRg1kgnR6we42Q2iHo0Sz7D8rZDoRU7CRVmtofhSDiWfdrN5bhIdynsFql/Zjpp2tkA7iKsn2Qg0y6QE4vSuCNlTcqSu0X1PYStDbHFXnSUjrydsP+HLJJtI4YxlHMyuWJSNNxLWLfY5mJpEB3oFNfuJ4SWuTYu+dqDLhHvI7QuiBdr6Cg92ngkgB6C7/BIb8s9Uju9omY/ofk6asZLISEF3qdwUKrbY9i2pDemMIBBBj9rOENS3esaSpa3eL8KhxQemJ8dtW0N8fmiyjlmqrXLtvXTMTPrBDEMj5TnEYVRPMiZz+rcwOZbjC57krC9VDmvHApgnE21tHCKuKCO4mENjyhM4NGlzelO5onGYzk9lV3WLAUG6WgcD+AYgZpFT1LBwHGGM5tJSU3Xl3KnRBfJ2ikFU4pVM7PRmYxzugLTSGmYUUiLX5ULYAgOhEDCSjs6E41MzCg8JrM8ejIZALuqtbSYM5M5M4Cc+5E0juUmAzjFrdjSkp02My3zzCHLTyu8BT/CPZhlIN3+6ZPhJxTehrfzesdyE8A0tIQD5iEoMabhHZzAEqGW40k8peFdCj8qU5puqn1ilp4UXvV2De+Pi4YfV3g33sNA90T3HeZqpXEZfZ/CT8ioNnR4ZOJg17CMPa3wAXfsUFd3f9f+qIx9SOHDMra6OzYUj06MHogOTvT2DfbFD0R7RP6TCj8l8nKmcOvUPsPRZfRnFD4qo8F4f9+hib7BkeEhGf6Ywsfxszycsa3j3I9uHYZWBi6ATsmCTyp8CueY5mb0NNcVs3lfkjNWHVuaYRepX1D4RbFZGRs9uD+2eyI62LUvFu0Jsui8wqeFWitTDM7ASPyIYWdNKx3AZznHx810UjinOCgN84zC590dwUyftKYNbsGTjDhTsmMmxNQXFJ6TOLSBoZ6Jnr5hWfO8wkV8kZssxQ6xowd1mz3dvIyA5vM//y0r8wqzmOMguceTEmL6uMVL9zY8tGLtTVVAUQV37ovsTlcsxl72DfYOxcXYLyu8hCsMIZPHkrhKd2CJCmYW/BJDOTo03B8/MCTZdVX/Gn5dw5cVfgNf4e5fyE+3lUrxOkaWYyo3pF0LTRlqaFyexgB+k7CpQPtsfcnuPcXgpIxsVsNXCWuXO7ovZ6a47IN4BZ4AfovjlpTW6fZktr1ORn9b4Rv4JhOUnsnwBklouSn6K+rtEBW/Kyp+b9nKeVRuuPL3Ff4Af8g85FjzRHlrQ0mu/TZnZsCt9TpOaZ2ZZPcD+BOOh+upLmHl0k4hnj8TZ/6cUMtHgRvYfhJ/ofCX+CuuVTuXZjyzAvzywuKU/g0BQq1/p/D3Qm/+lJGedKbE1D/KNrddhP+s8C/4VxYmpnS7q3gQ6Q7i3/EfGv5T4b/w30vON908TU84QkfapOGMnM4Ysqa7sU/W/I/C/+J7XPdmti8+1M0UbVupgnxc7L4mIf6/hNh9oxCP4vsKbwi8XpbMhABWSURlkuxEwsiwn+vn0S6GnObi4KfjKqgnryIfMT+US++KnFFqbLjeiuU9HAJRQFE5BZlkubxSp6XvFxf3cS5o6YDW3uILE9ZRUopWUSUfFru7mFn7BuPRwXjfSN+R6MTQcE90mAWxxW00k2Ew+dDWUUHVdItGIUWr6VaupFKTOJaE++EWW3/DDZ0pbaax9HCQ1tBajdYpCtP6+TPAwsEjKzujZTtyKiqx113H1JEg1dJGjTYp2kx1vPbNEB03x/ACcxI6l3Pum6PNcnZli6Kt7kZ1OJPkJQfjQ4MyfLui7e62ZmZHLXs6O2VlNOJTeOubZOYgRahJo2ZFLbSDt6BFHZPSs7LBcbf0GImUbhvJXtNI3QRf2cZx4dlWdzpb2El3aLRL0W66cwlfLplHWMX7QBd3STZr8j1Euk/OyLy6TdHdxKd7D09YtjcsyeXSvUEia1fUQXxCv2VREAOGM2UlZVNbGcXiMnHjLxlXQQMH1imB3T9/ASgxR6Z0KdpH3cwAhR2csKdEAKXOZyuHmGEoqqhXGKbCsWLWKcPu1rNGgA4wXDtO6LbMOKion2JM8by5ZEdNZ+o690U+THu7rSR7VBUz08ZgbuaYYY/oBexn+IzKKXHvfgN6pjgcjD4uLCY7qEbxJQR7TaLRYda4jJiYG1L6zLGkvm3RmWTbzpu6sY3L4c3K2QlhPXZi7cpr2Q5ZxbW6z7KcrGPrmQL82WoarfLTw3zaoEcUHaHRanp02XXj+mhX+eiYUHJCUVIQl31jkE1XE98Vtqzo7BWOs+WpIJl0QqNpRSniG/yWhUmFamiNuaiwu/pxvXgPrphZ/PXqYmeLiwrRHdDTcgzZFrOs6VymBHLXWyib3w8nLJi88drGldJuPpHHTUfKQPWl01y00luytVUtv0/TY4TbbypgjXj9phtP5a4rTMYdfOAsg/yR3y754OedcoC/buMtms8b8EVmQRf4hWiwOAkIwYvVKKchbCxON3hcJLVz0J6HCoXyuDUyh/XnoWJNedR557D1Aiv0oIpXb0KZq20LGwfW8Og6VCDMso0sXc+6N2Atavn/TXSIZ2goG9awKcDmK655+DWUsxvAicuoHws1zqKpP5JHy1kE+HHHqIxGQnfOoi12GTVjl7FnjB27jI6xJs8s7pvFXm+oexbRgQXpAVfqXSwdbJ5Df8schs7D23/BRcTA1LUAdrA/EkYQW3ELtnEo2xm5etyPBjyMRuiI8PxmXtHE1+EWN5jV8Lwuv9Oqv4oHBFcOTHCt5djLJLCyrzMeigVfuIzhsVmMxIrPAU+np83rafPV+CJXzuHLkRrfrjkcbveHxsL+PB76KBI1Pu+jIhuPPOWjgjik55Fo18JaeyAcuNJW7mkL1gRrys9hdzhQE9zVXhGuECX8yGPyLNY2hysu4UQZzkK5r1YZRp8K0vmrr55Hf8guWgp4O8/j3pBT/Cz3tnnPozl0svjtP4/N8ioKm8L+eYXuq6vQxwo7mpou4XHiy87RS3hrGb6EMxfxzhrvRfyY5yLeyz/v558P8vdH+PnTdBFnmy/h54jvrRpxPpov4hMbL+Ln5/BLoc/M4XOS8efxLBfCHC60+8K+ObzA4FwK++dwOfQrc/hVfkpxvszF6dbCKwzr10Kv5vF1rtHfyeNbSwV/xILmUoI/ZkHYdyWPPy2IxNR3pEkKVfEsZxvYycV9B6qxi0t6N2pwFzajjevibnTgHsSwB8fRjhn+OoN7+f6/B09z3Xwce/k+3YXPYR8uoBtXEMU30Ytv8/rv4CC+i368xqvfwACVYZD8GKIgDlElHqAQhvlMFKd6jFAEh6kVo9SJBymKMYphnEZ4EzyKhymHR+j9mKDP4FF6FrpblWNQV7kL/RrOaJjmf3w8B66yRxWLhzQcdT/PiHTnVSYMbZmYQaisUq9hw2vwde6VYalyLzftMFf5KB4stu/HuMp9/OyPvAx/6K+fE2y5cf92Fv8Q89xXK6/n0BipzeOfOjfO4d/avPz/d8+iusZbXf0JlDdtzOP/Rp8q40L6VpObhtefu5aBCJsCkmzWYPKY5J6b4vYyuUtPcFdOcw5SuI/HumG50VfCq30fqzS8QvXsN6++iC8WHR1nR4XatkVeZDyQJ0+s6WUEPC+h/rmmFzlkPE8Vc1Q1RzVNCx6scYPLsiaHtefYg1PME4+71gKg17Fa43wE5dcKRTvPsBVWhiPzbR8ZaL4iHV/j3XgOO5trvLvcoqYN7f6w/ytYF/bTC3Rb2O99gbYtdJaXAfnGfGdRbaGzqH7Bs+3Mm8Bb2YsnmHTexpi8navyDHPZO3An3sm4PMG4vMv1dB08V7mEfeyr5JhGJO3N33MReolr0yUsRtPDf5nZQk9G8tQ40OzNU2szNeXproWdI+SS9bs5xPcwu72Xv9+3pDI+z/xfUHd/EfANrM7zErHKPbEmVnlfEzHoZXnaO7pc7dPMwx9gRz/Im8eHFtRWB+VsU8R3a3GLqmC/elbT/jz1PXNNjd+l9iw89KAL1BiNu0kso0kee4iO8o+8TZBOBqVdw2XcsgGysJ4yZJOD8A8AUEsHCJMt3VhkDQAAqhkAAFBLAQIKAAoAAAgAAG+AzlwAAAAAAAAAAAAAAAAJAAQAAAAAAAAAAAAAAAAAAABNRVRBLUlORi/+ygAAUEsBAhQAFAAICAgAb4DOXAUEhGxCAAAAQQAAABQAAAAAAAAAAAAAAAAAKwAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAgoACgAACAAAb4DOXAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAArwAAAGNvbS9QSwECCgAKAAAIAABvgM5cAAAAAAAAAAAAAAAADwAAAAAAAAAAAAAAAADRAAAAY29tL2V2YWNpcGF0ZWQvUEsBAgoACgAACAAAb4DOXAAAAAAAAAAAAAAAABkAAAAAAAAAAAAAAAAA/gAAAGNvbS9ldmFjaXBhdGVkL2NhcmRjcmF3bC9QSwECCgAKAAAIAABvgM5cAAAAAAAAAAAAAAAAJQAAAAAAAAAAAAAAAAA1AQAAY29tL2V2YWNpcGF0ZWQvY2FyZGNyYXdsL21vZHRoZXNwaXJlL1BLAQIUABQACAgIAG+Azlx7arp+EgIAANYDAABNAAAAAAAAAAAAAAAAAHgBAABjb20vZXZhY2lwYXRlZC9jYXJkY3Jhd2wvbW9kdGhlc3BpcmUvR2FtZU5hdGl2ZUxhdW5jaGVyJFRlZU91dHB1dFN0cmVhbS5jbGFzc1BLAQIUABQACAgIAG+AzlyTLd1YZA0AAKoZAAA9AAAAAAAAAAAAAAAAAAUEAABjb20vZXZhY2lwYXRlZC9jYXJkY3Jhd2wvbW9kdGhlc3BpcmUvR2FtZU5hdGl2ZUxhdW5jaGVyLmNsYXNzUEsFBgAAAAAIAAgAbAIAANQRAAAAAA=="
     private val SKIP_ZIP_EXTRACTION_APP_IDS = setOf(
         1942280, // Brotato
-        646570,  // Slay the Spire - Workshop items include Java/JAR payloads
+        SlayTheSpireModTheSpireCompatibility.APP_ID,  // Slay the Spire - Workshop items include Java/JAR payloads
         564310,  // Serious Sam Fusion 2017 - .gro files are ZIP payloads read by the game
     )
 
     private val ZIP_PAYLOAD_EXTENSIONS_BY_APP_ID = mapOf(
-        646570 to setOf("jar"),
+        SlayTheSpireModTheSpireCompatibility.APP_ID to setOf("jar"),
         564310 to setOf("gro"),
     )
 
@@ -1334,23 +1336,76 @@ object WorkshopManager {
         // configureModSymlinks populates this for ColdClient games,
         // but cleanupInstalledModEntries only walks gameRootDir and
         // misses the global Steam root.
-        val globalModsJson = workshopDir.parentFile  // content/
-            ?.parentFile  // workshop/
-            ?.parentFile  // steamapps/
-            ?.parentFile  // Steam/
-            ?.let { File(it, "steam_settings/mods.json") }
-        if (globalModsJson != null && globalModsJson.isFile) {
-            globalModsJson.writeText("{}")
-            Timber.tag(TAG).d("Cleared global mods.json at ${globalModsJson.absolutePath}")
-        }
-        val globalModImages = globalModsJson?.parentFile?.let { File(it, "mod_images") }
-        if (globalModImages != null && globalModImages.isDirectory) {
-            globalModImages.deleteRecursively()
-            Timber.tag(TAG).d("Cleared global mod_images at ${globalModImages.absolutePath}")
-        }
+        clearGlobalWorkshopMetadata(workshopDir)
 
         if (workshopDir.exists()) {
             workshopDir.deleteRecursively()
+        }
+    }
+
+    fun cleanupDisabledWorkshopArtifactsForApp(context: Context, appId: Int) {
+        val winePrefix = getContainerWinePrefix(context, appId)
+        val workshopDir = getWorkshopContentDir(winePrefix, appId)
+        val gameRootDir = File(SteamService.getAppDirPath(appId))
+        val gameName = SteamService.getAppInfoOf(appId)?.name ?: ""
+
+        cleanupInstalledModEntries(gameRootDir, workshopDir, winePrefix, gameName)
+        cleanupGameTreeWorkshopSymlinks(gameRootDir, appId)
+        if (appId == SlayTheSpireModTheSpireCompatibility.APP_ID) {
+            SlayTheSpireModTheSpireCompatibility.cleanupManagedWorkshopFiles(gameRootDir)
+        }
+        clearGlobalWorkshopMetadata(workshopDir)
+        Timber.tag(TAG).i("Cleaned disabled Workshop artifacts for appId=$appId")
+    }
+
+    private fun cleanupGameTreeWorkshopSymlinks(gameRootDir: File, appId: Int) {
+        if (!gameRootDir.isDirectory) return
+        val marker = "/workshop/content/$appId/"
+        var removed = 0
+        gameRootDir.walkTopDown().maxDepth(8).forEach { entry ->
+            if (!Files.isSymbolicLink(entry.toPath())) return@forEach
+
+            val rawTarget = runCatching { Files.readSymbolicLink(entry.toPath()) }
+                .getOrNull()
+            val resolvedTarget = rawTarget?.let { target ->
+                val resolved = if (target.isAbsolute) target else entry.toPath().parent.resolve(target)
+                runCatching { resolved.toRealPath() }
+                    .getOrElse { resolved.normalize().toAbsolutePath() }
+            }
+
+            val targetText = listOfNotNull(rawTarget, resolvedTarget)
+                .joinToString("\n") { it.toString().replace('\\', '/') }
+            if (!targetText.contains(marker)) return@forEach
+
+            try {
+                Files.deleteIfExists(entry.toPath())
+                removed++
+            } catch (e: Exception) {
+                Timber.tag(TAG).w(e, "Failed to remove stale Workshop symlink ${entry.absolutePath}")
+            }
+        }
+        if (removed > 0) {
+            Timber.tag(TAG).i("Removed $removed stale game-tree Workshop symlink(s) for appId=$appId")
+        }
+    }
+
+    private fun clearGlobalWorkshopMetadata(workshopContentDir: File) {
+        val globalSettingsDir = workshopContentDir.parentFile  // content/
+            ?.parentFile  // workshop/
+            ?.parentFile  // steamapps/
+            ?.parentFile  // Steam/
+            ?.let { File(it, "steam_settings") }
+            ?: return
+
+        val globalModsJson = File(globalSettingsDir, "mods.json")
+        if (globalModsJson.isFile) {
+            globalModsJson.writeText("{}")
+            Timber.tag(TAG).d("Cleared global mods.json at ${globalModsJson.absolutePath}")
+        }
+        val globalModImages = File(globalSettingsDir, "mod_images")
+        if (globalModImages.isDirectory) {
+            globalModImages.deleteRecursively()
+            Timber.tag(TAG).d("Cleared global mod_images at ${globalModImages.absolutePath}")
         }
     }
 
@@ -1709,7 +1764,10 @@ object WorkshopManager {
      * (under C: drive) so gbe_fork returns it directly to games, bypassing
      * any symlink resolution issues.
      */
-    private fun buildModsJson(modDirs: List<File>, items: List<WorkshopItem>): JSONObject {
+    private fun buildModsJson(
+        modDirs: List<File>,
+        items: List<WorkshopItem>,
+    ): JSONObject {
         val itemsById = items.associateBy { it.publishedFileId }
         val modsObj = JSONObject()
         modDirs.forEach { itemDir ->
@@ -2272,9 +2330,14 @@ object WorkshopManager {
         workshopModPath: String = "",
         compatibilityOverride: WorkshopCompatibilityOverride? = null,
     ) {
+        val appId = workshopContentDir.name.toIntOrNull() ?: -1
+
         if (!workshopContentDir.exists()) {
             Timber.tag(TAG).d("Workshop content dir doesn't exist yet, skipping symlink config")
             return
+        }
+        if (appId == SlayTheSpireModTheSpireCompatibility.APP_ID) {
+            SlayTheSpireModTheSpireCompatibility.cleanupManagedWorkshopFiles(gameRootDir)
         }
         cleanupGeneratedSteamSettingsInWorkshopContent(workshopContentDir)
         // Only include mod directories that have actual content
@@ -2311,11 +2374,21 @@ object WorkshopManager {
         }
 
         if (modDirs.isNullOrEmpty()) {
+            if (appId == SlayTheSpireModTheSpireCompatibility.APP_ID && enabledIdSet != null) {
+                cleanupInstalledModEntries(gameRootDir, workshopContentDir, winePrefix, gameName)
+                clearGlobalWorkshopMetadata(workshopContentDir)
+            }
             Timber.tag(TAG).d("No mod directories with content in ${workshopContentDir.absolutePath}")
             return
         }
+        if (appId == SlayTheSpireModTheSpireCompatibility.APP_ID) {
+            SlayTheSpireModTheSpireCompatibility.configureModTheSpireLayout(
+                gameRootDir = gameRootDir,
+                modDirs = modDirs,
+                headlessLauncherJarBase64 = SLAY_THE_SPIRE_HEADLESS_LAUNCHER_JAR_BASE64,
+            )
+        }
 
-        val appId = workshopContentDir.name.toIntOrNull() ?: -1
         val isInsurgency = appId == 222880
         val isLeft4Dead2 = appId == 550
         val isSkyrim = appId == 72850 || gameName.contains("skyrim", ignoreCase = true)
@@ -2465,7 +2538,12 @@ object WorkshopManager {
         // Source engine games are excluded because they have their own
         // VPK/GMA/BSP handler and need ISteamUGC populated for mod discovery.
         val unityModTargets by lazy { detectUnityModTargets(gameRootDir, winePrefix) }
-        val modsJsonText by lazy { buildModsJson(modDirs, items).toString(2) }
+        val modsJsonText by lazy {
+            buildModsJson(
+                modDirs,
+                items,
+            ).toString(2)
+        }
 
         // When the game's binary contains ISteamUGC / GetItemInstallInfo
         // strings AND there's a HIGH-confidence mod directory, the game
@@ -2488,6 +2566,9 @@ object WorkshopManager {
             Timber.tag(TAG).i(
                 "Workshop compatibility override for $gameName: using Steam metadata only"
             )
+            false
+        } else if (appId == SlayTheSpireModTheSpireCompatibility.APP_ID) {
+            Timber.tag(TAG).i("Slay the Spire uses ModTheSpire local jars plus Steam metadata")
             false
         } else if (appId in WorkshopOverrideIds.forceStandardAppIds) {
             stdSeenWithHighDir = true // treat like stdSeen so Phase 6 + cleanup runs
@@ -3560,6 +3641,57 @@ object WorkshopManager {
     fun parseEnabledIds(idsString: String?): Set<Long> =
         (idsString ?: "").split(",").mapNotNull { it.trim().toLongOrNull() }.toSet()
 
+    internal fun localWorkshopItemsForEnabledIds(
+        appId: Int,
+        enabledIds: Set<Long>,
+        workshopContentDir: File,
+    ): List<WorkshopItem> =
+        enabledIds
+            .mapNotNull { itemId ->
+                val itemDir = File(workshopContentDir, itemId.toString())
+                if (!itemDir.isDirectory) return@mapNotNull null
+
+                val payloads = workshopPayloadFiles(itemDir).toList()
+                if (payloads.isEmpty()) return@mapNotNull null
+
+                val markerTimestamp = runCatching {
+                    File(itemDir, COMPLETE_MARKER).readText().trim().toLongOrNull()
+                }.getOrNull()
+
+                WorkshopItem(
+                    publishedFileId = itemId,
+                    appId = appId,
+                    title = itemId.toString(),
+                    fileSizeBytes = payloads.sumOf { it.length() },
+                    manifestId = 0L,
+                    timeUpdated = markerTimestamp ?: 0L,
+                    fileName = payloads.firstOrNull()?.name ?: "",
+                )
+            }
+
+    suspend fun configureLocalWorkshopContentForEnabledIds(
+        context: Context,
+        appId: Int,
+        enabledIds: Set<Long>,
+    ): Boolean {
+        if (enabledIds.isEmpty()) return false
+
+        val winePrefix = getContainerWinePrefix(context, appId)
+        val workshopContentDir = getWorkshopContentDir(winePrefix, appId)
+        val items = localWorkshopItemsForEnabledIds(appId, enabledIds, workshopContentDir)
+        if (items.isEmpty()) {
+            Timber.tag(TAG).w("No local Workshop payloads found for appId=$appId")
+            return false
+        }
+
+        runPostProcessing(null, items, workshopContentDir)
+        configureSymlinksForApp(context, appId, items, winePrefix, workshopContentDir)
+        Timber.tag(TAG).i(
+            "Configured ${items.size} local Workshop item(s) for appId=$appId without remote fetch"
+        )
+        return true
+    }
+
     /** Runs the full post-processing pipeline on downloaded workshop content. */
     suspend fun runPostProcessing(
         downloadedItems: List<WorkshopItem>?,
@@ -3830,13 +3962,22 @@ object WorkshopManager {
         enabledIds: Set<Long>,
         context: Context,
     ): WorkshopUpdateCheck? {
-        val steamClient = SteamService.instance?.steamClient ?: return null
-        val steamId = SteamService.userSteamId ?: return null
+        val steamClient = SteamService.instance?.steamClient
+        val steamId = SteamService.userSteamId
+        if (steamClient == null || steamId == null) {
+            if (appId == SlayTheSpireModTheSpireCompatibility.APP_ID) {
+                configureLocalWorkshopContentForEnabledIds(context, appId, enabledIds)
+            }
+            return null
+        }
 
         val fetchResult = getSubscribedItems(appId, steamClient, steamId)
 
         if (!fetchResult.succeeded || !fetchResult.isComplete) {
             Timber.tag(TAG).w("Workshop fetch incomplete/failed for appId=$appId; skipping update check")
+            if (appId == SlayTheSpireModTheSpireCompatibility.APP_ID) {
+                configureLocalWorkshopContentForEnabledIds(context, appId, enabledIds)
+            }
             return null
         }
 
@@ -3844,11 +3985,13 @@ object WorkshopManager {
 
         val winePrefix = getContainerWinePrefix(context, appId)
 
-        // Even if no enabled items remain, configure symlinks so stale
-        // symlinks from previously-enabled mods are cleaned up.
         if (items.isEmpty()) {
             val workshopContentDir = getWorkshopContentDir(winePrefix, appId)
-            configureSymlinksForApp(context, appId, emptyList(), winePrefix, workshopContentDir)
+            if (appId == SlayTheSpireModTheSpireCompatibility.APP_ID) {
+                cleanupDisabledWorkshopArtifactsForApp(context, appId)
+            } else {
+                configureSymlinksForApp(context, appId, emptyList(), winePrefix, workshopContentDir)
+            }
             return null
         }
 

--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -2331,13 +2331,15 @@ object WorkshopManager {
         compatibilityOverride: WorkshopCompatibilityOverride? = null,
     ) {
         val appId = workshopContentDir.name.toIntOrNull() ?: -1
+        val isSlayTheSpire = appId == SlayTheSpireModTheSpireCompatibility.APP_ID
+
+        if (isSlayTheSpire) {
+            SlayTheSpireModTheSpireCompatibility.cleanupManagedWorkshopFiles(gameRootDir)
+        }
 
         if (!workshopContentDir.exists()) {
             Timber.tag(TAG).d("Workshop content dir doesn't exist yet, skipping symlink config")
             return
-        }
-        if (appId == SlayTheSpireModTheSpireCompatibility.APP_ID) {
-            SlayTheSpireModTheSpireCompatibility.cleanupManagedWorkshopFiles(gameRootDir)
         }
         cleanupGeneratedSteamSettingsInWorkshopContent(workshopContentDir)
         // Only include mod directories that have actual content
@@ -2374,19 +2376,24 @@ object WorkshopManager {
         }
 
         if (modDirs.isNullOrEmpty()) {
-            if (appId == SlayTheSpireModTheSpireCompatibility.APP_ID && enabledIdSet != null) {
+            if (isSlayTheSpire && enabledIdSet != null) {
                 cleanupInstalledModEntries(gameRootDir, workshopContentDir, winePrefix, gameName)
                 clearGlobalWorkshopMetadata(workshopContentDir)
             }
             Timber.tag(TAG).d("No mod directories with content in ${workshopContentDir.absolutePath}")
             return
         }
-        if (appId == SlayTheSpireModTheSpireCompatibility.APP_ID) {
-            SlayTheSpireModTheSpireCompatibility.configureModTheSpireLayout(
-                gameRootDir = gameRootDir,
-                modDirs = modDirs,
-                headlessLauncherJarBase64 = SLAY_THE_SPIRE_HEADLESS_LAUNCHER_JAR_BASE64,
-            )
+        if (isSlayTheSpire) {
+            try {
+                SlayTheSpireModTheSpireCompatibility.configureModTheSpireLayout(
+                    gameRootDir = gameRootDir,
+                    modDirs = modDirs,
+                    headlessLauncherJarBase64 = SLAY_THE_SPIRE_HEADLESS_LAUNCHER_JAR_BASE64,
+                )
+            } catch (e: Exception) {
+                Timber.tag(TAG).w(e, "Failed to configure Slay the Spire ModTheSpire layout")
+                SlayTheSpireModTheSpireCompatibility.cleanupManagedWorkshopFiles(gameRootDir)
+            }
         }
 
         val isInsurgency = appId == 222880
@@ -3674,13 +3681,22 @@ object WorkshopManager {
         appId: Int,
         enabledIds: Set<Long>,
     ): Boolean {
-        if (enabledIds.isEmpty()) return false
+        val isSlayTheSpire = appId == SlayTheSpireModTheSpireCompatibility.APP_ID
+        if (enabledIds.isEmpty()) {
+            if (isSlayTheSpire) {
+                cleanupDisabledWorkshopArtifactsForApp(context, appId)
+            }
+            return false
+        }
 
         val winePrefix = getContainerWinePrefix(context, appId)
         val workshopContentDir = getWorkshopContentDir(winePrefix, appId)
         val items = localWorkshopItemsForEnabledIds(appId, enabledIds, workshopContentDir)
         if (items.isEmpty()) {
             Timber.tag(TAG).w("No local Workshop payloads found for appId=$appId")
+            if (isSlayTheSpire) {
+                cleanupDisabledWorkshopArtifactsForApp(context, appId)
+            }
             return false
         }
 

--- a/app/src/main/java/app/gamenative/workshop/compatibility/SlayTheSpireModTheSpireCompatibility.kt
+++ b/app/src/main/java/app/gamenative/workshop/compatibility/SlayTheSpireModTheSpireCompatibility.kt
@@ -37,19 +37,6 @@ object SlayTheSpireModTheSpireCompatibility {
         val exeRunDirOverride: String,
     )
 
-    fun shouldRefreshColdClient(steamRootDir: File, gameRootDir: File): Boolean {
-        val iniFile = File(steamRootDir, "ColdClientLoader.ini")
-        val launcherReady = isLauncherReady(gameRootDir)
-        if (!iniFile.isFile) return launcherReady
-        val text = iniFile.readText()
-        val usesHeadlessLauncher = text.contains(HEADLESS_LAUNCHER_CLASS)
-        val usesStaleDesktopClasspath = usesHeadlessLauncher &&
-            text.contains("desktop-1.0.jar")
-        return usesStaleDesktopClasspath ||
-            (launcherReady && !usesHeadlessLauncher) ||
-            (!launcherReady && usesHeadlessLauncher)
-    }
-
     fun resolveLaunchConfig(
         gameRootDir: File,
         fallbackCommandLine: String,

--- a/app/src/main/java/app/gamenative/workshop/compatibility/SlayTheSpireModTheSpireCompatibility.kt
+++ b/app/src/main/java/app/gamenative/workshop/compatibility/SlayTheSpireModTheSpireCompatibility.kt
@@ -2,8 +2,11 @@ package app.gamenative.workshop.compatibility
 
 import org.json.JSONObject
 import timber.log.Timber
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.file.Path
 import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.Base64
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
@@ -20,6 +23,7 @@ object SlayTheSpireModTheSpireCompatibility {
     private const val MOD_THE_SPIRE_ARGS = ".gamenative_modthespire_args"
     private const val HEADLESS_LAUNCHER_CLASS =
         "com.evacipated.cardcrawl.modthespire.GameNativeLauncher"
+    private const val MAX_METADATA_ENTRY_BYTES = 64 * 1024
     private val MOD_THE_SPIRE_JVM_ARGS = listOf(
         "-Xmx1G",
         "-Dsun.java2d.dpiaware=true",
@@ -109,8 +113,9 @@ object SlayTheSpireModTheSpireCompatibility {
             .forEach { itemDir ->
                 workshopJarPayloads(itemDir).forEach { jarFile ->
                     val outName = managedJarName(itemDir.name, jarFile.name)
-                    materializeModJar(jarFile, File(modsDir, outName))
-                    managedFiles += outName
+                    if (materializeModJar(jarFile, File(modsDir, outName))) {
+                        managedFiles += outName
+                    }
                 }
             }
 
@@ -165,21 +170,38 @@ object SlayTheSpireModTheSpireCompatibility {
         if (!manifestFile.isFile) return emptyList()
 
         return manifestFile.readText().lineSequence()
-            .map { it.trim() }
-            .filter { it.isNotEmpty() }
-            .mapNotNull { fileName -> readModId(File(modsDir, fileName)) }
+            .mapNotNull { fileName -> managedManifestFile(modsDir, fileName) }
+            .filter { it.isFile }
+            .mapNotNull { readModId(it) }
             .distinct()
             .toList()
     }
 
     private fun cleanupManagedJarFiles(modsDir: File, manifestFile: File) {
         if (manifestFile.isFile) {
-            manifestFile.readText().lines().filter { it.isNotBlank() }.forEach { fileName ->
-                try {
-                    Files.deleteIfExists(File(modsDir, fileName).toPath())
-                } catch (_: Exception) { }
-            }
+            manifestFile.readText().lineSequence()
+                .mapNotNull { fileName -> managedManifestFile(modsDir, fileName) }
+                .forEach { jarFile ->
+                    try {
+                        Files.deleteIfExists(jarFile.toPath())
+                    } catch (_: Exception) { }
+                }
         }
+    }
+
+    private fun managedManifestFile(modsDir: File, manifestEntry: String): File? {
+        val fileName = manifestEntry.trim()
+        if (fileName.isEmpty()) return null
+
+        val modsPath = modsDir.toPath().toAbsolutePath().normalize()
+        val filePath = modsPath.resolve(fileName).normalize()
+        if (!filePath.startsWith(modsPath) || filePath.parent != modsPath) {
+            Timber.tag("WorkshopManager").w(
+                "Ignoring unsafe Slay the Spire managed mod manifest entry: $fileName"
+            )
+            return null
+        }
+        return filePath.toFile()
     }
 
     private fun cleanupManagedLauncher(gameRootDir: File) {
@@ -248,35 +270,70 @@ object SlayTheSpireModTheSpireCompatibility {
     }.getOrDefault(false)
 
     private fun rewriteJarWithoutMetadataBom(source: File, destination: File): Boolean {
-        destination.parentFile?.mkdirs()
-        try {
-            Files.deleteIfExists(destination.toPath())
-        } catch (_: Exception) { }
+        val destinationPath = destination.toPath()
+        val tempDir = destination.parentFile?.toPath()
+            ?: destinationPath.toAbsolutePath().parent
+            ?: return false
+        Files.createDirectories(tempDir)
+        val tempPath = Files.createTempFile(tempDir, "${destination.name}.", ".tmp")
 
-        ZipInputStream(source.inputStream()).use { input ->
-            ZipOutputStream(destination.outputStream()).use { output ->
-                var entry = input.nextEntry
-                while (entry != null) {
-                    val outEntry = ZipEntry(entry.name).apply {
-                        time = entry.time
-                        comment = entry.comment
-                    }
-                    output.putNextEntry(outEntry)
-                    if (!entry.isDirectory) {
-                        if (isMetadataEntry(entry.name)) {
-                            val bytes = input.readBytes()
-                            output.write(bytes.stripUtf8Bom())
-                        } else {
-                            input.copyTo(output)
+        try {
+            ZipInputStream(source.inputStream()).use { input ->
+                ZipOutputStream(Files.newOutputStream(tempPath)).use { output ->
+                    var entry = input.nextEntry
+                    while (entry != null) {
+                        val outEntry = ZipEntry(entry.name).apply {
+                            time = entry.time
+                            comment = entry.comment
                         }
+                        output.putNextEntry(outEntry)
+                        if (!entry.isDirectory) {
+                            if (isMetadataEntry(entry.name)) {
+                                copyEntryWithoutUtf8Bom(input, output)
+                            } else {
+                                input.copyTo(output)
+                            }
+                        }
+                        output.closeEntry()
+                        input.closeEntry()
+                        entry = input.nextEntry
                     }
-                    output.closeEntry()
-                    input.closeEntry()
-                    entry = input.nextEntry
                 }
             }
+            moveReplacing(tempPath, destinationPath)
+        } catch (e: Exception) {
+            try {
+                Files.deleteIfExists(tempPath)
+            } catch (_: Exception) { }
+            throw e
         }
         return true
+    }
+
+    private fun moveReplacing(source: Path, destination: Path) {
+        try {
+            Files.move(
+                source,
+                destination,
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.ATOMIC_MOVE,
+            )
+        } catch (_: Exception) {
+            Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+
+    private fun copyEntryWithoutUtf8Bom(input: ZipInputStream, output: ZipOutputStream) {
+        val header = ByteArray(3)
+        val read = input.read(header)
+        val hasUtf8Bom = read == 3 &&
+            header[0] == 0xEF.toByte() &&
+            header[1] == 0xBB.toByte() &&
+            header[2] == 0xBF.toByte()
+        if (!hasUtf8Bom && read > 0) {
+            output.write(header, 0, read)
+        }
+        input.copyTo(output)
     }
 
     private fun readModId(jarFile: File): String? = runCatching {
@@ -285,10 +342,9 @@ object SlayTheSpireModTheSpireCompatibility {
                 ?: zip.entries().asSequence()
                     .firstOrNull { !it.isDirectory && it.name.endsWith("/ModTheSpire.json") }
             if (jsonEntry != null) {
-                val jsonText = zip.getInputStream(jsonEntry)
-                    .bufferedReader(Charsets.UTF_8)
-                    .use { it.readText() }
-                    .trimStart('\uFEFF')
+                val jsonText = readZipEntryText(zip, jsonEntry)
+                    ?.trimStart('\uFEFF')
+                    ?: return@use null
                 return@use JSONObject(jsonText)
                     .optString("modid")
                     .takeIf { it.isNotBlank() }
@@ -298,9 +354,8 @@ object SlayTheSpireModTheSpireCompatibility {
                 ?: zip.entries().asSequence()
                     .firstOrNull { !it.isDirectory && it.name.endsWith("/ModTheSpire.config") }
             if (configEntry != null) {
-                val configText = zip.getInputStream(configEntry)
-                    .bufferedReader(Charsets.UTF_8)
-                    .use { it.readText() }
+                val configText = readZipEntryText(zip, configEntry)
+                    ?: return@use null
                 return@use configText.lineSequence()
                     .map { it.trim() }
                     .firstOrNull { it.startsWith("ID=", ignoreCase = true) }
@@ -313,22 +368,39 @@ object SlayTheSpireModTheSpireCompatibility {
         }
     }.getOrNull()
 
+    private fun readZipEntryText(zip: ZipFile, entry: ZipEntry): String? {
+        if (entry.size > MAX_METADATA_ENTRY_BYTES) {
+            Timber.tag("WorkshopManager").w(
+                "Skipping oversized Slay the Spire mod metadata entry: ${entry.name}"
+            )
+            return null
+        }
+
+        return zip.getInputStream(entry).use { input ->
+            val output = ByteArrayOutputStream()
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            var totalBytes = 0
+            while (true) {
+                val read = input.read(buffer)
+                if (read == -1) break
+                totalBytes += read
+                if (totalBytes > MAX_METADATA_ENTRY_BYTES) {
+                    Timber.tag("WorkshopManager").w(
+                        "Skipping oversized Slay the Spire mod metadata entry: ${entry.name}"
+                    )
+                    return@use null
+                }
+                output.write(buffer, 0, read)
+            }
+            output.toString(Charsets.UTF_8.name())
+        }
+    }
+
     private fun isMetadataEntry(name: String): Boolean =
         name == "ModTheSpire.json" ||
             name.endsWith("/ModTheSpire.json") ||
             name == "ModTheSpire.config" ||
             name.endsWith("/ModTheSpire.config")
-
-    private fun ByteArray.stripUtf8Bom(): ByteArray =
-        if (size >= 3 &&
-            this[0] == 0xEF.toByte() &&
-            this[1] == 0xBB.toByte() &&
-            this[2] == 0xBF.toByte()
-        ) {
-            copyOfRange(3, size)
-        } else {
-            this
-        }
 
     private fun workshopJarPayloads(itemDir: File): List<File> =
         itemDir.listFiles()

--- a/app/src/main/java/app/gamenative/workshop/compatibility/SlayTheSpireModTheSpireCompatibility.kt
+++ b/app/src/main/java/app/gamenative/workshop/compatibility/SlayTheSpireModTheSpireCompatibility.kt
@@ -1,0 +1,357 @@
+package app.gamenative.workshop.compatibility
+
+import org.json.JSONObject
+import timber.log.Timber
+import java.io.File
+import java.nio.file.Files
+import java.util.Base64
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+object SlayTheSpireModTheSpireCompatibility {
+    const val APP_ID = 646570
+    const val HEADLESS_LAUNCHER_JAR = "GameNativeModTheSpireLauncher.jar"
+
+    private const val MOD_THE_SPIRE_WORKSHOP_ID = "1605060445"
+    private const val MOD_JAR_MANIFEST = ".gamenative_workshop_jars"
+    private const val MOD_THE_SPIRE_MARKER = ".gamenative_modthespire"
+    private const val MOD_THE_SPIRE_ARGS = ".gamenative_modthespire_args"
+    private const val HEADLESS_LAUNCHER_CLASS =
+        "com.evacipated.cardcrawl.modthespire.GameNativeLauncher"
+    private val MOD_THE_SPIRE_JVM_ARGS = listOf(
+        "-Xmx1G",
+        "-Dsun.java2d.dpiaware=true",
+        "-Dsun.java2d.d3d=false",
+        "-Dsun.java2d.noddraw=true",
+    )
+
+    data class LaunchConfig(
+        val executablePath: String,
+        val exeCommandLine: String,
+        val exeRunDirOverride: String,
+    )
+
+    fun shouldRefreshColdClient(steamRootDir: File, gameRootDir: File): Boolean {
+        val iniFile = File(steamRootDir, "ColdClientLoader.ini")
+        val launcherReady = isLauncherReady(gameRootDir)
+        if (!iniFile.isFile) return launcherReady
+        val text = iniFile.readText()
+        val usesHeadlessLauncher = text.contains(HEADLESS_LAUNCHER_CLASS)
+        val usesStaleDesktopClasspath = usesHeadlessLauncher &&
+            text.contains("desktop-1.0.jar")
+        return usesStaleDesktopClasspath ||
+            (launcherReady && !usesHeadlessLauncher) ||
+            (!launcherReady && usesHeadlessLauncher)
+    }
+
+    fun resolveLaunchConfig(
+        gameName: String,
+        gameRootDir: File,
+        fallbackCommandLine: String,
+    ): LaunchConfig? {
+        if (!isLauncherReady(gameRootDir)) return null
+
+        val managedModIds = readManagedModIds(gameRootDir)
+        if (!File(gameRootDir, "ModTheSpire.jar").isFile || managedModIds.isEmpty()) {
+            return null
+        }
+
+        return LaunchConfig(
+            executablePath = "jre/bin/java.exe",
+            exeCommandLine = buildCommandLine(
+                jarArgument = "ModTheSpire.jar",
+                modIds = managedModIds,
+                fallbackCommandLine = fallbackCommandLine,
+            ),
+            exeRunDirOverride = "steamapps\\common\\$gameName",
+        )
+    }
+
+    fun cleanupManagedWorkshopFiles(gameRootDir: File) {
+        val modsDir = File(gameRootDir, "mods")
+        val manifestFile = File(modsDir, MOD_JAR_MANIFEST)
+        cleanupManagedJarFiles(modsDir, manifestFile)
+        try {
+            Files.deleteIfExists(manifestFile.toPath())
+            if (modsDir.isDirectory && modsDir.listFiles()?.isEmpty() == true) {
+                modsDir.delete()
+            }
+        } catch (_: Exception) { }
+        cleanupManagedLauncher(gameRootDir)
+    }
+
+    fun configureModTheSpireLayout(
+        gameRootDir: File,
+        modDirs: List<File>,
+        headlessLauncherJarBase64: String,
+    ) {
+        val modTheSpireDir = modDirs.firstOrNull {
+            it.name == MOD_THE_SPIRE_WORKSHOP_ID
+        } ?: return
+        val modTheSpireJar = File(modTheSpireDir, "ModTheSpire.jar")
+            .takeIf { it.isFile }
+            ?: workshopJarPayloads(modTheSpireDir)
+                .firstOrNull { it.name.equals("ModTheSpire.jar", ignoreCase = true) }
+            ?: return
+
+        materializeWorkshopFile(modTheSpireJar, File(gameRootDir, "ModTheSpire.jar"))
+        writeHeadlessLauncher(gameRootDir, headlessLauncherJarBase64)
+        File(gameRootDir, MOD_THE_SPIRE_MARKER)
+            .writeText(modTheSpireJar.absolutePath)
+
+        val modsDir = File(gameRootDir, "mods")
+        val managedFiles = mutableListOf<String>()
+        modDirs
+            .filter { it.name != MOD_THE_SPIRE_WORKSHOP_ID }
+            .sortedBy { it.name.toLongOrNull() ?: Long.MAX_VALUE }
+            .forEach { itemDir ->
+                workshopJarPayloads(itemDir).forEach { jarFile ->
+                    val outName = managedJarName(itemDir.name, jarFile.name)
+                    materializeModJar(jarFile, File(modsDir, outName))
+                    managedFiles += outName
+                }
+            }
+
+        val manifestFile = File(modsDir, MOD_JAR_MANIFEST)
+        if (managedFiles.isNotEmpty()) {
+            manifestFile.writeText(managedFiles.joinToString("\n", postfix = "\n"))
+        } else {
+            try {
+                Files.deleteIfExists(manifestFile.toPath())
+            } catch (_: Exception) { }
+        }
+
+        Timber.tag("WorkshopManager").i(
+            "Configured Slay the Spire ModTheSpire root layout: " +
+                "${managedFiles.size} managed mod jar(s)"
+        )
+    }
+
+    private fun isLauncherReady(gameRootDir: File): Boolean {
+        if (!File(gameRootDir, "jre/bin/java.exe").isFile) return false
+        if (!File(gameRootDir, HEADLESS_LAUNCHER_JAR).isFile) return false
+        return File(gameRootDir, "ModTheSpire.jar").isFile &&
+            readManagedModIds(gameRootDir).isNotEmpty()
+    }
+
+    private fun buildCommandLine(
+        jarArgument: String,
+        modIds: List<String>,
+        fallbackCommandLine: String,
+    ): String = buildString {
+        val classPath = listOf(
+            HEADLESS_LAUNCHER_JAR,
+            jarArgument,
+        ).joinToString(";")
+        append(MOD_THE_SPIRE_JVM_ARGS.joinToString(" "))
+        append(' ')
+        append("-cp ")
+        append(quoteWindowsArgument(classPath))
+        append(' ')
+        append(HEADLESS_LAUNCHER_CLASS)
+        append(" --mods ")
+        append(modIds.joinToString(","))
+        if (fallbackCommandLine.isNotBlank()) {
+            append(' ')
+            append(fallbackCommandLine)
+        }
+    }
+
+    private fun readManagedModIds(gameRootDir: File): List<String> {
+        val modsDir = File(gameRootDir, "mods")
+        val manifestFile = File(modsDir, MOD_JAR_MANIFEST)
+        if (!manifestFile.isFile) return emptyList()
+
+        return manifestFile.readText().lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .mapNotNull { fileName -> readModId(File(modsDir, fileName)) }
+            .distinct()
+            .toList()
+    }
+
+    private fun cleanupManagedJarFiles(modsDir: File, manifestFile: File) {
+        if (manifestFile.isFile) {
+            manifestFile.readText().lines().filter { it.isNotBlank() }.forEach { fileName ->
+                try {
+                    Files.deleteIfExists(File(modsDir, fileName).toPath())
+                } catch (_: Exception) { }
+            }
+        }
+    }
+
+    private fun cleanupManagedLauncher(gameRootDir: File) {
+        val marker = File(gameRootDir, MOD_THE_SPIRE_MARKER)
+        if (!marker.isFile) return
+        listOf(
+            File(gameRootDir, "ModTheSpire.jar"),
+            File(gameRootDir, HEADLESS_LAUNCHER_JAR),
+            marker,
+            File(gameRootDir, MOD_THE_SPIRE_ARGS),
+        ).forEach { file ->
+            try {
+                Files.deleteIfExists(file.toPath())
+            } catch (_: Exception) { }
+        }
+    }
+
+    private fun writeHeadlessLauncher(gameRootDir: File, headlessLauncherJarBase64: String) {
+        val launcherFile = File(gameRootDir, HEADLESS_LAUNCHER_JAR)
+        launcherFile.parentFile?.mkdirs()
+        Files.write(
+            launcherFile.toPath(),
+            Base64.getDecoder().decode(headlessLauncherJarBase64),
+        )
+    }
+
+    private fun materializeModJar(source: File, destination: File): Boolean =
+        if (jarNeedsMetadataBomFix(source)) {
+            rewriteJarWithoutMetadataBom(source, destination)
+        } else {
+            materializeWorkshopFile(source, destination)
+        }
+
+    private fun materializeWorkshopFile(source: File, destination: File): Boolean {
+        destination.parentFile?.mkdirs()
+        try {
+            Files.deleteIfExists(destination.toPath())
+        } catch (_: Exception) { }
+
+        val srcPath = source.toPath()
+        val destPath = destination.toPath()
+
+        return try {
+            Files.createLink(destPath, srcPath)
+            true
+        } catch (_: Exception) {
+            Files.copy(srcPath, destPath)
+            true
+        }
+    }
+
+    private fun jarNeedsMetadataBomFix(source: File): Boolean = runCatching {
+        ZipFile(source).use { zip ->
+            zip.entries().asSequence()
+                .filter { !it.isDirectory && isMetadataEntry(it.name) }
+                .any { entry ->
+                    zip.getInputStream(entry).use { input ->
+                        val header = ByteArray(3)
+                        input.read(header) == 3 &&
+                            header[0] == 0xEF.toByte() &&
+                            header[1] == 0xBB.toByte() &&
+                            header[2] == 0xBF.toByte()
+                    }
+                }
+        }
+    }.getOrDefault(false)
+
+    private fun rewriteJarWithoutMetadataBom(source: File, destination: File): Boolean {
+        destination.parentFile?.mkdirs()
+        try {
+            Files.deleteIfExists(destination.toPath())
+        } catch (_: Exception) { }
+
+        ZipInputStream(source.inputStream()).use { input ->
+            ZipOutputStream(destination.outputStream()).use { output ->
+                var entry = input.nextEntry
+                while (entry != null) {
+                    val outEntry = ZipEntry(entry.name).apply {
+                        time = entry.time
+                        comment = entry.comment
+                    }
+                    output.putNextEntry(outEntry)
+                    if (!entry.isDirectory) {
+                        if (isMetadataEntry(entry.name)) {
+                            val bytes = input.readBytes()
+                            output.write(bytes.stripUtf8Bom())
+                        } else {
+                            input.copyTo(output)
+                        }
+                    }
+                    output.closeEntry()
+                    input.closeEntry()
+                    entry = input.nextEntry
+                }
+            }
+        }
+        return true
+    }
+
+    private fun readModId(jarFile: File): String? = runCatching {
+        ZipFile(jarFile).use { zip ->
+            val jsonEntry = zip.getEntry("ModTheSpire.json")
+                ?: zip.entries().asSequence()
+                    .firstOrNull { !it.isDirectory && it.name.endsWith("/ModTheSpire.json") }
+            if (jsonEntry != null) {
+                val jsonText = zip.getInputStream(jsonEntry)
+                    .bufferedReader(Charsets.UTF_8)
+                    .use { it.readText() }
+                    .trimStart('\uFEFF')
+                return@use JSONObject(jsonText)
+                    .optString("modid")
+                    .takeIf { it.isNotBlank() }
+            }
+
+            val configEntry = zip.getEntry("ModTheSpire.config")
+                ?: zip.entries().asSequence()
+                    .firstOrNull { !it.isDirectory && it.name.endsWith("/ModTheSpire.config") }
+            if (configEntry != null) {
+                val configText = zip.getInputStream(configEntry)
+                    .bufferedReader(Charsets.UTF_8)
+                    .use { it.readText() }
+                return@use configText.lineSequence()
+                    .map { it.trim() }
+                    .firstOrNull { it.startsWith("ID=", ignoreCase = true) }
+                    ?.substringAfter('=')
+                    ?.trim()
+                    ?.takeIf { it.isNotBlank() }
+            }
+
+            null
+        }
+    }.getOrNull()
+
+    private fun isMetadataEntry(name: String): Boolean =
+        name == "ModTheSpire.json" ||
+            name.endsWith("/ModTheSpire.json") ||
+            name == "ModTheSpire.config" ||
+            name.endsWith("/ModTheSpire.config")
+
+    private fun ByteArray.stripUtf8Bom(): ByteArray =
+        if (size >= 3 &&
+            this[0] == 0xEF.toByte() &&
+            this[1] == 0xBB.toByte() &&
+            this[2] == 0xBF.toByte()
+        ) {
+            copyOfRange(3, size)
+        } else {
+            this
+        }
+
+    private fun workshopJarPayloads(itemDir: File): List<File> =
+        itemDir.listFiles()
+            ?.filter {
+                it.isFile &&
+                    !it.name.startsWith(".") &&
+                    it.extension.equals("jar", ignoreCase = true)
+            }
+            ?.sortedBy { it.name.lowercase() }
+            ?: emptyList()
+
+    private fun managedJarName(itemId: String, fileName: String): String {
+        val sanitized = fileName
+            .replace(Regex("[<>:\"/\\\\|?*\\x00-\\x1F]"), "_")
+            .trim()
+            .ifEmpty { "mod.jar" }
+        return "${itemId}_$sanitized"
+    }
+
+    private fun quoteWindowsArgument(argument: String): String =
+        if (argument.any { it.isWhitespace() }) {
+            "\"" + argument.replace("\"", "\\\"") + "\""
+        } else {
+            argument
+        }
+}

--- a/app/src/main/java/app/gamenative/workshop/compatibility/SlayTheSpireModTheSpireCompatibility.kt
+++ b/app/src/main/java/app/gamenative/workshop/compatibility/SlayTheSpireModTheSpireCompatibility.kt
@@ -51,7 +51,6 @@ object SlayTheSpireModTheSpireCompatibility {
     }
 
     fun resolveLaunchConfig(
-        gameName: String,
         gameRootDir: File,
         fallbackCommandLine: String,
     ): LaunchConfig? {
@@ -62,6 +61,7 @@ object SlayTheSpireModTheSpireCompatibility {
             return null
         }
 
+        val gameRootColdClientPath = "steamapps\\common\\${gameRootDir.name}"
         return LaunchConfig(
             executablePath = "jre/bin/java.exe",
             exeCommandLine = buildCommandLine(
@@ -69,7 +69,7 @@ object SlayTheSpireModTheSpireCompatibility {
                 modIds = managedModIds,
                 fallbackCommandLine = fallbackCommandLine,
             ),
-            exeRunDirOverride = "steamapps\\common\\$gameName",
+            exeRunDirOverride = gameRootColdClientPath,
         )
     }
 
@@ -107,25 +107,35 @@ object SlayTheSpireModTheSpireCompatibility {
 
         val modsDir = File(gameRootDir, "mods")
         val managedFiles = mutableListOf<String>()
-        modDirs
-            .filter { it.name != MOD_THE_SPIRE_WORKSHOP_ID }
-            .sortedBy { it.name.toLongOrNull() ?: Long.MAX_VALUE }
-            .forEach { itemDir ->
-                workshopJarPayloads(itemDir).forEach { jarFile ->
-                    val outName = managedJarName(itemDir.name, jarFile.name)
-                    if (materializeModJar(jarFile, File(modsDir, outName))) {
-                        managedFiles += outName
+        var currentOutFile: File? = null
+        try {
+            modDirs
+                .filter { it.name != MOD_THE_SPIRE_WORKSHOP_ID }
+                .sortedBy { it.name.toLongOrNull() ?: Long.MAX_VALUE }
+                .forEach { itemDir ->
+                    workshopJarPayloads(itemDir).forEach { jarFile ->
+                        val outName = managedJarName(itemDir.name, jarFile.name)
+                        val outFile = File(modsDir, outName)
+                        currentOutFile = outFile
+                        if (materializeModJar(jarFile, outFile)) {
+                            managedFiles += outName
+                            currentOutFile = null
+                        }
                     }
                 }
-            }
 
-        val manifestFile = File(modsDir, MOD_JAR_MANIFEST)
-        if (managedFiles.isNotEmpty()) {
-            manifestFile.writeText(managedFiles.joinToString("\n", postfix = "\n"))
-        } else {
-            try {
-                Files.deleteIfExists(manifestFile.toPath())
-            } catch (_: Exception) { }
+            val manifestFile = File(modsDir, MOD_JAR_MANIFEST)
+            if (managedFiles.isNotEmpty()) {
+                manifestFile.writeText(managedFiles.joinToString("\n", postfix = "\n"))
+            } else {
+                try {
+                    Files.deleteIfExists(manifestFile.toPath())
+                } catch (_: Exception) { }
+            }
+        } catch (e: Exception) {
+            (managedFiles.map { File(modsDir, it) } + listOfNotNull(currentOutFile))
+                .forEach { runCatching { Files.deleteIfExists(it.toPath()) } }
+            throw e
         }
 
         Timber.tag("WorkshopManager").i(

--- a/app/src/test/java/app/gamenative/utils/SteamUtilsFileSearchTest.kt
+++ b/app/src/test/java/app/gamenative/utils/SteamUtilsFileSearchTest.kt
@@ -648,12 +648,12 @@ class SteamUtilsFileSearchTest {
             steamAppId.toString(), steamAppIdFile.readText().trim())
 
         // Verify files from experimental-drm.tzst are extracted to Steam directory
-        // At minimum, verify steamclient_loader_x64.dll exists (as checked in line 210 of SteamUtils.kt)
-        val steamClientLoaderDll = File(steamDir, "steamclient_loader_x64.dll")
+        // At minimum, verify steamclient_loader_x64.exe exists (as checked in SteamUtils.kt)
+        val steamClientLoader = File(steamDir, "steamclient_loader_x64.exe")
         // Note: If experimental-drm.tzst doesn't exist in test assets, this file won't exist
         // but the test should still verify the steam_settings creation worked
-        if (steamClientLoaderDll.exists()) {
-            assertTrue("steamclient_loader_x64.dll should exist after extraction", true)
+        if (steamClientLoader.exists()) {
+            assertTrue("steamclient_loader_x64.exe should exist after extraction", true)
         }
 
         // Verify steam_api64.dll in app directory is NOT replaced (remains original)


### PR DESCRIPTION
﻿## Description
There's been multiple reports of workshop support not working with Slay the Spire. 

This PR fixes StS workshop support by adding a small headless bootstrapper .jar so GameNative can launch ModTheSpire directly with selected Workshop mods, without using the ModTheSpire GUI.

## Recording

https://github.com/user-attachments/assets/42571ab4-d610-40c8-add9-ca08675bad7d


## Type of Change
- [X] Bug fix 
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [X] Other (requires prior approval) 

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slay the Spire Workshop mod launching by bundling a headless ModTheSpire launcher and building the `mods/` layout from Workshop JARs. Adds offline setup that uses local Workshop content and cleans up stale artifacts and symlinks.

- **Bug Fixes**
  - Bundle a headless ModTheSpire launcher JAR and make `ColdClient` run `jre/bin/java.exe` with the correct classpath and `--mods` from the game root; arguments are sanitized.
  - Build and track the `mods/` layout from Workshop JARs, strip UTF‑8 BOM from mod metadata when needed, and remove managed files on disable.
  - When Steam is missing/incomplete or no enabled mods remain, configure mods from local Workshop content; remove stale game‑tree symlinks pointing to `/workshop/content/<appId>/` and clear global `mods.json`/`mod_images`.
  - Fix `ColdClient` loader reuse check to look for `steamclient_loader_x64.exe` (not `.dll`).

<sup>Written for commit a94b38b45e805c5e0fff00d31ef1db619074fe38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slay the Spire ModTheSpire compatibility for managed mod layout and headless launching behavior.
  * Added local workshop content configuration to support launches when Steam/workshop data is missing or incomplete.
* **Improvements**
  * Enhanced cold-client launcher INI generation with resolved launch settings, sanitized paths/command lines, and improved Steam directory handling.
  * Strengthened workshop lifecycle management, including metadata cleanup and more reliable symlink/layout preparation.
* **Bug Fixes**
  * Added automatic cleanup of disabled workshop artifacts to prevent stale/leftover mod files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->