### PR TITLE
Fix touch gamepad rumble stalls and input flicker

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
@@ -255,6 +255,8 @@ class PhysicalControllerHandler(
     // offset: analog axis value for presses; must be 0f for releases (triggers use offset > 0f
     // to determine pressed state, sticks gate on isActionDown, everything else ignores offset)
     private fun handleInputEvent(binding: Binding, isActionDown: Boolean, offset: Float = 0f) {
+        if (binding == Binding.NONE) return
+
         if (binding.isGamepad) {
             val winHandler = xServer?.winHandler
             val state = profile?.gamepadState

--- a/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
@@ -732,6 +732,10 @@ public class ControlElement {
     }
 
     public boolean handleTouchMove(int pointerId, float x, float y) {
+        if (pointerId == currentPointerId && (type == Type.BUTTON || type == Type.SHOOTER_MODE)) {
+            return true;
+        }
+
         if (pointerId == currentPointerId && (type == Type.D_PAD || type == Type.STICK || type == Type.TRACKPAD)) {
             float deltaX, deltaY;
             Rect boundingBox = getBoundingBox();

--- a/app/src/main/java/com/winlator/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/widget/InputControlsView.java
@@ -967,6 +967,8 @@ public class InputControlsView extends View {
     }
 
     public void handleInputEvent(Binding binding, boolean isActionDown, float offset) {
+        if (binding == null || binding == Binding.NONE) return;
+
         if (binding.isGamepad()) {
             WinHandler winHandler = xServer != null ? xServer.getWinHandler() : null;
             GamepadState state = profile.getGamepadState();

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -98,6 +98,8 @@ public class WinHandler {
     private static final int OFF_HAT = 31;
     private static final int OFF_RUMBLE_LOW = 32;
     private static final int OFF_RUMBLE_HIGH = 34;
+    private static final int CONTROLLER_RUMBLE_DURATION_MS = 1000;
+    private static final int PHONE_RUMBLE_FALLBACK_DURATION_MS = 40;
 
     // Add method to set InputControlsView
     public void setInputControlsView(InputControlsView view) {
@@ -644,6 +646,11 @@ public class WinHandler {
         rumblePollerThread.start();
     }
 
+    private InputDevice getCurrentPhysicalControllerDevice() {
+        InputDevice device = InputDevice.getDevice(currentControllerId);
+        return ExternalController.isGameController(device) ? device : null;
+    }
+
     private void startVibration(short lowFreq, short highFreq) {
         // --- Step 1: Calculate the base amplitude once at the top ---
         int unsignedLowFreq = lowFreq & 0xFFFF;
@@ -657,20 +664,21 @@ public class WinHandler {
             stopVibration();
             return;
         }
-        isRumbling = true; // We know we are going to try to rumble.
         boolean controllerVibrated = false;
+        boolean phoneVibrated = false;
         // --- Step 2: Attempt to vibrate the physical controller first ---
-        InputDevice device = InputDevice.getDevice(currentControllerId);
+        InputDevice device = getCurrentPhysicalControllerDevice();
         if (device != null) {
             Vibrator controllerVibrator = device.getVibrator();
             if (controllerVibrator != null && controllerVibrator.hasVibrator()) {
-                controllerVibrator.vibrate(VibrationEffect.createOneShot(1000, amplitude));
+                controllerVibrator.vibrate(VibrationEffect.createOneShot(CONTROLLER_RUMBLE_DURATION_MS, amplitude));
                 controllerVibrated = true;
             }
         }
 
-        // --- Step 3: Fallback to phone vibration if physical controller fails or doesn't exist ---
-        if (!controllerVibrated) {
+        // --- Step 3: Fallback to phone vibration only for a real controller without rumble.
+        // Touch-only virtual gamepad rumble should not start a one-second phone vibration on every button press.
+        if (!controllerVibrated && device != null) {
             Log.w("WinHandler", "No physical controller vibrator found, falling back to device vibration.");
             Vibrator phoneVibrator = (Vibrator) activity.getSystemService(Context.VIBRATOR_SERVICE);
             if (phoneVibrator != null && phoneVibrator.hasVibrator()) {
@@ -681,15 +689,17 @@ public class WinHandler {
                 if (finalPhoneAmplitude > 255) finalPhoneAmplitude = 255;
                 if (finalPhoneAmplitude <= 1) finalPhoneAmplitude = 0;
                 if (finalPhoneAmplitude > 0) {
-                    phoneVibrator.vibrate(VibrationEffect.createOneShot(1000, finalPhoneAmplitude));
+                    phoneVibrator.vibrate(VibrationEffect.createOneShot(PHONE_RUMBLE_FALLBACK_DURATION_MS, finalPhoneAmplitude));
+                    phoneVibrated = true;
                 }
             }
         }
+        isRumbling = controllerVibrated || phoneVibrated;
     }
     private void stopVibration() {
         if (!isRumbling) return; // Simplified check
         // Attempt to stop the physical controller's vibration if it exists
-        InputDevice device = InputDevice.getDevice(currentControllerId);
+        InputDevice device = getCurrentPhysicalControllerDevice();
         if (device != null) {
             Vibrator vibrator = device.getVibrator();
             if (vibrator != null && vibrator.hasVibrator()) {

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -3,6 +3,7 @@ package com.winlator.winhandler;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.SystemClock;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.util.Log;
@@ -82,6 +83,7 @@ public class WinHandler {
     private short lastLowFreq = 0;  // Use 'short' instead of uint16_t
     private short lastHighFreq = 0; // Use 'short' instead of uint16_t
     private boolean isRumbling = false;
+    private long lastStandalonePhoneRumbleMs = 0;
     private boolean isShowingAssignDialog = false;
     private Context activity;
     private final java.util.Set<Integer> ignoredDeviceIds = new java.util.HashSet<>();
@@ -100,6 +102,8 @@ public class WinHandler {
     private static final int OFF_RUMBLE_HIGH = 34;
     private static final int CONTROLLER_RUMBLE_DURATION_MS = 1000;
     private static final int PHONE_RUMBLE_FALLBACK_DURATION_MS = 40;
+    private static final int STANDALONE_PHONE_RUMBLE_DURATION_MS = 70;
+    private static final int STANDALONE_PHONE_RUMBLE_THROTTLE_MS = 120;
 
     // Add method to set InputControlsView
     public void setInputControlsView(InputControlsView view) {
@@ -651,6 +655,15 @@ public class WinHandler {
         return ExternalController.isGameController(device) ? device : null;
     }
 
+    private int getPhoneRumbleAmplitude(int amplitude) {
+        float normalizedAmplitude = (float) amplitude / 255.0f;
+        float curvedAmplitude = (float) Math.pow(normalizedAmplitude, 0.6f);
+        int phoneAmplitude = (int) (curvedAmplitude * 255);
+        if (phoneAmplitude > 255) phoneAmplitude = 255;
+        if (phoneAmplitude <= 1) phoneAmplitude = 0;
+        return phoneAmplitude;
+    }
+
     private void startVibration(short lowFreq, short highFreq) {
         // --- Step 1: Calculate the base amplitude once at the top ---
         int unsignedLowFreq = lowFreq & 0xFFFF;
@@ -677,20 +690,27 @@ public class WinHandler {
         }
 
         // --- Step 3: Fallback to phone vibration only for a real controller without rumble.
-        // Touch-only virtual gamepad rumble should not start a one-second phone vibration on every button press.
         if (!controllerVibrated && device != null) {
             Log.w("WinHandler", "No physical controller vibrator found, falling back to device vibration.");
             Vibrator phoneVibrator = (Vibrator) activity.getSystemService(Context.VIBRATOR_SERVICE);
             if (phoneVibrator != null && phoneVibrator.hasVibrator()) {
-                // --- HAPTIC CURVE LOGIC to make phone vibration feel better ---
-                float normalizedAmplitude = (float) amplitude / 255.0f;
-                float curvedAmplitude = (float) Math.pow(normalizedAmplitude, 0.6f);
-                int finalPhoneAmplitude = (int) (curvedAmplitude * 255);
-                if (finalPhoneAmplitude > 255) finalPhoneAmplitude = 255;
-                if (finalPhoneAmplitude <= 1) finalPhoneAmplitude = 0;
+                int finalPhoneAmplitude = getPhoneRumbleAmplitude(amplitude);
                 if (finalPhoneAmplitude > 0) {
                     phoneVibrator.vibrate(VibrationEffect.createOneShot(PHONE_RUMBLE_FALLBACK_DURATION_MS, finalPhoneAmplitude));
                     phoneVibrated = true;
+                }
+            }
+        } else if (device == null) {
+            long now = SystemClock.uptimeMillis();
+            if (now - lastStandalonePhoneRumbleMs >= STANDALONE_PHONE_RUMBLE_THROTTLE_MS) {
+                Vibrator phoneVibrator = (Vibrator) activity.getSystemService(Context.VIBRATOR_SERVICE);
+                if (phoneVibrator != null && phoneVibrator.hasVibrator()) {
+                    int finalPhoneAmplitude = getPhoneRumbleAmplitude(amplitude);
+                    if (finalPhoneAmplitude > 0) {
+                        phoneVibrator.vibrate(VibrationEffect.createOneShot(STANDALONE_PHONE_RUMBLE_DURATION_MS, finalPhoneAmplitude));
+                        lastStandalonePhoneRumbleMs = now;
+                        phoneVibrated = true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
﻿## Description

This PR fixes the issue(s) reported in these posts: https://discord.com/channels/1378308569287622737/1515736066974417048 and https://discord.com/channels/1378308569287622737/1513044003430334654



Touchscreen gamepad presses could trigger long phone vibration fallback when games sent rumble to the virtual controller, causing visible hitching in rumble-heavy games. 

Touch button move jitter could also fall through to touchpad handling, making games briefly see mouse input and swap between PC/gamepad prompts.

This fixes both paths by limiting phone rumble fallback to real physical controllers, consuming move events for active touch buttons, and ignoring empty NONE bindings before they can be injected. 


## Recording

https://github.com/user-attachments/assets/a17627d7-060d-470c-af4e-505bc9d41318

## Type of Change
- [X] Bug fix 
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval) 

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes touch gamepad stalls and input flicker by scoping rumble correctly, restoring a throttled phone haptic when no controller is present, and filtering stray touch/mapping events. Improves smoothness in rumble-heavy games and stops prompt swapping.

- **Bug Fixes**
  - Use controller haptics when available; fall back to 40ms phone rumble only for real controllers without rumble.
  - Restore standalone phone rumble when no controller is present (70ms pulses, 120ms throttle) to avoid stalls.
  - Consume move events for active touch buttons (including shooter mode) to prevent mouse/touchpad fall-through.
  - Ignore `Binding.NONE` and null bindings in input handlers to stop injecting empty events.

<sup>Written for commit 611c91b0c4e42c52acd20e6ec7e9e8c9a6163198. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Fixed touch movement handling for button and shooter mode controls so drag actions register correctly.
* Improved controller vibration behavior with better timing, amplitude shaping, and reliable fallback to phone rumble when needed.
* Prevented input handling from processing “no-op” or null bindings to avoid unintended state updates.

**Performance**
* Reduced unnecessary input-processing work for invalid/no-op events to keep controls responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->