### PR TITLE
Fix installs on fresh SD cards

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/GameManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GameManagerDialog.kt
@@ -201,7 +201,7 @@ fun GameManagerDialog(
     }
 
     fun getInstallSizeInfo(): InstallSizeInfo {
-        val availableBytes = StorageUtils.getAvailableSpace(SteamService.defaultStoragePath)
+        val availableBytes = StorageUtils.getAvailableSpaceForUncreatedPath(SteamService.getAppDirPath(gameId))
 
         val baseGameInstallBytes = if (!isBaseGameInstalled) {
             downloadableDepots

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -1011,7 +1011,7 @@ class SteamAppScreen : BaseAppScreen() {
                     val depots = SteamService.getDownloadableDepots(gameId, language)
                     Timber.i("There are ${depots.size} depots belonging to ${libraryItem.appId}")
                     val branch = SteamService.getInstalledApp(gameId)?.branch ?: "public"
-                    val availableBytes = StorageUtils.getAvailableSpace(SteamService.defaultStoragePath)
+                    val availableBytes = StorageUtils.getAvailableSpaceForUncreatedPath(SteamService.getAppDirPath(gameId))
                     val downloadBytes = depots.values.sumOf {
                         SteamUtils.getDownloadBytes(it.manifests[branch])
                     }

--- a/app/src/main/java/app/gamenative/utils/StorageUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/StorageUtils.kt
@@ -33,6 +33,24 @@ object StorageUtils {
         return stat.blockSizeLong * stat.availableBlocksLong
     }
 
+    /**
+     * Free space on the volume that would contain [path], even if [path] doesn't exist yet
+     * (e.g. a game's install directory before the first download has created it). Walks up to
+     * the nearest existing ancestor, which is on the same volume, since [StatFs] needs an
+     * existing path. Throws only if no ancestor exists (e.g. a blank/invalid path).
+     */
+    fun getAvailableSpaceForUncreatedPath(path: String): Long {
+        var file: File? = File(path)
+        while (file != null && !file.exists()) {
+            file = file.parentFile
+        }
+        if (file == null) {
+            throw IllegalArgumentException("Invalid path: $path")
+        }
+        val stat = StatFs(file.path)
+        return stat.blockSizeLong * stat.availableBlocksLong
+    }
+
     fun getTotalSpace(path: String): Long {
         val file = File(path)
         if (!file.exists()) {


### PR DESCRIPTION
## Description
On a fresh SD card, the path for writing games did not exist. This meant when installing we showed the remaining space on internal storage and blocked the install if it was full.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix installs on fresh SD cards by checking free space on the SD card volume even when the game install folder doesn’t exist yet. This shows correct available space and prevents installs from being blocked by internal storage.

- **Bug Fixes**
  - Added `StorageUtils.getAvailableSpaceForUncreatedPath(path)` to compute free space from the nearest existing parent directory.
  - Switched free-space checks in `GameManagerDialog` and `SteamAppScreen` to use `SteamService.getAppDirPath(gameId)` with the new helper instead of `defaultStoragePath`.

<sup>Written for commit 59d888b81b534d421445aba9db75f8f53895a079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of available disk space calculations for game installation. The system now checks available space on the specific game installation destination rather than the default storage location, providing more accurate install button availability and space-related error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->