### PR TITLE
Fixed GOG cloud saves for games that don't have client id like Dead Cells

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGApiClient.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGApiClient.kt
@@ -248,9 +248,9 @@ object GOGApiClient {
      * Fetch client secret from GOG build metadata API
      * @param gameId GOG game ID
      * @param installPath Game install path (for platform detection, defaults to "windows")
-     * @return Client secret string, or null if not found
+     * @return Pair of (clientId, clientSecret) from the build metadata, or null if not found
      */
-    suspend fun getClientSecret(context: Context, gameId: String, installPath: String?): String? = withContext(Dispatchers.IO) {
+    suspend fun getClientCredentials(context: Context, gameId: String, installPath: String?): Pair<String, String>? = withContext(Dispatchers.IO) {
         try {
             val platform = "windows" // For now, assume Windows (proton)
             val buildsUrl = "https://content-system.gog.com/products/$gameId/os/$platform/builds?generation=2"
@@ -367,15 +367,17 @@ object GOGApiClient {
                 Timber.tag("GOG").d("[Cloud Saves] Parsing manifest JSON (${manifestStr.take(100)}...)")
                 val manifestJson = JSONObject(manifestStr)
 
-                // Extract clientSecret from manifest
+                // Extract clientId + clientSecret from manifest. Mirrors gogdl, which sources both from
+                // the build metadata — the goggame-*.info clientId is optional and absent for many games.
                 val clientSecret = manifestJson.optString("clientSecret", "")
+                val clientId = manifestJson.optString("clientId", "")
                 if (clientSecret.isEmpty()) {
                     Timber.tag("GOG").w("[Cloud Saves] No clientSecret in manifest for game $gameId")
                     return@withContext null
                 }
 
-                Timber.tag("GOG").d("[Cloud Saves] Successfully retrieved clientSecret for game $gameId")
-                return@withContext clientSecret
+                Timber.tag("GOG").d("[Cloud Saves] Retrieved client credentials for game $gameId")
+                return@withContext clientId to clientSecret
             }
 
         } catch (e: Exception) {

--- a/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
@@ -914,13 +914,13 @@ class GOGManager @Inject constructor(
      * @param context Android context
      * @param appId Game app ID
      * @param installPath Game install path
-     * @return Pair of (clientSecret, List of save location templates), or null if cloud saves not enabled or API call fails
+     * @return Triple of (clientId, clientSecret, List of save location templates), or null if cloud saves not enabled or API call fails
      */
     suspend fun getSaveSyncLocation(
         context: Context,
         appId: String,
         installPath: String,
-    ): Pair<String, List<GOGCloudSavesLocationTemplate>>? = withContext(Dispatchers.IO) {
+    ): Triple<String, String, List<GOGCloudSavesLocationTemplate>>? = withContext(Dispatchers.IO) {
         try {
             Timber.tag("GOG").d("[Cloud Saves] Getting save sync location for $appId")
             val gameId = ContainerUtils.extractGameIdFromContainerId(appId)
@@ -931,16 +931,18 @@ class GOGManager @Inject constructor(
                 return@withContext null
             }
 
-            // Extract clientId from info file
-            val clientId = infoJson.optString("clientId", "")
+            // Get clientId + clientSecret from the build metadata, like gogdl/Heroic. The goggame-*.info
+            // clientId is optional and missing for many games (e.g. Dead Cells), so prefer the .info value
+            // only as a hint and fall back to the build metadata, which always carries both.
+            val buildCredentials = GOGApiClient.getClientCredentials(context, gameId.toString(), installPath)
+            val clientId = infoJson.optString("clientId", "").ifEmpty { buildCredentials?.first ?: "" }
             if (clientId.isEmpty()) {
-                Timber.tag("GOG").w("[Cloud Saves] No clientId found in info file for game $gameId")
+                Timber.tag("GOG").w("[Cloud Saves] No clientId in info file or build metadata for game $gameId")
                 return@withContext null
             }
             Timber.tag("GOG").d("[Cloud Saves] Client ID: $clientId")
 
-            // Get clientSecret from build metadata
-            val clientSecret = GOGApiClient.getClientSecret(context, gameId.toString(), installPath) ?: ""
+            val clientSecret = buildCredentials?.second ?: ""
             if (clientSecret.isEmpty()) {
                 Timber.tag("GOG").w("[Cloud Saves] No clientSecret available for game $gameId")
             } else {
@@ -951,7 +953,7 @@ class GOGManager @Inject constructor(
             remoteConfigCache[clientId]?.let { cachedLocations ->
                 Timber.tag("GOG").d("[Cloud Saves] Using cached save locations for clientId $clientId (${cachedLocations.size} locations)")
                 // Cache only contains locations, we still need to fetch clientSecret fresh
-                return@withContext Pair(clientSecret, cachedLocations)
+                return@withContext Triple(clientId, clientSecret, cachedLocations)
             }
 
             // Android runs games through Wine, so always use Windows platform
@@ -1033,7 +1035,7 @@ class GOGManager @Inject constructor(
                 }
 
                 Timber.tag("GOG").i("[Cloud Saves] Found ${locations.size} save location(s) for game $gameId")
-                return@withContext Pair(clientSecret, locations)
+                return@withContext Triple(clientId, clientSecret, locations)
             }
         } catch (e: Exception) {
             Timber.tag("GOG").e(e, "[Cloud Saves] Failed to get save sync location for appId $appId")
@@ -1070,20 +1072,12 @@ class GOGManager @Inject constructor(
             }
             Timber.tag("GOG").d("[Cloud Saves] Game install path: $installPath")
 
-            // Get clientId from info file
-            val infoJson = readInfoFile(appId, installPath)
-            val clientId = infoJson?.optString("clientId", "") ?: ""
-            if (clientId.isEmpty()) {
-                Timber.tag("GOG").w("[Cloud Saves] No clientId found in info file for game $gameId")
-                return@withContext null
-            }
-            Timber.tag("GOG").d("[Cloud Saves] Client ID: $clientId")
-
-            // Fetch save locations from API (Android runs games through Wine, so always Windows)
+            // Fetch clientId + clientSecret + save locations from API (Android runs games through Wine,
+            // so always Windows). clientId comes from build metadata when the goggame-*.info omits it.
             Timber.tag("GOG").d("[Cloud Saves] Fetching save locations from API")
             val result = getSaveSyncLocation(context, appId, installPath)
 
-            if (result == null || result.second.isEmpty()) {
+            if (result == null || result.third.isEmpty()) {
                 // The remote config API returned no locations, meaning this game either has cloud
                 // saves disabled or no save paths configured. We don't fall back to the default
                 // GOG Galaxy path (%LOCALAPPDATA%/GOG.com/Galaxy/Applications/<clientId>/Storage/…)
@@ -1093,8 +1087,10 @@ class GOGManager @Inject constructor(
                 return@withContext null
             }
 
-            val clientSecret = result.first
-            val locations = result.second
+            val clientId = result.first
+            val clientSecret = result.second
+            val locations = result.third
+            Timber.tag("GOG").d("[Cloud Saves] Client ID: $clientId")
             Timber.tag("GOG").i("[Cloud Saves] Retrieved ${locations.size} save location(s) from API")
 
             // Resolve each location
@@ -1105,9 +1101,15 @@ class GOGManager @Inject constructor(
                 var resolvedPath = PathType.resolveGOGPathVariables(locationTemplate.location, installPath)
                 Timber.tag("GOG").d("[Cloud Saves] After GOG variable resolution: $resolvedPath")
 
-                // Map GOG Windows path to device path using PathType
-                // Pass appId to ensure we use the correct container-specific wine prefix
-                resolvedPath = PathType.toAbsPathForGOG(context, resolvedPath, appId)
+                // Install-relative locations (<?INSTALL?>) resolve to the real on-disk install dir, which
+                // is already an absolute host path — use it directly, like Heroic does. Only Windows-style
+                // locations (%LOCALAPPDATA% etc.) need mapping into the Wine prefix; running toAbsPathForGOG
+                // on an absolute host path wrongly re-roots it under .wine/drive_c.
+                resolvedPath = resolvedPath.replace("\\", "/")
+                if (!resolvedPath.startsWith(installPath.replace("\\", "/"))) {
+                    // Pass appId to ensure we use the correct container-specific wine prefix
+                    resolvedPath = PathType.toAbsPathForGOG(context, resolvedPath, appId)
+                }
                 Timber.tag("GOG").d("[Cloud Saves] After path mapping to Wine prefix: $resolvedPath")
 
                 // Normalize path to resolve any '..' or '.' components

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -4120,7 +4120,7 @@ private fun unpackExecutableFile(
             Timber.tag("installRedist").e(e, "Error installing redistributables: ${e.message}")
         }
     }
-    if (!needsUnpacking){
+    if (!needsUnpacking || ContainerUtils.extractGameSourceFromContainerId(appId) != GameSource.STEAM){
         return
     }
     try {


### PR DESCRIPTION
…fest like Dead Cells

## Description
Dead Cells didn't have a client id in the manifest so the cloud saves (upload and download) weren't working. Now fixed by following the pattern in gogdl
## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GOG cloud saves for games that lack a `clientId` in `goggame-*.info` (e.g., Dead Cells). We now read both `clientId` and `clientSecret` from GOG build metadata and handle install-relative save paths correctly.

- **Bug Fixes**
  - Source `clientId` and `clientSecret` from build metadata (mirrors `gogdl`), fixing cloud saves when the `.info` file omits `clientId`. Replaced `GOGApiClient.getClientSecret` with `getClientCredentials`, and `GOGManager.getSaveSyncLocation` now returns `(clientId, clientSecret, locations)` and falls back to metadata when needed.
  - Correct path resolution: treat `<?INSTALL?>` paths as absolute host paths and only map Windows-style paths into the Wine prefix. Minor: skip redistributable unpacking for non-Steam apps.

<sup>Written for commit a8cd2490a054be16d6e510c4f555ff4fa1b68061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Cloud Saves**
  * Improved cloud saves support with enhanced credential management and more robust save location detection for better reliability across different game configurations.

* **Bug Fixes**
  * Fixed game unpacking logic to properly identify Steam games and apply appropriate handling during cloud saves synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->