### PR TITLE
Fix/case insensitive cloud saves

### DIFF
--- a/app/src/main/java/app/gamenative/service/epic/EpicCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicCloudSavesManager.kt
@@ -1263,7 +1263,7 @@ object EpicCloudSavesManager {
         }
 
         // Resolve against on-disk casing to avoid creating duplicate dirs (e.g. locallow vs LocalLow).
-        val joinedPath = canonicalizeAppDataSegments(normalizedParts).joinToString("/")
+        val joinedPath = normalizedParts.joinToString("/")
         val resolved = FileUtils.resolveCaseInsensitive(File("/"), joinedPath)
         // guard against path traversal escaping the wine prefix
         val absPath = resolved.absolutePath
@@ -1320,22 +1320,6 @@ object EpicCloudSavesManager {
         Timber.tag("Epic").d("[Cloud Saves]   Resolved: ${actualPath.absolutePath}")
 
         return actualPath
-    }
-
-    // Fixes issue where saves were being lost due to inconsistencies in lower-case sub-folders in AppData
-    internal fun canonicalizeAppDataSegments(segments: List<String>): List<String> {
-        return segments.mapIndexed { index, segment ->
-            if (index > 0 && segments[index - 1].equals("AppData", ignoreCase = true)) {
-                when (segment.lowercase()) {
-                    "local" -> "Local"
-                    "locallow" -> "LocalLow"
-                    "roaming" -> "Roaming"
-                    else -> segment
-                }
-            } else {
-                segment
-            }
-        }
     }
 
     private fun getSyncTimestamp(context: Context, appId: Int): String? {

--- a/app/src/main/java/app/gamenative/service/epic/EpicCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicCloudSavesManager.kt
@@ -1262,10 +1262,16 @@ object EpicCloudSavesManager {
             }
         }
 
-        // resolve against on-disk casing to avoid creating duplicate dirs (e.g. locallow vs LocalLow)
-        // supersedes PR #701
-        val joinedPath = normalizedParts.joinToString("/")
-        val resolved = FileUtils.resolveCaseInsensitive(File("/"), joinedPath)
+        // Resolve against on-disk casing to avoid creating duplicate dirs (e.g. locallow vs LocalLow).
+        val joinedPath = "/${canonicalizeAppDataSegments(normalizedParts).joinToString("/")}"
+        val trustedRoots = buildList {
+            add(usersPath)
+            add(File(winePrefix))
+            if (installDir.isNotEmpty()) {
+                add(File(installDir))
+            }
+        }
+        val resolved = resolveAbsolutePathCaseInsensitive(joinedPath, trustedRoots)
         // guard against path traversal escaping the wine prefix
         val absPath = resolved.absolutePath
         val withinPrefix = absPath.startsWith("$winePrefix/") || absPath == winePrefix ||
@@ -1321,6 +1327,51 @@ object EpicCloudSavesManager {
         Timber.tag("Epic").d("[Cloud Saves]   Resolved: ${actualPath.absolutePath}")
 
         return actualPath
+    }
+
+    internal fun resolveAbsolutePathCaseInsensitive(
+        path: String,
+        trustedRoots: List<File> = emptyList(),
+    ): File {
+        val normalizedPath = path.replace('\\', '/')
+        trustedRoots.firstNotNullOfOrNull { root ->
+            val rootPath = root.absolutePath.replace('\\', '/').trimEnd('/')
+            if (normalizedPath == rootPath || normalizedPath.startsWith("$rootPath/")) {
+                val relativePath = normalizedPath.removePrefix(rootPath).trimStart('/')
+                FileUtils.resolveCaseInsensitive(root, relativePath)
+            } else {
+                null
+            }
+        }?.let { return it }
+
+        val pathFile = File(normalizedPath)
+        val rootPath = pathFile.toPath().root?.toString()?.replace('\\', '/')
+        val base = when {
+            pathFile.isAbsolute && rootPath != null -> File(rootPath)
+            normalizedPath.startsWith("/") -> File("/")
+            else -> File("")
+        }
+        val relativePath = when {
+            pathFile.isAbsolute && rootPath != null -> normalizedPath.removePrefix(rootPath).trimStart('/')
+            else -> normalizedPath.trimStart('/')
+        }
+        return FileUtils.resolveCaseInsensitive(base, relativePath)
+    }
+
+    // Fixes issue where saves were being lost due to inconsistencies in lower-case sub-folders in AppData
+    internal fun canonicalizeAppDataSegments(segments: List<String>): List<String> {
+        return segments.mapIndexed { index, segment ->
+            if (index > 0 && segments[index - 1].equals("AppData", ignoreCase = true)) {
+                when (segment.lowercase()) {
+                    "local" -> "Local"
+                    "locallow" -> "LocalLow"
+                    "roaming" -> "Roaming"
+                    else -> segment
+                }
+            } else {
+                segment
+            }
+        }
     }
 
     private fun getSyncTimestamp(context: Context, appId: Int): String? {

--- a/app/src/main/java/app/gamenative/service/epic/EpicCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicCloudSavesManager.kt
@@ -1263,15 +1263,8 @@ object EpicCloudSavesManager {
         }
 
         // Resolve against on-disk casing to avoid creating duplicate dirs (e.g. locallow vs LocalLow).
-        val joinedPath = "/${canonicalizeAppDataSegments(normalizedParts).joinToString("/")}"
-        val trustedRoots = buildList {
-            add(usersPath)
-            add(File(winePrefix))
-            if (installDir.isNotEmpty()) {
-                add(File(installDir))
-            }
-        }
-        val resolved = resolveAbsolutePathCaseInsensitive(joinedPath, trustedRoots)
+        val joinedPath = canonicalizeAppDataSegments(normalizedParts).joinToString("/")
+        val resolved = FileUtils.resolveCaseInsensitive(File("/"), joinedPath)
         // guard against path traversal escaping the wine prefix
         val absPath = resolved.absolutePath
         val withinPrefix = absPath.startsWith("$winePrefix/") || absPath == winePrefix ||
@@ -1327,35 +1320,6 @@ object EpicCloudSavesManager {
         Timber.tag("Epic").d("[Cloud Saves]   Resolved: ${actualPath.absolutePath}")
 
         return actualPath
-    }
-
-    internal fun resolveAbsolutePathCaseInsensitive(
-        path: String,
-        trustedRoots: List<File> = emptyList(),
-    ): File {
-        val normalizedPath = path.replace('\\', '/')
-        trustedRoots.firstNotNullOfOrNull { root ->
-            val rootPath = root.absolutePath.replace('\\', '/').trimEnd('/')
-            if (normalizedPath == rootPath || normalizedPath.startsWith("$rootPath/")) {
-                val relativePath = normalizedPath.removePrefix(rootPath).trimStart('/')
-                FileUtils.resolveCaseInsensitive(root, relativePath)
-            } else {
-                null
-            }
-        }?.let { return it }
-
-        val pathFile = File(normalizedPath)
-        val rootPath = pathFile.toPath().root?.toString()?.replace('\\', '/')
-        val base = when {
-            pathFile.isAbsolute && rootPath != null -> File(rootPath)
-            normalizedPath.startsWith("/") -> File("/")
-            else -> File("")
-        }
-        val relativePath = when {
-            pathFile.isAbsolute && rootPath != null -> normalizedPath.removePrefix(rootPath).trimStart('/')
-            else -> normalizedPath.trimStart('/')
-        }
-        return FileUtils.resolveCaseInsensitive(base, relativePath)
     }
 
     // Fixes issue where saves were being lost due to inconsistencies in lower-case sub-folders in AppData

--- a/app/src/main/java/app/gamenative/utils/FileUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/FileUtils.kt
@@ -226,15 +226,9 @@ object FileUtils {
     fun resolveCaseInsensitive(baseDir: File, relativePath: String): File {
         val segments = relativePath.replace('\\', '/').split('/').filter { it.isNotEmpty() }
         var current = baseDir
-        for ((i, segment) in segments.withIndex()) {
+        for (segment in segments) {
             val match = current.listFiles()?.firstOrNull { it.name.equals(segment, ignoreCase = true) }
-            if (match != null) {
-                current = match
-            } else {
-                // append remaining segments verbatim
-                for (j in i until segments.size) current = File(current, segments[j])
-                return current
-            }
+            current = match ?: File(current, segment)
         }
         return current
     }

--- a/app/src/test/java/app/gamenative/service/epic/EpicCloudSavesTest.kt
+++ b/app/src/test/java/app/gamenative/service/epic/EpicCloudSavesTest.kt
@@ -9,13 +9,16 @@ import app.gamenative.service.epic.manifest.EpicManifest
 import app.gamenative.service.epic.manifest.FileManifest
 import app.gamenative.service.epic.manifest.FileManifestList
 import app.gamenative.service.epic.manifest.ManifestMeta
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
+import org.junit.rules.TemporaryFolder
 
 /**
  * Tests for Epic Cloud Saves manifest & chunk correctness.
@@ -25,6 +28,9 @@ import java.nio.ByteOrder
  * and verified manually.
  */
 class EpicCloudSavesTest {
+
+    @get:Rule
+    val tmpDir = TemporaryFolder()
 
     // -------------------------------------------------------------------------
     // Rolling hash — test vectors produced by Legendary's get_hash()
@@ -74,6 +80,35 @@ class EpicCloudSavesTest {
     // -------------------------------------------------------------------------
     // CustomFields — read/write round-trip must be symmetric and include version byte
     // -------------------------------------------------------------------------
+
+    @Test
+    fun `absolute cloud save path resolves LocalLow using on-disk casing`() {
+        val wineUserDir = tmpDir.newFolder("prefix", "drive_c", "users", "xuser")
+        val saveDir = File(wineUserDir, "AppData/LocalLow/ZAUM Studio/Disco Elysium/SaveGames").apply {
+            mkdirs()
+        }
+
+        val metadataPath = File(wineUserDir, "AppData/locallow/ZAUM Studio/Disco Elysium/SaveGames")
+            .absolutePath
+            .replace('\\', '/')
+
+        val resolved = EpicCloudSavesManager.resolveAbsolutePathCaseInsensitive(
+            metadataPath,
+            trustedRoots = listOf(wineUserDir),
+        )
+
+        assertEquals(saveDir.absolutePath, resolved.absolutePath)
+        assertTrue(resolved.exists())
+    }
+
+    @Test
+    fun `AppData child segments are canonicalized before creating save paths`() {
+        val segments = listOf("data", "prefix", "AppData", "locallow", "ZAUM Studio")
+
+        val canonicalized = EpicCloudSavesManager.canonicalizeAppDataSegments(segments)
+
+        assertEquals(listOf("data", "prefix", "AppData", "LocalLow", "ZAUM Studio"), canonicalized)
+    }
 
     @Test
     fun `CustomFields round-trips through write then read`() {

--- a/app/src/test/java/app/gamenative/service/epic/EpicCloudSavesTest.kt
+++ b/app/src/test/java/app/gamenative/service/epic/EpicCloudSavesTest.kt
@@ -111,15 +111,6 @@ class EpicCloudSavesTest {
     }
 
     @Test
-    fun `AppData child segments are canonicalized before creating save paths`() {
-        val segments = listOf("data", "prefix", "AppData", "locallow", "ZAUM Studio")
-
-        val canonicalized = EpicCloudSavesManager.canonicalizeAppDataSegments(segments)
-
-        assertEquals(listOf("data", "prefix", "AppData", "LocalLow", "ZAUM Studio"), canonicalized)
-    }
-
-    @Test
     fun `CustomFields round-trips through write then read`() {
         val original = CustomFields()
         original["CloudSaveFolder"] = "{AppData}/nuclearthrone/"

--- a/app/src/test/java/app/gamenative/service/epic/EpicCloudSavesTest.kt
+++ b/app/src/test/java/app/gamenative/service/epic/EpicCloudSavesTest.kt
@@ -9,6 +9,7 @@ import app.gamenative.service.epic.manifest.EpicManifest
 import app.gamenative.service.epic.manifest.FileManifest
 import app.gamenative.service.epic.manifest.FileManifestList
 import app.gamenative.service.epic.manifest.ManifestMeta
+import app.gamenative.utils.FileUtils
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -92,12 +93,20 @@ class EpicCloudSavesTest {
             .absolutePath
             .replace('\\', '/')
 
-        val resolved = EpicCloudSavesManager.resolveAbsolutePathCaseInsensitive(
-            metadataPath,
-            trustedRoots = listOf(wineUserDir),
-        )
+        val resolved = FileUtils.resolveCaseInsensitive(File("/"), metadataPath)
 
         assertEquals(saveDir.absolutePath, resolved.absolutePath)
+        assertTrue(resolved.exists())
+    }
+
+    @Test
+    fun `resolveCaseInsensitive keeps matching after an unmatched parent segment`() {
+        val base = tmpDir.newFolder("base")
+        val deep = File(base, "Existing/Nested/LocalLow").apply { mkdirs() }
+
+        val resolved = FileUtils.resolveCaseInsensitive(base, "existing/nested/locallow")
+
+        assertEquals(deep.absolutePath, resolved.absolutePath)
         assertTrue(resolved.exists())
     }
 


### PR DESCRIPTION
## Description
The CaseInsensitiveFileSystem wasn't working. Disco Elysium saves on Epic were saving to locallow instead of LocalLow. This fixes it.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes case-insensitive path resolution so cloud saves use on-disk casing (e.g., AppData/LocalLow). Removes Epic-specific workaround and relies on the shared resolver to restore save detection for Disco Elysium (and other stores using the shared path resolver).

- **Bug Fixes**
  - Reworked `FileUtils.resolveCaseInsensitive` to continue matching across unreadable/missing parents, using literal segments only when needed; ensures `AppData/LocalLow` resolves to on-disk casing and avoids duplicate dirs.
  - Added tests for absolute LocalLow resolution and continued matching after an unmatched parent segment.

<sup>Written for commit eb47201f369cd2d55e4ee750bcf72923e822dd65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Epic Cloud Saves to correctly resolve AppData subfolder casing inconsistencies (e.g., LocalLow/locallow), preventing incorrect save directory targeting.
  * Enhanced case-insensitive path resolution so it continues matching deeper segments even if earlier segments don’t exactly match.

* **Tests**
  * Expanded coverage with on-disk temporary directory setups to validate absolute cloud save path resolution and case-insensitive directory matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->