### PR TITLE
Reduce Epic downloader CPU and thermal overhead on tablets

### DIFF
--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -1,8 +1,6 @@
 package app.gamenative.service.epic
 
 import android.content.Context
-import android.util.Log
-import app.gamenative.PrefManager
 import app.gamenative.data.DownloadInfo
 import app.gamenative.enums.Marker
 import app.gamenative.utils.CdnRankingUtils
@@ -66,6 +64,7 @@ class EpicDownloadManager @Inject constructor(
         private const val MAX_CHUNK_RETRIES = 3 // Maximum retries per chunk
         private const val RETRY_DELAY_MS = 1000L // Initial retry delay in milliseconds
         private const val STREAM_PROGRESS_TIME_INTERVAL_MS = 200L
+        private const val PROGRESS_UPDATE_GRANULARITY_BYTES = 256 * 1024L
     }
 
     /**
@@ -458,7 +457,8 @@ class EpicDownloadManager @Inject constructor(
                 downloadingAppIds = java.util.concurrent.CopyOnWriteArrayList(),
             )
 
-            val parallelDownloads = PrefManager.downloadSpeed.coerceAtLeast(1)
+            val parallelDownloads = DownloadSpeedConfig().maxDownloads
+                .coerceAtLeast(1)
             val downloadHttpClient = Net.httpForParallelDownloads(parallelDownloads)
 
             var downloadedChunks = 0
@@ -647,6 +647,23 @@ class EpicDownloadManager @Inject constructor(
         val digest = MessageDigest.getInstance("SHA-1")
         var totalBytesWritten = 0L
         var lastProgressEmitAt = System.currentTimeMillis()
+        var pendingProgressBytes = 0L
+
+        fun reportDownloadedBytes(bytes: Long) {
+            if (bytes <= 0L) return
+
+            pendingProgressBytes += bytes
+            if (pendingProgressBytes < PROGRESS_UPDATE_GRANULARITY_BYTES) return
+
+            downloadInfo.updateBytesDownloaded(pendingProgressBytes)
+            pendingProgressBytes = 0L
+
+            val now = System.currentTimeMillis()
+            if (now - lastProgressEmitAt >= STREAM_PROGRESS_TIME_INTERVAL_MS) {
+                downloadInfo.emitProgressChange()
+                lastProgressEmitAt = now
+            }
+        }
 
         inputStream.buffered().use { input ->
             // Read the entire header - determine size dynamically
@@ -723,8 +740,6 @@ class EpicDownloadManager @Inject constructor(
                 expectedSize.toInt()
             }
 
-            Timber.tag("Epic").d("Chunk header: magic=0x${magic.toString(16)}, headerVersion=$headerVersion, headerSize=$headerSize, compressedSize=$compressedSize, uncompressedSize=$uncompressedSize, storedAs=0x${storedAs.toString(16)}, isCompressed=$isCompressed, expectedSize=$expectedSize")
-
             outputFile.outputStream().buffered().use { output ->
                 if (isCompressed) {
                     // Streaming decompression
@@ -733,7 +748,6 @@ class EpicDownloadManager @Inject constructor(
                         val inputBuffer = ByteArray(65536) // 64KB compressed read buffer
                         val outputBuffer = ByteArray(65536) // 64KB decompressed write buffer
                         var endOfStream = false
-                        var firstRead = true
 
                         while (totalBytesWritten < uncompressedSize && !endOfStream) {
                             // Feed more input if needed
@@ -743,16 +757,7 @@ class EpicDownloadManager @Inject constructor(
                                     endOfStream = true
                                     Timber.tag("Epic").d("Unexpected end of stream: read=$totalBytesWritten, expected=$uncompressedSize")
                                 } else {
-                                    downloadInfo.updateBytesDownloaded(bytesRead.toLong())
-                                    val now = System.currentTimeMillis()
-                                    if (now - lastProgressEmitAt >= STREAM_PROGRESS_TIME_INTERVAL_MS) {
-                                        downloadInfo.emitProgressChange()
-                                        lastProgressEmitAt = now
-                                    }
-                                    if (firstRead) {
-                                        Log.d("Epic", "First compressed data bytes: ${inputBuffer.take(16).joinToString(" ") { "%02x".format(it) }}")
-                                        firstRead = false
-                                    }
+                                    reportDownloadedBytes(bytesRead.toLong())
                                     inflater.setInput(inputBuffer, 0, bytesRead)
                                 }
                             }
@@ -786,12 +791,7 @@ class EpicDownloadManager @Inject constructor(
                         val toRead = minOf(remaining, buffer.size)
                         val bytesRead = input.read(buffer, 0, toRead)
                         if (bytesRead == -1) break
-                        downloadInfo.updateBytesDownloaded(bytesRead.toLong())
-                        val now = System.currentTimeMillis()
-                        if (now - lastProgressEmitAt >= STREAM_PROGRESS_TIME_INTERVAL_MS) {
-                            downloadInfo.emitProgressChange()
-                            lastProgressEmitAt = now
-                        }
+                        reportDownloadedBytes(bytesRead.toLong())
                         output.write(buffer, 0, bytesRead)
                         digest.update(buffer, 0, bytesRead)
                         totalBytesWritten += bytesRead
@@ -815,6 +815,10 @@ class EpicDownloadManager @Inject constructor(
             val actualHex = actualHash.joinToString("") { "%02x".format(it) }
             outputFile.delete()
             throw Exception("Chunk hash verification failed: expected $expectedHex, got $actualHex")
+        }
+
+        if (pendingProgressBytes > 0L) {
+            downloadInfo.updateBytesDownloaded(pendingProgressBytes)
         }
 
         // Ensure UI receives a final progress update after this chunk's bytes.
@@ -871,7 +875,9 @@ class EpicDownloadManager @Inject constructor(
             val scope = CoroutineScope(Dispatchers.IO)
             val speedConfig = DownloadSpeedConfig()
             val parallelDownloads = speedConfig.maxDownloads
+                .coerceAtLeast(1)
             val parallelAssemble = speedConfig.maxDecompress
+                .coerceAtLeast(1)
             val downloadHttpClient = Net.httpForParallelDownloads(parallelDownloads)
 
             val totalChunks = chunkQueue.size
@@ -883,10 +889,25 @@ class EpicDownloadManager @Inject constructor(
             // Calculate total expected installed size once (sum of all file sizes)
             val totalExpectedSize = files.sumOf { it.fileSize }
 
+            data class ChunkAssemblyPart(
+                val file: app.gamenative.service.epic.manifest.FileManifest,
+                val chunk: ChunkPart,
+            )
+
+            val mutableChunkPartsByGuid = HashMap<String, MutableList<ChunkAssemblyPart>>(totalChunks)
+            files.forEach { file ->
+                file.chunkParts.forEach { chunk ->
+                    mutableChunkPartsByGuid.getOrPut(chunk.guidStr) { mutableListOf() }
+                        .add(ChunkAssemblyPart(file, chunk))
+                }
+            }
+
+            val chunkPartsByGuid = mutableChunkPartsByGuid.mapValues { it.value.toList() }
+            chunkPartsByGuid.forEach { (guidStr, assemblyParts) ->
+                chunkUsageCounts[guidStr] = AtomicInteger(assemblyParts.size)
+            }
             chunkQueue.forEach { chunkInfo ->
-                chunkUsageCounts[chunkInfo.guidStr] = AtomicInteger(
-                    files.sumOf { file -> file.chunkParts.count { chunk -> chunk.guidStr == chunkInfo.guidStr } }
-                )
+                chunkUsageCounts.putIfAbsent(chunkInfo.guidStr, AtomicInteger(0))
             }
 
             val networkChunkFlow = MutableSharedFlow<app.gamenative.service.epic.manifest.ChunkInfo>(extraBufferCapacity = Int.MAX_VALUE)
@@ -902,29 +923,17 @@ class EpicDownloadManager @Inject constructor(
                     return Result.failure(Exception("Download cancelled"))
                 }
 
-                // 1. Find all files that contain this chunk
-                val matchedFiles = files.filter { file ->
-                    file.chunkParts.any { chunk -> chunk.guidStr == guidStr }
-                }
-
-                // 2. For each file found, try to assemble if all chunks are ready
                 var assemblySuccessCount = 0
 
-                matchedFiles.forEach { file ->
-                    file.chunkParts.withIndex()
-                        .filter { (_, chunk) -> chunk.guidStr == guidStr }
-                        .forEach { (chunkIndex, chunk) ->
-                            val result = assembleFileParallel(file, chunk, chunkCacheDir, installDir)
-                            if (result.isSuccess) {
-                                // 3. If assembly is successful and all chunks in downloadedChunkIds, increment file counter
-                                assemblySuccessCount++
-                            } else {
-                                Timber.tag("EPIC").d(result.exceptionOrNull()?.message ?: "Failed to assemble ${file.filename}")
-                            }
-                        }
+                chunkPartsByGuid[guidStr].orEmpty().forEach { assemblyPart ->
+                    val result = assembleFileParallel(assemblyPart.file, assemblyPart.chunk, chunkCacheDir, installDir)
+                    if (result.isSuccess) {
+                        assemblySuccessCount++
+                    } else {
+                        Timber.tag("EPIC").d(result.exceptionOrNull()?.message ?: "Failed to assemble ${assemblyPart.file.filename}")
+                    }
                 }
 
-                // 4. Decrement usage count only when assembly is successful
                 if (assemblySuccessCount > 0) {
                     val usageCount = chunkUsageCounts[guidStr]?.addAndGet(-assemblySuccessCount)
                     if (usageCount != null && usageCount <= 0) {
@@ -1028,8 +1037,6 @@ class EpicDownloadManager @Inject constructor(
                     return@launch
                 }
 
-                val chunksAdded = mutableListOf<String>()
-
                 // Sort files by total chunk usage (lowest first) - files with less-shared chunks complete faster and free cache sooner
                 val sortedFiles = files.sortedBy { file ->
                     file.chunkParts.sumOf { chunk ->
@@ -1043,8 +1050,6 @@ class EpicDownloadManager @Inject constructor(
                         Timber.tag("EPIC").w("Download cancelled during file iteration")
                         return@launch
                     }
-                    Timber.tag("EPIC").v("Pre-allocating ${file.filename}")
-
                     // Allocating file before download
                     val outputFile = File(installDir, file.filename)
                     outputFile.parentFile?.mkdirs()
@@ -1062,9 +1067,7 @@ class EpicDownloadManager @Inject constructor(
                 }
 
                 chunkQueue.forEach { chunkInfo ->
-                    chunksAdded.add(chunkInfo.guidStr)
                     networkChunkFlow.emit(chunkInfo)
-                    Timber.tag("EPIC").v("Emitted chunk ${chunkInfo.guidStr} to download flow")
                 }
             }
 


### PR DESCRIPTION
## Description

This is a follow-up to #1036, rebased/adapted after the recent Epic downloader refactor in #1554.

The current Flow-based Epic downloader is faster and more reliable than the previous implementation, but on large chunked installs it can still create excessive local CPU/thermal overhead on thermally constrained Android tablets.

Test device:

- Device: OnePlus Pad 3 / OPD2415
- Android: 16
- Game tested: NBA 2K21 from Epic
- Approx install size: ~99 GB
- Chunk count observed: ~99,110 chunks

What I observed on current master during a real Epic download:

- `app.gamenative` around ~180–225% CPU
- around ~127 threads
- heavy `DefaultDispatcher` / `HeapTaskDaemon` activity
- repeated per-chunk log output
- CPU0 observed up to roughly ~63°C
- device became noticeably hot to the touch

This patch reduces local downloader overhead while preserving the core download behavior.

It does not change:

- Epic manifest parsing
- chunk hash verification
- install layout
- CDN selection
- ownership/login behavior

## What changed

- Use the existing Download Speed setting / `DownloadSpeedConfig` for Epic parallelism instead of hardcoded Epic-specific caps.
- Batch byte progress updates instead of updating on every small read.
- Remove hot-path per-chunk debug logging.
- Pre-index chunk-to-file assembly metadata so assembly does not repeatedly scan every file/chunk part for each downloaded chunk.
- Keep lower-bound safety so download/decompress parallelism never falls below 1.

## Recording

I do not have a full screen recording yet, but I can attach terminal/logcat screenshots from the on-device test if needed.

## Type of Change

- [ ] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Validation

Built locally:

- `:app:compileModernDebugKotlin`

Installed and tested on-device with a real Epic NBA 2K21 download before the last review adjustment.

Patched behavior observed during that on-device test:

- download continued successfully
- progress advanced from `11.41%` to `11.75%` in 30 seconds
- approximate throughput: ~11 MB/s / ~88 Mbps
- later snapshot: `21.24%` downloaded and still stable
- `app.gamenative` around ~96–129% CPU
- around ~70–73 threads
- thermal status stayed at `0`
- CPU0 around ~43–45°C
- battery around ~37°C
- skin around ~40–41°C

Latest PR revision validation:

- `:app:compileModernDebugKotlin`

The latest revision removes Epic-specific hardcoded parallelism caps and now follows the app's existing Download Speed setting via `DownloadSpeedConfig`.

The goal is not to maximize peak throughput at all costs. The goal is to keep large Epic downloads stable and usable on Android tablets without creating unnecessary sustained CPU/thermal pressure, while still respecting the user's configured Download Speed setting.

## Checklist

- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR.
- [x] This change aligns with the current project scope (core functionality, stability, or performance).
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved download progress reporting with smoother, rate-limited updates.
  * Optimized parallel downloading and chunk assembly for more efficient transfers.
  * Reduced unnecessary processing and logging during downloads.

* **Reliability**
  * Added cancellation checks while preparing downloaded files.
  * Ensured remaining progress is reported when decompression completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->