### PR TITLE
fix: early start epic download before all files are allocated

### DIFF
--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -1025,6 +1025,7 @@ class EpicDownloadManager @Inject constructor(
                     return@launch
                 }
 
+                val chunkMap = chunkQueue.associateBy { it.guidStr }
                 val chunksAdded = mutableListOf<String>()
 
                 files.forEach { file ->
@@ -1049,7 +1050,8 @@ class EpicDownloadManager @Inject constructor(
                         file.chunkParts.forEach { part ->
                             if (!chunksAdded.contains(part.guidStr)) {
                                 chunksAdded.add(part.guidStr)
-                                val chunkInfo = chunkQueue.first { it.guidStr == part.guidStr }
+                                val chunkInfo = chunkMap[part.guidStr]
+                                    ?: throw IllegalStateException("Chunk ${part.guidStr} referenced by file but not found in chunkQueue")
                                 networkChunkFlow.emit(chunkInfo)
                                 Timber.tag("EPIC").v("Emitted chunk ${chunkInfo.guidStr} to download flow")
                             }

--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -1045,15 +1045,18 @@ class EpicDownloadManager @Inject constructor(
                         RandomAccessFile(outputFile.path, "rw").use {
                             it.setLength(totalSize)
                         }
+
+                        file.chunkParts.forEach { part ->
+                            if (!chunksAdded.contains(part.guidStr)) {
+                                chunksAdded.add(part.guidStr)
+                                val chunkInfo = chunkQueue.first { it.guidStr == part.guidStr }
+                                networkChunkFlow.emit(chunkInfo)
+                                Timber.tag("EPIC").v("Emitted chunk ${chunkInfo.guidStr} to download flow")
+                            }
+                        }
                     } catch (e: IOException) {
                         throw IOException("Failed to allocate file ${outputFile.path}: ${e.message}")
                     }
-                }
-
-                chunkQueue.forEach { chunkInfo ->
-                    chunksAdded.add(chunkInfo.guidStr)
-                    networkChunkFlow.emit(chunkInfo)
-                    Timber.tag("EPIC").v("Emitted chunk ${chunkInfo.guidStr} to download flow")
                 }
             }
 


### PR DESCRIPTION
## Description
fix: early start epic download before all files are allocated

## Recording
None

## Type of Change
- [ ] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start Epic downloads earlier by emitting chunks for each file immediately after it’s preallocated, instead of waiting for all files. This reduces startup latency and overlaps disk allocation with network transfers.

- **Performance**
  - Emit each file’s chunk parts immediately, de-duped via `chunksAdded`.
  - Remove the final full `chunkQueue` flush; chunks stream as files become ready.
  - Use a `chunkMap` for O(1) lookup and validate file chunk references, throwing if a referenced chunk is missing.

<sup>Written for commit 251fc0565455fe7c969346ebc893305af1b8e222. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chunk handling in Epic game downloads to process and emit only the chunks referenced by each output file during the pre-allocation phase, resulting in more accurate download assembly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->