### PR TITLE
Repeat physical controller scroll bindings while held

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
@@ -25,9 +25,16 @@ class PhysicalControllerHandler(
     private val onOpenNavigationMenu: (() -> Unit)? = null,
     private val onShowKeyboard: (() -> Unit)? = null
 ) {
+    companion object {
+        private const val SCROLL_REPEAT_INTERVAL_MS = 90L
+    }
+
     private val TAG = "gncontrol"
     private val mouseMoveOffset = PointF(0f, 0f)
     private var mouseMoveTimer: Timer? = null
+    private var scrollRepeatTimer: Timer? = null
+    private val scrollRepeatLock = Any()
+    private val activeScrollBindings = mutableSetOf<Binding>()
     // track which axis keycodes are currently "pressed" so we only release on actual transitions.
     // accessed only from main thread (MotionEvent dispatch + Compose lifecycle), no sync needed.
     private val activeAxisBindings = mutableSetOf<Int>()
@@ -47,6 +54,7 @@ class PhysicalControllerHandler(
 
     fun setProfile(profile: ControlsProfile?) {
         releaseActiveAxes()
+        clearScrollRepeats()
         this.profile = profile
         Log.d(TAG, "PhysicalControllerHandler: Profile set to ${profile?.name}")
 
@@ -66,6 +74,7 @@ class PhysicalControllerHandler(
         mouseMoveTimer?.cancel()
         mouseMoveTimer = null
         mouseMoveOffset.set(0f, 0f)
+        clearScrollRepeats()
         showKeyboardPressed = false
     }
 
@@ -186,6 +195,61 @@ class PhysicalControllerHandler(
                 }
             }, 0, 1000 / 60)
         }
+    }
+
+    private fun handleScrollBinding(binding: Binding, isActionDown: Boolean): Boolean {
+        if (binding != Binding.MOUSE_SCROLL_UP && binding != Binding.MOUSE_SCROLL_DOWN) {
+            return false
+        }
+
+        var pulseImmediately = false
+        synchronized(scrollRepeatLock) {
+            if (isActionDown) {
+                pulseImmediately = activeScrollBindings.add(binding)
+                createScrollRepeatTimerLocked()
+            } else {
+                activeScrollBindings.remove(binding)
+                if (activeScrollBindings.isEmpty()) {
+                    cancelScrollRepeatTimerLocked()
+                }
+            }
+        }
+
+        if (pulseImmediately) {
+            sendScrollPulse(binding)
+        }
+        return true
+    }
+
+    private fun createScrollRepeatTimerLocked() {
+        if (scrollRepeatTimer != null) return
+        scrollRepeatTimer = Timer()
+        scrollRepeatTimer?.schedule(object : TimerTask() {
+            override fun run() {
+                val bindings = synchronized(scrollRepeatLock) {
+                    activeScrollBindings.toList()
+                }
+                bindings.forEach { sendScrollPulse(it) }
+            }
+        }, SCROLL_REPEAT_INTERVAL_MS, SCROLL_REPEAT_INTERVAL_MS)
+    }
+
+    private fun cancelScrollRepeatTimerLocked() {
+        scrollRepeatTimer?.cancel()
+        scrollRepeatTimer = null
+    }
+
+    private fun clearScrollRepeats() {
+        synchronized(scrollRepeatLock) {
+            activeScrollBindings.clear()
+            cancelScrollRepeatTimerLocked()
+        }
+    }
+
+    private fun sendScrollPulse(binding: Binding) {
+        val pointerButton = binding.pointerButton ?: return
+        xServer?.injectPointerButtonPress(pointerButton)
+        xServer?.injectPointerButtonRelease(pointerButton)
     }
 
     /**
@@ -358,6 +422,8 @@ class PhysicalControllerHandler(
                     createMouseMoveTimer()
                 }
                 // Don't reset when isActionDown=false - mouseMoveOffset is reset at the start of processJoystickInput
+            } else if (handleScrollBinding(binding, isActionDown)) {
+                // Mouse wheel events are pulses, not held button state.
             } else {
                 // For keyboard/mouse button bindings, inject into XServer
                 val pointerButton = binding.pointerButton


### PR DESCRIPTION
## Description
This is a requested feature / bug fix from here: https://discord.com/channels/1378308569287622737/1515943534878789642

Adds repeat handling for physical controller bindings mapped to mouse wheel up/down. So if a controller's analog stick is set up for mouse wheel scroll up/down, it continuously scrolls instead of just emitting a single scroll event.


## Recording

https://github.com/user-attachments/assets/e3a4153f-d829-49f3-aee5-9d90ca99a287

## Type of Change
- [X] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [X] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved mouse wheel scrolling for physical controllers: wheel actions now repeat continuously while the wheel binding is held.
  * Scrolling starts immediately on press and automatically stops once the wheel binding is released, providing smoother navigation for long lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->