### PR TITLE
fix: app not responding issue on different situations

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1338,22 +1338,20 @@ class SteamService : Service(), IChallengeUrlChanged {
             // Remove from DB
             workshopPausedApps.remove(appId)
             with(instance!!) {
-                scope.launch {
-                    db.withTransaction {
-                        appInfoDao.deleteApp(appId)
-                        changeNumbersDao.deleteByAppId(appId)
-                        fileChangeListsDao.deleteByAppId(appId)
-                        steamFileHashCacheDao.deleteByAppId(appId)
-                        downloadingAppInfoDao.deleteApp(appId)
-                        appDao.clearWorkshopState(appId)
+                db.withTransaction {
+                    appInfoDao.deleteApp(appId)
+                    changeNumbersDao.deleteByAppId(appId)
+                    fileChangeListsDao.deleteByAppId(appId)
+                    steamFileHashCacheDao.deleteByAppId(appId)
+                    downloadingAppInfoDao.deleteApp(appId)
+                    appDao.clearWorkshopState(appId)
 
-                        val indirectDlcAppIds = getDownloadableDlcAppsOf(appId).orEmpty().map { it.id }
-                        indirectDlcAppIds.forEach { dlcAppId ->
-                            appInfoDao.deleteApp(dlcAppId)
-                            changeNumbersDao.deleteByAppId(dlcAppId)
-                            fileChangeListsDao.deleteByAppId(dlcAppId)
-                            steamFileHashCacheDao.deleteByAppId(dlcAppId)
-                        }
+                    val indirectDlcAppIds = getDownloadableDlcAppsOf(appId).orEmpty().map { it.id }
+                    indirectDlcAppIds.forEach { dlcAppId ->
+                        appInfoDao.deleteApp(dlcAppId)
+                        changeNumbersDao.deleteByAppId(dlcAppId)
+                        fileChangeListsDao.deleteByAppId(dlcAppId)
+                        steamFileHashCacheDao.deleteByAppId(dlcAppId)
                     }
                 }
             }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1309,7 +1309,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             return container.executablePath.ifEmpty { getInstalledExe(gameId) }
         }
 
-        fun deleteApp(appId: Int): Boolean {
+        suspend fun deleteApp(appId: Int): Boolean = withContext(Dispatchers.IO) {
             // snapshot path before marker removal (removing the marker changes resolution)
             val appInfo = getInstalledApp(appId)
             val result = if (appInfo?.isImported == true) {
@@ -1358,7 +1358,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                 }
             }
 
-            return result
+            return@withContext result
         }
 
         fun downloadApp(appId: Int): DownloadInfo? {

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -605,33 +605,27 @@ private fun LibraryScreenContent(
 
     // Global key/motion bootstrap path for cases where Compose focus was lost by touch mode.
     // This runs at the app event bus layer, independent of current Compose focus target.
-    DisposableEffect(
-        selectedAppId,
-        isSystemMenuOpen,
-        state.isOptionsPanelOpen,
-        state.isSearching,
-        state.appInfoList.size,
-        state.currentTab,
-    ) {
-        val canBootstrapContentFocus: () -> Boolean = {
-            val now = SystemClock.uptimeMillis()
-            selectedAppId == null &&
-                !isSystemMenuOpen &&
-                !state.isOptionsPanelOpen &&
-                !state.isSearching &&
-                state.appInfoList.isNotEmpty() &&
-                controllerBootstrapNeeded &&
-                !rootHasFocus &&
-                (now - lastBootstrapAtMs) > 250L
-        }
-        val canNavigateTabsWithoutFocus: () -> Boolean = {
-            selectedAppId == null &&
-                !isSystemMenuOpen &&
-                !state.isOptionsPanelOpen &&
-                !state.isSearching &&
-                !rootHasFocus
-        }
+    // Helper functions defined in composable scope to capture latest state on each recomposition.
+    val canBootstrapContentFocus: () -> Boolean = {
+        val now = SystemClock.uptimeMillis()
+        selectedAppId == null &&
+            !isSystemMenuOpen &&
+            !state.isOptionsPanelOpen &&
+            !state.isSearching &&
+            state.appInfoList.isNotEmpty() &&
+            controllerBootstrapNeeded &&
+            !rootHasFocus &&
+            (now - lastBootstrapAtMs) > 250L
+    }
+    val canNavigateTabsWithoutFocus: () -> Boolean = {
+        selectedAppId == null &&
+            !isSystemMenuOpen &&
+            !state.isOptionsPanelOpen &&
+            !state.isSearching &&
+            !rootHasFocus
+    }
 
+    DisposableEffect(Unit) {
         val onGlobalKeyEvent: (AndroidEvent.KeyEvent) -> Boolean = { androidEvent ->
             val event = androidEvent.event
             if (event.action != KeyEvent.ACTION_DOWN) {

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/AmazonAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/AmazonAppScreen.kt
@@ -41,6 +41,7 @@ import com.winlator.container.ContainerData
 import com.winlator.core.StringUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -362,7 +363,7 @@ override fun isInstalled(context: Context, libraryItem: LibraryItem): Boolean =
                     }
                 }
             } finally {
-                withContext(Dispatchers.Main) {
+                withContext(NonCancellable + Dispatchers.Main) {
                     showDeletingDialog = false
                 }
             }
@@ -659,7 +660,7 @@ override fun isInstalled(context: Context, libraryItem: LibraryItem): Boolean =
                                     PluviaApp.events.emitJava(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.AMAZON))
                                 }
                             } finally {
-                                withContext(Dispatchers.Main) {
+                                withContext(NonCancellable + Dispatchers.Main) {
                                     showDeletingDialog = false
                                 }
                             }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/AmazonAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/AmazonAppScreen.kt
@@ -5,6 +5,7 @@ import app.gamenative.ui.util.SnackbarManager
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import app.gamenative.ui.component.dialog.LoadingDialog
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -88,6 +89,9 @@ class AmazonAppScreen : BaseAppScreen() {
 
         fun shouldShowUninstallDialog(appId: String): Boolean =
             uninstallDialogAppIds.contains(appId)
+
+        // Shared state for deletion progress dialog
+        var showDeletingDialog by mutableStateOf(false)
 
         /** Resolve productId from a library item's appId-backed gameId. */
         fun productIdOf(libraryItem: LibraryItem): String =
@@ -345,13 +349,17 @@ override fun isInstalled(context: Context, libraryItem: LibraryItem): Boolean =
     private fun performUninstall(context: Context, libraryItem: LibraryItem) {
         val productId = productIdOf(libraryItem)
         Timber.tag(TAG).i("performUninstall: deleting game $productId")
+        showDeletingDialog = true
         CoroutineScope(Dispatchers.IO).launch {
             val result = AmazonService.deleteGame(context, productId)
             DownloadService.invalidateCache()
-            if (result.isSuccess) {
-                Timber.tag(TAG).i("Uninstall succeeded for $productId")
-            } else {
-                Timber.tag(TAG).e("Uninstall failed for $productId: ${result.exceptionOrNull()?.message}")
+            withContext(Dispatchers.Main) {
+                showDeletingDialog = false
+                if (result.isSuccess) {
+                    Timber.tag(TAG).i("Uninstall succeeded for $productId")
+                } else {
+                    Timber.tag(TAG).e("Uninstall failed for $productId: ${result.exceptionOrNull()?.message}")
+                }
             }
         }
     }
@@ -631,6 +639,8 @@ override fun isInstalled(context: Context, libraryItem: LibraryItem): Boolean =
                 DialogType.CANCEL_APP_DOWNLOAD -> {
                     {
                         Timber.tag(TAG).i("Confirmed cancel/delete download for: $productId")
+                        BaseAppScreen.hideInstallDialog(appId)
+                        showDeletingDialog = true
                         val downloadInfo = AmazonService.getDownloadInfo(productId)
                         downloadInfo?.cancel()
                         scope.launch {
@@ -638,7 +648,7 @@ override fun isInstalled(context: Context, libraryItem: LibraryItem): Boolean =
                             AmazonService.deleteGame(context, productId)
                             DownloadService.invalidateCache()
                             withContext(Dispatchers.Main) {
-                                BaseAppScreen.hideInstallDialog(appId)
+                                showDeletingDialog = false
                                 val gameId = libraryItem.gameId
                                 PluviaApp.events.emitJava(AndroidEvent.DownloadStatusChanged(gameId, false))
                                 PluviaApp.events.emitJava(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.AMAZON))
@@ -686,6 +696,15 @@ override fun isInstalled(context: Context, libraryItem: LibraryItem): Boolean =
                 onDismiss = {
                     hideAmazonInstallDialog(appId)
                 },
+            )
+        }
+
+        // ── Deletion progress dialog ──
+        if (showDeletingDialog) {
+            LoadingDialog(
+                visible = true,
+                progress = -1f,
+                message = stringResource(R.string.deleting),
             )
         }
 

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/AmazonAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/AmazonAppScreen.kt
@@ -351,14 +351,19 @@ override fun isInstalled(context: Context, libraryItem: LibraryItem): Boolean =
         Timber.tag(TAG).i("performUninstall: deleting game $productId")
         showDeletingDialog = true
         CoroutineScope(Dispatchers.IO).launch {
-            val result = AmazonService.deleteGame(context, productId)
-            DownloadService.invalidateCache()
-            withContext(Dispatchers.Main) {
-                showDeletingDialog = false
-                if (result.isSuccess) {
-                    Timber.tag(TAG).i("Uninstall succeeded for $productId")
-                } else {
-                    Timber.tag(TAG).e("Uninstall failed for $productId: ${result.exceptionOrNull()?.message}")
+            try {
+                val result = AmazonService.deleteGame(context, productId)
+                DownloadService.invalidateCache()
+                withContext(Dispatchers.Main) {
+                    if (result.isSuccess) {
+                        Timber.tag(TAG).i("Uninstall succeeded for $productId")
+                    } else {
+                        Timber.tag(TAG).e("Uninstall failed for $productId: ${result.exceptionOrNull()?.message}")
+                    }
+                }
+            } finally {
+                withContext(Dispatchers.Main) {
+                    showDeletingDialog = false
                 }
             }
         }
@@ -644,14 +649,19 @@ override fun isInstalled(context: Context, libraryItem: LibraryItem): Boolean =
                         val downloadInfo = AmazonService.getDownloadInfo(productId)
                         downloadInfo?.cancel()
                         scope.launch {
-                            downloadInfo?.awaitCompletion()
-                            AmazonService.deleteGame(context, productId)
-                            DownloadService.invalidateCache()
-                            withContext(Dispatchers.Main) {
-                                showDeletingDialog = false
-                                val gameId = libraryItem.gameId
-                                PluviaApp.events.emitJava(AndroidEvent.DownloadStatusChanged(gameId, false))
-                                PluviaApp.events.emitJava(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.AMAZON))
+                            try {
+                                downloadInfo?.awaitCompletion()
+                                AmazonService.deleteGame(context, productId)
+                                DownloadService.invalidateCache()
+                                withContext(Dispatchers.Main) {
+                                    val gameId = libraryItem.gameId
+                                    PluviaApp.events.emitJava(AndroidEvent.DownloadStatusChanged(gameId, false))
+                                    PluviaApp.events.emitJava(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.AMAZON))
+                                }
+                            } finally {
+                                withContext(Dispatchers.Main) {
+                                    showDeletingDialog = false
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
@@ -522,7 +522,6 @@ class CustomGameAppScreen : BaseAppScreen() {
                                     }
 
                                     withContext(Dispatchers.Main) {
-                                        showDeletingDialog = false
                                         // Navigate back and show notification
                                         SnackbarManager.show("\"${libraryItem.name}\" has been deleted")
 
@@ -535,9 +534,12 @@ class CustomGameAppScreen : BaseAppScreen() {
                                     }
                                 } catch (e: Exception) {
                                     withContext(Dispatchers.Main) {
+                                        SnackbarManager.show("Failed to delete game: ${e.message}")
+                                    }
+                                } finally {
+                                    withContext(Dispatchers.Main) {
                                         showDeletingDialog = false
                                     }
-                                    SnackbarManager.show("Failed to delete game: ${e.message}")
                                 }
                             }
                         }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
@@ -26,6 +26,7 @@ import app.gamenative.utils.SteamGridDB
 import app.gamenative.utils.StorageUtils
 import com.winlator.container.ContainerData
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -537,7 +538,7 @@ class CustomGameAppScreen : BaseAppScreen() {
                                         SnackbarManager.show("Failed to delete game: ${e.message}")
                                     }
                                 } finally {
-                                    withContext(Dispatchers.Main) {
+                                    withContext(NonCancellable + Dispatchers.Main) {
                                         showDeletingDialog = false
                                     }
                                 }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import app.gamenative.ui.component.dialog.LoadingDialog
 import androidx.compose.runtime.*
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalContext
@@ -54,6 +55,9 @@ class CustomGameAppScreen : BaseAppScreen() {
         fun shouldShowDeleteDialog(appId: String): Boolean {
             return deleteDialogAppIds.contains(appId)
         }
+
+        // Shared state for deletion progress dialog
+        var showDeletingDialog by mutableStateOf(false)
     }
     @Composable
     override fun getGameDisplayInfo(
@@ -463,6 +467,15 @@ class CustomGameAppScreen : BaseAppScreen() {
         val context = LocalContext.current
         val scope = rememberCoroutineScope()
 
+        // Track deletion progress dialog state
+        if (showDeletingDialog) {
+            LoadingDialog(
+                visible = true,
+                progress = -1f,
+                message = stringResource(R.string.deleting),
+            )
+        }
+
         // Track delete dialog state
         var showDeleteDialog by remember { mutableStateOf(shouldShowDeleteDialog(libraryItem.appId)) }
 
@@ -487,6 +500,7 @@ class CustomGameAppScreen : BaseAppScreen() {
                     TextButton(
                         onClick = {
                             hideDeleteDialog(libraryItem.appId)
+                            showDeletingDialog = true
 
                             // Delete the game folder and container
                             scope.launch {
@@ -507,10 +521,11 @@ class CustomGameAppScreen : BaseAppScreen() {
                                         CustomGameScanner.invalidateCache()
                                     }
 
-                                    // Navigate back and show notification
-                                    SnackbarManager.show("\"${libraryItem.name}\" has been deleted")
-
                                     withContext(Dispatchers.Main) {
+                                        showDeletingDialog = false
+                                        // Navigate back and show notification
+                                        SnackbarManager.show("\"${libraryItem.name}\" has been deleted")
+
                                         // Small delay to ensure file system updates are complete
                                         // before navigating back (list will auto-refresh when displayed)
                                         delay(100)
@@ -519,6 +534,9 @@ class CustomGameAppScreen : BaseAppScreen() {
                                         onBack()
                                     }
                                 } catch (e: Exception) {
+                                    withContext(Dispatchers.Main) {
+                                        showDeletingDialog = false
+                                    }
                                     SnackbarManager.show("Failed to delete game: ${e.message}")
                                 }
                             }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import app.gamenative.ui.component.dialog.LoadingDialog
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -71,6 +72,9 @@ class EpicAppScreen : BaseAppScreen() {
             Timber.tag(TAG).d("shouldShowUninstallDialog: appId=$appId, result=$result")
             return result
         }
+
+        // Shared state for deletion progress dialog
+        var showDeletingDialog by mutableStateOf(false)
 
         // Shared state for install dialog - list of appIds that should show the dialog
         private val installDialogAppIds = mutableStateListOf<String>()
@@ -480,18 +484,25 @@ class EpicAppScreen : BaseAppScreen() {
      */
     private fun performUninstall(context: Context, libraryItem: LibraryItem) {
         Timber.tag(TAG).i("Uninstalling Epic game: ${libraryItem.appId}")
+        showDeletingDialog = true
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 val result = EpicService.deleteGame(context, libraryItem.gameId)
                 DownloadService.invalidateCache()
 
-                if (result.isSuccess) {
-                    Timber.tag(TAG).i("Epic game uninstalled successfully: ${libraryItem.appId}")
-                } else {
-                    Timber.e("Failed to uninstall Epic game: ${libraryItem.appId} - ${result.exceptionOrNull()?.message}")
-                    SnackbarManager.show(context.getString(R.string.epic_uninstall_failed, result.exceptionOrNull()?.message ?: ""))
+                withContext(Dispatchers.Main) {
+                    showDeletingDialog = false
+                    if (result.isSuccess) {
+                        Timber.tag(TAG).i("Epic game uninstalled successfully: ${libraryItem.appId}")
+                    } else {
+                        Timber.e("Failed to uninstall Epic game: ${libraryItem.appId} - ${result.exceptionOrNull()?.message}")
+                        SnackbarManager.show(context.getString(R.string.epic_uninstall_failed, result.exceptionOrNull()?.message ?: ""))
+                    }
                 }
             } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    showDeletingDialog = false
+                }
                 Timber.e(e, "Error uninstalling Epic game")
                 SnackbarManager.show(context.getString(R.string.epic_uninstall_error, e.message ?: ""))
             }
@@ -792,6 +803,8 @@ class EpicAppScreen : BaseAppScreen() {
                 app.gamenative.ui.enums.DialogType.CANCEL_APP_DOWNLOAD -> {
                     {
                         Timber.tag(TAG).i("Cancelling/deleting Epic download for: $gameId")
+                        BaseAppScreen.hideInstallDialog(appId)
+                        showDeletingDialog = true
                         val downloadInfo = EpicService.getDownloadInfo(gameId)
                         downloadInfo?.cancel()
                         scope.launch {
@@ -800,7 +813,7 @@ class EpicAppScreen : BaseAppScreen() {
                             EpicService.deleteGame(context, gameId)
                             DownloadService.invalidateCache()
                             withContext(Dispatchers.Main) {
-                                BaseAppScreen.hideInstallDialog(appId)
+                                showDeletingDialog = false
                                 app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.DownloadStatusChanged(gameId, false))
                                 app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged(gameId, app.gamenative.data.GameSource.EPIC))
                             }
@@ -836,6 +849,15 @@ class EpicAppScreen : BaseAppScreen() {
                 onDismissRequest = {
                     hideGameManagerDialog(gameId)
                 }
+            )
+        }
+
+        // Show deletion progress dialog
+        if (showDeletingDialog) {
+            LoadingDialog(
+                visible = true,
+                progress = -1f,
+                message = stringResource(R.string.deleting),
             )
         }
 

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
@@ -39,6 +39,7 @@ import java.io.File
 import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -504,7 +505,7 @@ class EpicAppScreen : BaseAppScreen() {
                     SnackbarManager.show(context.getString(R.string.epic_uninstall_error, e.message ?: ""))
                 }
             } finally {
-                withContext(Dispatchers.Main) {
+                withContext(NonCancellable + Dispatchers.Main) {
                     showDeletingDialog = false
                 }
             }
@@ -809,18 +810,23 @@ class EpicAppScreen : BaseAppScreen() {
                         showDeletingDialog = true
                         val downloadInfo = EpicService.getDownloadInfo(gameId)
                         downloadInfo?.cancel()
-                        scope.launch {
+                        scope.launch(Dispatchers.IO) {
                             try {
                                 downloadInfo?.awaitCompletion()
                                 EpicService.cleanupDownload(context, gameId)
-                                EpicService.deleteGame(context, gameId)
+                                val result = EpicService.deleteGame(context, gameId)
                                 DownloadService.invalidateCache()
                                 withContext(Dispatchers.Main) {
-                                    app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.DownloadStatusChanged(gameId, false))
-                                    app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged(gameId, app.gamenative.data.GameSource.EPIC))
+                                    if (result.isSuccess) {
+                                        app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.DownloadStatusChanged(gameId, false))
+                                        app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged(gameId, app.gamenative.data.GameSource.EPIC))
+                                    } else {
+                                        Timber.tag(TAG).e("Failed to delete Epic game after cancel: $gameId - ${result.exceptionOrNull()?.message}")
+                                        SnackbarManager.show("Failed to delete download: ${result.exceptionOrNull()?.message ?: ""}")
+                                    }
                                 }
                             } finally {
-                                withContext(Dispatchers.Main) {
+                                withContext(NonCancellable + Dispatchers.Main) {
                                     showDeletingDialog = false
                                 }
                             }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/EpicAppScreen.kt
@@ -491,7 +491,6 @@ class EpicAppScreen : BaseAppScreen() {
                 DownloadService.invalidateCache()
 
                 withContext(Dispatchers.Main) {
-                    showDeletingDialog = false
                     if (result.isSuccess) {
                         Timber.tag(TAG).i("Epic game uninstalled successfully: ${libraryItem.appId}")
                     } else {
@@ -500,11 +499,14 @@ class EpicAppScreen : BaseAppScreen() {
                     }
                 }
             } catch (e: Exception) {
+                Timber.e(e, "Error uninstalling Epic game")
+                withContext(Dispatchers.Main) {
+                    SnackbarManager.show(context.getString(R.string.epic_uninstall_error, e.message ?: ""))
+                }
+            } finally {
                 withContext(Dispatchers.Main) {
                     showDeletingDialog = false
                 }
-                Timber.e(e, "Error uninstalling Epic game")
-                SnackbarManager.show(context.getString(R.string.epic_uninstall_error, e.message ?: ""))
             }
         }
     }
@@ -808,14 +810,19 @@ class EpicAppScreen : BaseAppScreen() {
                         val downloadInfo = EpicService.getDownloadInfo(gameId)
                         downloadInfo?.cancel()
                         scope.launch {
-                            downloadInfo?.awaitCompletion()
-                            EpicService.cleanupDownload(context, gameId)
-                            EpicService.deleteGame(context, gameId)
-                            DownloadService.invalidateCache()
-                            withContext(Dispatchers.Main) {
-                                showDeletingDialog = false
-                                app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.DownloadStatusChanged(gameId, false))
-                                app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged(gameId, app.gamenative.data.GameSource.EPIC))
+                            try {
+                                downloadInfo?.awaitCompletion()
+                                EpicService.cleanupDownload(context, gameId)
+                                EpicService.deleteGame(context, gameId)
+                                DownloadService.invalidateCache()
+                                withContext(Dispatchers.Main) {
+                                    app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.DownloadStatusChanged(gameId, false))
+                                    app.gamenative.PluviaApp.events.emit(app.gamenative.events.AndroidEvent.LibraryInstallStatusChanged(gameId, app.gamenative.data.GameSource.EPIC))
+                                }
+                            } finally {
+                                withContext(Dispatchers.Main) {
+                                    showDeletingDialog = false
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -32,6 +32,7 @@ import com.winlator.container.ContainerData
 import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -422,7 +423,7 @@ class GOGAppScreen : BaseAppScreen() {
                     SnackbarManager.show("Failed to uninstall game: ${e.message}")
                 }
             } finally {
-                withContext(Dispatchers.Main) {
+                withContext(NonCancellable + Dispatchers.Main) {
                     showDeletingDialog = false
                 }
             }
@@ -727,7 +728,7 @@ class GOGAppScreen : BaseAppScreen() {
                                     }
                                 }
                             } finally {
-                                withContext(Dispatchers.Main) {
+                                withContext(NonCancellable + Dispatchers.Main) {
                                     showDeletingDialog = false
                                 }
                             }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import app.gamenative.ui.component.dialog.LoadingDialog
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -66,6 +67,9 @@ class GOGAppScreen : BaseAppScreen() {
             Timber.tag(TAG).d("shouldShowUninstallDialog: appId=$appId, result=$result")
             return result
         }
+
+        // Shared state for deletion progress dialog
+        var showDeletingDialog by mutableStateOf(false)
 
         /**
          * Formats bytes into a human-readable string (KB, MB, GB).
@@ -395,21 +399,28 @@ class GOGAppScreen : BaseAppScreen() {
 
     private fun performUninstall(context: Context, libraryItem: LibraryItem) {
         Timber.i("Uninstalling GOG game: ${libraryItem.appId}")
+        showDeletingDialog = true
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 // Delegate to GOGService which calls GOGManager.deleteGame
                 val result = GOGService.deleteGame(context, libraryItem)
                 DownloadService.invalidateCache()
 
-                if (result.isSuccess) {
-                    Timber.i("Successfully uninstalled GOG game: ${libraryItem.appId}")
-                    SnackbarManager.show("Game uninstalled successfully")
-                } else {
-                    val error = result.exceptionOrNull()
-                    Timber.e(error, "Failed to uninstall GOG game: ${libraryItem.appId}")
-                    SnackbarManager.show("Failed to uninstall game: ${error?.message}")
+                withContext(Dispatchers.Main) {
+                    showDeletingDialog = false
+                    if (result.isSuccess) {
+                        Timber.i("Successfully uninstalled GOG game: ${libraryItem.appId}")
+                        SnackbarManager.show("Game uninstalled successfully")
+                    } else {
+                        val error = result.exceptionOrNull()
+                        Timber.e(error, "Failed to uninstall GOG game: ${libraryItem.appId}")
+                        SnackbarManager.show("Failed to uninstall game: ${error?.message}")
+                    }
                 }
             } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    showDeletingDialog = false
+                }
                 Timber.e(e, "Error uninstalling GOG game")
                 SnackbarManager.show("Failed to uninstall game: ${e.message}")
             }
@@ -685,6 +696,7 @@ class GOGAppScreen : BaseAppScreen() {
                 app.gamenative.ui.enums.DialogType.CANCEL_APP_DOWNLOAD -> {
                     {
                         BaseAppScreen.hideInstallDialog(appId)
+                        showDeletingDialog = true
                         val gameId = libraryItem.gameId.toString()
                         CoroutineScope(Dispatchers.IO).launch {
                             val downloadInfo = GOGService.getDownloadInfo(gameId)
@@ -698,16 +710,22 @@ class GOGAppScreen : BaseAppScreen() {
                             val isInstalledAfterCancel = GOGService.isGameInstalled(gameId)
                             if (isInstalledAfterCancel) {
                                 // Download completed and game ended up installed; don't show "Download cancelled"
+                                withContext(Dispatchers.Main) {
+                                    showDeletingDialog = false
+                                }
                                 return@launch
                             }
 
                             val result = GOGService.deleteGame(context, libraryItem)
                             DownloadService.invalidateCache()
-                            if (wasDownloading && !isInstalledAfterCancel) {
-                                SnackbarManager.show("Download cancelled")
-                            }
-                            if (result.isFailure) {
-                                SnackbarManager.show("Failed to delete download: ${result.exceptionOrNull()?.message}")
+                            withContext(Dispatchers.Main) {
+                                showDeletingDialog = false
+                                if (wasDownloading && !isInstalledAfterCancel) {
+                                    SnackbarManager.show("Download cancelled")
+                                }
+                                if (result.isFailure) {
+                                    SnackbarManager.show("Failed to delete download: ${result.exceptionOrNull()?.message}")
+                                }
                             }
                         }
                     }
@@ -734,6 +752,15 @@ class GOGAppScreen : BaseAppScreen() {
                 dismissBtnText = installDialogState.dismissBtnText,
                 title = installDialogState.title,
                 message = installDialogState.message,
+            )
+        }
+
+        // Show deletion progress dialog
+        if (showDeletingDialog) {
+            LoadingDialog(
+                visible = true,
+                progress = -1f,
+                message = stringResource(R.string.deleting),
             )
         }
 

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/GOGAppScreen.kt
@@ -407,7 +407,6 @@ class GOGAppScreen : BaseAppScreen() {
                 DownloadService.invalidateCache()
 
                 withContext(Dispatchers.Main) {
-                    showDeletingDialog = false
                     if (result.isSuccess) {
                         Timber.i("Successfully uninstalled GOG game: ${libraryItem.appId}")
                         SnackbarManager.show("Game uninstalled successfully")
@@ -418,11 +417,14 @@ class GOGAppScreen : BaseAppScreen() {
                     }
                 }
             } catch (e: Exception) {
+                Timber.e(e, "Error uninstalling GOG game")
+                withContext(Dispatchers.Main) {
+                    SnackbarManager.show("Failed to uninstall game: ${e.message}")
+                }
+            } finally {
                 withContext(Dispatchers.Main) {
                     showDeletingDialog = false
                 }
-                Timber.e(e, "Error uninstalling GOG game")
-                SnackbarManager.show("Failed to uninstall game: ${e.message}")
             }
         }
     }
@@ -699,32 +701,34 @@ class GOGAppScreen : BaseAppScreen() {
                         showDeletingDialog = true
                         val gameId = libraryItem.gameId.toString()
                         CoroutineScope(Dispatchers.IO).launch {
-                            val downloadInfo = GOGService.getDownloadInfo(gameId)
-                            val wasDownloading = downloadInfo != null &&
-                                downloadInfo.isActive() &&
-                                (downloadInfo.getProgress() ?: 0f) < 1f
-                            downloadInfo?.cancel()
-                            downloadInfo?.awaitCompletion()
-                            GOGService.cleanupDownload(gameId)
+                            try {
+                                val downloadInfo = GOGService.getDownloadInfo(gameId)
+                                val wasDownloading = downloadInfo != null &&
+                                    downloadInfo.isActive() &&
+                                    (downloadInfo.getProgress() ?: 0f) < 1f
+                                downloadInfo?.cancel()
+                                downloadInfo?.awaitCompletion()
+                                GOGService.cleanupDownload(gameId)
 
-                            val isInstalledAfterCancel = GOGService.isGameInstalled(gameId)
-                            if (isInstalledAfterCancel) {
-                                // Download completed and game ended up installed; don't show "Download cancelled"
+                                val isInstalledAfterCancel = GOGService.isGameInstalled(gameId)
+                                if (isInstalledAfterCancel) {
+                                    // Download completed and game ended up installed; don't show "Download cancelled"
+                                    return@launch
+                                }
+
+                                val result = GOGService.deleteGame(context, libraryItem)
+                                DownloadService.invalidateCache()
+                                withContext(Dispatchers.Main) {
+                                    if (wasDownloading && !isInstalledAfterCancel) {
+                                        SnackbarManager.show("Download cancelled")
+                                    }
+                                    if (result.isFailure) {
+                                        SnackbarManager.show("Failed to delete download: ${result.exceptionOrNull()?.message}")
+                                    }
+                                }
+                            } finally {
                                 withContext(Dispatchers.Main) {
                                     showDeletingDialog = false
-                                }
-                                return@launch
-                            }
-
-                            val result = GOGService.deleteGame(context, libraryItem)
-                            DownloadService.invalidateCache()
-                            withContext(Dispatchers.Main) {
-                                showDeletingDialog = false
-                                if (wasDownloading && !isInstalledAfterCancel) {
-                                    SnackbarManager.show("Download cancelled")
-                                }
-                                if (result.isFailure) {
-                                    SnackbarManager.show("Failed to delete download: ${result.exceptionOrNull()?.message}")
                                 }
                             }
                         }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -1124,11 +1124,14 @@ class SteamAppScreen : BaseAppScreen() {
                         hideInstallDialog(gameId)
                         showDeletingDialog = true
                         CoroutineScope(Dispatchers.IO).launch {
-                            SteamService.deleteApp(gameId)
-                            DownloadService.invalidateCache()
-                            PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.STEAM))
-                            withContext(Dispatchers.Main) {
-                                showDeletingDialog = false
+                            try {
+                                SteamService.deleteApp(gameId)
+                                DownloadService.invalidateCache()
+                                PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.STEAM))
+                            } finally {
+                                withContext(Dispatchers.Main) {
+                                    showDeletingDialog = false
+                                }
                             }
                         }
                     }
@@ -1249,36 +1252,41 @@ class SteamAppScreen : BaseAppScreen() {
                             showDeletingDialog = true
 
                             CoroutineScope(Dispatchers.IO).launch {
-                                val installedAppInfo = getInstalledApp(libraryItem.gameId)
+                                try {
+                                    val installedAppInfo = getInstalledApp(libraryItem.gameId)
 
-                                val success = SteamService.deleteApp(gameId)
-                                DownloadService.invalidateCache()
-                                withContext(Dispatchers.Main) {
-                                    ContainerUtils.deleteContainer(context, libraryItem.appId)
-                                }
-                                withContext(Dispatchers.Main) {
-                                    showDeletingDialog = false
-                                    if (success) {
-                                        PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.STEAM))
-                                        SnackbarManager.show(
-                                            context.getString(
-                                                R.string.steam_uninstall_success,
-                                                appInfo?.name ?: libraryItem.name,
-                                            ),
-                                        )
-                                        PostHog.capture(
-                                            event = "game_uninstalled",
-                                            properties = mapOf("game_name" to (appInfo?.name ?: "")),
-                                        )
-                                    } else {
-                                        SnackbarManager.show(context.getString(R.string.steam_uninstall_failed))
-                                    }
-                                }
-
-                                // Back to home screen as the game is imported
-                                if (success && installedAppInfo?.isImported == true) {
+                                    val success = SteamService.deleteApp(gameId)
+                                    DownloadService.invalidateCache()
                                     withContext(Dispatchers.Main) {
-                                        onBack()
+                                        ContainerUtils.deleteContainer(context, libraryItem.appId)
+                                    }
+                                    withContext(Dispatchers.Main) {
+                                        if (success) {
+                                            PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.STEAM))
+                                            SnackbarManager.show(
+                                                context.getString(
+                                                    R.string.steam_uninstall_success,
+                                                    appInfo?.name ?: libraryItem.name,
+                                                ),
+                                            )
+                                            PostHog.capture(
+                                                event = "game_uninstalled",
+                                                properties = mapOf("game_name" to (appInfo?.name ?: "")),
+                                            )
+                                        } else {
+                                            SnackbarManager.show(context.getString(R.string.steam_uninstall_failed))
+                                        }
+                                    }
+
+                                    // Back to home screen as the game is imported
+                                    if (success && installedAppInfo?.isImported == true) {
+                                        withContext(Dispatchers.Main) {
+                                            onBack()
+                                        }
+                                    }
+                                } finally {
+                                    withContext(Dispatchers.Main) {
+                                        showDeletingDialog = false
                                     }
                                 }
                             }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -75,6 +75,7 @@ import java.nio.file.Paths
 import kotlin.io.path.pathString
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -1129,7 +1130,7 @@ class SteamAppScreen : BaseAppScreen() {
                                 DownloadService.invalidateCache()
                                 PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.STEAM))
                             } finally {
-                                withContext(Dispatchers.Main) {
+                                withContext(NonCancellable + Dispatchers.Main) {
                                     showDeletingDialog = false
                                 }
                             }
@@ -1285,7 +1286,7 @@ class SteamAppScreen : BaseAppScreen() {
                                         }
                                     }
                                 } finally {
-                                    withContext(Dispatchers.Main) {
+                                    withContext(NonCancellable + Dispatchers.Main) {
                                         showDeletingDialog = false
                                     }
                                 }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -224,6 +224,9 @@ class SteamAppScreen : BaseAppScreen() {
         fun getPendingUpdateVerifyOperation(gameId: Int): AppOptionMenuType? {
             return pendingUpdateVerifyOperations[gameId]
         }
+
+        // Shared state for deletion progress dialog
+        var showDeletingDialog by mutableStateOf(false)
     }
 
     @Composable
@@ -1118,12 +1121,14 @@ class SteamAppScreen : BaseAppScreen() {
                         val downloadInfo = SteamService.getAppDownloadInfo(gameId)
                         downloadInfo?.cancel()
                         SteamService.workshopPausedApps.remove(gameId)
+                        hideInstallDialog(gameId)
+                        showDeletingDialog = true
                         CoroutineScope(Dispatchers.IO).launch {
                             SteamService.deleteApp(gameId)
                             DownloadService.invalidateCache()
                             PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.STEAM))
                             withContext(Dispatchers.Main) {
-                                hideInstallDialog(gameId)
+                                showDeletingDialog = false
                             }
                         }
                     }
@@ -1241,6 +1246,7 @@ class SteamAppScreen : BaseAppScreen() {
                     TextButton(
                         onClick = {
                             hideUninstallDialog(libraryItem.appId)
+                            showDeletingDialog = true
 
                             CoroutineScope(Dispatchers.IO).launch {
                                 val installedAppInfo = getInstalledApp(libraryItem.gameId)
@@ -1251,6 +1257,7 @@ class SteamAppScreen : BaseAppScreen() {
                                     ContainerUtils.deleteContainer(context, libraryItem.appId)
                                 }
                                 withContext(Dispatchers.Main) {
+                                    showDeletingDialog = false
                                     if (success) {
                                         PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.STEAM))
                                         SnackbarManager.show(
@@ -1296,6 +1303,15 @@ class SteamAppScreen : BaseAppScreen() {
                 currentFile = current,
                 movedFiles = moved,
                 totalFiles = total,
+            )
+        }
+
+        // Deletion progress dialog
+        if (showDeletingDialog) {
+            LoadingDialog(
+                visible = true,
+                progress = -1f,
+                message = stringResource(R.string.deleting),
             )
         }
 

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1293,152 +1293,153 @@ fun XServerScreen(
         }   // preserve suspend state across activity recreation while a game is still running
     }
 
-    DisposableEffect(lifecycleOwner, container) {
-        val onActivityDestroyed: (AndroidEvent.ActivityDestroyed) -> Unit = {
-            Timber.i("onActivityDestroyed")
-            exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
-        }
-        val onKeyEvent: (AndroidEvent.KeyEvent) -> Boolean = {
-            val isKeyboard = Keyboard.isKeyboardDevice(it.event.device)
-            val isPhysicalKeyboard = isKeyboard && it.event.device?.isVirtual != true
-            val isGamepad = ExternalController.isGameController(it.event.device)
-            val waitingForManualResume =
-                manualResumeMode &&
-                    PluviaApp.isOverlayPaused &&
-                    !showQuickMenu &&
-                    !keepPausedForEditor
-            // logD("onKeyEvent(${it.event.device.sources})\n\tisGamepad: $isGamepad\n\tisKeyboard: $isKeyboard\n\t${it.event}")
+    // Event handlers defined in composable scope to capture latest state on each recomposition
+    val onActivityDestroyed: (AndroidEvent.ActivityDestroyed) -> Unit = {
+        Timber.i("onActivityDestroyed")
+        exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+    }
+    val onKeyEvent: (AndroidEvent.KeyEvent) -> Boolean = {
+        val isKeyboard = Keyboard.isKeyboardDevice(it.event.device)
+        val isPhysicalKeyboard = isKeyboard && it.event.device?.isVirtual != true
+        val isGamepad = ExternalController.isGameController(it.event.device)
+        val waitingForManualResume =
+            manualResumeMode &&
+                PluviaApp.isOverlayPaused &&
+                !showQuickMenu &&
+                !keepPausedForEditor
+        // logD("onKeyEvent(${it.event.device.sources})\n\tisGamepad: $isGamepad\n\tisKeyboard: $isKeyboard\n\t${it.event}")
 
-            if (waitingForManualResume) {
-                when (it.event.keyCode) {
-                    KeyEvent.KEYCODE_ENTER,
-                    KeyEvent.KEYCODE_BUTTON_A,
-                    KeyEvent.KEYCODE_BUTTON_START -> {
-                        if (it.event.action == KeyEvent.ACTION_DOWN && it.event.repeatCount == 0) {
-                            resumeFromManualButton()
-                        }
-                        true
-                    }
-                    else -> false
-                }
-            } else if ((showElementEditor || keepPausedForEditor || showQuickMenu || isEditMode) && (isGamepad || isKeyboard)) {
-                val escPressed = !keepPausedForEditor &&
-                    isKeyboard &&
-                    it.event.keyCode == KeyEvent.KEYCODE_ESCAPE
-                if (escPressed) {
-                    keyboardEscMenuHandler.handleOverlayEsc(it.event, keyboard)
+        if (waitingForManualResume) {
+            when (it.event.keyCode) {
+                KeyEvent.KEYCODE_ENTER,
+                KeyEvent.KEYCODE_BUTTON_A,
+                KeyEvent.KEYCODE_BUTTON_START -> {
                     if (it.event.action == KeyEvent.ACTION_DOWN && it.event.repeatCount == 0) {
-                        if (BuildConfig.MODERN_ANDROID) {
-                            (context as? ComponentActivity)?.onBackPressedDispatcher?.onBackPressed()
-                        } else {
-                            gameBack()
-                        }
+                        resumeFromManualButton()
                     }
                     true
-                } else {
-                    // Let Compose focus system handle keyboard and gamepad navigation/selection while menu is visible.
-                    false
                 }
-            } else {
-                var handled = false
-                if (isGamepad) {
-                    xServerView!!.getxServer().winHandler.setCurrentController(it.event.device.id);
-                    handled = physicalControllerHandler?.onKeyEvent(it.event) == true
-                    if (!handled) handled = PluviaApp.inputControlsView?.onKeyEvent(it.event) == true
-                    // Final fallback to WinHandler passthrough
-                    if (!handled) handled = xServerView!!.getxServer().winHandler.onKeyEvent(it.event)
-                }
-                if (!handled && isKeyboard) {
-                    val isShiftEscPressed = it.event.keyCode == KeyEvent.KEYCODE_ESCAPE &&
-                        it.event.isShiftPressed &&
-                        it.event.action == KeyEvent.ACTION_DOWN &&
-                        it.event.repeatCount == 0
-                    if (isShiftEscPressed &&
-                        !showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode) {
-                        keyboardEscMenuHandler.cancel()
-                        gameBack()
-                        handled = true
-                    } else if (isPhysicalKeyboard && keyboardEscMenuHandler.isEsc(it.event) &&
-                        !showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode) {
-                        handled = keyboardEscMenuHandler.handleGameEsc(
-                            event = it.event,
-                            keyboard = keyboard,
-                            canOpenMenu = { !showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode },
-                            openMenu = gameBack,
-                        )
+                else -> false
+            }
+        } else if ((showElementEditor || keepPausedForEditor || showQuickMenu || isEditMode) && (isGamepad || isKeyboard)) {
+            val escPressed = !keepPausedForEditor &&
+                isKeyboard &&
+                it.event.keyCode == KeyEvent.KEYCODE_ESCAPE
+            if (escPressed) {
+                keyboardEscMenuHandler.handleOverlayEsc(it.event, keyboard)
+                if (it.event.action == KeyEvent.ACTION_DOWN && it.event.repeatCount == 0) {
+                    if (BuildConfig.MODERN_ANDROID) {
+                        (context as? ComponentActivity)?.onBackPressedDispatcher?.onBackPressed()
                     } else {
-                        if (it.event.device?.isVirtual == true) {
-                            handled = keyboard?.onVirtualKeyEvent(it.event) == true
-                        } else {
-                            handled = keyboard?.onKeyEvent(it.event) == true
-                        }
+                        gameBack()
                     }
                 }
-                handled
-            }
-        }
-        val onMotionEvent: (AndroidEvent.MotionEvent) -> Boolean = {
-            val isGamepad = ExternalController.isGameController(it.event?.device)
-
-            if ((showElementEditor || keepPausedForEditor || showQuickMenu || isEditMode) && isGamepad) {
-                // Let Compose consume any gamepad motion while menu is visible.
+                true
+            } else {
+                // Let Compose focus system handle keyboard and gamepad navigation/selection while menu is visible.
                 false
-            } else {
-                var handled = false
-                if (isGamepad && it.event != null) {
-                    xServerView!!.getxServer().winHandler.setCurrentController(it.event.device.id);
-                    handled = physicalControllerHandler?.onGenericMotionEvent(it.event!!) == true
-                    if (!handled) handled = PluviaApp.inputControlsView?.onGenericMotionEvent(it.event) == true
-                    // Final fallback to WinHandler passthrough
-                    if (!handled) handled = xServerView!!.getxServer().winHandler.onGenericMotionEvent(it.event)
-                }
-                if (PluviaApp.touchpadView?.hasPointerCapture() != true && !PluviaApp.isOverlayPaused) {
-                    if ((it.event != null) && (it.event.device != null)) {
-                        val device = it.event.device
-                        val isExternal = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) device.isExternal else true
-                        if (device.supportsSource(InputDevice.SOURCE_TOUCHPAD) &&
-                            !isExternal) {
-                            // Samsung DeX Touchpad app
-                            hasInternalTouchpad = true
-                            if (!showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode &&
-                                !hasUpdatedScreenGamepad) {
-                                hasUpdatedScreenGamepad = true
-                                hideInputControls()
-                                areControlsVisible = false
-                            }
-                        }
-                        tryCapturePointer()
+            }
+        } else {
+            var handled = false
+            if (isGamepad) {
+                xServerView!!.getxServer().winHandler.setCurrentController(it.event.device.id);
+                handled = physicalControllerHandler?.onKeyEvent(it.event) == true
+                if (!handled) handled = PluviaApp.inputControlsView?.onKeyEvent(it.event) == true
+                // Final fallback to WinHandler passthrough
+                if (!handled) handled = xServerView!!.getxServer().winHandler.onKeyEvent(it.event)
+            }
+            if (!handled && isKeyboard) {
+                val isShiftEscPressed = it.event.keyCode == KeyEvent.KEYCODE_ESCAPE &&
+                    it.event.isShiftPressed &&
+                    it.event.action == KeyEvent.ACTION_DOWN &&
+                    it.event.repeatCount == 0
+                if (isShiftEscPressed &&
+                    !showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode) {
+                    keyboardEscMenuHandler.cancel()
+                    gameBack()
+                    handled = true
+                } else if (isPhysicalKeyboard && keyboardEscMenuHandler.isEsc(it.event) &&
+                    !showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode) {
+                    handled = keyboardEscMenuHandler.handleGameEsc(
+                        event = it.event,
+                        keyboard = keyboard,
+                        canOpenMenu = { !showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode },
+                        openMenu = gameBack,
+                    )
+                } else {
+                    if (it.event.device?.isVirtual == true) {
+                        handled = keyboard?.onVirtualKeyEvent(it.event) == true
+                    } else {
+                        handled = keyboard?.onKeyEvent(it.event) == true
                     }
                 }
-                val event = it.event
-                val device = event?.device
-                if (!usingScreenMirror && device?.name == "scrcpy") {
-                    usingScreenMirror = true
-                }
-                handled
             }
+            handled
         }
-        val onGuestProgramTerminated: (AndroidEvent.GuestProgramTerminated) -> Unit = {
-            Timber.i("onGuestProgramTerminated")
-            exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
-        }
-        val onForceCloseApp: (SteamEvent.ForceCloseApp) -> Unit = {
-            Timber.i("onForceCloseApp")
-            exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
-        }
-        val onPlayingBlocked: (SteamEvent.PlayingBlocked) -> Unit = { event ->
-            if (isOffline || container.isSteamOfflineMode()) {
-                Timber.i("onPlayingBlocked suppressed (offline=$isOffline, containerOffline=${container.isSteamOfflineMode()})")
-            } else {
-                Timber.i("onPlayingBlocked remoteAppName=${event.remoteAppName}")
-                playingBlockedRemoteName = event.remoteAppName
-                showPlayingBlockedDialog = true
-            }
-        }
-        val debugCallback = Callback<String> { outputLine ->
-            Timber.i(outputLine ?: "")
-        }
+    }
+    val onMotionEvent: (AndroidEvent.MotionEvent) -> Boolean = {
+        val isGamepad = ExternalController.isGameController(it.event?.device)
 
+        if ((showElementEditor || keepPausedForEditor || showQuickMenu || isEditMode) && isGamepad) {
+            // Let Compose consume any gamepad motion while menu is visible.
+            false
+        } else {
+            var handled = false
+            if (isGamepad && it.event != null) {
+                xServerView!!.getxServer().winHandler.setCurrentController(it.event.device.id);
+                handled = physicalControllerHandler?.onGenericMotionEvent(it.event!!) == true
+                if (!handled) handled = PluviaApp.inputControlsView?.onGenericMotionEvent(it.event) == true
+                // Final fallback to WinHandler passthrough
+                if (!handled) handled = xServerView!!.getxServer().winHandler.onGenericMotionEvent(it.event)
+            }
+            if (PluviaApp.touchpadView?.hasPointerCapture() != true && !PluviaApp.isOverlayPaused) {
+                if ((it.event != null) && (it.event.device != null)) {
+                    val device = it.event.device
+                    val isExternal = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) device.isExternal else true
+                    if (device.supportsSource(InputDevice.SOURCE_TOUCHPAD) &&
+                        !isExternal) {
+                        // Samsung DeX Touchpad app
+                        hasInternalTouchpad = true
+                        if (!showElementEditor && !keepPausedForEditor && !showQuickMenu && !isEditMode &&
+                            !hasUpdatedScreenGamepad) {
+                            hasUpdatedScreenGamepad = true
+                            hideInputControls()
+                            areControlsVisible = false
+                        }
+                    }
+                    tryCapturePointer()
+                }
+            }
+            val event = it.event
+            val device = event?.device
+            if (!usingScreenMirror && device?.name == "scrcpy") {
+                usingScreenMirror = true
+            }
+            handled
+        }
+    }
+    val onGuestProgramTerminated: (AndroidEvent.GuestProgramTerminated) -> Unit = {
+        Timber.i("onGuestProgramTerminated")
+        exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+    }
+    val onForceCloseApp: (SteamEvent.ForceCloseApp) -> Unit = {
+        Timber.i("onForceCloseApp")
+        exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
+    }
+    val onPlayingBlocked: (SteamEvent.PlayingBlocked) -> Unit = { event ->
+        if (isOffline || container.isSteamOfflineMode()) {
+            Timber.i("onPlayingBlocked suppressed (offline=$isOffline, containerOffline=${container.isSteamOfflineMode()})")
+        } else {
+            Timber.i("onPlayingBlocked remoteAppName=${event.remoteAppName}")
+            playingBlockedRemoteName = event.remoteAppName
+            showPlayingBlockedDialog = true
+        }
+    }
+    val debugCallback = Callback<String> { outputLine ->
+        Timber.i(outputLine ?: "")
+    }
+
+    DisposableEffect(Unit) {
         PluviaApp.events.on<AndroidEvent.ActivityDestroyed, Unit>(onActivityDestroyed)
         PluviaApp.events.on<AndroidEvent.KeyEvent, Boolean>(onKeyEvent)
         PluviaApp.events.on<AndroidEvent.MotionEvent, Boolean>(onMotionEvent)

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1161,6 +1161,7 @@
     <string name="steam_imagefs_installed">ImageFS installeret. Prøv at redigere container igen.</string>
     <string name="steam_imagefs_install_failed">Kunne ikke installere ImageFS: %s</string>
     <string name="steam_uninstall_game_title">Afinstallér spil</string>
+    <string name="deleting">Sletter…</string>
     <string name="amazon_uninstall_game_title">Afinstallér spil</string>
     <string name="amazon_uninstall_confirmation_message">Er du sikker på, at du vil afinstallere %1$s? Denne handling kan ikke fortrydes.</string>
     <string name="amazon_install_game_title">Download spil</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -39,6 +39,7 @@
     <string name="steam_uninstall_confirmation_message">Möchtest du %1$s wirklich deinstallieren? Das kann nicht rückgängig gemacht werden.</string>
     <string name="steam_uninstall_success">%1$s wurde deinstalliert</string>
     <string name="steam_uninstall_failed">Spiel konnte nicht deinstalliert werden</string>
+    <string name="deleting">Löschen…</string>
     <string name="amazon_uninstall_game_title">Spiel deinstallieren</string>
     <string name="amazon_uninstall_confirmation_message">Möchtest du %1$s wirklich deinstallieren? Das kann nicht rückgängig gemacht werden.</string>
     <string name="amazon_install_game_title">Spiel herunterladen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -40,6 +40,7 @@
     <string name="steam_uninstall_confirmation_message">¿Deseas desinstalar %1$s? Esta acción no se puede deshacer.</string>
     <string name="steam_uninstall_success">%1$s ha sido desinstalado.</string>
     <string name="steam_uninstall_failed">Error al desinstalar el juego.</string>
+    <string name="deleting">Eliminando…</string>
     <string name="amazon_uninstall_game_title">Desinstalar juego</string>
     <string name="amazon_uninstall_confirmation_message">¿Deseas desinstalar %1$s? Esta acción no se puede deshacer.</string>
     <string name="amazon_install_game_title">Instalar juego</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -40,6 +40,7 @@
     <string name="steam_uninstall_confirmation_message">Êtes-vous sûr de vouloir désinstaller %1$s ? Cette action ne peut pas être annulée.</string>
     <string name="steam_uninstall_success">%1$s a été désinstallé</string>
     <string name="steam_uninstall_failed">Échec de la désinstallation du jeu</string>
+    <string name="deleting">Suppression…</string>
     <string name="amazon_uninstall_game_title">Désinstaller le jeu</string>
     <string name="amazon_uninstall_confirmation_message">Êtes-vous sûr de vouloir désinstaller %1$s ? Cette action ne peut pas être annulée.</string>
     <string name="amazon_install_game_title">Télécharger le jeu</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -40,6 +40,7 @@
     <string name="steam_uninstall_confirmation_message">Sei sicuro di voler disinstallare %1$s? Questa azione non può essere annullata.</string>
     <string name="steam_uninstall_success">%1$s è stato disinstallato</string>
     <string name="steam_uninstall_failed">Impossibile disinstallare il gioco</string>
+    <string name="deleting">Eliminazione…</string>
     <string name="amazon_uninstall_game_title">Disinstalla gioco</string>
     <string name="amazon_uninstall_confirmation_message">Sei sicuro di voler disinstallare %1$s? Questa azione non può essere annullata.</string>
     <string name="amazon_install_game_title">Scarica gioco</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -39,6 +39,7 @@
     <string name="steam_uninstall_confirmation_message">%1$s をアンインストールしてもよろしいですか?この操作は元に戻すことができません。</string>
     <string name="steam_uninstall_success">%1$s はアンインストールされました</string>
     <string name="steam_uninstall_failed">ゲームのアンインストールに失敗しました</string>
+    <string name="deleting">削除中…</string>
     <string name="amazon_uninstall_game_title">ゲームをアンインストールする</string>
     <string name="amazon_uninstall_confirmation_message">%1$s をアンインストールしてもよろしいですか?この操作は元に戻すことができません。</string>
     <string name="amazon_install_game_title">ゲームをダウンロード</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -40,6 +40,7 @@
     <string name="steam_uninstall_confirmation_message">%1$s을(를) 제거하시겠습니까? 이 작업은 취소할 수 없습니다.</string>
     <string name="steam_uninstall_success">%1$s이(가) 제거되었습니다</string>
     <string name="steam_uninstall_failed">게임 제거 실패</string>
+    <string name="deleting">삭제 중…</string>
     <string name="amazon_uninstall_game_title">게임 제거</string>
     <string name="amazon_uninstall_confirmation_message">%1$s을(를) 제거하시겠습니까? 이 작업은 취소할 수 없습니다.</string>
     <string name="amazon_install_game_title">게임 다운로드</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -40,6 +40,7 @@
     <string name="steam_uninstall_confirmation_message">Czy na pewno chcesz odinstalować %1$s? Tej akcji nie można cofnąć.</string>
     <string name="steam_uninstall_success">%1$s odinstalowano</string>
     <string name="steam_uninstall_failed">Nie udało się odinstalować gry</string>
+    <string name="deleting">Usuwanie…</string>
     <string name="amazon_uninstall_game_title">Odinstaluj grę</string>
     <string name="amazon_uninstall_confirmation_message">Czy na pewno chcesz odinstalować %1$s? Tej akcji nie można cofnąć.</string>
     <string name="amazon_install_game_title">Pobierz grę</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1161,6 +1161,7 @@
     <string name="steam_imagefs_installed">ImageFS instalado. Por favor, tente editar o contêiner novamente.</string>
     <string name="steam_imagefs_install_failed">Falha ao instalar ImageFS: %s</string>
     <string name="steam_uninstall_game_title">Desinstalar jogo</string>
+    <string name="deleting">Excluindo…</string>
     <string name="amazon_uninstall_game_title">Desinstalar jogo</string>
     <string name="amazon_uninstall_confirmation_message">Tem certeza de que deseja desinstalar %1$s? Esta ação não pode ser desfeita.</string>
     <string name="amazon_install_game_title">Baixar jogo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -40,6 +40,7 @@
     <string name="steam_uninstall_confirmation_message">Sigur vrei să dezinstalezi %1$s? Această acțiune nu poate fi anulată.</string>
     <string name="steam_uninstall_success">%1$s a fost dezinstalat</string>
     <string name="steam_uninstall_failed">Dezinstalarea jocului a eșuat</string>
+    <string name="deleting">Ștergere…</string>
     <string name="amazon_uninstall_game_title">Dezinstalare joc</string>
     <string name="amazon_uninstall_confirmation_message">Sigur vrei să dezinstalezi %1$s? Această acțiune nu poate fi anulată.</string>
     <string name="amazon_install_game_title">Descărcare joc</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1156,6 +1156,7 @@ https://gamenative.app
     <string name="steam_type">Тип Steam</string>
     <string name="steam_uninstall_confirmation_message">Вы уверены, что хотите удалить %1$s? Это действие не может быть отменено.</string>
     <string name="steam_uninstall_failed">Ошибка удаления игры</string>
+    <string name="deleting">Удаление…</string>
     <string name="steam_uninstall_game_title">Удалить игру</string>
     <string name="steam_uninstall_success">%1$s была удалена</string>
     <string name="steam_update_message">Пожалуйста, убедитесь, что ваши сохранения загружены в облако или скопированы, поскольку они могут быть перезаписаны.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -40,6 +40,7 @@
     <string name="steam_uninstall_confirmation_message">Ви впевнені, що хочете деінсталювати %1$s? Цю дію не можна скасувати.</string>
     <string name="steam_uninstall_success">%1$s деінстальовано</string>
     <string name="steam_uninstall_failed">Помилка деінсталяції гри</string>
+    <string name="deleting">Видалення…</string>
     <string name="amazon_uninstall_game_title">Деінсталювати гру</string>
     <string name="amazon_uninstall_confirmation_message">Ви впевнені, що хочете деінсталювати %1$s? Цю дію не можна скасувати.</string>
     <string name="amazon_install_game_title">Завантажити гру</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -39,6 +39,7 @@
     <string name="steam_uninstall_confirmation_message">确定要卸载 %1$s 吗？此操作无法撤销</string>
     <string name="steam_uninstall_success">%1$s 已卸载</string>
     <string name="steam_uninstall_failed">卸载游戏失败</string>
+    <string name="deleting">正在删除…</string>
     <string name="amazon_uninstall_game_title">卸载游戏</string>
     <string name="amazon_uninstall_confirmation_message">确定要卸载 %1$s 吗？此操作无法撤销</string>
     <string name="amazon_install_game_title">下载游戏</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -39,6 +39,7 @@
     <string name="steam_uninstall_confirmation_message">您確定要卸載 %1$s 嗎? 此操作無法撤回</string>
     <string name="steam_uninstall_success">%1$s 已卸載</string>
     <string name="steam_uninstall_failed">卸載遊戲失敗</string>
+    <string name="deleting">正在刪除…</string>
     <string name="amazon_uninstall_game_title">卸載遊戲</string>
     <string name="amazon_uninstall_confirmation_message">您確定要卸載 %1$s 嗎? 此操作無法撤回</string>
     <string name="amazon_install_game_title">下載遊戲</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="steam_uninstall_confirmation_message">Are you sure you want to uninstall %1$s? This action cannot be undone.</string>
     <string name="steam_uninstall_success">%1$s has been uninstalled</string>
     <string name="steam_uninstall_failed">Failed to uninstall game</string>
+    <string name="deleting">Deleting…</string>
     <string name="amazon_uninstall_game_title">Uninstall Game</string>
     <string name="amazon_uninstall_confirmation_message">Are you sure you want to uninstall %1$s? This action cannot be undone.</string>
     <string name="amazon_install_game_title">Download Game</string>


### PR DESCRIPTION
## Description
Enhances application responsiveness by offloading I/O, showing deletion progress, and optimizing Compose event listeners.

These changes primarily focus on preventing Application Not Responding (ANR) errors by moving blocking operations to background threads, providing visual feedback during lengthy processes, and optimizing Compose UI lifecycle management for global event listeners.

## Recording
None

## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed ANRs and input freezes by registering global key/motion listeners once, moving delete work off the main thread, and showing a non-blocking “Deleting…” dialog during uninstall and cancel-download flows.

- **Bug Fixes**
  - Stabilized global listeners by defining handlers in composable scope and registering once with `DisposableEffect(Unit)`; applied to `LibraryScreen` and `XServerScreen` to prevent stale callbacks and reduce `PluviaApp.events` churn.
  - Made `SteamService.deleteApp` a suspend function on `Dispatchers.IO` and ran DB work inside `withTransaction` (no extra `launch`) to avoid blocking the UI.
  - Added a `LoadingDialog` with a localized “Deleting…” message during uninstall/cancel-delete for Amazon, Epic, GOG, Steam, and Custom screens; ensured UI updates run on the main thread and dialogs are always dismissed in `finally` with `NonCancellable`.

<sup>Written for commit 159221e5626ca498e448cd8e19e0197ca02022cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements (Library & XServer)**
  * Improved key/motion event handling so focus behavior and tab navigation are more consistent, without repeatedly resetting listeners.

* **New Features (Deletion UX)**
  * Added a “deleting” loading/progress dialog across uninstall and delete flows (including cancel-download cases) for supported library screens.

* **Documentation/Localization**
  * Added a new localized **“deleting”** status string to all supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->