### PR TITLE
Reuse running game on intent launch instead of relaunching

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -63,6 +63,7 @@ import app.gamenative.enums.PathType
 import app.gamenative.enums.SaveLocation
 import app.gamenative.enums.SyncResult
 import app.gamenative.events.AndroidEvent
+import app.gamenative.service.ActiveGameRegistry
 import app.gamenative.service.SteamService
 import app.gamenative.service.amazon.AmazonService
 import com.posthog.PostHog
@@ -342,6 +343,14 @@ fun PluviaMain(
     // shared intent-launch path. resolves isOffline at the call site because intent launches can
     // arrive pre-login (cold-boot via stored creds) and downstream cloud-sync needs a settled answer.
     val launchIntentApp: (resolvedAppId: String, hasTemporaryOverride: Boolean) -> Unit = { resolvedAppId, hasTemporaryOverride ->
+        val requestedGameId = runCatching { ContainerUtils.extractGameIdFromContainerId(resolvedAppId) }.getOrNull()
+        if (SteamService.keepAlive && requestedGameId != null && ActiveGameRegistry.get()?.appId == requestedGameId) {
+            Timber.i("[PluviaMain]: Game $resolvedAppId already running; bringing XServer screen forward")
+            if (navController.currentDestination?.route != PluviaScreen.XServer.route) {
+                navController.navigate(PluviaScreen.XServer.route)
+            }
+            return@launchIntentApp
+        }
         MainActivity.wasLaunchedViaExternalIntent = true
         trackGameLaunched(resolvedAppId)
         viewModel.setLaunchedAppId(resolvedAppId)

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -349,38 +349,38 @@ fun PluviaMain(
             if (navController.currentDestination?.route != PluviaScreen.XServer.route) {
                 navController.navigate(PluviaScreen.XServer.route)
             }
-            return@launchIntentApp
-        }
-        MainActivity.wasLaunchedViaExternalIntent = true
-        trackGameLaunched(resolvedAppId)
-        viewModel.setLaunchedAppId(resolvedAppId)
-        viewModel.setBootToContainer(false)
-        scope.launch(Dispatchers.IO) {
-            val gameSource = ContainerUtils.extractGameSourceFromContainerId(resolvedAppId)
-            val isOffline = when {
-                gameSource != GameSource.STEAM -> false
-                SteamService.isLoggedIn -> false
-                !NetworkMonitor.hasInternet.value -> true
-                else -> {
-                    viewModel.setLoadingDialogVisible(true)
-                    viewModel.setLoadingDialogMessage(context.getString(R.string.connecting_to_steam))
-                    viewModel.setLoadingDialogProgress(-1f)
-                    !SteamUtils.awaitSteamLogin()
+        } else {
+            MainActivity.wasLaunchedViaExternalIntent = true
+            trackGameLaunched(resolvedAppId)
+            viewModel.setLaunchedAppId(resolvedAppId)
+            viewModel.setBootToContainer(false)
+            scope.launch(Dispatchers.IO) {
+                val gameSource = ContainerUtils.extractGameSourceFromContainerId(resolvedAppId)
+                val isOffline = when {
+                    gameSource != GameSource.STEAM -> false
+                    SteamService.isLoggedIn -> false
+                    !NetworkMonitor.hasInternet.value -> true
+                    else -> {
+                        viewModel.setLoadingDialogVisible(true)
+                        viewModel.setLoadingDialogMessage(context.getString(R.string.connecting_to_steam))
+                        viewModel.setLoadingDialogProgress(-1f)
+                        !SteamUtils.awaitSteamLogin()
+                    }
                 }
+                // sync viewModel — dialog retries + replaceSteamApi read isOffline.value
+                viewModel.setOffline(isOffline)
+                preLaunchApp(
+                    context = context,
+                    appId = resolvedAppId,
+                    useTemporaryOverride = hasTemporaryOverride,
+                    setLoadingDialogVisible = viewModel::setLoadingDialogVisible,
+                    setLoadingProgress = viewModel::setLoadingDialogProgress,
+                    setLoadingMessage = viewModel::setLoadingDialogMessage,
+                    setMessageDialogState = setMessageDialogState,
+                    onSuccess = viewModel::launchApp,
+                    isOffline = isOffline,
+                )
             }
-            // sync viewModel — dialog retries + replaceSteamApi read isOffline.value
-            viewModel.setOffline(isOffline)
-            preLaunchApp(
-                context = context,
-                appId = resolvedAppId,
-                useTemporaryOverride = hasTemporaryOverride,
-                setLoadingDialogVisible = viewModel::setLoadingDialogVisible,
-                setLoadingProgress = viewModel::setLoadingDialogProgress,
-                setLoadingMessage = viewModel::setLoadingDialogMessage,
-                setMessageDialogState = setMessageDialogState,
-                onSuccess = viewModel::launchApp,
-                isOffline = isOffline,
-            )
         }
     }
 


### PR DESCRIPTION
## Problem

When a game is launched via an external intent (`app.gamenative.LAUNCH_GAME`) while that same game is **already running**, the app tears down the session and relaunches a fresh instance. There was no check for an already-running game anywhere in the intent-launch path.

## Fix

Add a guard at the top of `launchIntentApp` (the shared funnel for cold-start, deferred, and warm-start intent launches in `PluviaMain.kt`). If `SteamService.keepAlive` is set and `ActiveGameRegistry`'s active game matches the requested appId, it just brings the existing XServer screen forward instead of relaunching.

A different game still launches normally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse the currently running game when an external intent launches the same app, instead of tearing it down and relaunching. In `PluviaMain.kt`, we extract the requested gameId and check `SteamService.keepAlive` with `ActiveGameRegistry`; if it’s the same app we bring the `XServer` screen forward via a clear `if/else` flow, and different games still launch normally.

<sup>Written for commit d14b233dc14348e8a69d2ec328819a3d28e02536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when attempting to launch an already-active game by reusing the running session and smoothly navigating to the in-app screen, avoiding redundant external launch steps and state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->