### PR TITLE
Xr permission compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ app/keystores/*
 __pycache__/
 resign.keystore
 
+/app/modernXr/
+
 # Steam bootstrap shim source — withheld out of respect for Valve, since it
 # encodes internal details of Steam's proprietary client that Valve does not
 # publish. See THIRD_PARTY_NOTICES ("Steam Client Bootstrap Shim").

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,6 +24,9 @@ val keystoreProperties: Properties? = if (keystorePropertiesFile.exists()) {
 val posthogApiKey: String = project.findProperty("POSTHOG_API_KEY") as String? ?: System.getenv("POSTHOG_API_KEY") ?: ""
 val posthogHost: String = project.findProperty("POSTHOG_HOST") as String? ?: System.getenv("POSTHOG_HOST") ?: "https://us.i.posthog.com"
 
+val metaAppId: String = project.findProperty("META_APP_ID") as String? ?: System.getenv("META_APP_ID") ?: ""
+val productSku: String = project.findProperty("PRODUCT_SKU") as String? ?: System.getenv("PRODUCT_SKU") ?: ""
+
 room {
     schemaDirectory("$projectDir/schemas")
 }
@@ -59,6 +62,7 @@ android {
 
         manifestPlaceholders["screenOrientation"] = "unspecified"
         buildConfigField("boolean", "XR_BUILD", "false")
+        buildConfigField("boolean", "MODERN_XR", "false")
 
         versionCode = 14
         versionName = "1.1.0"
@@ -150,6 +154,9 @@ android {
             buildConfigField("boolean", "MODERN_ANDROID", "true")
             buildConfigField("String", "PRELOAD_BIONIC_SO", "\"libredirect-bionic-wx.so\"")
             buildConfigField("boolean", "XR_BUILD", "true")
+            buildConfigField("boolean", "MODERN_XR", "true")
+            buildConfigField("String", "META_APP_ID", "\"$metaAppId\"")
+            buildConfigField("String", "PRODUCT_SKU", "\"$productSku\"")
             manifestPlaceholders["screenOrientation"] = "landscape"
         }
     }
@@ -220,16 +227,25 @@ android {
             isIncludeAndroidResources = true
         }
     }
+
+    lint {
+        // Locale files ship full AndroidX appcompat (abc_*) translations that aren't in the
+        // default locale. These extra translations are harmless and pre-existing; without this
+        // the release-only lintVital pass fails on 150+ ExtraTranslation errors.
+        disable += "ExtraTranslation"
+    }
     dynamicFeatures += setOf(":ubuntufs")
 
     // Configure Assets to be used in different variants
     sourceSets {
         getByName("legacy") {
+            java.srcDir("src/nonXr/java")
             assets {
                 srcDirs("src/legacy/assets", "src/main/assets")
             }
         }
         getByName("legacyXr") {
+            java.srcDir("src/nonXr/java")
             manifest.srcFile("src/legacy/AndroidManifest.xml")
             assets {
                 srcDirs("src/legacy/assets", "src/main/assets")
@@ -239,6 +255,7 @@ android {
             }
         }
         getByName("modern") {
+            java.srcDir("src/nonXr/java")
             assets {
                 srcDirs("src/modern/assets", "src/main/assets")
             }
@@ -391,4 +408,7 @@ dependencies {
     implementation("com.posthog:posthog-android:3.8.0")
 
     implementation("com.auth0.android:jwtdecode:2.0.2")
+
+    "modernXrImplementation"("com.meta.horizon.platform.sdk:core-kotlin:0.2.2")
+    "modernXrImplementation"("com.meta.horizon.platform.sdk:iap-kotlin:0.2.2")
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -34,3 +34,8 @@
 -keep class timber.log.Timber { *; }
 -keep class app.gamenative.ReleaseTree { *; }
 
+-keep class horizon.** { *; }
+-keep class com.meta.horizon.** { *; }
+-dontwarn horizon.**
+-dontwarn com.meta.horizon.**
+

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,12 @@
     <uses-permission android:name="android.permission.READ_LOGS" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" tools:node="remove" />
+
     <queries>
         <intent>
             <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/app/gamenative/MainActivity.kt
+++ b/app/src/main/java/app/gamenative/MainActivity.kt
@@ -153,6 +153,8 @@ class MainActivity : ComponentActivity() {
         )
         super.onCreate(savedInstanceState)
 
+        app.gamenative.launch.installLaunchReadiness(applicationContext, lifecycleScope)
+
         if (isHeadset(this)) {
             requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
             android.view.InputDevice.getDeviceIds().forEach { id ->
@@ -199,7 +201,7 @@ class MainActivity : ComponentActivity() {
             }
 
             LaunchedEffect(Unit) {
-                if (!hasNotificationPermission && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                if (!BuildConfig.MODERN_XR && !hasNotificationPermission && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                 }
             }
@@ -353,6 +355,8 @@ class MainActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         PluviaApp.isActivityInForeground = true
+
+        lifecycleScope.launch { app.gamenative.launch.LaunchReadiness.refresh() }
         // Re-apply immersive mode to ensure fullscreen persists
         if (!desiredSystemUiVisible) {
             applyImmersiveMode()

--- a/app/src/main/java/app/gamenative/launch/LaunchReadiness.kt
+++ b/app/src/main/java/app/gamenative/launch/LaunchReadiness.kt
@@ -1,0 +1,35 @@
+package app.gamenative.launch
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+
+object LaunchReadiness {
+
+    interface Check {
+        val pending: Boolean
+
+        suspend fun refresh()
+
+        suspend fun resolve(activity: Activity): Boolean
+
+        @Composable
+        fun Prompt(activity: Activity, onResolved: () -> Unit)
+    }
+
+    @Volatile
+    var check: Check? = null
+
+    val pending: Boolean get() = check?.pending ?: false
+
+    suspend fun refresh() {
+        check?.refresh()
+    }
+
+    suspend fun resolve(activity: Activity): Boolean = check?.resolve(activity) ?: true
+
+    @Composable
+    fun Prompt(activity: Activity, onResolved: () -> Unit) {
+        val c = check
+        if (c != null) c.Prompt(activity, onResolved) else onResolved()
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1,6 +1,7 @@
 package app.gamenative.ui
 
 import android.content.Context
+import android.app.Activity
 import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -80,6 +81,7 @@ import app.gamenative.ui.component.dialog.state.MessageDialogState
 import app.gamenative.ui.components.BootingSplash
 import app.gamenative.ui.enums.AppOptionMenuType
 import app.gamenative.ui.enums.ConnectionState
+import app.gamenative.launch.LaunchReadiness
 import app.gamenative.ui.enums.DialogType
 import app.gamenative.ui.enums.Orientation
 import app.gamenative.ui.model.MainViewModel
@@ -328,6 +330,7 @@ fun PluviaMain(
 
     // Check for updates on app start
     LaunchedEffect(Unit) {
+        if (BuildConfig.MODERN_XR) return@LaunchedEffect
         val checkedUpdateInfo = UpdateChecker.checkForUpdate(context)
         if (checkedUpdateInfo != null) {
             val appVersionCode = BuildConfig.VERSION_CODE
@@ -847,6 +850,7 @@ fun PluviaMain(
                 setMessageDialogState(MessageDialogState(false))
             }
         }
+
 
         DialogType.EXECUTABLE_NOT_FOUND -> {
             onConfirmClick = null
@@ -1554,6 +1558,12 @@ fun preLaunchApp(
     val gameId = ContainerUtils.extractGameIdFromContainerId(appId)
 
     CoroutineScope(Dispatchers.IO).launch {
+        if (LaunchReadiness.pending) {
+            setLoadingDialogVisible(false)
+            (context as? Activity)?.let { LaunchReadiness.resolve(it) }
+            return@launch
+        }
+
         // create container if it does not already exist
         // TODO: combine somehow with container creation in HomeLibraryAppScreen
         val containerManager = ContainerManager(context)

--- a/app/src/main/java/app/gamenative/ui/component/dialog/LaunchReadinessDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/LaunchReadinessDialog.kt
@@ -1,0 +1,58 @@
+package app.gamenative.ui.component.dialog
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import app.gamenative.ui.theme.PluviaTheme
+
+@Composable
+fun LaunchReadinessDialog(
+    isLoading: Boolean,
+    title: String,
+    message: String,
+    confirmText: String,
+    dismissText: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = { if (!isLoading) onDismiss() },
+        title = { Text(text = title) },
+        text = {
+            if (isLoading) {
+                CircularProgressIndicator(modifier = Modifier.size(32.dp))
+            } else {
+                Text(text = message)
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm, enabled = !isLoading) { Text(text = confirmText) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isLoading) { Text(text = dismissText) }
+        },
+    )
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
+@Composable
+private fun Preview_LaunchReadinessDialog() {
+    PluviaTheme {
+        LaunchReadinessDialog(
+            isLoading = false,
+            title = "Title",
+            message = "Message body goes here.",
+            confirmText = "Confirm",
+            dismissText = "Not now",
+            onConfirm = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -1201,6 +1201,9 @@ abstract class BaseAppScreen {
             }
         }
 
+        val launchActivity = context as? android.app.Activity
+        var showReadiness by remember { mutableStateOf(false) }
+
         // Render the common UI
         app.gamenative.ui.screen.library.AppScreenContent(
             displayInfo = displayInfo,
@@ -1212,10 +1215,14 @@ abstract class BaseAppScreen {
             isUpdatePending = isUpdatePendingState,
             downloadInfo = downloadInfo,
             onDownloadInstallClick = {
-                onDownloadInstallClick(context, libraryItem, onClickPlay)
-                uiScope.launch {
-                    delay(100)
-                    performStateRefresh(true)
+                if (app.gamenative.launch.LaunchReadiness.pending) {
+                    showReadiness = true
+                } else {
+                    onDownloadInstallClick(context, libraryItem, onClickPlay)
+                    uiScope.launch {
+                        delay(100)
+                        performStateRefresh(true)
+                    }
                 }
             },
             onPauseResumeClick = {
@@ -1234,6 +1241,19 @@ abstract class BaseAppScreen {
             onBack = onBack,
             optionsMenu = optionsMenu.toTypedArray(),
         )
+
+        if (showReadiness && launchActivity != null) {
+            app.gamenative.launch.LaunchReadiness.Prompt(launchActivity) {
+                showReadiness = false
+                if (!app.gamenative.launch.LaunchReadiness.pending) {
+                    onDownloadInstallClick(context, libraryItem, onClickPlay)
+                    uiScope.launch {
+                        delay(100)
+                        performStateRefresh(true)
+                    }
+                }
+            }
+        }
 
         // Show container config dialog if needed
         if (showConfigDialog) {

--- a/app/src/modernXr/AndroidManifest.xml
+++ b/app/src/modernXr/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_LOGS" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" tools:node="remove" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" tools:node="remove" />
+
+</manifest>

--- a/app/src/modernXr/java/app/gamenative/launch/LaunchReadinessInstaller.kt
+++ b/app/src/modernXr/java/app/gamenative/launch/LaunchReadinessInstaller.kt
@@ -1,0 +1,7 @@
+package app.gamenative.launch
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+
+fun installLaunchReadiness(context: Context, scope: CoroutineScope) {
+}

--- a/app/src/nonXr/java/app/gamenative/launch/LaunchReadinessInstaller.kt
+++ b/app/src/nonXr/java/app/gamenative/launch/LaunchReadinessInstaller.kt
@@ -1,0 +1,7 @@
+package app.gamenative.launch
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+
+fun installLaunchReadiness(context: Context, scope: CoroutineScope) {
+}


### PR DESCRIPTION
## Description
Changes for Quest store compliance for modern XR build

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the modern XR build compliant with the Meta Quest Store by removing rejected permissions and adding a launch-readiness gate that blocks starting a game until required checks pass. Wires up the Meta Horizon SDK only for `modernXr`, without affecting non‑XR builds.

- New Features
  - Modern XR compliance: removed unused and Horizon-rejected permissions via base and `modernXr` manifests.
  - Launch readiness gate: new `app.gamenative.launch.LaunchReadiness` API and dialog; installed in `MainActivity`, integrated with `BaseAppScreen` and pre-launch flow; refreshes on resume; skips notification prompt and startup update checks on modern XR.
  - Build setup: added `MODERN_XR` flag, `META_APP_ID` and `PRODUCT_SKU` BuildConfig fields, ProGuard rules for Horizon SDK, lint tweak, `modernXr` wiring with installer stubs, `.gitignore` update; added `com.meta.horizon.platform.sdk:core-kotlin:0.2.2` and `com.meta.horizon.platform.sdk:iap-kotlin:0.2.2`.

- Migration
  - Provide `META_APP_ID` and `PRODUCT_SKU` via Gradle properties or env vars when building `modernXr`.
  - No changes required for non‑XR builds.

<sup>Written for commit 1a36525857798305edb8d4d4892fc1bc621fd4d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Added a launch readiness verification flow that can display a prompt before proceeding with download/install actions.
* Introduced a new “launch readiness” dialog component for the verification UI.

**Configuration & Permissions**
* Removed selected media-related runtime permissions from the merged manifest.
* Modern XR builds no longer request the notification permission on startup.
* Added targeted ProGuard rules to improve Horizon-related release handling.

**Build System**
* Added Meta Horizon/modern XR build configuration, dependencies, and variant-specific setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->