### PR TITLE
Updated Steam/Epic/GOG notifications to correctly show downloads

### DIFF
--- a/app/src/main/java/app/gamenative/service/NotificationHelper.kt
+++ b/app/src/main/java/app/gamenative/service/NotificationHelper.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import androidx.core.app.NotificationCompat
 import androidx.core.net.toUri
 import app.gamenative.MainActivity
+import app.gamenative.data.DownloadInfo
 import app.gamenative.PrefManager
 import app.gamenative.R
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -29,12 +30,17 @@ class NotificationHelper @Inject constructor(@ApplicationContext private val con
         private const val NOTIFICATION_ID_SUMMARY = 100
 
         const val ACTION_EXIT = "com.oxgames.pluvia.EXIT"
+
+        private const val NO_PROGRESS = -2
     }
 
     private val notificationManager: NotificationManager =
         context.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
 
     private val activeServices = mutableSetOf<Int>()
+
+    @Volatile
+    private var summaryContent: String = "Connected"
 
     init {
         createNotificationChannel()
@@ -63,7 +69,22 @@ class NotificationHelper @Inject constructor(@ApplicationContext private val con
 
     @Synchronized
     fun notify(content: String, id: Int = NOTIFICATION_ID_STEAM) {
+        summaryContent = content
         val notification = createServiceNotification(id, content)
+        notificationManager.notify(id, notification)
+        activeServices.add(id)
+        refreshSummary()
+    }
+
+    /**
+     * Updates a foreground-service notification to reflect an active data-transfer task
+     * (download/cloud sync), with an optional progress bar. [progress]: 0..100 = determinate,
+     * -1 = indeterminate (e.g. syncing), any other value = no progress bar.
+     */
+    @Synchronized
+    fun notifyProgress(content: String, progress: Int, id: Int = NOTIFICATION_ID_STEAM) {
+        summaryContent = content
+        val notification = buildNotification(serviceNameFor(id), content, isSummary = false, progress = progress)
         notificationManager.notify(id, notification)
         activeServices.add(id)
         refreshSummary()
@@ -95,6 +116,27 @@ class NotificationHelper @Inject constructor(@ApplicationContext private val con
     fun createForegroundNotification(content: String): Notification =
         createServiceNotification(NOTIFICATION_ID_STEAM, content)
 
+    /**
+     * Drives a live "Downloading <name> · X%" progress notification off [downloadInfo]'s existing
+     * progress callbacks (event-driven, throttled to whole-percent changes). Reverts to idle when
+     * the download finishes. Call once per download, per service [id].
+     */
+    fun trackDownload(downloadInfo: DownloadInfo, name: String, id: Int = NOTIFICATION_ID_STEAM) {
+        val title = name.ifBlank { "your game" }
+        var lastPct = -1
+        downloadInfo.addProgressListener { fraction ->
+            val pct = (fraction * 100f).toInt().coerceIn(0, 100)
+            if (pct != lastPct) {
+                lastPct = pct
+                if (pct >= 100) showIdle(id) else notifyProgress("Downloading $title · $pct%", pct, id)
+            }
+        }
+    }
+
+    fun showSyncing(id: Int = NOTIFICATION_ID_STEAM) = notifyProgress("Syncing cloud saves…", -1, id)
+
+    fun showIdle(id: Int = NOTIFICATION_ID_STEAM) = notifyProgress("Connected", -2, id)
+
     @Synchronized
     fun markActive(id: Int) {
         if (activeServices.add(id)) refreshSummary()
@@ -110,11 +152,11 @@ class NotificationHelper @Inject constructor(@ApplicationContext private val con
 
     private fun buildSummary(): Notification = buildNotification(
         title = context.getString(R.string.app_name),
-        content = "Connected",
+        content = summaryContent,
         isSummary = true,
     )
 
-    private fun buildNotification(title: String, content: String, isSummary: Boolean): Notification {
+    private fun buildNotification(title: String, content: String, isSummary: Boolean, progress: Int = NO_PROGRESS): Notification {
         val intent = Intent(
             Intent.ACTION_VIEW,
             "pluvia://home".toUri(),
@@ -163,6 +205,12 @@ class NotificationHelper @Inject constructor(@ApplicationContext private val con
             .setContentIntent(pendingIntent)
             .setGroup(GROUP_KEY)
             .addAction(0, "Exit", stopPendingIntent)
+
+        when {
+            progress == NO_PROGRESS -> {}
+            progress < 0 -> builder.setProgress(0, 0, true)
+            else -> builder.setProgress(100, progress.coerceIn(0, 100), false)
+        }
 
         if (isSummary) builder.setGroupSummary(true)
 

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -230,6 +230,8 @@ class SteamService : Service(), IChallengeUrlChanged {
 
     private lateinit var notificationHelper: NotificationHelper
 
+    private val notifierOrNull: NotificationHelper? get() = if (::notificationHelper.isInitialized) notificationHelper else null
+
     internal var callbackManager: CallbackManager? = null
     internal var steamClient: SteamClient? = null
     internal val callbackSubscriptions: ArrayList<Closeable> = ArrayList()
@@ -395,7 +397,9 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         private fun tryAcquireSync(appId: Int): Boolean {
             val flag = getSyncFlag(appId)
-            return flag.compareAndSet(false, true)
+            val acquired = flag.compareAndSet(false, true)
+            if (acquired) instance?.notifierOrNull?.showSyncing(NotificationHelper.NOTIFICATION_ID_STEAM)
+            return acquired
         }
 
         private fun releaseSync(appId: Int) {
@@ -404,6 +408,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             if (flag != null && !flag.get()) {
                 syncInProgressApps.remove(appId, flag)
             }
+            instance?.notifierOrNull?.showIdle(NotificationHelper.NOTIFICATION_ID_STEAM)
         }
 
         // Track whether a game is currently running to prevent premature service stop
@@ -1822,6 +1827,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                 // map (line ~1666 short-circuit).
                 downloadJobs[appId] = di
                 notifyDownloadStarted(appId)
+                instance?.notifierOrNull?.trackDownload(di, getAppInfoOf(appId)?.name.orEmpty(), NotificationHelper.NOTIFICATION_ID_STEAM)
 
                 val downloadJob = instance!!.scope.launch {
                     try {
@@ -3424,6 +3430,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             startForeground(NotificationHelper.NOTIFICATION_ID_STEAM, notification)
         }
         notificationHelper.markActive(NotificationHelper.NOTIFICATION_ID_STEAM)
+        notificationHelper.showIdle(NotificationHelper.NOTIFICATION_ID_STEAM)
 
         when (intent?.action) {
             NotificationHelper.ACTION_EXIT -> {

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -159,6 +159,8 @@ class EpicService : Service() {
 
         private fun setSyncInProgress(inProgress: Boolean) {
             syncInProgress = inProgress
+            if (inProgress) getInstance()?.notifierOrNull?.showSyncing(NotificationHelper.NOTIFICATION_ID_EPIC)
+            else getInstance()?.notifierOrNull?.showIdle(NotificationHelper.NOTIFICATION_ID_EPIC)
         }
 
         fun isSyncInProgress(): Boolean = syncInProgress
@@ -421,6 +423,7 @@ class EpicService : Service() {
 
             instance.activeDownloads[appId] = downloadInfo
             downloadInfo.setActive(true)
+            instance.notifierOrNull?.trackDownload(downloadInfo, game.title ?: "", NotificationHelper.NOTIFICATION_ID_EPIC)
 
             // Start download in background
             val job = instance.scope.launch {
@@ -606,6 +609,8 @@ class EpicService : Service() {
     }
 
     private lateinit var notificationHelper: NotificationHelper
+
+    private val notifierOrNull: NotificationHelper? get() = if (::notificationHelper.isInitialized) notificationHelper else null
 
     @Inject
     lateinit var epicManager: EpicManager

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -173,6 +173,8 @@ class GOGService : Service() {
 
         private fun setSyncInProgress(inProgress: Boolean) {
             syncInProgress = inProgress
+            if (inProgress) getInstance()?.notifierOrNull?.showSyncing(NotificationHelper.NOTIFICATION_ID_GOG)
+            else getInstance()?.notifierOrNull?.showIdle(NotificationHelper.NOTIFICATION_ID_GOG)
         }
 
         fun isSyncInProgress(): Boolean = syncInProgress
@@ -350,6 +352,7 @@ class GOGService : Service() {
 
             // Track in activeDownloads first
             instance.activeDownloads[gameId] = downloadInfo
+            instance.notifierOrNull?.trackDownload(downloadInfo, "", NotificationHelper.NOTIFICATION_ID_GOG)
 
             // Launch download in service scope so it runs independently
             val job = instance.scope.launch {
@@ -625,6 +628,8 @@ class GOGService : Service() {
     }
 
     private lateinit var notificationHelper: NotificationHelper
+
+    private val notifierOrNull: NotificationHelper? get() = if (::notificationHelper.isInitialized) notificationHelper else null
 
     @Inject
     lateinit var gogManager: GOGManager


### PR DESCRIPTION
## Description
For the Play Store, we need to demonstrate why the foreground notifications are required. Updated them to show actual download status instead of just saying "Connected..."

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Foreground notifications for Steam, Epic, and GOG now show real download progress and cloud-sync status instead of a generic "Connected" message. This improves transparency for users and helps justify foreground-service usage for the Play Store.

- **New Features**
  - Added progress notifications (0–100%) for downloads via `trackDownload`, with per-service updates.
  - Indeterminate progress for cloud saves (“Syncing cloud saves…”) and automatic return to “Connected” when idle.
  - Summary notification now mirrors the latest active status across services.

<sup>Written for commit 58c37f7eb87fb428a6f3339f39083208cb40ab90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications now show download progress for active tasks, including determinate and indeterminate progress states.
  * Sync and download activity now updates the foreground notification more clearly, switching between syncing and idle states as work starts and finishes.

* **Bug Fixes**
  * Improved notification handling so progress updates are applied safely during service startup and ongoing downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->