### PR TITLE
Fix R/B channel swap on SurfaceFlinger display renderer

### DIFF
--- a/app/src/main/cpp/asurfacerenderer/gpuimage.c
+++ b/app/src/main/cpp/asurfacerenderer/gpuimage.c
@@ -226,11 +226,12 @@ Java_com_winlator_renderer_GPUImage_copyHardwareBuffer(
         AHardwareBuffer_describe(dstAhb, &desc);
         uint32_t dstStride = desc.stride;
 
-        if (dstStride == (uint32_t)srcStride) {
-            memcpy(dstAddr, srcAddr, (size_t)dstStride * height * 4);
-        } else {
-            for (int y = 0; y < height; y++) {
-                memcpy(dstAddr + y * dstStride, srcAddr + y * srcStride, width * 4);
+        for (int y = 0; y < height; y++) {
+            const uint32_t* s = srcAddr + (size_t)y * (uint32_t)srcStride;
+            uint32_t* d = dstAddr + (size_t)y * dstStride;
+            for (int x = 0; x < width; x++) {
+                uint32_t px = s[x];
+                d[x] = (px & 0xFF00FF00u) | ((px & 0x00FF0000u) >> 16) | ((px & 0x000000FFu) << 16);
             }
         }
 
@@ -270,6 +271,28 @@ Java_com_winlator_renderer_GPUImage_createHardwareBuffer(
          rdesc.layers);
 
     dump_ahb_usage(rdesc.usage);
+    return (jlong)(uintptr_t)ahb;
+}
+
+JNIEXPORT jlong JNICALL
+Java_com_winlator_renderer_GPUImage_createScanoutHardwareBuffer(
+        JNIEnv *env, jobject obj, jshort width, jshort height)
+{
+    AHardwareBuffer_Desc desc;
+    memset(&desc, 0, sizeof(desc));
+    desc.width  = width;
+    desc.height = height;
+    desc.layers = 1;
+    desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+    desc.usage  = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE
+                  | AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN
+                  | AHARDWAREBUFFER_USAGE_COMPOSER_OVERLAY;
+
+    AHardwareBuffer *ahb = NULL;
+    if (AHardwareBuffer_allocate(&desc, &ahb) != 0) {
+        LOGE("nativeCreateScanoutHardwareBuffer: alloc failed (%u x %u)", desc.width, desc.height);
+        return 0;
+    }
     return (jlong)(uintptr_t)ahb;
 }
 

--- a/app/src/main/java/com/winlator/renderer/GPUImage.java
+++ b/app/src/main/java/com/winlator/renderer/GPUImage.java
@@ -26,7 +26,7 @@ public class GPUImage extends Texture {
             this.width = nativeGetWidth(hardwareBufferPtr);
             this.height = nativeGetHeight(hardwareBufferPtr);
             for (int i = 0; i < 3; i++)
-                swapchainAhbs[i] = createHardwareBuffer(width, height);
+                swapchainAhbs[i] = createScanoutHardwareBuffer(width, height);
             if (virtualData == null) {
                 System.err.println("Error: Failed to lock hardware buffer");
                 destroyHardwareBuffer(hardwareBufferPtr);
@@ -154,6 +154,8 @@ public class GPUImage extends Texture {
     private native long hardwareBufferFromSocket(int fd);
 
     private native long createHardwareBuffer(short width, short height);
+
+    private native long createScanoutHardwareBuffer(short width, short height);
 
     private native void destroyHardwareBuffer(long hardwareBufferPtr);
 


### PR DESCRIPTION
## Problem
Colors render correctly on the **GL** and **Vulkan** display renderers, but red/blue are swapped on the **SurfaceFlinger** renderer.

## Root cause
The X-server window content from the guest is **BGRA** (`VK_FORMAT_B8G8R8A8_UNORM`; `setSwapRB` is never called, confirming the content really is BGRA). The triple-buffered scanout AHBs handed to SurfaceFlinger were allocated as `HAL_PIXEL_FORMAT_BGRA_8888` (format 5) with a plain `memcpy`.

GL/Vulkan *sample* the texture and interpret BGRA correctly. But the Adreno hardware composer / SurfaceFlinger does not properly support `BGRA_8888` — most HWCs only handle `RGBA/RGBX` and treat the BGRA memory as RGBA, swapping R and B. So the bug is specific to the direct-to-SurfaceFlinger path.

## Fix (isolated to the SurfaceFlinger scanout path)
- Allocate the 3 scanout AHBs as `R8G8B8A8_UNORM` (RGBA) + `COMPOSER_OVERLAY` via a new `createScanoutHardwareBuffer`.
- `copyHardwareBuffer` now swizzles B↔R (BGRA → RGBA) instead of a straight `memcpy`.

SurfaceFlinger now receives an RGBA buffer with RGBA content. The shared `hardwareBufferPtr` used by GL/Vulkan stays BGRA, so those renderers are unaffected.

## Files
- `app/src/main/cpp/asurfacerenderer/gpuimage.c`
- `app/src/main/java/com/winlator/renderer/GPUImage.java`

## Notes / trade-offs
- The per-frame copy is now a pixel swizzle instead of a `memcpy` (same memory bandwidth, slightly more ALU; SIMD-able later).
- Fallback path: if `virtualData` is null the code presents the raw BGRA `hardwareBufferPtr` directly, which would still swap — but the normal triple-buffered path is fixed.

## Testing
Set the container Display Renderer to **SurfaceFlinger** and launch a game; colors should match GL/Vulkan.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes red/blue channel swap on the SurfaceFlinger renderer by allocating scanout buffers as RGBA and swizzling during copy. Colors now match GL/Vulkan; only the SurfaceFlinger path is changed.

- **Bug Fixes**
  - Allocate triple-buffer scanout AHBs as RGBA (`AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM`) with `AHARDWAREBUFFER_USAGE_COMPOSER_OVERLAY`.
  - Add `createScanoutHardwareBuffer` and use it for the SurfaceFlinger swapchain.
  - Replace memcpy in `copyHardwareBuffer` with a B↔R swizzle (BGRA → RGBA).
  - GL/Vulkan paths keep BGRA input and are unaffected.

<sup>Written for commit b68c043f692b4fc37c46100da9a4e868ac0b5673. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

