### PR TITLE
fix: unset qam brightness when exiting game

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_LOGS" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" tools:ignore="ProtectedPermissions" />
 
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" tools:node="remove" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" tools:node="remove" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,8 +19,6 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_LOGS" />
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.WRITE_SETTINGS" tools:ignore="ProtectedPermissions" />
-
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" tools:node="remove" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" tools:node="remove" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" tools:node="remove" />

--- a/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
@@ -1,7 +1,15 @@
 package app.gamenative.ui.component
 
+import android.content.Intent
+import android.database.ContentObserver
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.provider.Settings
 import android.view.KeyEvent
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
@@ -46,6 +54,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -69,6 +78,7 @@ import androidx.compose.ui.unit.dp
 import app.gamenative.R
 import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.ui.util.ScreenEffectsConfig
+import app.gamenative.ui.util.SnackbarManager
 import app.gamenative.ui.util.adaptivePanelWidth
 import app.gamenative.ui.util.applyScreenEffectsConfig
 import app.gamenative.ui.util.loadScreenEffectsConfig
@@ -155,16 +165,64 @@ private fun DisplayBrightnessRow(
 ) {
     val context = LocalContext.current
     val activity = remember(context) { BrightnessManager.findActivity(context) }
-    // Without an Activity there is no window brightness target to control.
+    // Without an Activity there is no system brightness target to control.
     if (activity == null) return
     var displayBrightness by remember(activity) {
         mutableFloatStateOf(BrightnessManager.readDisplayBrightness(activity))
     }
+    val writeSettingsLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult(),
+    ) {
+        BrightnessManager.clearDisplayBrightnessOverride(activity)
+        displayBrightness = BrightnessManager.readDisplayBrightness(activity)
+    }
+
+    DisposableEffect(activity) {
+        BrightnessManager.clearDisplayBrightnessOverride(activity)
+
+        val contentResolver = activity.contentResolver
+        val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
+            override fun onChange(selfChange: Boolean) {
+                displayBrightness = BrightnessManager.readDisplayBrightness(activity)
+            }
+        }
+
+        contentResolver.registerContentObserver(
+            Settings.System.getUriFor(Settings.System.SCREEN_BRIGHTNESS),
+            false,
+            observer,
+        )
+        contentResolver.registerContentObserver(
+            Settings.System.getUriFor(Settings.System.SCREEN_BRIGHTNESS_MODE),
+            false,
+            observer,
+        )
+
+        onDispose {
+            contentResolver.unregisterContentObserver(observer)
+            BrightnessManager.clearDisplayBrightnessOverride(activity)
+        }
+    }
+
+    fun requestWriteSettingsPermission() {
+        SnackbarManager.show(context.getString(R.string.display_brightness_permission_required))
+        writeSettingsLauncher.launch(
+            Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
+                data = Uri.parse("package:${context.packageName}")
+            },
+        )
+    }
 
     fun setDisplayBrightness(value: Float) {
         val next = BrightnessManager.snapDisplayBrightness(value)
-        displayBrightness = next
-        BrightnessManager.applyDisplayBrightness(activity, next)
+        if (!BrightnessManager.canWriteSystemSettings(context)) {
+            requestWriteSettingsPermission()
+            return
+        }
+
+        if (BrightnessManager.applyDisplayBrightness(activity, next)) {
+            displayBrightness = BrightnessManager.readDisplayBrightness(activity)
+        }
     }
 
     ScreenEffectAdjustmentRow(

--- a/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
@@ -1,15 +1,11 @@
 package app.gamenative.ui.component
 
-import android.content.Intent
 import android.database.ContentObserver
-import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
 import android.view.KeyEvent
 import androidx.activity.compose.BackHandler
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
@@ -78,7 +74,6 @@ import androidx.compose.ui.unit.dp
 import app.gamenative.R
 import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.ui.util.ScreenEffectsConfig
-import app.gamenative.ui.util.SnackbarManager
 import app.gamenative.ui.util.adaptivePanelWidth
 import app.gamenative.ui.util.applyScreenEffectsConfig
 import app.gamenative.ui.util.loadScreenEffectsConfig
@@ -165,21 +160,13 @@ private fun DisplayBrightnessRow(
 ) {
     val context = LocalContext.current
     val activity = remember(context) { BrightnessManager.findActivity(context) }
-    // Without an Activity there is no system brightness target to control.
+    // Without an Activity there is no window brightness target to control.
     if (activity == null) return
     var displayBrightness by remember(activity) {
         mutableFloatStateOf(BrightnessManager.readDisplayBrightness(activity))
     }
-    val writeSettingsLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.StartActivityForResult(),
-    ) {
-        BrightnessManager.clearDisplayBrightnessOverride(activity)
-        displayBrightness = BrightnessManager.readDisplayBrightness(activity)
-    }
 
     DisposableEffect(activity) {
-        BrightnessManager.clearDisplayBrightnessOverride(activity)
-
         val contentResolver = activity.contentResolver
         val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
             override fun onChange(selfChange: Boolean) {
@@ -200,29 +187,13 @@ private fun DisplayBrightnessRow(
 
         onDispose {
             contentResolver.unregisterContentObserver(observer)
-            BrightnessManager.clearDisplayBrightnessOverride(activity)
         }
-    }
-
-    fun requestWriteSettingsPermission() {
-        SnackbarManager.show(context.getString(R.string.display_brightness_permission_required))
-        writeSettingsLauncher.launch(
-            Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
-                data = Uri.parse("package:${context.packageName}")
-            },
-        )
     }
 
     fun setDisplayBrightness(value: Float) {
         val next = BrightnessManager.snapDisplayBrightness(value)
-        if (!BrightnessManager.canWriteSystemSettings(context)) {
-            requestWriteSettingsPermission()
-            return
-        }
-
-        if (BrightnessManager.applyDisplayBrightness(activity, next)) {
-            displayBrightness = BrightnessManager.readDisplayBrightness(activity)
-        }
+        displayBrightness = next
+        BrightnessManager.applyDisplayBrightness(activity, next)
     }
 
     ScreenEffectAdjustmentRow(

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2,8 +2,12 @@ package app.gamenative.ui.screen.xserver
 
 import android.app.Activity
 import android.content.Context
+import android.database.ContentObserver
 import android.graphics.Color
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.provider.Settings
 import android.util.Log
 import android.view.Display
 import android.view.Gravity
@@ -112,6 +116,7 @@ import app.gamenative.utils.ManifestComponentHelper
 import app.gamenative.utils.downloader.DXWrapperDownloader
 import app.gamenative.utils.downloader.GraphicsDriverDownloader
 import app.gamenative.utils.PreInstallSteps
+import app.gamenative.utils.BrightnessManager
 import app.gamenative.utils.SteamTokenLogin
 import app.gamenative.utils.SteamUtils
 import app.gamenative.utils.downloader.WinComponentDownloader
@@ -342,6 +347,34 @@ fun XServerScreen(
 
     val container = remember(appId) {
         ContainerUtils.getContainer(context, appId)
+    }
+    val activity = remember(context) { BrightnessManager.findActivity(context) }
+
+    DisposableEffect(activity) {
+        if (activity == null) return@DisposableEffect onDispose { }
+
+        val contentResolver = activity.contentResolver
+        val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
+            override fun onChange(selfChange: Boolean) {
+                BrightnessManager.clearDisplayBrightnessOverride(activity)
+            }
+        }
+
+        contentResolver.registerContentObserver(
+            Settings.System.getUriFor(Settings.System.SCREEN_BRIGHTNESS),
+            false,
+            observer,
+        )
+        contentResolver.registerContentObserver(
+            Settings.System.getUriFor(Settings.System.SCREEN_BRIGHTNESS_MODE),
+            false,
+            observer,
+        )
+
+        onDispose {
+            contentResolver.unregisterContentObserver(observer)
+            BrightnessManager.clearDisplayBrightnessOverride(activity)
+        }
     }
 
     val suspendPolicy = remember(container.id) { container.suspendPolicy }

--- a/app/src/main/java/app/gamenative/utils/BrightnessManager.kt
+++ b/app/src/main/java/app/gamenative/utils/BrightnessManager.kt
@@ -3,100 +3,60 @@ package app.gamenative.utils
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
-import android.os.Build
 import android.provider.Settings
 import androidx.annotation.MainThread
 import kotlin.math.roundToInt
 
-class BrightnessManager(private val activity: Activity, private val targetBrightness: Float) {
-    private var savedBrightness: Float = UNSET_BRIGHTNESS
-    private var isDimmed = false
+object BrightnessManager {
+    private const val UNSET_BRIGHTNESS = -1f
+    const val DISPLAY_BRIGHTNESS_STEP = 0.05f
+    const val DISPLAY_BRIGHTNESS_MIN = 0.05f
+    const val DISPLAY_BRIGHTNESS_MAX = 1f
 
-    @MainThread
-    fun dim() {
-        if (isDimmed) return
-        val window = activity.window
-        savedBrightness = window.attributes.screenBrightness
-        val params = window.attributes
-        params.screenBrightness = targetBrightness
-        window.attributes = params
-        isDimmed = true
+    tailrec fun findActivity(context: Context): Activity? {
+        return when (context) {
+            is Activity -> context
+            is ContextWrapper -> findActivity(context.baseContext)
+            else -> null
+        }
+    }
+
+    fun snapDisplayBrightness(value: Float): Float {
+        return (value / DISPLAY_BRIGHTNESS_STEP)
+            .roundToInt()
+            .times(DISPLAY_BRIGHTNESS_STEP)
+            .coerceIn(DISPLAY_BRIGHTNESS_MIN, DISPLAY_BRIGHTNESS_MAX)
     }
 
     @MainThread
-    fun restore() {
-        if (!isDimmed) return
-        val window = activity.window
-        val params = window.attributes
-        params.screenBrightness = savedBrightness
-        window.attributes = params
-        savedBrightness = UNSET_BRIGHTNESS
-        isDimmed = false
+    fun clearDisplayBrightnessOverride(activity: Activity) {
+        val params = activity.window.attributes
+        if (params.screenBrightness == UNSET_BRIGHTNESS) return
+        params.screenBrightness = UNSET_BRIGHTNESS
+        activity.window.attributes = params
     }
 
-    companion object {
-        private const val UNSET_BRIGHTNESS = -1f
-        private const val SYSTEM_BRIGHTNESS_MAX = 255f
-        const val DISPLAY_BRIGHTNESS_STEP = 0.05f
-        const val DISPLAY_BRIGHTNESS_MIN = 0.05f
-        const val DISPLAY_BRIGHTNESS_MAX = 1f
-
-        tailrec fun findActivity(context: Context): Activity? {
-            return when (context) {
-                is Activity -> context
-                is ContextWrapper -> findActivity(context.baseContext)
-                else -> null
-            }
+    @MainThread
+    fun readDisplayBrightness(activity: Activity): Float {
+        val windowBrightness = activity.window.attributes.screenBrightness
+        if (windowBrightness in DISPLAY_BRIGHTNESS_MIN..DISPLAY_BRIGHTNESS_MAX) {
+            return snapDisplayBrightness(windowBrightness)
         }
 
-        fun canWriteSystemSettings(context: Context): Boolean {
-            return Build.VERSION.SDK_INT < Build.VERSION_CODES.M || Settings.System.canWrite(context)
-        }
-
-        fun snapDisplayBrightness(value: Float): Float {
-            return (value / DISPLAY_BRIGHTNESS_STEP)
-                .roundToInt()
-                .times(DISPLAY_BRIGHTNESS_STEP)
-                .coerceIn(DISPLAY_BRIGHTNESS_MIN, DISPLAY_BRIGHTNESS_MAX)
-        }
-
-        @MainThread
-        fun clearDisplayBrightnessOverride(activity: Activity) {
-            val params = activity.window.attributes
-            if (params.screenBrightness == UNSET_BRIGHTNESS) return
-            params.screenBrightness = UNSET_BRIGHTNESS
-            activity.window.attributes = params
-        }
-
-        @MainThread
-        fun readDisplayBrightness(activity: Activity): Float {
-            val systemBrightness = runCatching {
-                Settings.System.getInt(
-                    activity.contentResolver,
-                    Settings.System.SCREEN_BRIGHTNESS,
-                ) / SYSTEM_BRIGHTNESS_MAX
-            }.getOrDefault(0.5f)
-
-            return snapDisplayBrightness(systemBrightness)
-        }
-
-        @MainThread
-        fun applyDisplayBrightness(activity: Activity, value: Float): Boolean {
-            val next = snapDisplayBrightness(value)
-            val brightness = (next * SYSTEM_BRIGHTNESS_MAX).roundToInt()
-            val contentResolver = activity.contentResolver
-            val manualModeApplied = Settings.System.putInt(
-                contentResolver,
-                Settings.System.SCREEN_BRIGHTNESS_MODE,
-                Settings.System.SCREEN_BRIGHTNESS_MODE_MANUAL,
-            )
-            val brightnessApplied = Settings.System.putInt(
-                contentResolver,
+        val systemBrightness = runCatching {
+            Settings.System.getInt(
+                activity.contentResolver,
                 Settings.System.SCREEN_BRIGHTNESS,
-                brightness,
-            )
-            clearDisplayBrightnessOverride(activity)
-            return manualModeApplied && brightnessApplied
-        }
+            ) / 255f
+        }.getOrDefault(0.5f)
+
+        return snapDisplayBrightness(systemBrightness)
+    }
+
+    @MainThread
+    fun applyDisplayBrightness(activity: Activity, value: Float) {
+        val params = activity.window.attributes
+        params.screenBrightness = value.coerceIn(DISPLAY_BRIGHTNESS_MIN, DISPLAY_BRIGHTNESS_MAX)
+        activity.window.attributes = params
     }
 }

--- a/app/src/main/java/app/gamenative/utils/BrightnessManager.kt
+++ b/app/src/main/java/app/gamenative/utils/BrightnessManager.kt
@@ -3,6 +3,7 @@ package app.gamenative.utils
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.os.Build
 import android.provider.Settings
 import androidx.annotation.MainThread
 import kotlin.math.roundToInt
@@ -35,6 +36,7 @@ class BrightnessManager(private val activity: Activity, private val targetBright
 
     companion object {
         private const val UNSET_BRIGHTNESS = -1f
+        private const val SYSTEM_BRIGHTNESS_MAX = 255f
         const val DISPLAY_BRIGHTNESS_STEP = 0.05f
         const val DISPLAY_BRIGHTNESS_MIN = 0.05f
         const val DISPLAY_BRIGHTNESS_MAX = 1f
@@ -47,6 +49,10 @@ class BrightnessManager(private val activity: Activity, private val targetBright
             }
         }
 
+        fun canWriteSystemSettings(context: Context): Boolean {
+            return Build.VERSION.SDK_INT < Build.VERSION_CODES.M || Settings.System.canWrite(context)
+        }
+
         fun snapDisplayBrightness(value: Float): Float {
             return (value / DISPLAY_BRIGHTNESS_STEP)
                 .roundToInt()
@@ -55,27 +61,42 @@ class BrightnessManager(private val activity: Activity, private val targetBright
         }
 
         @MainThread
-        fun readDisplayBrightness(activity: Activity): Float {
-            val windowBrightness = activity.window.attributes.screenBrightness
-            if (windowBrightness in DISPLAY_BRIGHTNESS_MIN..DISPLAY_BRIGHTNESS_MAX) {
-                return snapDisplayBrightness(windowBrightness)
-            }
+        fun clearDisplayBrightnessOverride(activity: Activity) {
+            val params = activity.window.attributes
+            if (params.screenBrightness == UNSET_BRIGHTNESS) return
+            params.screenBrightness = UNSET_BRIGHTNESS
+            activity.window.attributes = params
+        }
 
+        @MainThread
+        fun readDisplayBrightness(activity: Activity): Float {
             val systemBrightness = runCatching {
                 Settings.System.getInt(
                     activity.contentResolver,
                     Settings.System.SCREEN_BRIGHTNESS,
-                ) / 255f
+                ) / SYSTEM_BRIGHTNESS_MAX
             }.getOrDefault(0.5f)
 
             return snapDisplayBrightness(systemBrightness)
         }
 
         @MainThread
-        fun applyDisplayBrightness(activity: Activity, value: Float) {
-            val params = activity.window.attributes
-            params.screenBrightness = value.coerceIn(DISPLAY_BRIGHTNESS_MIN, DISPLAY_BRIGHTNESS_MAX)
-            activity.window.attributes = params
+        fun applyDisplayBrightness(activity: Activity, value: Float): Boolean {
+            val next = snapDisplayBrightness(value)
+            val brightness = (next * SYSTEM_BRIGHTNESS_MAX).roundToInt()
+            val contentResolver = activity.contentResolver
+            val manualModeApplied = Settings.System.putInt(
+                contentResolver,
+                Settings.System.SCREEN_BRIGHTNESS_MODE,
+                Settings.System.SCREEN_BRIGHTNESS_MODE_MANUAL,
+            )
+            val brightnessApplied = Settings.System.putInt(
+                contentResolver,
+                Settings.System.SCREEN_BRIGHTNESS,
+                brightness,
+            )
+            clearDisplayBrightnessOverride(activity)
+            return manualModeApplied && brightnessApplied
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,6 +245,7 @@
     <string name="quick_menu_title">Quick Menu</string>
     <string name="quick_menu_back">Back</string>
     <string name="display_brightness">Display brightness</string>
+    <string name="display_brightness_permission_required">Allow GameNative to modify system settings to control device brightness.</string>
     <string name="screen_effects">Screen Effects</string>
     <string name="screen_effects_live_preview">Changes apply instantly to the current game.</string>
     <string name="screen_effects_scaling">Scaling</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,7 +245,6 @@
     <string name="quick_menu_title">Quick Menu</string>
     <string name="quick_menu_back">Back</string>
     <string name="display_brightness">Display brightness</string>
-    <string name="display_brightness_permission_required">Allow GameNative to modify system settings to control device brightness.</string>
     <string name="screen_effects">Screen Effects</string>
     <string name="screen_effects_live_preview">Changes apply instantly to the current game.</string>
     <string name="screen_effects_scaling">Scaling</string>


### PR DESCRIPTION
## Description
This changes the QAM brightness control to use device-global Android brightness instead of a GameNative window-only override. now requests the `WRITE_SETTINGS` permission, but in exchange global device brightness is synced in app and on device.

## Recording


https://github.com/user-attachments/assets/61d9577a-5c10-48d3-a6ea-8f41adee11ec


## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Brightness controls now stay in sync with the device’s current screen brightness settings.
  - Display brightness updates automatically when system brightness or brightness mode changes.

- **Bug Fixes**
  - Improved brightness handling so app-level brightness overrides are cleared when system settings change or the screen view closes.
  - Added safer cleanup to avoid lingering listeners and stale brightness states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->