### PR TITLE
fix: Add missing locale keys across all locales

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -148,6 +148,10 @@
     <string name="delete">Slet</string>
     <string name="copy_from">Kopiér fra</string>
     <string name="ok">Ok</string>
+    <string name="container_config_custom_resolution_title">Angiv brugerdefineret opløsning</string>
+    <string name="container_config_custom_resolution_separator">x</string>
+    <string name="container_config_custom_resolution_error_nonzero">Bredde og højde skal være større end 0</string>
+    <string name="container_config_custom_resolution_error_aspect">Bredden skal være større end højden</string>
     <string name="storage_info">Lagerinformation</string>
     <string name="duplicate">Duplikér</string>
     <string name="reconfigure">Konfigurér igen</string>
@@ -183,6 +187,7 @@
     <string name="toggle_orientation">Skift orientering</string>
     <string name="task_manager">Jobliste</string>
     <string name="tools_wine_processes_running_hint">%1$d kører, tryk/klik på en proces for at lukke den</string>
+    <string name="tools_wine_processes_empty">Ingen kørende EXE-filer fundet.</string>
     <string name="magnifier">Forstørrelsesglas</string>
     <string name="logs">Logfiler</string>
     <string name="exit_game">Afslut</string>
@@ -216,6 +221,7 @@
     <string name="screen_effects_live_preview">Ændringer anvendes straks på det aktuelle spil.</string>
     <string name="screen_effects_color_adjustments">Farvejusteringer</string>
     <string name="screen_effects_shader_toggles">Shader-effekter</string>
+    <string name="screen_effects_scaling_mode">Skaleringstilstand</string>
     <string name="screen_effects_brightness">Lysstyrke</string>
     <string name="screen_effects_contrast">Kontrast</string>
     <string name="screen_effects_gamma">Gamma</string>
@@ -269,6 +275,7 @@
     <string name="performance_hud_battery_level">Batteriniveau</string>
     <string name="performance_hud_power_draw">Strømforbrug</string>
     <string name="performance_hud_runtime_left">Resterende tid</string>
+    <string name="performance_hud_battery_temperature">Batteritemperatur</string>
     <string name="performance_hud_clock_time">Klokkeslæt</string>
     <string name="performance_hud_cpu_temperature">CPU-temperatur</string>
     <string name="performance_hud_gpu_temperature">GPU-temperatur</string>
@@ -498,6 +505,8 @@
     <!-- Container Configuration: Steam Integration -->
     <string name="force_dlc">Gennemtving DLC</string>
     <string name="force_dlc_description">Kun aktiver hvis DLC\'er ikke opdages, eller gemfiler med DLC ikke virker</string>
+    <string name="local_saves_only">Kun lokale gemfiler</string>
+    <string name="local_saves_only_description">Deaktiver synkronisering af cloud-gemfiler for dette spil, og behold gemfiler kun på enheden</string>
     <string name="launch_steam_client_beta">Start Steam-klient (Beta)</string>
     <string name="steam_offline_mode">Steam Offline-tilstand</string>
     <string name="steam_offline_mode_description">Start Steam-spil i offline-tilstand</string>
@@ -510,6 +519,7 @@
     <string name="achievement_position_bottom_left">Nederst til venstre</string>
     <string name="achievement_position_bottom_right">Nederst til højre</string>
     <string name="launch_steam_client_description">Reducerer ydelse og gør opstart langsommere\nMuliggør online-spil og løser DRM- og controllerproblemer\nIkke alle spil virker</string>
+    <string name="launch_bionic_steam">Aktivér eksperimentel Bionic Steam</string>
     <string name="allow_steam_updates">Tillad Steam-opdateringer</string>
     <string name="allow_steam_updates_description">Opdaterer Steam til nyeste version. Reducerer ydelsen markant.</string>
     <string name="steam_type">Steam-type</string>
@@ -685,6 +695,7 @@
     <string name="enable_csmt">Aktivér CSMT (Command Stream Multi-Thread)</string>
     <string name="enable_strict_shader_math">Aktivér Strict Shader Math</string>
     <string name="mouse_warp_override">Mouse Warp Override</string>
+    <string name="renderer_present_modes">Renderer-præsentationstilstand</string>
 
     <!-- Container Configuration: Management -->
     <string name="environment_variables">Miljøvariabler</string>
@@ -742,6 +753,8 @@
     <string name="settings_emulation_default_config_title">Redigér standardkonfiguration</string>
     <string name="settings_emulation_default_config_subtitle">De indledende containerindstillinger for hvert spil (påvirker ikke allerede installerede spil)</string>
     <string name="settings_emulation_default_config_dialog_title">Standard containerkonfiguration</string>
+    <string name="settings_emulation_auto_apply_known_config_title">Anvend kendt konfiguration automatisk</string>
+    <string name="settings_emulation_auto_apply_known_config_subtitle">Anvend automatisk anbefalede indstillinger for Steam-spil ved første start</string>
     <string name="settings_emulation_box64_presets_title">Box64-forudindstillinger</string>
     <string name="settings_emulation_box64_presets_subtitle">Vis, redigér og opret Box64-forudindstillinger</string>
     <string name="settings_emulation_driver_manager_title">Driverhåndtering</string>
@@ -878,6 +891,8 @@
     <string name="library_need_internet">Internet påkrævet for installation</string>
     <string name="library_wifi_only_enabled">Installation kun via Wi-Fi/LAN aktiveret</string>
     <string name="library_file_count">Fil %1$d af %2$d</string>
+    <string name="download_no_wifi">Ikke forbundet til Wi-Fi/LAN</string>
+    <string name="download_paused_wifi">Download sat på pause – venter på Wi-Fi/LAN</string>
 
     <!-- TODO: Manual review - PluviaMain: Update & App Info -->
     <string name="main_update_available_title">Opdatering tilgængelig</string>
@@ -900,6 +915,7 @@
     <string name="main_discord_support_title">Virkede spillet?</string>
     <string name="main_discord_support_message">Tilmeld dig Discord for at få support til at rette dit spil eller forbedre ydelsen.</string>
     <string name="main_open_discord">Åbn Discord</string>
+    <string name="main_downloading_entry">Downloader %s</string>
 
     <!-- TODO: Manual review - PluviaMain: Game Launch -->
     <string name="main_downloading_steam">Downloader Steam...</string>
@@ -1313,6 +1329,15 @@
     <string name="workshop_processing">Behandler mods…</string>
     <string name="workshop_failed_count">%1$d workshop-mod(s) kunne ikke opdateres</string>
     <string name="workshop_download_failed">Download mislykkedes</string>
+    <string name="option_open_store_page">Åbn butikssiden</string>
+    <string name="option_export_for_frontend">Eksportér til frontend</string>
+    <string name="option_open_container">Åbn container</string>
+    <string name="option_edit_container">Redigér container</string>
+    <string name="option_reset_to_defaults">Nulstil container</string>
+    <string name="option_get_support">Få support</string>
+    <string name="option_submit_feedback">Send feedback</string>
+    <string name="option_reset_drm">Nulstil DRM</string>
+    <string name="option_use_known_config">Brug kendt konfiguration</string>
 
     <!-- Recommendations -->
     <string name="recommended_badge">Anbefalet</string>
@@ -1335,6 +1360,18 @@
      <string name="steam_save_import_failed">Kunne ikke importere gemte filer: %s</string>
     <string name="option_import_saves">Importér gemte spil</string>
     <string name="option_export_saves">Eksportér gemte spil</string>
+    <string name="option_verify_files">Verificér filer</string>
+    <string name="option_update">Opdatér</string>
+    <string name="option_move_to_external_storage">Flyt til ekstern lager</string>
+    <string name="option_move_to_internal_storage">Flyt til intern lager</string>
+    <string name="option_force_cloud_sync">Gennemtving cloud-synkronisering</string>
+    <string name="option_browse_online_saves">Gennemse online-gemfiler</string>
+    <string name="option_force_download_remote">Gennemtving download af fjern-gemfiler</string>
+    <string name="option_force_upload_local">Gennemtving upload af lokale gemfiler</string>
+    <string name="option_fetch_game_images">Hent spilbilleder</string>
+    <string name="option_test_graphics">Test grafik</string>
+    <string name="option_manage_dlc">Administrér DLC</string>
+    <string name="option_manage_workshop">Administrér Workshop</string>
     <!-- HLTB (How Long To Beat) -->
     <string name="hltb_main_story">Hovedhistorie</string>
     <string name="hltb_main_plus_extras">Hoved + Ekstra</string>
@@ -1401,6 +1438,8 @@
     <string name="frontend_sync_confirm_keep">Behold</string>
     <string name="frontend_sync_resync_all">Synkroniser alt igen</string>
     <string name="frontend_sync_resync_complete">Frontend-synkronisering fuldført</string>
+    <string name="frontend_sync_pick_directory_cd">Vælg mappe til %1$s</string>
+    <string name="frontend_sync_clear_directory_cd">Ryd mappe for %1$s</string>
     <string name="screen_effects_scaling">Skalering</string>
     <string name="screen_effects_upscaling">Opskalering</string>
     <string name="screen_effects_basic_scaling">Grundlæggende skalering</string>
@@ -1422,6 +1461,17 @@
     <string name="screen_effects_scaling_mode_dls_desc">Skarphed / klarhed.</string>
     <string name="screen_effects_scaling_mode_natural">Naturlig</string>
     <string name="screen_effects_scaling_mode_natural_desc">Varmere farvetone.</string>
+    <string name="screen_effects_fsr">FSR 1.0</string>
+    <string name="screen_effects_fsr_description">Officiel AMD FidelityFX Super Resolution 1.0 med EASU + RCAS, der bruger en lavere intern renderopløsning og opskalerer til fuld opløsning.</string>
+    <string name="screen_effects_fsr_quality">FSR-kvalitet</string>
+    <string name="screen_effects_fsr_quality_ultra_quality">Ultra-kvalitet</string>
+    <string name="screen_effects_fsr_quality_quality">Kvalitet</string>
+    <string name="screen_effects_fsr_quality_balanced">Balanceret</string>
+    <string name="screen_effects_fsr_quality_performance">Ydelse</string>
+    <string name="screen_effects_fsr_sharpness">FSR-skarphed</string>
+    <string name="screen_effects_fsr_sharpness_value">%1$d/5</string>
+    <string name="screen_effects_launch_sharpness">Skarphed ved opstart</string>
+    <string name="screen_effects_launch_sharpness_note">CAS og DLS anvendes via vkBasalt og træder i kraft næste gang du starter spillet.</string>
     <string name="stats_key_runs">Vellykkede kørsler på din GPU</string>
     <string name="stats_key_reviews">5-stjernede anmeldelser (din GPU / din enhed)</string>
     <string name="stats_key_fps">Forventet FPS</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -212,6 +212,10 @@
     <string name="delete">Löschen</string>
     <string name="copy_from">Kopieren von</string>
     <string name="ok">OK</string>
+    <string name="container_config_custom_resolution_title">Eigene Auflösung festlegen</string>
+    <string name="container_config_custom_resolution_separator">x</string>
+    <string name="container_config_custom_resolution_error_nonzero">Breite und Höhe müssen größer als 0 sein</string>
+    <string name="container_config_custom_resolution_error_aspect">Breite muss größer als Höhe sein</string>
     <string name="storage_info">Speicherinformation</string>
     <string name="duplicate">Duplizieren</string>
     <string name="reconfigure">Neu konfigurieren</string>
@@ -247,6 +251,7 @@
     <string name="toggle_orientation">Ausrichtung wechseln</string>
     <string name="task_manager">Task-Manager</string>
     <string name="tools_wine_processes_running_hint">%1$d aktiv, tippe/klicke auf einen Prozess, um ihn zu schließen</string>
+    <string name="tools_wine_processes_empty">Keine laufenden EXE-Dateien erkannt.</string>
     <string name="magnifier">Lupe</string>
     <string name="logs">Logs</string>
     <string name="exit_game">Beenden</string>
@@ -280,6 +285,7 @@
     <string name="screen_effects_live_preview">Änderungen werden sofort auf das aktuelle Spiel angewendet.</string>
     <string name="screen_effects_color_adjustments">Farbkorrekturen</string>
     <string name="screen_effects_shader_toggles">Shader-Effekte</string>
+    <string name="screen_effects_scaling_mode">Skalierungsmodus</string>
     <string name="screen_effects_brightness">Helligkeit</string>
     <string name="screen_effects_contrast">Kontrast</string>
     <string name="screen_effects_gamma">Gamma</string>
@@ -333,6 +339,7 @@
     <string name="performance_hud_battery_level">Batteriestand</string>
     <string name="performance_hud_power_draw">Stromverbrauch</string>
     <string name="performance_hud_runtime_left">Verbleibende Laufzeit</string>
+    <string name="performance_hud_battery_temperature">Akkutemperatur</string>
     <string name="performance_hud_clock_time">Uhrzeit</string>
     <string name="performance_hud_cpu_temperature">CPU-Temperatur</string>
     <string name="performance_hud_gpu_temperature">GPU-Temperatur</string>
@@ -638,6 +645,8 @@
     <string name="unpack_files_description">Nur verwenden, wenn \'Application Load Error 3:0000065432\' auftritt.</string>
     <string name="force_dlc">DLC erzwingen</string>
     <string name="force_dlc_description">Nur aktivieren, falls DLCs nicht erkannt werden oder Spielstände mit DLC nicht funktionieren</string>
+    <string name="local_saves_only">Nur lokale Spielstände</string>
+    <string name="local_saves_only_description">Cloud-Synchronisierung der Spielstände für dieses Spiel deaktivieren und Spielstände nur auf dem Gerät behalten</string>
     <string name="launch_steam_client_beta">Steam-Client starten (Beta)</string>
     <string name="steam_offline_mode">Steam Offline-Modus</string>
     <string name="steam_offline_mode_description">Steam-Spiele im Offlinemodus starten</string>
@@ -650,6 +659,7 @@
     <string name="achievement_position_bottom_left">Unten links</string>
     <string name="achievement_position_bottom_right">Unten rechts</string>
     <string name="launch_steam_client_description">Reduziert Performance und verlängert den Start\nErmöglicht Online-Spiel und behebt DRM- und Controller-Probleme\nNicht alle Spiele funktionieren</string>
+    <string name="launch_bionic_steam">Experimentelles Bionic Steam aktivieren</string>
     <string name="allow_steam_updates">Steam-Updates erlauben</string>
     <string name="allow_steam_updates_description">Aktualisiert Steam auf die neueste Version. Reduziert die Leistung spürbar.</string>
     <string name="steam_type">Steam-Typ</string>
@@ -672,6 +682,7 @@
     <string name="sync_frame">Jedes Frame synchronisieren</string>
     <string name="disable_present_wait">KHR_present_wait deaktivieren</string>
     <string name="present_modes">Präsentationsmodi</string>
+    <string name="renderer_present_modes">Renderer-Präsentationsmodus</string>
     <string name="resource_type">Speicherressourcen-Typ</string>
     <string name="bcn_emulation">BCn-Emulation</string>
     <string name="bcn_emulation_type">BCn-Emulationstyp</string>
@@ -885,6 +896,8 @@
     <string name="settings_emulation_default_config_title">Standardkonfiguration ändern</string>
     <string name="settings_emulation_default_config_subtitle">Die Grundeinstellungen für neue Container (betrifft bereits bestehende Spiele nicht)</string>
     <string name="settings_emulation_default_config_dialog_title">Standard-Container-Konfiguration</string>
+    <string name="settings_emulation_auto_apply_known_config_title">Bekannte Konfiguration automatisch anwenden</string>
+    <string name="settings_emulation_auto_apply_known_config_subtitle">Beim ersten Start automatisch empfohlene Einstellungen für Steam-Spiele anwenden</string>
     <string name="settings_emulation_box64_presets_title">Box64-Voreinstellungen</string>
     <string name="settings_emulation_box64_presets_subtitle">Voreinstellungen anzeigen, ändern oder neu erstellen</string>
     <string name="settings_emulation_driver_manager_title">Treiberverwaltung</string>
@@ -1010,6 +1023,8 @@
     <string name="library_need_internet">Internetverbindung erforderlich</string>
     <string name="library_wifi_only_enabled">Installieren nur über WLAN/LAN aktiviert</string>
     <string name="library_file_count">Datei %1$d von %2$d</string>
+    <string name="download_no_wifi">Nicht mit Wi-Fi/LAN verbunden</string>
+    <string name="download_paused_wifi">Download pausiert – warte auf Wi-Fi/LAN</string>
     <!-- PluviaMain: Update & App Info -->
     <string name="main_update_available_title">Update verfügbar</string>
     <string name="main_update_available_message">Eine neue Version (%1$s) ist verfügbar!%2$s</string>
@@ -1030,6 +1045,7 @@
     <string name="main_discord_support_title">Hat das Spiel funktioniert?</string>
     <string name="main_discord_support_message">Tritt dem Discord bei, um Hilfe für dein Spiel oder Performance zu erhalten.</string>
     <string name="main_open_discord">Discord öffnen</string>
+    <string name="main_downloading_entry">%s wird heruntergeladen</string>
     <!-- PluviaMain: Game Launch -->
     <string name="main_downloading_steam">Steam wird heruntergeladen…</string>
     <string name="main_installing_glibc">GLIBC-Komponenten werden installiert…</string>
@@ -1383,6 +1399,15 @@
     <string name="workshop_processing">Mods werden verarbeitet…</string>
     <string name="workshop_failed_count">%1$d Workshop-Mod(s) konnten nicht aktualisiert werden</string>
     <string name="workshop_download_failed">Download fehlgeschlagen</string>
+    <string name="option_open_store_page">Store-Seite öffnen</string>
+    <string name="option_export_for_frontend">Für Frontend exportieren</string>
+    <string name="option_open_container">Container öffnen</string>
+    <string name="option_edit_container">Container bearbeiten</string>
+    <string name="option_reset_to_defaults">Container zurücksetzen</string>
+    <string name="option_get_support">Support erhalten</string>
+    <string name="option_submit_feedback">Feedback senden</string>
+    <string name="option_reset_drm">DRM zurücksetzen</string>
+    <string name="option_use_known_config">Bekannte Konfiguration verwenden</string>
 
     <!-- Recommendations -->
     <string name="recommended_badge">Empfohlen</string>
@@ -1405,6 +1430,18 @@
      <string name="steam_save_import_failed">Spielstände konnten nicht importiert werden: %s</string>
     <string name="option_import_saves">Spielstände importieren</string>
     <string name="option_export_saves">Spielstände exportieren</string>
+    <string name="option_verify_files">Dateien überprüfen</string>
+    <string name="option_update">Aktualisieren</string>
+    <string name="option_move_to_external_storage">Auf externen Speicher verschieben</string>
+    <string name="option_move_to_internal_storage">Auf internen Speicher verschieben</string>
+    <string name="option_force_cloud_sync">Cloud-Synchronisierung erzwingen</string>
+    <string name="option_browse_online_saves">Online-Spielstände durchsuchen</string>
+    <string name="option_force_download_remote">Download der Remote-Spielstände erzwingen</string>
+    <string name="option_force_upload_local">Upload der lokalen Spielstände erzwingen</string>
+    <string name="option_fetch_game_images">Spielbilder abrufen</string>
+    <string name="option_test_graphics">Grafik testen</string>
+    <string name="option_manage_dlc">DLC verwalten</string>
+    <string name="option_manage_workshop">Workshop verwalten</string>
     <!-- HLTB (How Long To Beat) -->
     <string name="hltb_main_story">Hauptstory</string>
     <string name="hltb_main_plus_extras">Haupt + Extras</string>
@@ -1471,6 +1508,8 @@
     <string name="frontend_sync_confirm_keep">Behalten</string>
     <string name="frontend_sync_resync_all">Alle neu synchronisieren</string>
     <string name="frontend_sync_resync_complete">Frontend-Synchronisierung abgeschlossen</string>
+    <string name="frontend_sync_pick_directory_cd">Verzeichnis für %1$s auswählen</string>
+    <string name="frontend_sync_clear_directory_cd">Verzeichnis für %1$s löschen</string>
     <string name="screen_effects_scaling">Skalierung</string>
     <string name="screen_effects_upscaling">Hochskalierung</string>
     <string name="screen_effects_basic_scaling">Einfache Skalierung</string>
@@ -1492,6 +1531,17 @@
     <string name="screen_effects_scaling_mode_dls_desc">Schärfen / Klarheit.</string>
     <string name="screen_effects_scaling_mode_natural">Natürlich</string>
     <string name="screen_effects_scaling_mode_natural_desc">Wärmerer Farbton.</string>
+    <string name="screen_effects_fsr">FSR 1.0</string>
+    <string name="screen_effects_fsr_description">Offizielles AMD FidelityFX Super Resolution 1.0 mit EASU + RCAS, niedrigerer interner Renderauflösung und Hochskalierung auf volle Auflösung.</string>
+    <string name="screen_effects_fsr_quality">FSR-Qualität</string>
+    <string name="screen_effects_fsr_quality_ultra_quality">Ultra-Qualität</string>
+    <string name="screen_effects_fsr_quality_quality">Qualität</string>
+    <string name="screen_effects_fsr_quality_balanced">Ausgewogen</string>
+    <string name="screen_effects_fsr_quality_performance">Leistung</string>
+    <string name="screen_effects_fsr_sharpness">FSR-Schärfe</string>
+    <string name="screen_effects_fsr_sharpness_value">%1$d/5</string>
+    <string name="screen_effects_launch_sharpness">Schärfe beim Start</string>
+    <string name="screen_effects_launch_sharpness_note">CAS und DLS werden über vkBasalt angewendet und sind beim nächsten Spielstart wirksam.</string>
     <string name="stats_key_runs">Erfolgreiche Starts auf deiner GPU</string>
     <string name="stats_key_reviews">5-Sterne-Bewertungen (deine GPU / dein Gerät)</string>
     <string name="stats_key_fps">Erwartete FPS</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -269,6 +269,7 @@
     <string name="toggle_orientation">Alternar orientación</string>
     <string name="task_manager">Administrador de tareas</string>
     <string name="tools_wine_processes_running_hint">%1$d en ejecución, toca/haz clic en un proceso para cerrarlo</string>
+    <string name="tools_wine_processes_empty">No se detectaron EXE en ejecución.</string>
     <string name="magnifier">Lupa</string>
     <string name="logs">Registros</string>
     <string name="exit_game">Salir</string>
@@ -302,6 +303,7 @@
     <string name="screen_effects_live_preview">Los cambios se aplican al instante al juego actual.</string>
     <string name="screen_effects_color_adjustments">Ajustes de color</string>
     <string name="screen_effects_shader_toggles">Efectos de shader</string>
+    <string name="screen_effects_scaling_mode">Modo de escalado</string>
     <string name="screen_effects_brightness">Brillo</string>
     <string name="screen_effects_contrast">Contraste</string>
     <string name="screen_effects_gamma">Gamma</string>
@@ -355,6 +357,7 @@
     <string name="performance_hud_battery_level">Nivel de batería</string>
     <string name="performance_hud_power_draw">Consumo de energía</string>
     <string name="performance_hud_runtime_left">Tiempo restante</string>
+    <string name="performance_hud_battery_temperature">Temperatura de la batería</string>
     <string name="performance_hud_clock_time">Hora</string>
     <string name="performance_hud_cpu_temperature">Temperatura de CPU</string>
     <string name="performance_hud_gpu_temperature">Temperatura de GPU</string>
@@ -710,8 +713,11 @@
     <string name="unpack_files_description">Úsalo solo si obtienes el error \'Application Load Error 3:0000065432\'.</string>
     <string name="force_dlc">Forzar DLC</string>
     <string name="force_dlc_description">Actívalo solo si los DLC no se detectan o los archivos de guardados con DLC no funcionan.</string>
+    <string name="local_saves_only">Solo guardados locales</string>
+    <string name="local_saves_only_description">Desactiva la sincronización de guardados en la nube para este juego y mantén las partidas solo en el dispositivo</string>
     <string name="launch_steam_client_beta">Iniciar cliente de Steam (Beta)</string>
     <string name="launch_steam_client_description">Reduce el rendimiento y ralentiza el inicio.\nPermite el juego en línea y soluciona problemas de DRM y de mando.\nNo todos los juegos funcionan.</string>
+    <string name="launch_bionic_steam">Habilitar Bionic Steam experimental</string>
     <string name="steam_offline_mode">Modo sin conexión de Steam</string>
     <string name="steam_offline_mode_description">Inicia juegos de Steam en modo sin conexión.</string>
     <string name="epic_offline_mode">Modo sin conexión de Epic</string>
@@ -745,6 +751,7 @@
     <string name="sync_frame">Sincronizar cada fotograma</string>
     <string name="disable_present_wait">Desactivar KHR_present_wait</string>
     <string name="present_modes">Modos de presentación</string>
+    <string name="renderer_present_modes">Modo de presentación del renderizador</string>
     <string name="resource_type">Tipo de recurso de memoria</string>
     <string name="bcn_emulation">Emulación BCn</string>
     <string name="bcn_emulation_type">Tipo de emulación BCn</string>
@@ -1067,6 +1074,8 @@
     <string name="library_need_internet">Necesitas conexión a internet para instalar.</string>
     <string name="library_wifi_only_enabled">Instalación solo por Wi-Fi/LAN habilitada.</string>
     <string name="library_file_count">Archivo %1$d de %2$d</string>
+    <string name="download_no_wifi">Sin conexión a Wi-Fi/LAN</string>
+    <string name="download_paused_wifi">Descarga pausada – esperando a Wi-Fi/LAN</string>
 
     <!-- PluviaMain: Update & App Info -->
     <string name="main_update_available_title">Actualización disponible</string>
@@ -1448,6 +1457,15 @@
     <string name="workshop_processing">Procesando mods…</string>
     <string name="workshop_failed_count">%1$d mod(s) del Workshop no se pudieron actualizar</string>
     <string name="workshop_download_failed">Error en la descarga</string>
+    <string name="option_open_store_page">Abrir página de la tienda</string>
+    <string name="option_export_for_frontend">Exportar para frontend</string>
+    <string name="option_open_container">Abrir contenedor</string>
+    <string name="option_edit_container">Editar contenedor</string>
+    <string name="option_reset_to_defaults">Restablecer contenedor</string>
+    <string name="option_get_support">Obtener soporte</string>
+    <string name="option_submit_feedback">Enviar comentarios</string>
+    <string name="option_reset_drm">Restablecer DRM</string>
+    <string name="option_use_known_config">Usar configuración conocida</string>
 
     <!-- Recommendations -->
     <string name="recommended_badge">Recomendado</string>
@@ -1470,6 +1488,18 @@
      <string name="steam_save_import_failed">Error al importar partidas: %s</string>
     <string name="option_import_saves">Importar partidas guardadas</string>
     <string name="option_export_saves">Exportar partidas guardadas</string>
+    <string name="option_verify_files">Verificar archivos</string>
+    <string name="option_update">Actualizar</string>
+    <string name="option_move_to_external_storage">Mover a almacenamiento externo</string>
+    <string name="option_move_to_internal_storage">Mover a almacenamiento interno</string>
+    <string name="option_force_cloud_sync">Forzar sincronización en la nube</string>
+    <string name="option_browse_online_saves">Explorar partidas en línea</string>
+    <string name="option_force_download_remote">Forzar descarga de partidas remotas</string>
+    <string name="option_force_upload_local">Forzar subida de partidas locales</string>
+    <string name="option_fetch_game_images">Obtener imágenes del juego</string>
+    <string name="option_test_graphics">Probar gráficos</string>
+    <string name="option_manage_dlc">Gestionar DLC</string>
+    <string name="option_manage_workshop">Gestionar Workshop</string>
     <!-- HLTB (How Long To Beat) -->
     <string name="hltb_main_story">Historia principal</string>
     <string name="hltb_main_plus_extras">Principal + Extras</string>
@@ -1536,6 +1566,8 @@
     <string name="frontend_sync_confirm_keep">Conservar</string>
     <string name="frontend_sync_resync_all">Resincronizar todo</string>
     <string name="frontend_sync_resync_complete">Sincronización de frontend completada</string>
+    <string name="frontend_sync_pick_directory_cd">Elegir directorio para %1$s</string>
+    <string name="frontend_sync_clear_directory_cd">Borrar directorio para %1$s</string>
     <string name="screen_effects_scaling">Escalado</string>
     <string name="screen_effects_upscaling">Superescalado</string>
     <string name="screen_effects_basic_scaling">Escalado básico</string>
@@ -1557,6 +1589,17 @@
     <string name="screen_effects_scaling_mode_dls_desc">Pasada de nitidez / claridad.</string>
     <string name="screen_effects_scaling_mode_natural">Natural</string>
     <string name="screen_effects_scaling_mode_natural_desc">Tono de color más cálido.</string>
+    <string name="screen_effects_fsr">FSR 1.0</string>
+    <string name="screen_effects_fsr_description">AMD FidelityFX Super Resolution 1.0 oficial usando EASU + RCAS con una resolución de renderizado interno más baja y un reescalado a resolución completa.</string>
+    <string name="screen_effects_fsr_quality">Calidad de FSR</string>
+    <string name="screen_effects_fsr_quality_ultra_quality">Ultra calidad</string>
+    <string name="screen_effects_fsr_quality_quality">Calidad</string>
+    <string name="screen_effects_fsr_quality_balanced">Equilibrado</string>
+    <string name="screen_effects_fsr_quality_performance">Rendimiento</string>
+    <string name="screen_effects_fsr_sharpness">Nitidez de FSR</string>
+    <string name="screen_effects_fsr_sharpness_value">%1$d/5</string>
+    <string name="screen_effects_launch_sharpness">Nitidez de inicio</string>
+    <string name="screen_effects_launch_sharpness_note">CAS y DLS se aplican a través de vkBasalt y surten efecto la próxima vez que inicies el juego.</string>
     <string name="stats_key_runs">Ejecuciones correctas en tu GPU</string>
     <string name="stats_key_reviews">Reseñas de 5 estrellas (tu GPU / tu dispositivo)</string>
     <string name="stats_key_fps">FPS esperados</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -219,6 +219,10 @@
     <string name="delete">Supprimer</string>
     <string name="copy_from">Copier depuis</string>
     <string name="ok">Ok</string>
+    <string name="container_config_custom_resolution_title">Définir une résolution personnalisée</string>
+    <string name="container_config_custom_resolution_separator">x</string>
+    <string name="container_config_custom_resolution_error_nonzero">La largeur et la hauteur doivent être supérieures à 0</string>
+    <string name="container_config_custom_resolution_error_aspect">La largeur doit être supérieure à la hauteur</string>
     <string name="storage_info">Informations de stockage</string>
     <string name="duplicate">Dupliquer</string>
     <string name="reconfigure">Reconfigurer</string>
@@ -254,6 +258,7 @@
     <string name="toggle_orientation">Basculer l\'orientation</string>
     <string name="task_manager">Gestionnaire de tâches</string>
     <string name="tools_wine_processes_running_hint">%1$d en cours, touchez/cliquez sur un processus pour le fermer</string>
+    <string name="tools_wine_processes_empty">Aucun EXE en cours d\'exécution détecté.</string>
     <string name="magnifier">Loupe</string>
     <string name="logs">Journaux</string>
     <string name="exit_game">Quitter</string>
@@ -287,6 +292,7 @@
     <string name="screen_effects_live_preview">Les modifications s’appliquent instantanément au jeu en cours.</string>
     <string name="screen_effects_color_adjustments">Réglages des couleurs</string>
     <string name="screen_effects_shader_toggles">Effets de shader</string>
+    <string name="screen_effects_scaling_mode">Mode de mise à l\'échelle</string>
     <string name="screen_effects_brightness">Luminosité</string>
     <string name="screen_effects_contrast">Contraste</string>
     <string name="screen_effects_gamma">Gamma</string>
@@ -340,6 +346,7 @@
     <string name="performance_hud_battery_level">Niveau de batterie</string>
     <string name="performance_hud_power_draw">Consommation d’énergie</string>
     <string name="performance_hud_runtime_left">Autonomie restante</string>
+    <string name="performance_hud_battery_temperature">Température de la batterie</string>
     <string name="performance_hud_clock_time">Heure</string>
     <string name="performance_hud_cpu_temperature">Température CPU</string>
     <string name="performance_hud_gpu_temperature">Température GPU</string>
@@ -661,6 +668,8 @@
     <string name="unpack_files_description">Utiliser uniquement si vous obtenez \'Application Load Error 3:0000065432\'.</string>
     <string name="force_dlc">Forcer les DLC</string>
     <string name="force_dlc_description">N\'activer que si les DLC ne sont pas détectés ou si les sauvegardes avec DLC ne fonctionnent pas</string>
+    <string name="local_saves_only">Sauvegardes locales uniquement</string>
+    <string name="local_saves_only_description">Désactiver la synchronisation des sauvegardes dans le cloud pour ce jeu et conserver les sauvegardes uniquement sur l\'appareil</string>
     <string name="launch_steam_client_beta">Lancer le client Steam (Bêta)</string>
     <string name="steam_offline_mode">Mode Hors Ligne Steam</string>
     <string name="steam_offline_mode_description">Lancer les jeux Steam en mode hors ligne</string>
@@ -673,6 +682,7 @@
     <string name="achievement_position_bottom_left">En bas à gauche</string>
     <string name="achievement_position_bottom_right">En bas à droite</string>
     <string name="launch_steam_client_description">Réduit les performances et ralentit le lancement\nPermet le jeu en ligne et corrige les problèmes de DRM et de contrôleur\nTous les jeux ne fonctionnent pas</string>
+    <string name="launch_bionic_steam">Activer Bionic Steam expérimental</string>
     <string name="allow_steam_updates">Autoriser les mises à jour Steam</string>
     <string name="allow_steam_updates_description">Met à jour Steam vers la dernière version. Réduit considérablement les performances.</string>
     <string name="steam_type">Type Steam</string>
@@ -696,6 +706,7 @@
     <string name="sync_frame">Synchroniser chaque image</string>
     <string name="disable_present_wait">Désactiver KHR_present_wait</string>
     <string name="present_modes">Modes de présentation</string>
+    <string name="renderer_present_modes">Mode de présentation du moteur de rendu</string>
     <string name="resource_type">Type de ressource mémoire</string>
     <string name="bcn_emulation">Émulation BCn</string>
     <string name="bcn_emulation_type">Type d\'émulation BCn</string>
@@ -918,6 +929,8 @@
     <string name="settings_emulation_default_config_title">Modifier la configuration par défaut</string>
     <string name="settings_emulation_default_config_subtitle">Les paramètres de conteneur initiaux pour chaque jeu (n\'affecte pas les jeux déjà installés)</string>
     <string name="settings_emulation_default_config_dialog_title">Configuration de conteneur par défaut</string>
+    <string name="settings_emulation_auto_apply_known_config_title">Appliquer automatiquement la configuration connue</string>
+    <string name="settings_emulation_auto_apply_known_config_subtitle">Appliquer automatiquement les paramètres recommandés pour les jeux Steam au premier lancement</string>
     <string name="settings_emulation_box64_presets_title">Préréglages Box64</string>
     <string name="settings_emulation_box64_presets_subtitle">Voir, modifier et créer des préréglages Box64</string>
     <string name="settings_emulation_driver_manager_title">Gestionnaire de pilotes</string>
@@ -1054,6 +1067,8 @@
     <string name="library_need_internet">Connexion internet nécessaire pour installer</string>
     <string name="library_wifi_only_enabled">Installation sur Wi-Fi/LAN uniquement activée</string>
     <string name="library_file_count">Fichier %1$d sur %2$d</string>
+    <string name="download_no_wifi">Non connecté au Wi-Fi/LAN</string>
+    <string name="download_paused_wifi">Téléchargement en pause – en attente du Wi-Fi/LAN</string>
 
     <!-- PluviaMain: Update & App Info -->
     <string name="main_update_available_title">Mise à jour disponible</string>
@@ -1076,6 +1091,7 @@
     <string name="main_discord_support_title">Le jeu a-t-il fonctionné ?</string>
     <string name="main_discord_support_message">Rejoignez le Discord pour obtenir de l\'aide pour réparer votre jeu ou améliorer les performances.</string>
     <string name="main_open_discord">Ouvrir Discord</string>
+    <string name="main_downloading_entry">Téléchargement de %s</string>
 
     <!-- PluviaMain: Game Launch -->
     <string name="main_downloading_steam">Téléchargement de Steam…</string>
@@ -1443,6 +1459,15 @@
     <string name="workshop_processing">Traitement des mods…</string>
     <string name="workshop_failed_count">%1$d mod(s) Workshop n\'ont pas pu être mis à jour</string>
     <string name="workshop_download_failed">Échec du téléchargement</string>
+    <string name="option_open_store_page">Ouvrir la page de la boutique</string>
+    <string name="option_export_for_frontend">Exporter pour le frontend</string>
+    <string name="option_open_container">Ouvrir le conteneur</string>
+    <string name="option_edit_container">Modifier le conteneur</string>
+    <string name="option_reset_to_defaults">Réinitialiser le conteneur</string>
+    <string name="option_get_support">Obtenir de l\'aide</string>
+    <string name="option_submit_feedback">Envoyer un commentaire</string>
+    <string name="option_reset_drm">Réinitialiser le DRM</string>
+    <string name="option_use_known_config">Utiliser la configuration connue</string>
 
     <!-- Recommendations -->
     <string name="recommended_badge">Recommandé</string>
@@ -1465,6 +1490,18 @@
      <string name="steam_save_import_failed">Échec de l\'importation des sauvegardes : %s</string>
     <string name="option_import_saves">Importer les sauvegardes</string>
     <string name="option_export_saves">Exporter les sauvegardes</string>
+    <string name="option_verify_files">Vérifier les fichiers</string>
+    <string name="option_update">Mettre à jour</string>
+    <string name="option_move_to_external_storage">Déplacer vers le stockage externe</string>
+    <string name="option_move_to_internal_storage">Déplacer vers le stockage interne</string>
+    <string name="option_force_cloud_sync">Forcer la synchronisation cloud</string>
+    <string name="option_browse_online_saves">Parcourir les sauvegardes en ligne</string>
+    <string name="option_force_download_remote">Forcer le téléchargement des sauvegardes distantes</string>
+    <string name="option_force_upload_local">Forcer l\'envoi des sauvegardes locales</string>
+    <string name="option_fetch_game_images">Récupérer les images du jeu</string>
+    <string name="option_test_graphics">Tester les graphismes</string>
+    <string name="option_manage_dlc">Gérer les DLC</string>
+    <string name="option_manage_workshop">Gérer le Workshop</string>
     <!-- HLTB (How Long To Beat) -->
     <string name="hltb_main_story">Histoire principale</string>
     <string name="hltb_main_plus_extras">Principal + Extras</string>
@@ -1531,6 +1568,8 @@
     <string name="frontend_sync_confirm_keep">Conserver</string>
     <string name="frontend_sync_resync_all">Tout resynchroniser</string>
     <string name="frontend_sync_resync_complete">Synchronisation frontend terminée</string>
+    <string name="frontend_sync_pick_directory_cd">Choisir un dossier pour %1$s</string>
+    <string name="frontend_sync_clear_directory_cd">Effacer le dossier pour %1$s</string>
     <string name="screen_effects_scaling">Mise à l\'échelle</string>
     <string name="screen_effects_upscaling">Super-résolution</string>
     <string name="screen_effects_basic_scaling">Mise à l\'échelle de base</string>
@@ -1552,6 +1591,17 @@
     <string name="screen_effects_scaling_mode_dls_desc">Passe de netteté / clarté.</string>
     <string name="screen_effects_scaling_mode_natural">Naturel</string>
     <string name="screen_effects_scaling_mode_natural_desc">Teinte plus chaude.</string>
+    <string name="screen_effects_fsr">FSR 1.0</string>
+    <string name="screen_effects_fsr_description">AMD FidelityFX Super Resolution 1.0 officiel utilisant EASU + RCAS avec une résolution de rendu interne réduite et une mise à l\'échelle en pleine résolution.</string>
+    <string name="screen_effects_fsr_quality">Qualité FSR</string>
+    <string name="screen_effects_fsr_quality_ultra_quality">Ultra qualité</string>
+    <string name="screen_effects_fsr_quality_quality">Qualité</string>
+    <string name="screen_effects_fsr_quality_balanced">Équilibré</string>
+    <string name="screen_effects_fsr_quality_performance">Performance</string>
+    <string name="screen_effects_fsr_sharpness">Netteté FSR</string>
+    <string name="screen_effects_fsr_sharpness_value">%1$d/5</string>
+    <string name="screen_effects_launch_sharpness">Netteté au lancement</string>
+    <string name="screen_effects_launch_sharpness_note">CAS et DLS sont appliqués via vkBasalt et prennent effet au prochain lancement du jeu.</string>
     <string name="stats_key_runs">Lancements réussis sur votre GPU</string>
     <string name="stats_key_reviews">Avis 5 étoiles (votre GPU / votre appareil)</string>
     <string name="stats_key_fps">FPS attendus</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -258,6 +258,7 @@
     <string name="toggle_orientation">Cambia Orientamento</string>
     <string name="task_manager">Gestione Attività</string>
     <string name="tools_wine_processes_running_hint">%1$d in esecuzione, tocca/fai clic su un processo per chiuderlo</string>
+    <string name="tools_wine_processes_empty">Nessun EXE in esecuzione rilevato.</string>
     <string name="magnifier">Lente d\'ingrandimento</string>
     <string name="logs">Log</string>
     <string name="exit_game">Esci</string>
@@ -291,6 +292,7 @@
     <string name="screen_effects_live_preview">Le modifiche si applicano istantaneamente al gioco corrente.</string>
     <string name="screen_effects_color_adjustments">Regolazioni colore</string>
     <string name="screen_effects_shader_toggles">Effetti shader</string>
+    <string name="screen_effects_scaling_mode">Modalità di scaling</string>
     <string name="screen_effects_brightness">Luminosità</string>
     <string name="screen_effects_contrast">Contrasto</string>
     <string name="screen_effects_gamma">Gamma</string>
@@ -344,6 +346,7 @@
     <string name="performance_hud_battery_level">Livello batteria</string>
     <string name="performance_hud_power_draw">Consumo energetico</string>
     <string name="performance_hud_runtime_left">Autonomia residua</string>
+    <string name="performance_hud_battery_temperature">Temperatura batteria</string>
     <string name="performance_hud_clock_time">Ora</string>
     <string name="performance_hud_cpu_temperature">Temperatura CPU</string>
     <string name="performance_hud_gpu_temperature">Temperatura GPU</string>
@@ -665,6 +668,8 @@
     <string name="unpack_files_description">Usa solo se ottieni \'Application Load Error 3:0000065432\'.</string>
     <string name="force_dlc">Forza DLC</string>
     <string name="force_dlc_description">Abilita solo se i DLC non vengono rilevati o i salvataggi con DLC non funzionano</string>
+    <string name="local_saves_only">Solo salvataggi locali</string>
+    <string name="local_saves_only_description">Disabilita la sincronizzazione dei salvataggi cloud per questo gioco e mantieni i salvataggi solo sul dispositivo</string>
     <string name="launch_steam_client_beta">Avvia Client Steam (Beta)</string>
     <string name="steam_offline_mode">Modalità Offline Steam</string>
     <string name="steam_offline_mode_description">Avvia i giochi Steam in modalità offline</string>
@@ -677,6 +682,7 @@
     <string name="achievement_position_bottom_left">In basso a sinistra</string>
     <string name="achievement_position_bottom_right">In basso a destra</string>
     <string name="launch_steam_client_description">Riduce le prestazioni e rallenta l\'avvio\nConsente il gioco online e corregge problemi di DRM e controller\nNon tutti i giochi funzionano</string>
+    <string name="launch_bionic_steam">Abilita Bionic Steam sperimentale</string>
     <string name="allow_steam_updates">Consenti aggiornamenti Steam</string>
     <string name="allow_steam_updates_description">Aggiorna Steam all\'ultima versione. Riduce significativamente le prestazioni.</string>
     <string name="steam_type">Tipo Steam</string>
@@ -700,6 +706,7 @@
     <string name="sync_frame">Sincronizza Ogni Fotogramma</string>
     <string name="disable_present_wait">Disabilita KHR_present_wait</string>
     <string name="present_modes">Modalità Presentazione</string>
+    <string name="renderer_present_modes">Modalità Presentazione Renderer</string>
     <string name="resource_type">Tipo Risorsa Memoria</string>
     <string name="bcn_emulation">Emulazione BCn</string>
     <string name="bcn_emulation_type">Tipo Emulazione BCn</string>
@@ -914,6 +921,8 @@
     <string name="settings_emulation_default_config_title">Modifica Config Predefinita</string>
     <string name="settings_emulation_default_config_subtitle">Le impostazioni iniziali del container per ogni gioco (non influisce sui giochi già installati)</string>
     <string name="settings_emulation_default_config_dialog_title">Config Container Predefinita</string>
+    <string name="settings_emulation_auto_apply_known_config_title">Applica automaticamente config nota</string>
+    <string name="settings_emulation_auto_apply_known_config_subtitle">Applica automaticamente le impostazioni consigliate per i giochi Steam al primo avvio</string>
     <string name="settings_emulation_box64_presets_title">Preset Box64</string>
     <string name="settings_emulation_box64_presets_subtitle">Visualizza, modifica e crea preset Box64</string>
     <string name="settings_emulation_driver_manager_title">Gestione Driver</string>
@@ -1049,6 +1058,8 @@
     <string name="library_need_internet">Serve internet per installare</string>
     <string name="library_wifi_only_enabled">Installa solo tramite Wi-Fi/LAN abilitato</string>
     <string name="library_file_count">File %1$d di %2$d</string>
+    <string name="download_no_wifi">Non connesso a Wi-Fi/LAN</string>
+    <string name="download_paused_wifi">Download in pausa – in attesa di Wi-Fi/LAN</string>
 
     <!-- PluviaMain: Update & App Info -->
     <string name="main_update_available_title">Aggiornamento Disponibile</string>
@@ -1071,6 +1082,7 @@
     <string name="main_discord_support_title">Il gioco ha funzionato?</string>
     <string name="main_discord_support_message">Unisciti al Discord per ottenere supporto per correggere il tuo gioco o migliorare le prestazioni.</string>
     <string name="main_open_discord">Apri Discord</string>
+    <string name="main_downloading_entry">Download di %s in corso</string>
 
     <!-- PluviaMain: Game Launch -->
     <string name="main_downloading_steam">Scaricamento Steam...</string>
@@ -1438,6 +1450,15 @@
     <string name="workshop_processing">Elaborazione mod…</string>
     <string name="workshop_failed_count">%1$d mod del Workshop non aggiornati</string>
     <string name="workshop_download_failed">Download non riuscito</string>
+    <string name="option_open_store_page">Apri pagina dello store</string>
+    <string name="option_export_for_frontend">Esporta per frontend</string>
+    <string name="option_open_container">Apri container</string>
+    <string name="option_edit_container">Modifica container</string>
+    <string name="option_reset_to_defaults">Reimposta container</string>
+    <string name="option_get_support">Ottieni supporto</string>
+    <string name="option_submit_feedback">Invia feedback</string>
+    <string name="option_reset_drm">Reimposta DRM</string>
+    <string name="option_use_known_config">Usa config nota</string>
 
     <!-- Recommendations -->
     <string name="recommended_badge">Consigliato</string>
@@ -1460,6 +1481,18 @@
      <string name="steam_save_import_failed">Importazione salvataggi fallita: %s</string>
     <string name="option_import_saves">Importa salvataggi</string>
     <string name="option_export_saves">Esporta salvataggi</string>
+    <string name="option_verify_files">Verifica file</string>
+    <string name="option_update">Aggiorna</string>
+    <string name="option_move_to_external_storage">Sposta su archiviazione esterna</string>
+    <string name="option_move_to_internal_storage">Sposta su archiviazione interna</string>
+    <string name="option_force_cloud_sync">Forza sincronizzazione cloud</string>
+    <string name="option_browse_online_saves">Sfoglia salvataggi online</string>
+    <string name="option_force_download_remote">Forza download salvataggi remoti</string>
+    <string name="option_force_upload_local">Forza caricamento salvataggi locali</string>
+    <string name="option_fetch_game_images">Recupera immagini del gioco</string>
+    <string name="option_test_graphics">Prova grafica</string>
+    <string name="option_manage_dlc">Gestisci DLC</string>
+    <string name="option_manage_workshop">Gestisci Workshop</string>
     <!-- HLTB (How Long To Beat) -->
     <string name="hltb_main_story">Storia principale</string>
     <string name="hltb_main_plus_extras">Principale + Extra</string>
@@ -1526,6 +1559,8 @@
     <string name="frontend_sync_confirm_keep">Mantieni</string>
     <string name="frontend_sync_resync_all">Risincronizza tutto</string>
     <string name="frontend_sync_resync_complete">Sincronizzazione frontend completata</string>
+    <string name="frontend_sync_pick_directory_cd">Scegli cartella per %1$s</string>
+    <string name="frontend_sync_clear_directory_cd">Cancella cartella per %1$s</string>
     <string name="screen_effects_scaling">Ridimensionamento</string>
     <string name="screen_effects_upscaling">Super risoluzione</string>
     <string name="screen_effects_basic_scaling">Ridimensionamento di base</string>
@@ -1547,6 +1582,17 @@
     <string name="screen_effects_scaling_mode_dls_desc">Passaggio di nitidezza / chiarezza.</string>
     <string name="screen_effects_scaling_mode_natural">Naturale</string>
     <string name="screen_effects_scaling_mode_natural_desc">Tonalità più calda.</string>
+    <string name="screen_effects_fsr">FSR 1.0</string>
+    <string name="screen_effects_fsr_description">AMD FidelityFX Super Resolution 1.0 ufficiale, che usa EASU + RCAS con una risoluzione di rendering interna inferiore e un upscale a piena risoluzione.</string>
+    <string name="screen_effects_fsr_quality">Qualità FSR</string>
+    <string name="screen_effects_fsr_quality_ultra_quality">Ultra Qualità</string>
+    <string name="screen_effects_fsr_quality_quality">Qualità</string>
+    <string name="screen_effects_fsr_quality_balanced">Bilanciato</string>
+    <string name="screen_effects_fsr_quality_performance">Prestazioni</string>
+    <string name="screen_effects_fsr_sharpness">Nitidezza FSR</string>
+    <string name="screen_effects_fsr_sharpness_value">%1$d/5</string>
+    <string name="screen_effects_launch_sharpness">Nitidezza all\'avvio</string>
+    <string name="screen_effects_launch_sharpness_note">CAS e DLS vengono applicati tramite vkBasalt e hanno effetto al prossimo avvio del gioco.</string>
     <string name="stats_key_runs">Esecuzioni riuscite sulla tua GPU</string>
     <string name="stats_key_reviews">Recensioni a 5 stelle (la tua GPU / il tuo dispositivo)</string>
     <string name="stats_key_fps">FPS previsti</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1482,6 +1482,8 @@
     <!-- App option menu labels -->
     <string name="option_open_store_page">ストアページを開く</string>
     <string name="option_export_for_frontend">フロントエンド用にエクスポート</string>
+    <string name="frontend_sync_pick_directory_cd">%1$s のディレクトリを選択</string>
+    <string name="frontend_sync_clear_directory_cd">%1$s のディレクトリをクリア</string>
     <string name="option_open_container">オープンコンテナ</string>
     <string name="option_edit_container">コンテナの編集</string>
     <string name="option_reset_to_defaults">コンテナをリセットする</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -266,6 +266,7 @@
     <string name="toggle_orientation">Przełącz orientację</string>
     <string name="task_manager">Menedżer zadań</string>
     <string name="tools_wine_processes_running_hint">%1$d uruchomionych, stuknij/kliknij proces, aby go zamknąć</string>
+    <string name="tools_wine_processes_empty">Nie wykryto uruchomionych plików EXE.</string>
     <string name="magnifier">Lupa</string>
     <string name="logs">Logi</string>
     <string name="exit_game">Wyjdź</string>
@@ -299,6 +300,7 @@
     <string name="screen_effects_live_preview">Zmiany są natychmiast stosowane do bieżącej gry.</string>
     <string name="screen_effects_color_adjustments">Regulacja kolorów</string>
     <string name="screen_effects_shader_toggles">Efekty shaderów</string>
+    <string name="screen_effects_scaling_mode">Tryb skalowania</string>
     <string name="screen_effects_brightness">Jasność</string>
     <string name="screen_effects_contrast">Kontrast</string>
     <string name="screen_effects_gamma">Gamma</string>
@@ -352,6 +354,7 @@
     <string name="performance_hud_battery_level">Poziom baterii</string>
     <string name="performance_hud_power_draw">Pobór mocy</string>
     <string name="performance_hud_runtime_left">Pozostały czas</string>
+    <string name="performance_hud_battery_temperature">Temperatura baterii</string>
     <string name="performance_hud_clock_time">Czas</string>
     <string name="performance_hud_cpu_temperature">Temperatura CPU</string>
     <string name="performance_hud_gpu_temperature">Temperatura GPU</string>
@@ -674,6 +677,8 @@
     <string name="unpack_files_description">Używaj tylko w przypadku błędu \'Application Load Error\'. Może zmniejszyć FPS.</string>
     <string name="force_dlc">Wymuś DLC</string>
     <string name="force_dlc_description">Włącz tylko jeśli DLC nie są wykrywane lub zapisy z DLC nie działają</string>
+    <string name="local_saves_only">Tylko zapisy lokalne</string>
+    <string name="local_saves_only_description">Wyłącz synchronizację zapisów w chmurze dla tej gry i przechowuj zapisy tylko na urządzeniu</string>
     <string name="launch_steam_client_beta">Uruchom Klienta Steam (Beta)</string>
     <string name="steam_offline_mode">Tryb Offline Steam</string>
     <string name="steam_offline_mode_description">Uruchamiaj gry Steam w trybie offline</string>
@@ -686,6 +691,7 @@
     <string name="achievement_position_bottom_left">Lewy dolny</string>
     <string name="achievement_position_bottom_right">Prawy dolny</string>
     <string name="launch_steam_client_description">Zmniejsza wydajność i spowalnia uruchamianie\nPozwala na grę online i naprawia problemy z DRM oraz kontrolerem\nNie wszystkie gry działają</string>
+    <string name="launch_bionic_steam">Włącz eksperymentalny Bionic Steam</string>
     <string name="allow_steam_updates">Zezwól na aktualizacje Steam</string>
     <string name="allow_steam_updates_description">Aktualizuje Steam do najnowszej wersji. Znacząco zmniejsza wydajność.</string>
     <string name="steam_type">Typ Steam</string>
@@ -709,6 +715,7 @@
     <string name="sync_frame">Synchronizuj każdą klatkę</string>
     <string name="disable_present_wait">Wyłącz KHR_present_wait</string>
     <string name="present_modes">Tryby prezentacji</string>
+    <string name="renderer_present_modes">Tryb prezentacji renderera</string>
     <string name="resource_type">Typ zasobu pamięci</string>
     <string name="bcn_emulation">Emulacja BCn</string>
     <string name="bcn_emulation_type">Typ emulacji BCn</string>
@@ -931,6 +938,8 @@
     <string name="settings_emulation_default_config_title">Zmodyfikuj domyślną konfigurację</string>
     <string name="settings_emulation_default_config_subtitle">Początkowe ustawienia kontenera dla każdej gry (nie wpływa na już zainstalowane gry)</string>
     <string name="settings_emulation_default_config_dialog_title">Domyślna konfiguracja kontenera</string>
+    <string name="settings_emulation_auto_apply_known_config_title">Automatycznie zastosuj znaną konfigurację</string>
+    <string name="settings_emulation_auto_apply_known_config_subtitle">Automatycznie zastosuj zalecane ustawienia dla gier Steam przy pierwszym uruchomieniu</string>
     <string name="settings_emulation_box64_presets_title">Presety Box64</string>
     <string name="settings_emulation_box64_presets_subtitle">Przeglądaj, modyfikuj i twórz presety Box64</string>
     <string name="settings_emulation_driver_manager_title">Menedżer sterowników</string>
@@ -1066,6 +1075,8 @@
     <string name="library_need_internet">Wymagany internet do instalacji</string>
     <string name="library_wifi_only_enabled">Włączono instalację tylko przez Wi-Fi/LAN</string>
     <string name="library_file_count">Plik %1$d z %2$d</string>
+    <string name="download_no_wifi">Brak połączenia z Wi-Fi/LAN</string>
+    <string name="download_paused_wifi">Pobieranie wstrzymane – oczekiwanie na Wi-Fi/LAN</string>
 
     <!-- PluviaMain: Update & App Info -->
     <string name="main_update_available_title">Dostępna aktualizacja</string>
@@ -1088,6 +1099,7 @@
     <string name="main_discord_support_title">Czy gra zadziałała?</string>
     <string name="main_discord_support_message">Dołącz do Discorda, aby uzyskać pomoc w naprawie gry lub poprawie wydajności.</string>
     <string name="main_open_discord">Otwórz Discord</string>
+    <string name="main_downloading_entry">Pobieranie %s</string>
 
     <!-- PluviaMain: Game Launch -->
     <string name="main_downloading_steam">Pobieranie Steam...</string>
@@ -1445,6 +1457,15 @@
     <string name="workshop_processing">Przetwarzanie modów…</string>
     <string name="workshop_failed_count">Nie udało się zaktualizować %1$d modów z Warsztatu</string>
     <string name="workshop_download_failed">Pobieranie nie powiodło się</string>
+    <string name="option_open_store_page">Otwórz stronę sklepu</string>
+    <string name="option_export_for_frontend">Eksportuj dla frontendu</string>
+    <string name="option_open_container">Otwórz kontener</string>
+    <string name="option_edit_container">Edytuj kontener</string>
+    <string name="option_reset_to_defaults">Zresetuj kontener</string>
+    <string name="option_get_support">Uzyskaj pomoc</string>
+    <string name="option_submit_feedback">Wyślij opinię</string>
+    <string name="option_reset_drm">Zresetuj DRM</string>
+    <string name="option_use_known_config">Użyj znanej konfiguracji</string>
 
     <!-- Recommendations -->
     <string name="recommended_badge">Polecane</string>
@@ -1467,6 +1488,18 @@
      <string name="steam_save_import_failed">Nie udało się zaimportować zapisów: %s</string>
     <string name="option_import_saves">Importuj zapisy</string>
     <string name="option_export_saves">Eksportuj zapisy</string>
+    <string name="option_verify_files">Zweryfikuj pliki</string>
+    <string name="option_update">Aktualizuj</string>
+    <string name="option_move_to_external_storage">Przenieś na pamięć zewnętrzną</string>
+    <string name="option_move_to_internal_storage">Przenieś do pamięci wewnętrznej</string>
+    <string name="option_force_cloud_sync">Wymuś synchronizację z chmurą</string>
+    <string name="option_browse_online_saves">Przeglądaj zapisy online</string>
+    <string name="option_force_download_remote">Wymuś pobranie zapisów zdalnych</string>
+    <string name="option_force_upload_local">Wymuś przesłanie zapisów lokalnych</string>
+    <string name="option_fetch_game_images">Pobierz obrazy gry</string>
+    <string name="option_test_graphics">Przetestuj grafikę</string>
+    <string name="option_manage_dlc">Zarządzaj DLC</string>
+    <string name="option_manage_workshop">Zarządzaj Workshop</string>
     <!-- HLTB (How Long To Beat) -->
     <string name="hltb_main_story">Główna fabuła</string>
     <string name="hltb_main_plus_extras">Główna + Dodatki</string>
@@ -1533,6 +1566,8 @@
     <string name="frontend_sync_confirm_keep">Zachowaj</string>
     <string name="frontend_sync_resync_all">Ponowna synchronizacja wszystkich</string>
     <string name="frontend_sync_resync_complete">Synchronizacja frontend zakończona</string>
+    <string name="frontend_sync_pick_directory_cd">Wybierz katalog dla %1$s</string>
+    <string name="frontend_sync_clear_directory_cd">Wyczyść katalog dla %1$s</string>
     <string name="screen_effects_scaling">Skalowanie</string>
     <string name="screen_effects_upscaling">Skalowanie w górę</string>
     <string name="screen_effects_basic_scaling">Podstawowe skalowanie</string>
@@ -1554,6 +1589,17 @@
     <string name="screen_effects_scaling_mode_dls_desc">Wyostrzanie / klarowność.</string>
     <string name="screen_effects_scaling_mode_natural">Naturalny</string>
     <string name="screen_effects_scaling_mode_natural_desc">Cieplejszy odcień kolorów.</string>
+    <string name="screen_effects_fsr">FSR 1.0</string>
+    <string name="screen_effects_fsr_description">Oficjalne AMD FidelityFX Super Resolution 1.0 wykorzystujące EASU + RCAS z niższą wewnętrzną rozdzielczością renderowania i skalowaniem do pełnej rozdzielczości.</string>
+    <string name="screen_effects_fsr_quality">Jakość FSR</string>
+    <string name="screen_effects_fsr_quality_ultra_quality">Ultra jakość</string>
+    <string name="screen_effects_fsr_quality_quality">Jakość</string>
+    <string name="screen_effects_fsr_quality_balanced">Zrównoważony</string>
+    <string name="screen_effects_fsr_quality_performance">Wydajność</string>
+    <string name="screen_effects_fsr_sharpness">Ostrość FSR</string>
+    <string name="screen_effects_fsr_sharpness_value">%1$d/5</string>
+    <string name="screen_effects_launch_sharpness">Ostrość przy uruchomieniu</string>
+    <string name="screen_effects_launch_sharpness_note">CAS i DLS są stosowane przez vkBasalt i zaczynają działać przy następnym uruchomieniu gry.</string>
     <string name="stats_key_runs">Udane uruchomienia na twoim GPU</string>
     <string name="stats_key_reviews">Recenzje 5-gwiazdkowe (twój GPU / twoje urządzenie)</string>
     <string name="stats_key_fps">Oczekiwane FPS</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -148,6 +148,10 @@
     <string name="delete">Excluir</string>
     <string name="copy_from">Copiar de</string>
     <string name="ok">Ok</string>
+    <string name="container_config_custom_resolution_title">Definir resolução personalizada</string>
+    <string name="container_config_custom_resolution_separator">x</string>
+    <string name="container_config_custom_resolution_error_nonzero">A largura e a altura devem ser maiores que 0</string>
+    <string name="container_config_custom_resolution_error_aspect">A largura deve ser maior que a altura</string>
     <string name="storage_info">Info de armazenamento</string>
     <string name="duplicate">Duplicar</string>
     <string name="reconfigure">Reconfigurar</string>
@@ -183,6 +187,7 @@
     <string name="toggle_orientation">Alternar Orientação</string>
     <string name="task_manager">Gerenciador de tarefas</string>
     <string name="tools_wine_processes_running_hint">%1$d em execução, toque/clique em um processo para fechá-lo</string>
+    <string name="tools_wine_processes_empty">Nenhum EXE em execução detectado.</string>
     <string name="magnifier">Lupa</string>
     <string name="logs">Logs</string>
     <string name="exit_game">Sair</string>
@@ -216,6 +221,7 @@
     <string name="screen_effects_live_preview">As alterações são aplicadas instantaneamente ao jogo atual.</string>
     <string name="screen_effects_color_adjustments">Ajustes de cor</string>
     <string name="screen_effects_shader_toggles">Efeitos de shader</string>
+    <string name="screen_effects_scaling_mode">Modo de escalonamento</string>
     <string name="screen_effects_brightness">Brilho</string>
     <string name="screen_effects_contrast">Contraste</string>
     <string name="screen_effects_gamma">Gama</string>
@@ -269,6 +275,7 @@
     <string name="performance_hud_battery_level">Nível da bateria</string>
     <string name="performance_hud_power_draw">Consumo de energia</string>
     <string name="performance_hud_runtime_left">Tempo restante</string>
+    <string name="performance_hud_battery_temperature">Temperatura da bateria</string>
     <string name="performance_hud_clock_time">Hora</string>
     <string name="performance_hud_cpu_temperature">Temperatura da CPU</string>
     <string name="performance_hud_gpu_temperature">Temperatura da GPU</string>
@@ -498,6 +505,8 @@
     <!-- Container Configuration: Steam Integration -->
     <string name="force_dlc">Forçar DLC</string>
     <string name="force_dlc_description">Ative somente se os DLCs não forem detectados ou os saves com DLC não estiverem funcionando</string>
+    <string name="local_saves_only">Apenas saves locais</string>
+    <string name="local_saves_only_description">Desativa a sincronização de saves na nuvem para este jogo e mantém os saves somente no dispositivo</string>
     <string name="launch_steam_client_beta">Iniciar o cliente Steam (Beta)</string>
     <string name="steam_offline_mode">Modo Offline do Steam</string>
     <string name="steam_offline_mode_description">Iniciar jogos Steam no modo offline</string>
@@ -510,6 +519,7 @@
     <string name="achievement_position_bottom_left">Inferior esquerdo</string>
     <string name="achievement_position_bottom_right">Inferior direito</string>
     <string name="launch_steam_client_description">Reduz o desempenho e atrasa a inicialização\nPermite jogo online e corrige problemas de DRM e de controle\nNem todos os jogos funcionam</string>
+    <string name="launch_bionic_steam">Ativar Bionic Steam experimental</string>
     <string name="allow_steam_updates">Permitir atualizações do Steam</string>
     <string name="allow_steam_updates_description">Atualiza o Steam para a versão mais recente. Reduz significativamente o desempenho.</string>
     <string name="steam_type">Tipo de Steam</string>
@@ -679,6 +689,7 @@
 
     <!-- Container Configuration: Rendering -->
     <string name="renderer">Renderizador</string>
+    <string name="renderer_present_modes">Modo de apresentação do renderizador</string>
     <string name="gpu_name">Nome da GPU</string>
     <string name="offscreen_rendering_mode">Modo de Renderização Offscreen</string>
     <string name="video_memory_size">Tamanho da Memória de Vídeo</string>
@@ -742,6 +753,8 @@
     <string name="settings_emulation_default_config_title">Modificar configuração padrão</string>
     <string name="settings_emulation_default_config_subtitle">As configurações iniciais do contêiner para cada jogo (não afeta jogos já instalados)</string>
     <string name="settings_emulation_default_config_dialog_title">Configuração padrão do contêiner</string>
+    <string name="settings_emulation_auto_apply_known_config_title">Aplicar configuração conhecida automaticamente</string>
+    <string name="settings_emulation_auto_apply_known_config_subtitle">Aplica automaticamente as configurações recomendadas para jogos Steam na primeira inicialização</string>
     <string name="settings_emulation_box64_presets_title">Predefinições do Box64</string>
     <string name="settings_emulation_box64_presets_subtitle">Visualizar, modificar e criar predefinições do Box64</string>
     <string name="settings_emulation_driver_manager_title">Gerenciador de drivers</string>
@@ -878,6 +891,8 @@
     <string name="library_need_internet">Internet necessária para instalar</string>
     <string name="library_wifi_only_enabled">Instalação apenas por Wi-Fi/LAN habilitada</string>
     <string name="library_file_count">Arquivo %1$d de %2$d</string>
+    <string name="download_no_wifi">Não conectado ao Wi-Fi/LAN</string>
+    <string name="download_paused_wifi">Download pausado – aguardando Wi-Fi/LAN</string>
 
     <!-- TODO: Revisão manual - PluviaMain: Atualização e informações do app -->
     <string name="main_update_available_title">Atualização disponível</string>
@@ -900,6 +915,7 @@
     <string name="main_discord_support_title">O jogo funcionou?</string>
     <string name="main_discord_support_message">Junte-se ao Discord para obter suporte para corrigir seu jogo ou melhorar o desempenho.</string>
     <string name="main_open_discord">Abrir Discord</string>
+    <string name="main_downloading_entry">Baixando %s</string>
 
     <!-- TODO: Revisão manual - PluviaMain: Inicialização do jogo -->
     <string name="main_downloading_steam">Baixando Steam...</string>
@@ -1313,6 +1329,15 @@
     <string name="workshop_processing">Processando mods…</string>
     <string name="workshop_failed_count">%1$d mod(s) da Oficina não puderam ser atualizados</string>
     <string name="workshop_download_failed">Falha no download</string>
+    <string name="option_open_store_page">Abrir página da loja</string>
+    <string name="option_export_for_frontend">Exportar para frontend</string>
+    <string name="option_open_container">Abrir contêiner</string>
+    <string name="option_edit_container">Editar contêiner</string>
+    <string name="option_reset_to_defaults">Redefinir contêiner</string>
+    <string name="option_get_support">Obter suporte</string>
+    <string name="option_submit_feedback">Enviar feedback</string>
+    <string name="option_reset_drm">Redefinir DRM</string>
+    <string name="option_use_known_config">Usar configuração conhecida</string>
 
     <!-- Recommendations -->
     <string name="recommended_badge">Recomendado</string>
@@ -1335,6 +1360,18 @@
      <string name="steam_save_import_failed">Falha ao importar saves: %s</string>
     <string name="option_import_saves">Importar saves</string>
     <string name="option_export_saves">Exportar saves</string>
+    <string name="option_verify_files">Verificar arquivos</string>
+    <string name="option_update">Atualizar</string>
+    <string name="option_move_to_external_storage">Mover para armazenamento externo</string>
+    <string name="option_move_to_internal_storage">Mover para armazenamento interno</string>
+    <string name="option_force_cloud_sync">Forçar sincronização na nuvem</string>
+    <string name="option_browse_online_saves">Procurar saves online</string>
+    <string name="option_force_download_remote">Forçar download dos saves remotos</string>
+    <string name="option_force_upload_local">Forçar upload dos saves locais</string>
+    <string name="option_fetch_game_images">Buscar imagens do jogo</string>
+    <string name="option_test_graphics">Testar gráficos</string>
+    <string name="option_manage_dlc">Gerenciar DLC</string>
+    <string name="option_manage_workshop">Gerenciar Workshop</string>
     <!-- HLTB (How Long To Beat) -->
     <string name="hltb_main_story">História principal</string>
     <string name="hltb_main_plus_extras">Principal + Extras</string>
@@ -1401,6 +1438,8 @@
     <string name="frontend_sync_confirm_keep">Manter</string>
     <string name="frontend_sync_resync_all">Ressincronizar tudo</string>
     <string name="frontend_sync_resync_complete">Sincronização de frontend concluída</string>
+    <string name="frontend_sync_pick_directory_cd">Escolher diretório para %1$s</string>
+    <string name="frontend_sync_clear_directory_cd">Limpar diretório de %1$s</string>
     <string name="screen_effects_scaling">Escalonamento</string>
     <string name="screen_effects_upscaling">Ampliação</string>
     <string name="screen_effects_basic_scaling">Escalonamento básico</string>
@@ -1422,6 +1461,17 @@
     <string name="screen_effects_scaling_mode_dls_desc">Passe de nitidez / clareza.</string>
     <string name="screen_effects_scaling_mode_natural">Natural</string>
     <string name="screen_effects_scaling_mode_natural_desc">Tom de cor mais quente.</string>
+    <string name="screen_effects_fsr">FSR 1.0</string>
+    <string name="screen_effects_fsr_description">AMD FidelityFX Super Resolution 1.0 oficial usando EASU + RCAS com uma resolução de renderização interna mais baixa e upscale em resolução total.</string>
+    <string name="screen_effects_fsr_quality">Qualidade do FSR</string>
+    <string name="screen_effects_fsr_quality_ultra_quality">Ultra Qualidade</string>
+    <string name="screen_effects_fsr_quality_quality">Qualidade</string>
+    <string name="screen_effects_fsr_quality_balanced">Equilibrado</string>
+    <string name="screen_effects_fsr_quality_performance">Desempenho</string>
+    <string name="screen_effects_fsr_sharpness">Nitidez do FSR</string>
+    <string name="screen_effects_fsr_sharpness_value">%1$d/5</string>
+    <string name="screen_effects_launch_sharpness">Nitidez na inicialização</string>
+    <string name="screen_effects_launch_sharpness_note">CAS e DLS são aplicados através do vkBasalt e entram em vigor na próxima vez que você iniciar o jogo.</string>
     <string name="stats_key_runs">Execuções bem-sucedidas na sua GPU</string>
     <string name="stats_key_reviews">Avaliações 5 estrelas (sua GPU / seu dispositivo)</string>
     <string name="stats_key_fps">FPS esperado</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -256,6 +256,7 @@
     <string name="toggle_orientation">Comută orientarea</string>
     <string name="task_manager">Manager de activități</string>
     <string name="tools_wine_processes_running_hint">%1$d în execuție, atinge/clic pe un proces pentru a-l închide</string>
+    <string name="tools_wine_processes_empty">Niciun EXE în execuție detectat.</string>
     <string name="magnifier">Lupă</string>
     <string name="logs">Loguri</string>
     <string name="exit_game">Ieșire</string>
@@ -289,6 +290,7 @@
     <string name="screen_effects_live_preview">Modificările se aplică instantaneu jocului curent.</string>
     <string name="screen_effects_color_adjustments">Ajustări de culoare</string>
     <string name="screen_effects_shader_toggles">Efecte shader</string>
+    <string name="screen_effects_scaling_mode">Mod de scalare</string>
     <string name="screen_effects_brightness">Luminozitate</string>
     <string name="screen_effects_contrast">Contrast</string>
     <string name="screen_effects_gamma">Gamma</string>
@@ -342,6 +344,7 @@
     <string name="performance_hud_battery_level">Nivel baterie</string>
     <string name="performance_hud_power_draw">Consum de energie</string>
     <string name="performance_hud_runtime_left">Timp rămas</string>
+    <string name="performance_hud_battery_temperature">Temperatura bateriei</string>
     <string name="performance_hud_clock_time">Ora</string>
     <string name="performance_hud_cpu_temperature">Temperatura CPU</string>
     <string name="performance_hud_gpu_temperature">Temperatura GPU</string>
@@ -666,6 +669,8 @@
 	<string name="unpack_files_description">Folosește doar dacă primești \'Application Load Error 3:0000065432\'.</string>
 	<string name="force_dlc">Forțează DLC</string>
 	<string name="force_dlc_description">Activează doar dacă DLC‑urile nu sunt detectate sau salvările cu DLC nu funcționează</string>
+	<string name="local_saves_only">Doar salvări locale</string>
+	<string name="local_saves_only_description">Dezactivează sincronizarea salvărilor în cloud pentru acest joc și păstrează salvările doar pe dispozitiv</string>
 	<string name="launch_steam_client_beta">Pornește Steam Client (Beta)</string>
 	<string name="steam_offline_mode">Mod Offline Steam</string>
 	<string name="steam_offline_mode_description">Pornește jocurile Steam în mod offline</string>
@@ -678,6 +683,7 @@
 	<string name="achievement_position_bottom_left">Stânga jos</string>
 	<string name="achievement_position_bottom_right">Dreapta jos</string>
 	<string name="launch_steam_client_description">Reduce performanța și încetinește lansarea\nPermite joc online și rezolvă probleme DRM și controller\nNu toate jocurile funcționează</string>
+	<string name="launch_bionic_steam">Activează Bionic Steam experimental</string>
 	<string name="allow_steam_updates">Permite actualizările Steam</string>
 	<string name="allow_steam_updates_description">Actualizează Steam la ultima versiune. Reduce semnificativ performanța.</string>
 	<string name="steam_type">Tip Steam</string>
@@ -701,6 +707,7 @@
 	<string name="sync_frame">Sincronizează fiecare cadru</string>
 	<string name="disable_present_wait">Dezactivează KHR_present_wait</string>
 	<string name="present_modes">Moduri de prezentare</string>
+	<string name="renderer_present_modes">Mod de prezentare renderer</string>
 	<string name="resource_type">Tip resursă de memorie</string>
 	<string name="bcn_emulation">Emulare BCn</string>
 	<string name="bcn_emulation_type">Tip emulare BCn</string>
@@ -923,6 +930,8 @@
 	<string name="settings_emulation_default_config_title">Modifică configurația implicită</string>
 	<string name="settings_emulation_default_config_subtitle">Setările inițiale ale containerului pentru fiecare joc (nu afectează jocurile deja instalate)</string>
 	<string name="settings_emulation_default_config_dialog_title">Config container implicit</string>
+	<string name="settings_emulation_auto_apply_known_config_title">Aplică automat configurația cunoscută</string>
+	<string name="settings_emulation_auto_apply_known_config_subtitle">Aplică automat setările recomandate pentru jocurile Steam la prima lansare</string>
 	<string name="settings_emulation_box64_presets_title">Presetări Box64</string>
 	<string name="settings_emulation_box64_presets_subtitle">Vizualizează, modifică și creează presetări Box64</string>
 	<string name="settings_emulation_driver_manager_title">Manager drivere</string>
@@ -1058,6 +1067,8 @@
 	<string name="library_need_internet">Este necesar internet pentru instalare</string>
 	<string name="library_wifi_only_enabled">Instalare doar prin Wi‑Fi/LAN activată</string>
 	<string name="library_file_count">Fișier %1$d din %2$d</string>
+	<string name="download_no_wifi">Neconectat la Wi-Fi/LAN</string>
+	<string name="download_paused_wifi">Descărcare în pauză – se așteaptă Wi-Fi/LAN</string>
 
 	<!-- PluviaMain: Update & App Info -->
 	<string name="main_update_available_title">Actualizare disponibilă</string>
@@ -1080,6 +1091,7 @@
 	<string name="main_discord_support_title">A funcționat jocul?</string>
 	<string name="main_discord_support_message">Alătură-te serverului de Discord pentru suport și optimizare.</string>
 	<string name="main_open_discord">Deschide Discord</string>
+	<string name="main_downloading_entry">Se descarcă %s</string>
 
 	<!-- PluviaMain: Game Launch -->
 	<string name="main_downloading_steam">Se descarcă Steam...</string>
@@ -1448,6 +1460,15 @@
     <string name="workshop_processing">Se procesează modurile…</string>
     <string name="workshop_failed_count">%1$d mod(uri) Workshop nu au putut fi actualizate</string>
     <string name="workshop_download_failed">Descărcarea a eșuat</string>
+    <string name="option_open_store_page">Deschide pagina din magazin</string>
+    <string name="option_export_for_frontend">Exportă pentru frontend</string>
+    <string name="option_open_container">Deschide containerul</string>
+    <string name="option_edit_container">Editează containerul</string>
+    <string name="option_reset_to_defaults">Resetează containerul</string>
+    <string name="option_get_support">Obține suport</string>
+    <string name="option_submit_feedback">Trimite feedback</string>
+    <string name="option_reset_drm">Resetează DRM</string>
+    <string name="option_use_known_config">Folosește configurația cunoscută</string>
 
     <!-- Recommendations -->
     <string name="recommended_badge">Recomandat</string>
@@ -1470,6 +1491,18 @@
      <string name="steam_save_import_failed">Importul salvărilor a eșuat: %s</string>
     <string name="option_import_saves">Importă salvări</string>
     <string name="option_export_saves">Exportă salvări</string>
+    <string name="option_verify_files">Verifică fișierele</string>
+    <string name="option_update">Actualizează</string>
+    <string name="option_move_to_external_storage">Mută pe stocarea externă</string>
+    <string name="option_move_to_internal_storage">Mută pe stocarea internă</string>
+    <string name="option_force_cloud_sync">Forțează sincronizarea în cloud</string>
+    <string name="option_browse_online_saves">Răsfoiește salvările online</string>
+    <string name="option_force_download_remote">Forțează descărcarea salvărilor remote</string>
+    <string name="option_force_upload_local">Forțează încărcarea salvărilor locale</string>
+    <string name="option_fetch_game_images">Preia imaginile jocului</string>
+    <string name="option_test_graphics">Testează grafica</string>
+    <string name="option_manage_dlc">Gestionează DLC</string>
+    <string name="option_manage_workshop">Gestionează Workshop</string>
     <!-- HLTB (How Long To Beat) -->
     <string name="hltb_main_story">Poveste principală</string>
     <string name="hltb_main_plus_extras">Principal + Suplimente</string>
@@ -1536,6 +1569,8 @@
     <string name="frontend_sync_confirm_keep">Păstrați</string>
     <string name="frontend_sync_resync_all">Resincronizare completă</string>
     <string name="frontend_sync_resync_complete">Sincronizare frontend finalizată</string>
+    <string name="frontend_sync_pick_directory_cd">Alege directorul pentru %1$s</string>
+    <string name="frontend_sync_clear_directory_cd">Șterge directorul pentru %1$s</string>
     <string name="screen_effects_scaling">Scalare</string>
     <string name="screen_effects_upscaling">Scalare superioară</string>
     <string name="screen_effects_basic_scaling">Scalare de bază</string>
@@ -1557,6 +1592,17 @@
     <string name="screen_effects_scaling_mode_dls_desc">Trecere de claritate.</string>
     <string name="screen_effects_scaling_mode_natural">Natural</string>
     <string name="screen_effects_scaling_mode_natural_desc">Ton de culoare mai cald.</string>
+    <string name="screen_effects_fsr">FSR 1.0</string>
+    <string name="screen_effects_fsr_description">AMD FidelityFX Super Resolution 1.0 oficial, folosind EASU + RCAS cu o rezoluție internă de randare mai mică și scalare la rezoluția completă.</string>
+    <string name="screen_effects_fsr_quality">Calitate FSR</string>
+    <string name="screen_effects_fsr_quality_ultra_quality">Ultra Calitate</string>
+    <string name="screen_effects_fsr_quality_quality">Calitate</string>
+    <string name="screen_effects_fsr_quality_balanced">Echilibrat</string>
+    <string name="screen_effects_fsr_quality_performance">Performanță</string>
+    <string name="screen_effects_fsr_sharpness">Claritate FSR</string>
+    <string name="screen_effects_fsr_sharpness_value">%1$d/5</string>
+    <string name="screen_effects_launch_sharpness">Claritate la lansare</string>
+    <string name="screen_effects_launch_sharpness_note">CAS și DLS sunt aplicate prin vkBasalt și au efect la următoarea lansare a jocului.</string>
     <string name="stats_key_runs">Rulări reușite pe GPU-ul tău</string>
     <string name="stats_key_reviews">Recenzii de 5 stele (GPU-ul tău / dispozitivul tău)</string>
     <string name="stats_key_fps">FPS estimat</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -429,6 +429,8 @@
     <string name="fexcore_version">Версия FEXCore</string>
     <string name="force_dlc">Принудительно включить DLC</string>
     <string name="force_dlc_description">Включайте только если DLC не обнаружены или сохранения с DLC не работают</string>
+    <string name="local_saves_only">Только локальные сохранения</string>
+    <string name="local_saves_only_description">Отключить синхронизацию облачных сохранений для этой игры и хранить сохранения только на устройстве</string>
     <string name="frame_synchronization">Синхронизация кадров</string>
     <string name="game_executable_not_found">Исполняемый файл не смог быть автоматически выбран. Пожалуйста, установите путь исполняемого файла в настройках контейнера.</string>
     <string name="game_executable_not_found_title">Невозможно запустить</string>
@@ -575,6 +577,7 @@
     <string name="launch_steam_client_description">Снижает производительность и замедляет запуск
 Позволяет играть в сети и исправляет проблемы с DRM и контроллером
 Не все игры работают</string>
+    <string name="launch_bionic_steam">Включить экспериментальный Bionic Steam</string>
     <string name="left_analog_stick">Левый аналоговый джойстик</string>
     <string name="left_stick">Левый джойстик</string>
     <string name="left_stick_down">Левый джойстик вниз</string>
@@ -614,6 +617,8 @@ Ubuntu RootFs - releases.ubuntu.com/focal</string>
     <string name="library_failed_to_export">Ошибка экспорта: %s</string>
     <string name="library_family_shared">Семейно общее</string>
     <string name="library_file_count">Файл %1$d из %2$d</string>
+    <string name="download_no_wifi">Нет подключения к Wi-Fi/LAN</string>
+    <string name="download_paused_wifi">Загрузка приостановлена – ожидание Wi-Fi/LAN</string>
     <string name="library_filters">Фильтры</string>
     <string name="library_game_count">%1$d игр • %2$d установлено</string>
     <string name="library_gpu_compatible">GPU совместимо</string>
@@ -860,6 +865,7 @@ https://gamenative.app
     <string name="position">Положение</string>
     <string name="position_value">X: %1$d, Y: %2$d</string>
     <string name="present_modes">Режимы представления</string>
+    <string name="renderer_present_modes">Режим представления рендерера</string>
     <string name="preset_arrows">Стрелки</string>
     <string name="preset_dpad">D-Pad</string>
     <string name="preset_left_stick">Левый джойстик</string>
@@ -880,6 +886,7 @@ https://gamenative.app
     <string name="screen_effects_live_preview">Изменения мгновенно применяются к текущей игре.</string>
     <string name="screen_effects_color_adjustments">Настройка цвета</string>
     <string name="screen_effects_shader_toggles">Эффекты шейдеров</string>
+    <string name="screen_effects_scaling_mode">Режим масштабирования</string>
     <string name="screen_effects_brightness">Яркость</string>
     <string name="screen_effects_contrast">Контрастность</string>
     <string name="screen_effects_gamma">Гамма</string>
@@ -933,6 +940,7 @@ https://gamenative.app
     <string name="performance_hud_battery_level">Уровень батареи</string>
     <string name="performance_hud_power_draw">Потребление энергии</string>
     <string name="performance_hud_runtime_left">Оставшееся время</string>
+    <string name="performance_hud_battery_temperature">Температура батареи</string>
     <string name="performance_hud_clock_time">Время</string>
     <string name="performance_hud_cpu_temperature">Температура CPU</string>
     <string name="performance_hud_gpu_temperature">Температура GPU</string>
@@ -1245,6 +1253,7 @@ https://gamenative.app
     <string name="tab_steam">Steam</string>
     <string name="task_manager">Менеджер задач</string>
     <string name="tools_wine_processes_running_hint">%1$d запущено, нажмите/кликните по процессу, чтобы закрыть его</string>
+    <string name="tools_wine_processes_empty">Запущенные EXE не обнаружены.</string>
     <string name="template_percent">%1$d процент.</string>
     <string name="thumbstick_buttons">Кнопки джойстика</string>
     <string name="thumbstick_buttons_category">Кнопки джойстика</string>
@@ -1376,6 +1385,15 @@ https://gamenative.app
     <string name="workshop_processing">Обработка модов…</string>
     <string name="workshop_failed_count">Не удалось обновить %1$d мод(ов) Мастерской</string>
     <string name="workshop_download_failed">Ошибка загрузки</string>
+    <string name="option_open_store_page">Открыть страницу в магазине</string>
+    <string name="option_export_for_frontend">Экспортировать для фронтенда</string>
+    <string name="option_open_container">Открыть контейнер</string>
+    <string name="option_edit_container">Редактировать контейнер</string>
+    <string name="option_reset_to_defaults">Сбросить контейнер</string>
+    <string name="option_get_support">Получить поддержку</string>
+    <string name="option_submit_feedback">Отправить отзыв</string>
+    <string name="option_reset_drm">Сбросить DRM</string>
+    <string name="option_use_known_config">Использовать известную конфигурацию</string>
 
     <!-- Recommendations -->
     <string name="recommended_badge">Рекомендуемое</string>
@@ -1398,6 +1416,18 @@ https://gamenative.app
      <string name="steam_save_import_failed">Не удалось импортировать сохранения: %s</string>
     <string name="option_import_saves">Импортировать сохранения</string>
     <string name="option_export_saves">Экспортировать сохранения</string>
+    <string name="option_verify_files">Проверить файлы</string>
+    <string name="option_update">Обновить</string>
+    <string name="option_move_to_external_storage">Переместить во внешнее хранилище</string>
+    <string name="option_move_to_internal_storage">Переместить во внутреннее хранилище</string>
+    <string name="option_force_cloud_sync">Принудительная синхронизация облака</string>
+    <string name="option_browse_online_saves">Просмотреть онлайн-сохранения</string>
+    <string name="option_force_download_remote">Принудительно загрузить удалённые сохранения</string>
+    <string name="option_force_upload_local">Принудительно выгрузить локальные сохранения</string>
+    <string name="option_fetch_game_images">Загрузить изображения игры</string>
+    <string name="option_test_graphics">Проверить графику</string>
+    <string name="option_manage_dlc">Управление DLC</string>
+    <string name="option_manage_workshop">Управление Workshop</string>
     <!-- HLTB (How Long To Beat) -->
     <string name="hltb_main_story">Основной сюжет</string>
     <string name="hltb_main_plus_extras">Основное + Дополнения</string>
@@ -1464,6 +1494,8 @@ https://gamenative.app
     <string name="frontend_sync_confirm_keep">Сохранить</string>
     <string name="frontend_sync_resync_all">Повторная синхронизация всего</string>
     <string name="frontend_sync_resync_complete">Синхронизация frontend завершена</string>
+    <string name="frontend_sync_pick_directory_cd">Выбрать каталог для %1$s</string>
+    <string name="frontend_sync_clear_directory_cd">Очистить каталог для %1$s</string>
     <string name="screen_effects_scaling">Масштабирование</string>
     <string name="screen_effects_upscaling">Апскейлинг</string>
     <string name="screen_effects_basic_scaling">Базовое масштабирование</string>
@@ -1485,6 +1517,17 @@ https://gamenative.app
     <string name="screen_effects_scaling_mode_dls_desc">Повышение резкости / чёткости.</string>
     <string name="screen_effects_scaling_mode_natural">Естественный</string>
     <string name="screen_effects_scaling_mode_natural_desc">Более тёплый оттенок.</string>
+    <string name="screen_effects_fsr">FSR 1.0</string>
+    <string name="screen_effects_fsr_description">Официальный AMD FidelityFX Super Resolution 1.0 с использованием EASU + RCAS с пониженным внутренним разрешением рендеринга и апскейлингом до полного разрешения.</string>
+    <string name="screen_effects_fsr_quality">Качество FSR</string>
+    <string name="screen_effects_fsr_quality_ultra_quality">Ультра качество</string>
+    <string name="screen_effects_fsr_quality_quality">Качество</string>
+    <string name="screen_effects_fsr_quality_balanced">Сбалансированное</string>
+    <string name="screen_effects_fsr_quality_performance">Производительность</string>
+    <string name="screen_effects_fsr_sharpness">Резкость FSR</string>
+    <string name="screen_effects_fsr_sharpness_value">%1$d/5</string>
+    <string name="screen_effects_launch_sharpness">Резкость при запуске</string>
+    <string name="screen_effects_launch_sharpness_note">CAS и DLS применяются через vkBasalt и вступают в силу при следующем запуске игры.</string>
     <string name="stats_key_runs">Успешные запуски на вашем GPU</string>
     <string name="stats_key_reviews">5-звёздочные отзывы (ваш GPU / ваше устройство)</string>
     <string name="stats_key_fps">Ожидаемый FPS</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -253,6 +253,7 @@
     <string name="toggle_orientation">Перемкнути орієнтацію екрана</string>
     <string name="task_manager">Диспетчер завдань</string>
     <string name="tools_wine_processes_running_hint">%1$d запущено, торкніться/клацніть процес, щоб закрити його</string>
+    <string name="tools_wine_processes_empty">Запущених EXE не виявлено.</string>
     <string name="magnifier">Лупа</string>
     <string name="logs">Журнали</string>
     <string name="exit_game">Вийти з гри</string>
@@ -286,6 +287,7 @@
     <string name="screen_effects_live_preview">Зміни миттєво застосовуються до поточної гри.</string>
     <string name="screen_effects_color_adjustments">Налаштування кольору</string>
     <string name="screen_effects_shader_toggles">Ефекти шейдерів</string>
+    <string name="screen_effects_scaling_mode">Режим масштабування</string>
     <string name="screen_effects_brightness">Яскравість</string>
     <string name="screen_effects_contrast">Контрастність</string>
     <string name="screen_effects_gamma">Гама</string>
@@ -339,6 +341,7 @@
     <string name="performance_hud_battery_level">Рівень батареї</string>
     <string name="performance_hud_power_draw">Споживання енергії</string>
     <string name="performance_hud_runtime_left">Залишок часу</string>
+    <string name="performance_hud_battery_temperature">Температура батареї</string>
     <string name="performance_hud_clock_time">Час</string>
     <string name="performance_hud_cpu_temperature">Температура CPU</string>
     <string name="performance_hud_gpu_temperature">Температура GPU</string>
@@ -660,6 +663,8 @@
     <string name="unpack_files_description">Використовувати лише якщо з\'являється \'Application Load Error 3:0000065432\'.</string>
     <string name="force_dlc">Примусити DLC</string>
     <string name="force_dlc_description">Увімкнути лише тоді, якщо не виявлено DLC або не працюють збереження з DLC</string>
+    <string name="local_saves_only">Лише локальні збереження</string>
+    <string name="local_saves_only_description">Вимкнути синхронізацію хмарних збережень для цієї гри та зберігати збереження лише на пристрої</string>
     <string name="launch_steam_client_beta">Запустити клієнт Steam (Бета)</string>
     <string name="steam_offline_mode">Режим Офлайн Steam</string>
     <string name="steam_offline_mode_description">Запускати ігри Steam в офлайн режимі</string>
@@ -672,6 +677,7 @@
     <string name="achievement_position_bottom_left">Лівий нижній</string>
     <string name="achievement_position_bottom_right">Правий нижній</string>
     <string name="launch_steam_client_description">Зменшує продуктивність та сповільнює запуск.\nДозволяє онлайн гру, а також вирішує проблему DRM та контролеру.\nПрацює не з усіма іграми</string>
+    <string name="launch_bionic_steam">Увімкнути експериментальний Bionic Steam</string>
     <string name="allow_steam_updates">Дозволити оновлення клієнту Steam</string>
     <string name="allow_steam_updates_description">Оновлює клієнт Steam до останньої версії. Значно зменшує продуктивність.</string>
     <string name="steam_type">Версія Steam</string>
@@ -695,6 +701,7 @@
     <string name="sync_frame">Синхронізувати кожен кадр</string>
     <string name="disable_present_wait">Вимкнути KHR_present_wait</string>
     <string name="present_modes">Режими відображення</string>
+    <string name="renderer_present_modes">Режим відображення рендерера</string>
     <string name="resource_type">Тип ресурсу пам\'яті</string>
     <string name="bcn_emulation">Емуляція BCn</string>
     <string name="bcn_emulation_type">Тип емуляції BCn</string>
@@ -917,6 +924,8 @@
     <string name="settings_emulation_default_config_title">Змінити стандартну конфігурацію</string>
     <string name="settings_emulation_default_config_subtitle">Стандартні налаштування контейнера для кожної гри (не впливає на вже інстальовані ігри)</string>
     <string name="settings_emulation_default_config_dialog_title">Стандартні налаштування контейнера</string>
+    <string name="settings_emulation_auto_apply_known_config_title">Автоматично застосовувати відому конфігурацію</string>
+    <string name="settings_emulation_auto_apply_known_config_subtitle">Автоматично застосовувати рекомендовані налаштування для ігор Steam при першому запуску</string>
     <string name="settings_emulation_box64_presets_title">Box64 Пресети</string>
     <string name="settings_emulation_box64_presets_subtitle">Перегляд, зміна та створення пресетів Box64</string>
     <string name="settings_emulation_driver_manager_title">Менеджер драйвера</string>
@@ -1052,6 +1061,8 @@
     <string name="library_need_internet">Потрібне інтернет-з\'єднання для інсталяції</string>
     <string name="library_wifi_only_enabled">Увімкнено інсталяцію лише через Wi-Fi/LAN</string>
     <string name="library_file_count">Файл %1$d з %2$d</string>
+    <string name="download_no_wifi">Немає підключення до Wi-Fi/LAN</string>
+    <string name="download_paused_wifi">Завантаження призупинено – очікування Wi-Fi/LAN</string>
 
     <!-- PluviaMain: Update & App Info -->
     <string name="main_update_available_title">Доступне оновлення</string>
@@ -1074,6 +1085,7 @@
     <string name="main_discord_support_title">Чи працювала гра?</string>
     <string name="main_discord_support_message">Долучайтесь до нашого Discord, щоб отримати підтримку у виправленні чи покращенні роботи ігор.</string>
     <string name="main_open_discord">Відкрити Discord</string>
+    <string name="main_downloading_entry">Завантаження %s</string>
 
     <!-- PluviaMain: Game Launch -->
     <string name="main_downloading_steam">Завантаження Steam...</string>
@@ -1441,6 +1453,15 @@
     <string name="workshop_processing">Обробка модів…</string>
     <string name="workshop_failed_count">Не вдалося оновити %1$d мод(ів) Майстерні</string>
     <string name="workshop_download_failed">Помилка завантаження</string>
+    <string name="option_open_store_page">Відкрити сторінку магазину</string>
+    <string name="option_export_for_frontend">Експортувати для frontend</string>
+    <string name="option_open_container">Відкрити контейнер</string>
+    <string name="option_edit_container">Редагувати контейнер</string>
+    <string name="option_reset_to_defaults">Скинути контейнер</string>
+    <string name="option_get_support">Отримати підтримку</string>
+    <string name="option_submit_feedback">Надіслати відгук</string>
+    <string name="option_reset_drm">Скинути DRM</string>
+    <string name="option_use_known_config">Використати відому конфігурацію</string>
 
     <!-- Recommendations -->
     <string name="recommended_badge">Рекомендовано</string>
@@ -1463,6 +1484,18 @@
      <string name="steam_save_import_failed">Не вдалося імпортувати збереження: %s</string>
     <string name="option_import_saves">Імпортувати збереження</string>
     <string name="option_export_saves">Експортувати збереження</string>
+    <string name="option_verify_files">Перевірити файли</string>
+    <string name="option_update">Оновити</string>
+    <string name="option_move_to_external_storage">Перемістити на зовнішнє сховище</string>
+    <string name="option_move_to_internal_storage">Перемістити на внутрішнє сховище</string>
+    <string name="option_force_cloud_sync">Примусова синхронізація з хмарою</string>
+    <string name="option_browse_online_saves">Переглянути онлайн-збереження</string>
+    <string name="option_force_download_remote">Примусово завантажити віддалені збереження</string>
+    <string name="option_force_upload_local">Примусово вивантажити локальні збереження</string>
+    <string name="option_fetch_game_images">Отримати зображення гри</string>
+    <string name="option_test_graphics">Перевірити графіку</string>
+    <string name="option_manage_dlc">Керувати DLC</string>
+    <string name="option_manage_workshop">Керувати Workshop</string>
     <!-- HLTB (How Long To Beat) -->
     <string name="hltb_main_story">Основний сюжет</string>
     <string name="hltb_main_plus_extras">Основне + Доповнення</string>
@@ -1529,6 +1562,8 @@
     <string name="frontend_sync_confirm_keep">Зберегти</string>
     <string name="frontend_sync_resync_all">Повторна синхронізація всього</string>
     <string name="frontend_sync_resync_complete">Синхронізація frontend завершена</string>
+    <string name="frontend_sync_pick_directory_cd">Вибрати каталог для %1$s</string>
+    <string name="frontend_sync_clear_directory_cd">Очистити каталог для %1$s</string>
     <string name="screen_effects_scaling">Масштабування</string>
     <string name="screen_effects_upscaling">Апскейлінг</string>
     <string name="screen_effects_basic_scaling">Базове масштабування</string>
@@ -1550,6 +1585,17 @@
     <string name="screen_effects_scaling_mode_dls_desc">Прохід різкості / чіткості.</string>
     <string name="screen_effects_scaling_mode_natural">Природний</string>
     <string name="screen_effects_scaling_mode_natural_desc">Тепліший відтінок.</string>
+    <string name="screen_effects_fsr">FSR 1.0</string>
+    <string name="screen_effects_fsr_description">Офіційний AMD FidelityFX Super Resolution 1.0 з використанням EASU + RCAS зі зниженою внутрішньою роздільністю рендерингу та апскейлом до повної роздільності.</string>
+    <string name="screen_effects_fsr_quality">Якість FSR</string>
+    <string name="screen_effects_fsr_quality_ultra_quality">Ультраякість</string>
+    <string name="screen_effects_fsr_quality_quality">Якість</string>
+    <string name="screen_effects_fsr_quality_balanced">Збалансовано</string>
+    <string name="screen_effects_fsr_quality_performance">Продуктивність</string>
+    <string name="screen_effects_fsr_sharpness">Чіткість FSR</string>
+    <string name="screen_effects_fsr_sharpness_value">%1$d/5</string>
+    <string name="screen_effects_launch_sharpness">Чіткість при запуску</string>
+    <string name="screen_effects_launch_sharpness_note">CAS і DLS застосовуються через vkBasalt і набувають чинності при наступному запуску гри.</string>
     <string name="stats_key_runs">Успішні запуски на вашому GPU</string>
     <string name="stats_key_reviews">5-зіркові відгуки (ваш GPU / ваш пристрій)</string>
     <string name="stats_key_fps">Очікуваний FPS</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -668,6 +668,7 @@
     <string name="achievement_position_bottom_left">左下</string>
     <string name="achievement_position_bottom_right">右下</string>
     <string name="launch_steam_client_description">降低性能并减慢启动速度\n允许在线游玩并修复 DRM 和控制器问题\n并非所有游戏都适用</string>
+    <string name="launch_bionic_steam">启用实验性 Bionic Steam</string>
     <string name="allow_steam_updates">允许 Steam 更新</string>
     <string name="allow_steam_updates_description">将 Steam 更新至最新版本，会显著降低性能</string>
     <string name="steam_type">Steam 类型</string>
@@ -690,6 +691,7 @@
     <string name="sync_frame">同步每帧图像</string>
     <string name="disable_present_wait">禁用 KHR_present_wait</string>
     <string name="present_modes">呈现模式</string>
+    <string name="renderer_present_modes">渲染器呈现模式</string>
     <string name="resource_type">内存资源类型</string>
     <string name="bcn_emulation">BCn 模拟</string>
     <string name="bcn_emulation_type">BCn 模拟类型</string>
@@ -1616,6 +1618,8 @@
     <string name="frontend_sync_confirm_keep">保留</string>
     <string name="frontend_sync_resync_all">重新同步全部</string>
     <string name="frontend_sync_resync_complete">前端同步完成</string>
+    <string name="frontend_sync_pick_directory_cd">为 %1$s 选择目录</string>
+    <string name="frontend_sync_clear_directory_cd">为 %1$s 清除目录</string>
     <string name="stats_key_runs">在您的GPU上成功运行的次数</string>
     <string name="stats_key_reviews">五星好评（您的GPU / 您的设备）</string>
     <string name="stats_key_fps">预计FPS</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -670,6 +670,7 @@
     <string name="achievement_position_bottom_left">左下</string>
     <string name="achievement_position_bottom_right">右下</string>
     <string name="launch_steam_client_description">降低效能並減慢啟動速度\n允許線上遊玩並修復 DRM 和控制器問題\n並非所有遊戲都適用</string>
+    <string name="launch_bionic_steam">啟用實驗性 Bionic Steam</string>
     <string name="allow_steam_updates">允許 Steam 更新</string>
     <string name="allow_steam_updates_description">將 Steam 更新至最新版本, 會顯著降低效能</string>
     <string name="steam_type">Steam 類型</string>
@@ -692,6 +693,7 @@
     <string name="sync_frame">同步每幀影像</string>
     <string name="disable_present_wait">停用 KHR_present_wait</string>
     <string name="present_modes">當前模式</string>
+    <string name="renderer_present_modes">算繪器呈現模式</string>
     <string name="resource_type">記憶體資源類型</string>
     <string name="bcn_emulation">BCn 模擬</string>
     <string name="bcn_emulation_type">BCn 模擬類型</string>
@@ -1607,6 +1609,8 @@
     <string name="frontend_sync_confirm_keep">保留</string>
     <string name="frontend_sync_resync_all">重新同步全部</string>
     <string name="frontend_sync_resync_complete">前端同步完成</string>
+    <string name="frontend_sync_pick_directory_cd">為 %1$s 選擇目錄</string>
+    <string name="frontend_sync_clear_directory_cd">清除 %1$s 的目錄</string>
     <string name="stats_key_runs">在您的GPU上成功執行的次數</string>
     <string name="stats_key_reviews">五星評論（您的GPU / 您的裝置）</string>
     <string name="stats_key_fps">預計FPS</string>


### PR DESCRIPTION
## Description
<!-- What changed and why? -->
A handful of string keys only existed in the English `strings.xml` and were missing from the translated files, so those parts of the UI showed up in English for everyone else. This just fills in the gaps.

I went through each locale that was behind and added the missing keys: `da`, `de`, `es`, `fr`, `it`, `ja`, `pl`, `pt-rBR`, `ro`, `ru`, `uk`, `zh-rCN` and `zh-rTW` (`ko` was already complete). Each new string sits in the same section as it does in the other locale files so things stay consistent, the format placeholders (`%s`, `%1$d` and friends) are left alone, and product names like FSR, vkBasalt, Steam and DLC are kept as-is.

It's additions only: no code changes, the base English file is untouched, and nothing existing was overwritten. I also double-checked that every file still parses as valid XML.

## Recording
<!-- Attach a short recording/GIF showing the change -->
Not much to show here since it's only new translation entries, with no new screens or behaviour. The affected text just renders in the device language now instead of falling back to English.

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized text for new UI options across the app, including Steam/container settings, download status states, frontend sync actions, and game management actions.
  * Added new screen effects options, including FSR 1.0 quality and sharpness controls, plus related launch notes.
  * Added labels for renderer presentation modes, battery temperature in the performance HUD, and custom container resolution settings.
  * Added new save behavior text for local-only saves and experimental Bionic Steam.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->