### PR TITLE
Created FramPacingLogger.java for debugging

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -418,6 +418,9 @@ fun XServerScreen(
             exitWatchJob?.cancel()
             exitWatchJob = null
             keyboardEscMenuHandler.cancel()
+            // [FramePacingLogger] Game session is ending — stop the reporter and wipe
+            // the session so the next game (re)populates fresh context lines on launch.
+            com.winlator.renderer.FramePacingLogger.setEnabled(false)
         }
     }
     var isKeyboardVisible = false
@@ -554,6 +557,8 @@ fun XServerScreen(
         xServerView?.getxServer()
             ?.getExtension<PresentExtension>(PresentExtension.MAJOR_OPCODE.toInt())
             ?.setFrameRateLimit(limit)
+        // [FramePacingLogger] Mirror the QuickMenu FPS-limiter state into the report.
+        com.winlator.renderer.FramePacingLogger.updateFpsLimiterState(fpsLimiterEnabled, fpsLimiterTarget)
     }
 
     fun effectiveFpsLimit(): Int =
@@ -3397,6 +3402,66 @@ private fun setupXEnvironment(
         Timber.i("Env Vars (Final Guest): ${envVars.toString()}")   // Log the actual env vars being passed
         Timber.i("Guest Executable: ${guestProgramLauncherComponent.guestExecutable}") // Log the command
         Timber.i("---------------------------")
+
+        // [FramePacingLogger] Per-game opt-in: GN_FRAME_LOG=1 in the container's
+        // Environment Variables. ALWAYS re-apply the enable state — a new game launched
+        // in the same process without the flag must disable the previous game's report
+        // (otherwise it keeps logging the prior game's name/exe/limits).
+        val frameLogEnabled = envVars.get("GN_FRAME_LOG") == "1"
+        com.winlator.renderer.FramePacingLogger.setEnabled(frameLogEnabled)
+        if (frameLogEnabled) {
+            com.winlator.renderer.FramePacingLogger.notifyLaunch(
+                envVars.get("DXVK_FRAME_RATE"),
+                envVars.get("VKD3D_FRAME_RATE"),
+                envVars.get("MANGOHUD_CONFIG"),
+            )
+            try {
+                val dxConfig = DXVKHelper.parseConfig(container.dxWrapperConfig)
+                // Only report the wrapper that is actually selected: the dxvk bundle always
+                // carries a vkd3dVersion in its config, but VKD3D is only used when the
+                // wrapper type is vkd3d (D3D12). Gate each version on the wrapper type.
+                val dxWrapper = container.dxWrapper
+                val dxvkVer = if (dxWrapper.contains("dxvk", true)) dxConfig.get("version", "") else ""
+                val vkd3dVer = if (dxWrapper.contains("vkd3d", true)) dxConfig.get("vkd3dVersion", "") else ""
+                // Concrete driver: the graphics-driver config "version" holds the real driver
+                // build (e.g. the adrenotools Turnip build); graphicsDriver is the wrapper layer.
+                val gdConfig = KeyValueSet(container.getGraphicsDriverConfig())
+                val driverVer = gdConfig.get("version", "").ifEmpty { container.graphicsDriverVersion }
+                // Low-cost: reuse already-loaded Steam app info / launch info (no extra I/O).
+                // Exe: container.executablePath is set for ALL sources (Steam/GOG/Epic/…);
+                // fall back to the Steam LaunchInfo. Show just the basename (e.g. Dishonored.exe).
+                val rawExe = container.executablePath.takeIf { it.isNotBlank() }
+                    ?: appLaunchInfo?.executable
+                val gameExe = rawExe
+                    ?.substringAfterLast('/')?.substringAfterLast('\\')
+                    ?.takeIf { it.isNotEmpty() } ?: "UNKNOWN"
+                // Name: source-aware resolver covers Steam/GOG/Epic/Amazon/Custom; then
+                // container name → exe basename (strip .exe) → UNKNOWN.
+                val resolvedName = ContainerUtils.resolveGameName(appId)
+                val gameName = resolvedName.takeIf { it.isNotEmpty() && !it.equals("Unknown", true) }
+                    ?: container.name.takeIf { it.isNotEmpty() }
+                    ?: gameExe.substringBeforeLast('.').takeIf { it.isNotEmpty() && it != "UNKNOWN" }
+                    ?: "UNKNOWN"
+                com.winlator.renderer.FramePacingLogger.notifyDeviceInfo(
+                    gameName,                                // game name (Steam name → container name)
+                    gameExe,                                 // launch executable (may differ from name)
+                    "${Build.MANUFACTURER} ${Build.MODEL}",  // device
+                    GPUInformation.getRenderer(context),     // GPU renderer string
+                    dxWrapper,                               // active DX wrapper type
+                    dxvkVer,                                 // DXVK version (blank if wrapper != dxvk)
+                    vkd3dVer,                                // VKD3D version (blank if wrapper != vkd3d)
+                    container.graphicsDriver,                // graphics driver / wrapper layer
+                    driverVer,                               // concrete driver build/version
+                )
+                // [FramePacingLogger] Panel info for the live vs max refresh / judder line.
+                val frameLogDisplay = ContextCompat.getSystemService(context, DisplayManager::class.java)
+                    ?.getDisplay(Display.DEFAULT_DISPLAY)
+                com.winlator.renderer.FramePacingLogger.notifyDisplayInfo(frameLogDisplay)
+            } catch (e: Exception) {
+                Timber.w(e, "[FramePacingLogger] Failed to report device info")
+            }
+            Timber.i("[FramePacingLogger] enabled via GN_FRAME_LOG=1")
+        }
     }
 
     // Request encrypted app ticket for Steam games at launch time

--- a/app/src/main/java/com/winlator/renderer/ASurfaceRenderer.java
+++ b/app/src/main/java/com/winlator/renderer/ASurfaceRenderer.java
@@ -454,6 +454,7 @@ public class ASurfaceRenderer implements WindowManager.OnWindowModificationListe
 
                     nativeSetWindowBuffer(windowId, ahbPtr, fence, 0, 0);
                     if (hudRef != null) hudRef.update();
+                    FramePacingLogger.recordSurfaceFlingerPresent(false); // [FramePacingLogger] SurfaceFlinger present (CPU/AHB path)
 
                     if (isFallback) {
                         g.lock();
@@ -477,6 +478,7 @@ public class ASurfaceRenderer implements WindowManager.OnWindowModificationListe
                 if (ahbPtr != 0) {
                     nativeSetWindowBuffer(windowId, ahbPtr, -1, windowId, xSerial);
                     if (hudRef != null) hudRef.update();
+                    FramePacingLogger.recordSurfaceFlingerPresent(true); // [FramePacingLogger] SurfaceFlinger present (GPU/AHB path)
                 }
             }
         }

--- a/app/src/main/java/com/winlator/renderer/FramePacingLogger.java
+++ b/app/src/main/java/com/winlator/renderer/FramePacingLogger.java
@@ -1,0 +1,501 @@
+package com.winlator.renderer;
+
+import android.util.Log;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Global FPS diagnostics: counts frames from every presentation path and
+ * reports to logcat every 10 seconds. Use GN_FRAME_LOG = 1
+ *
+ * Upstream splits compositing into THREE renderers; each has a hook below:
+ *  - GLRenderer          (OpenGL / VirGL passthrough) → recordGLDrawFrame()
+ *  - VulkanRenderer      (Vulkan compositor + zero-copy scanout) → recordVkUpdate()/recordVkContent*()
+ *  - ASurfaceRenderer    (SurfaceFlinger direct scanout) → recordSurfaceFlingerPresent()
+ *
+ * Cross-cutting frame producers / pacers also reported:
+ *  - X Present protocol  (PresentExtension.presentPixmap) — back-pressure paced; recordXPresent()
+ *  - Vortek native       (VortekRendererComponent) — native Vulkan source; recordVortekPresent()
+ *
+ * NOTE FOR MAINTAINERS: every call to a record/update method below is the
+ * ONLY footprint this logger has in the renderer code. Search "[FramePacingLogger]"
+ * to find every anchor. Removing an anchor just drops that path from the report.
+ */
+public final class FramePacingLogger {
+    private static final String TAG = "FramePacing";
+    private static final long REPORT_INTERVAL_MS = 10_000L; // 10 seconds
+    // Hold off the very first report so it doesn't spam logcat while the game is
+    // still opening (heavy I/O). First report lands ~INITIAL_DELAY + INTERVAL after launch.
+    private static final long INITIAL_DELAY_MS = 10_000L; // 10 seconds
+
+    // ── Per-path frame counters ──────────────────────────────────────────────
+    private static final AtomicInteger cntXPresent        = new AtomicInteger(0);
+    private static final AtomicInteger cntXPresentScanout = new AtomicInteger(0);
+    private static final AtomicInteger cntXPresentCopy    = new AtomicInteger(0);
+    private static final AtomicInteger cntVkAHB           = new AtomicInteger(0);
+    private static final AtomicInteger cntVkScanout       = new AtomicInteger(0);
+    private static final AtomicInteger cntVkPixels        = new AtomicInteger(0);
+    private static final AtomicInteger cntGLDraw          = new AtomicInteger(0);
+    private static final AtomicInteger cntVkSkipped       = new AtomicInteger(0);
+    private static final AtomicInteger cntGLSkipped       = new AtomicInteger(0);
+    private static final AtomicInteger cntVortek          = new AtomicInteger(0);
+    private static final AtomicInteger cntVkUpdate        = new AtomicInteger(0);
+    // SurfaceFlinger (ASurfaceRenderer) — the 3rd renderer; SurfaceControl scanout submissions.
+    private static final AtomicInteger cntSfGpu           = new AtomicInteger(0);
+    private static final AtomicInteger cntSfCpu           = new AtomicInteger(0);
+
+    // ── Limit state (updated by each subsystem) ──────────────────────────────
+    private static volatile int  presentExtLimit   = 0;   // 0 = unlimited
+    private static volatile int  vkScanoutHint     = 0;   // SurfaceControl rate hint; 0 = cleared
+    private static volatile boolean limiterEnabled = false;
+    private static volatile int  limiterTarget     = 0;
+
+    // ── Launch-time env-var state (set when the Wine process is spawned) ─────
+    private static volatile String launchDxvkFrameRate   = "NOT SET";
+    private static volatile String launchVkd3dFrameLimit = "NOT SET";
+    private static volatile String launchMangoHudConfig  = "NOT SET";
+
+    // ── Session/device identification (set at launch) ───────────────────────
+    private static volatile String sessionGameName    = "UNKNOWN";
+    private static volatile String sessionGameExe     = "UNKNOWN";
+    private static volatile String sessionDevice      = "UNKNOWN";
+    private static volatile String sessionGpu         = "UNKNOWN";
+    private static volatile String sessionDxWrapper   = "UNKNOWN";
+    private static volatile String sessionDxvkVersion = "NOT SET";
+    private static volatile String sessionVkd3dVersion = "NOT SET";
+    private static volatile String sessionDriver      = "UNKNOWN";
+    private static volatile String sessionDriverVersion = "UNKNOWN";
+
+    // Display panel. We hold the system Display so each report can read the LIVE
+    // refresh rate — Display.getRefreshRate() is a cached field read (not a probe),
+    // so it is effectively free. maxRefreshHz is computed once at launch.
+    private static volatile android.view.Display sessionDisplay = null;
+    private static volatile float displayMaxRefreshHz = 0f;
+
+    // Authoritative on-screen FPS as measured by FrameRating (the value the
+    // Performance HUD shows and which matches the device's own fps counter). This
+    // is the real present rate of the topmost window, not a renderer submission count.
+    private static volatile float measuredFps    = 0f;
+    private static volatile float measuredAvgFps = 0f;
+
+    // ── Background reporter ──────────────────────────────────────────────────
+    private static volatile Thread sReportThread = null;
+    private static volatile boolean reporterStarted = false;
+
+    // ── Enable flag — off by default; set via GN_FRAME_LOG=1 env var ────────
+    private static volatile boolean enabled = false;
+
+    private FramePacingLogger() {}
+
+    /**
+     * Enable or disable the frame pacing logger.
+     * When disabled the reporter thread is stopped and all record/log calls
+     * become no-ops. Called from XServerScreen when GN_FRAME_LOG=1 is set.
+     */
+    public static synchronized void setEnabled(boolean enable) {
+        enabled = enable;
+        if (!enable) {
+            // Disabling (e.g. a new game launched without GN_FRAME_LOG) must stop the
+            // reporter AND wipe the previous game's session so nothing stale lingers.
+            stopReporter();
+            resetSession();
+        }
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    // Self-starting: any record* call spins up the 10 s reporter if not already
+    // running, so we get data even without an explicit notifyLaunch() hook.
+    private static void maybeStartReporter() {
+        if (!enabled) return;
+        if (reporterStarted) return;
+        ensureReporterRunning();
+    }
+
+    /** Call once when the game process is about to be launched. */
+    public static synchronized void notifyLaunch(
+            String dxvkFrameRate, String vkd3dFrameLimit, String mangoHudConfig) {
+        if (!enabled) return;
+        // Fresh launch: clear any leftover session/counters from a previous game that
+        // ran in this same process, then record this game's launch-time env vars.
+        resetSession();
+        launchDxvkFrameRate   = dxvkFrameRate  != null && !dxvkFrameRate.isEmpty()
+                                ? dxvkFrameRate   : "NOT SET";
+        launchVkd3dFrameLimit = vkd3dFrameLimit != null && !vkd3dFrameLimit.isEmpty()
+                                ? vkd3dFrameLimit : "NOT SET";
+        launchMangoHudConfig  = mangoHudConfig  != null && !mangoHudConfig.isEmpty()
+                                ? mangoHudConfig  : "NOT SET";
+        ensureReporterRunning();
+        Log.i(TAG, "FramePacingLogger: game launching — DXVK_FRAME_RATE=" + launchDxvkFrameRate
+                + "  VKD3D_FRAME_LIMIT=" + launchVkd3dFrameLimit
+                + "  MANGOHUD_CONFIG=" + launchMangoHudConfig);
+    }
+
+    /**
+     * Record the session / device identification for the current run.
+     * Logged on launch and repeated at the top of every periodic report so the
+     * captured logcat is self-describing.
+     *
+     * @param gameName     human-readable game / container name
+     * @param gameExe      launch executable name (may differ from the game name)
+     * @param device       device manufacturer + model
+     * @param gpu          GPU renderer string
+     * @param dxWrapper    active DX wrapper type (dxvk / vkd3d / wined3d …)
+     * @param dxvkVersion  active DXVK version (empty when the wrapper is not DXVK)
+     * @param vkd3dVersion active VKD3D version (empty when the wrapper is not VKD3D)
+     * @param driver       graphics driver / wrapper layer name
+     * @param driverVersion concrete driver version (e.g. the adrenotools driver build)
+     */
+    public static synchronized void notifyDeviceInfo(
+            String gameName, String gameExe, String device, String gpu,
+            String dxWrapper, String dxvkVersion, String vkd3dVersion,
+            String driver, String driverVersion) {
+        if (!enabled) return;
+        sessionGameName    = orDefault(gameName,    "UNKNOWN");
+        sessionGameExe     = orDefault(gameExe,     "UNKNOWN");
+        sessionDevice      = orDefault(device,      "UNKNOWN");
+        sessionGpu         = orDefault(gpu,         "UNKNOWN");
+        sessionDxWrapper   = orDefault(dxWrapper,   "UNKNOWN");
+        sessionDxvkVersion = orDefault(dxvkVersion, "not used");
+        sessionVkd3dVersion = orDefault(vkd3dVersion, "not used");
+        sessionDriver      = orDefault(driver,      "UNKNOWN");
+        sessionDriverVersion = orDefault(driverVersion, "UNKNOWN");
+        Log.i(TAG, "Game: " + sessionGameName + "  |  Exe: " + sessionGameExe
+                + "  |  Device: " + sessionDevice + "  |  GPU: " + sessionGpu);
+        Log.i(TAG, "Wrapper: " + sessionDxWrapper + "  |  DXVK: " + sessionDxvkVersion
+                + "  |  VKD3D: " + sessionVkd3dVersion + "  |  Driver: " + sessionDriver
+                + "  |  Driver ver: " + sessionDriverVersion);
+    }
+
+    private static String orDefault(String value, String fallback) {
+        return value != null && !value.isEmpty() ? value : fallback;
+    }
+
+    /**
+     * Record the display panel for the current session so the report can show the
+     * live vs. max refresh rate (useful for judder diagnosis: a present rate that
+     * doesn't evenly divide the panel Hz produces uneven frame pacing).
+     * Held as a reference so each report reads getRefreshRate() live (free read).
+     */
+    public static synchronized void notifyDisplayInfo(android.view.Display display) {
+        if (!enabled) return;
+        sessionDisplay = display;
+        float maxHz = 0f;
+        if (display != null) {
+            try {
+                for (android.view.Display.Mode m : display.getSupportedModes()) {
+                    if (m.getRefreshRate() > maxHz) maxHz = m.getRefreshRate();
+                }
+                if (maxHz <= 0f) maxHz = display.getRefreshRate();
+            } catch (Throwable ignored) { /* keep 0 = unknown */ }
+        }
+        displayMaxRefreshHz = maxHz;
+    }
+
+    /**
+     * Called by FrameRating each reading with the authoritative on-screen FPS the
+     * Performance HUD displays (smoothed present rate of the topmost app window).
+     * This is the number the user sees in the HUD / device counter — show it so the
+     * report can be cross-checked against the renderer submission counts.
+     */
+    public static void updateMeasuredFps(float currentFps, float avgFps) {
+        measuredFps    = currentFps;
+        measuredAvgFps = avgFps;
+    }
+
+    // ── Frame recording API ──────────────────────────────────────────────────
+
+    /**
+     * Called by PresentExtension for each PRESENT_PIXMAP request handled.
+     * @param isScanout true when routed to the zero-copy scanout path
+     * @param isCopy    true when content is blitted into the compositor
+     */
+    public static void recordXPresent(boolean isScanout, boolean isCopy) {
+        maybeStartReporter();
+        cntXPresent.incrementAndGet();
+        if (isScanout) cntXPresentScanout.incrementAndGet();
+        else if (isCopy) cntXPresentCopy.incrementAndGet();
+    }
+
+    /** Called by VortekRendererComponent each time a Vortek-rendered frame is
+     *  pushed to the window (native Vulkan present that bypasses X Present). */
+    public static void recordVortekPresent() {
+        maybeStartReporter();
+        cntVortek.incrementAndGet();
+    }
+
+    /**
+     * Called by ASurfaceRenderer for each SurfaceControl buffer submission —
+     * this is the 3rd renderer (SurfaceFlinger direct scanout).
+     * @param isGpu true = GPU/AHB image path; false = CPU/AHB fallback path
+     */
+    public static void recordSurfaceFlingerPresent(boolean isGpu) {
+        maybeStartReporter();
+        if (isGpu) cntSfGpu.incrementAndGet();
+        else       cntSfCpu.incrementAndGet();
+    }
+
+    /**
+     * Called by VulkanRenderer.onUpdateWindowContent — the COMMON compositor sink
+     * for every source (X Present, Vortek forceUpdate, etc.). Comparing this rate
+     * against recordXPresent tells us whether frames originate from X Present.
+     */
+    public static void recordVkUpdate() {
+        maybeStartReporter();
+        cntVkUpdate.incrementAndGet();
+    }
+
+    /**
+     * Called by VulkanRenderer for each direct AHB content update.
+     * @param isScanout true if the buffer is routed to the zero-copy scanout surface
+     */
+    public static void recordVkContentAHB(boolean isScanout) {
+        maybeStartReporter();
+        if (isScanout) cntVkScanout.incrementAndGet();
+        else           cntVkAHB.incrementAndGet();
+    }
+
+    /** Called by VulkanRenderer for each pixel/software-blit content update. */
+    public static void recordVkContentPixels() {
+        maybeStartReporter();
+        cntVkPixels.incrementAndGet();
+    }
+
+    /** Called by VulkanRenderer when a content update is skipped by the runtime FPS limiter. */
+    public static void recordVkContentSkipped() {
+        cntVkSkipped.incrementAndGet();
+    }
+
+    /** Called by GLRenderer.onDrawFrame() on every EGL swap. */
+    public static void recordGLDrawFrame() {
+        maybeStartReporter();
+        cntGLDraw.incrementAndGet();
+    }
+
+    /** Called by GLRenderer when a render request is skipped by the runtime FPS limiter. */
+    public static void recordGLDrawSkipped() {
+        cntGLSkipped.incrementAndGet();
+    }
+
+    // ── Limit-state update API ───────────────────────────────────────────────
+
+    /** Updated by PresentExtension whenever setFrameRateLimit is called. */
+    public static void updatePresentExtLimit(int limit) {
+        presentExtLimit = limit;
+        if (!enabled) return;
+        Log.d(TAG, "PresentExtension frame limit → " + (limit > 0 ? limit + " fps" : "UNLIMITED"));
+    }
+
+    /**
+     * Updated by VulkanRenderer whenever a SurfaceControl rate hint is applied.
+     * @param hint 0 = hint cleared (no pinning), >0 = hint fps value
+     */
+    public static void updateVkScanoutHint(int hint) {
+        vkScanoutHint = hint;
+        if (!enabled) return;
+        Log.d(TAG, "VulkanRenderer SurfaceControl hint → "
+                + (hint > 0 ? hint + " fps" : "cleared (no pinning)"));
+    }
+
+    /**
+     * Updated by XServerScreen whenever the quick-menu fps limiter state changes.
+     */
+    public static void updateFpsLimiterState(boolean enabled2, int target) {
+        limiterEnabled = enabled2;
+        limiterTarget  = target;
+        if (!enabled) return;
+        Log.d(TAG, "QuickMenu FPS limiter → " + (enabled2 ? "ON @ " + target + " fps" : "OFF (unlimited)"));
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    private static void resetCounters() {
+        cntXPresent.set(0); cntXPresentScanout.set(0); cntXPresentCopy.set(0);
+        cntVkAHB.set(0);    cntVkScanout.set(0);        cntVkPixels.set(0);
+        cntGLDraw.set(0);
+        cntVkSkipped.set(0); cntGLSkipped.set(0);
+        cntVortek.set(0);    cntVkUpdate.set(0);
+        cntSfGpu.set(0);     cntSfCpu.set(0);
+    }
+
+    // Wipe ALL per-game state so a new launch (or a disable) never carries the
+    // previous game's identity, limits or counters over within the same process.
+    private static void resetSession() {
+        sessionGameName    = "UNKNOWN";
+        sessionGameExe     = "UNKNOWN";
+        sessionDevice      = "UNKNOWN";
+        sessionGpu         = "UNKNOWN";
+        sessionDxWrapper   = "UNKNOWN";
+        sessionDxvkVersion = "NOT SET";
+        sessionVkd3dVersion = "NOT SET";
+        sessionDriver      = "UNKNOWN";
+        sessionDriverVersion = "UNKNOWN";
+        sessionDisplay      = null;
+        displayMaxRefreshHz = 0f;
+        measuredFps         = 0f;
+        measuredAvgFps      = 0f;
+        launchDxvkFrameRate   = "NOT SET";
+        launchVkd3dFrameLimit = "NOT SET";
+        launchMangoHudConfig  = "NOT SET";
+        presentExtLimit = 0;
+        vkScanoutHint   = 0;
+        limiterEnabled  = false;
+        limiterTarget   = 0;
+        resetCounters();
+    }
+
+    private static synchronized void stopReporter() {
+        if (sReportThread != null) {
+            sReportThread.interrupt();
+            sReportThread = null;
+        }
+        reporterStarted = false;
+    }
+
+    private static synchronized void ensureReporterRunning() {
+        if (sReportThread != null && sReportThread.isAlive()) return;
+        reporterStarted = true;
+        sReportThread = new Thread(() -> {
+            // Quiet startup window: wait out the busy loading phase, then reset so the
+            // first reported 10 s window is an accurate sample (not the startup burst).
+            try { Thread.sleep(INITIAL_DELAY_MS); }
+            catch (InterruptedException e) { return; }
+            resetCounters();
+            while (!Thread.interrupted()) {
+                try { Thread.sleep(REPORT_INTERVAL_MS); }
+                catch (InterruptedException e) { break; }
+                report();
+            }
+        }, "FramePacingLogger");
+        sReportThread.setDaemon(true);
+        sReportThread.setPriority(Thread.MIN_PRIORITY);
+        sReportThread.start();
+    }
+
+    private static void report() {
+        if (!enabled) return;
+        // Snap and reset counters atomically-per-counter
+        int xPresent   = cntXPresent.getAndSet(0);
+        int xScanout   = cntXPresentScanout.getAndSet(0);
+        int xCopy      = cntXPresentCopy.getAndSet(0);
+        int vkAHB      = cntVkAHB.getAndSet(0);
+        int vkScanout  = cntVkScanout.getAndSet(0);
+        int vkPixels   = cntVkPixels.getAndSet(0);
+        int glDraw     = cntGLDraw.getAndSet(0);
+        int vkSkipped  = cntVkSkipped.getAndSet(0);
+        int glSkipped  = cntGLSkipped.getAndSet(0);
+        int vortek     = cntVortek.getAndSet(0);
+        int vkUpdate   = cntVkUpdate.getAndSet(0);
+        int sfGpu      = cntSfGpu.getAndSet(0);
+        int sfCpu      = cntSfCpu.getAndSet(0);
+
+        float sec = REPORT_INTERVAL_MS / 1000f;
+
+        // Live panel refresh (cached field read — effectively free).
+        float curHz = 0f;
+        android.view.Display d = sessionDisplay;
+        if (d != null) { try { curHz = d.getRefreshRate(); } catch (Throwable ignored) {} }
+
+        Log.i(TAG, "══════════ FRAME PACING REPORT (last 10 s) ══════════");
+        Log.i(TAG, "  Game: " + sessionGameName + "  |  Exe: " + sessionGameExe
+                + "  |  Device: " + sessionDevice + "  |  GPU: " + sessionGpu);
+        Log.i(TAG, "  Wrapper: " + sessionDxWrapper + "  |  DXVK: " + sessionDxvkVersion
+                + "  |  VKD3D: " + sessionVkd3dVersion + "  |  Driver: " + sessionDriver
+                + "  |  Driver ver: " + sessionDriverVersion);
+        Log.i(TAG, String.format(
+                "  [X Present protocol]  %.1f fps  | total=%d  scanout=%d  copy=%d",
+                xPresent / sec, xPresent, xScanout, xCopy));
+        Log.i(TAG, String.format(
+                "    └─ back-pressure paced by PresentExtension (idle-notify delay = %s)",
+                presentExtLimit > 0 ? presentExtLimit + " fps target" : "UNLIMITED – no delay"));
+        Log.i(TAG, String.format(
+                "  [Vortek native]       %.1f fps  | %d frames  (native Vulkan present, bypasses X Present)",
+                vortek / sec, vortek));
+        Log.i(TAG, String.format(
+                "  [Vk compositor sink]  %.1f fps  | %d onUpdateWindowContent calls (ALL sources)",
+                vkUpdate / sec, vkUpdate));
+        Log.i(TAG, String.format(
+                "  [VkRenderer AHB]      %.1f fps  | %d frames  (non-scanout compositor path)",
+                vkAHB / sec, vkAHB));
+        Log.i(TAG, String.format(
+                "  [VkRenderer Scanout]  %.1f fps  | %d frames  (zero-copy SurfaceControl path)",
+                vkScanout / sec, vkScanout));
+        Log.i(TAG, String.format(
+            "  [VkRenderer Pixels]   %.1f fps  | %d frames  (software pixel blit)",
+            vkPixels / sec, vkPixels));
+        Log.i(TAG, String.format(
+            "  [SurfaceFlinger ASR]  %.1f fps  | gpu=%d cpu=%d  (SurfaceControl direct scanout)",
+            (sfGpu + sfCpu) / sec, sfGpu, sfCpu));
+        Log.i(TAG, String.format(
+            "  [GL Renderer draws]   %.1f fps  | %d frames  (EGL onDrawFrame)",
+            glDraw / sec, glDraw));
+        Log.i(TAG, String.format(
+                "  [HUD measured FPS]    %.1f fps now  | %.1f fps avg  (FrameRating: on-screen present of topmost window — matches HUD)",
+                measuredFps, measuredAvgFps));
+        Log.i(TAG, String.format(
+                "  [Limiter skipped]     Vk=%d  GL=%d  (updates intentionally not submitted)",
+                vkSkipped, glSkipped));
+        Log.i(TAG, "  ─────────────── Source diagnosis ───────────────");
+        // If the compositor sink is busy but X Present is idle, frames are NOT
+        // coming through PresentExtension → X-Present back-pressure cannot cap them.
+        String source;
+        if (xPresent > 5 && xPresent >= vortek) source = "X Present (PresentExtension CAN cap)";
+        else if (vortek > 5)                    source = "Vortek native (PresentExtension CANNOT cap)";
+        else if ((sfGpu + sfCpu) > 5)           source = "SurfaceFlinger ASR (X Present CAN cap via idle-notify)";
+        else if (vkUpdate > 5)                  source = "compositor-only (X Present NOT the source)";
+        else                                    source = "idle / no frames";
+        Log.i(TAG, "  Frame source        : " + source);
+        // Judder check: prefer the HUD-measured on-screen FPS (FrameRating — matches the
+        // device counter); fall back to the dominant renderer submission count. If the
+        // panel Hz isn't a near-integer multiple of that rate, frames are held an uneven
+        // number of vsyncs → visible stutter even at a "stable" average fps.
+        float submitFps = Math.max(Math.max(xPresent, vortek), Math.max(sfGpu + sfCpu,
+                Math.max(vkUpdate, glDraw))) / sec;
+        boolean usingHud = measuredFps > 0.5f;
+        float presentFps = usingHud ? measuredFps : submitFps;
+        if (curHz > 0f && presentFps > 1f) {
+            float ratio = curHz / presentFps;          // vsyncs per presented frame
+            float frac  = Math.abs(ratio - Math.round(ratio));
+            String verdict = frac < 0.08f
+                    ? "even cadence (clean multiple of refresh)"
+                    : "UNEVEN cadence → judder likely (present rate not a clean divisor of panel Hz)";
+            Log.i(TAG, String.format(
+                    "  Pacing vs display   : %.1f fps %s @ %.1f Hz → %.2f vsync/frame — %s",
+                    presentFps, usingHud ? "on-screen (HUD)" : "submitted", curHz, ratio, verdict));
+            if (usingHud && Math.abs(submitFps - measuredFps) > 2f) {
+                Log.i(TAG, String.format(
+                        "    └─ note: renderer submitted %.1f fps but only %.1f fps reached the screen (HUD)",
+                        submitFps, measuredFps));
+            }
+        }
+        Log.i(TAG, "  ───────────────────────── Active Limiters ─────────────────────────");
+        Log.i(TAG, String.format(
+                "  QuickMenu limiter   : %s  target=%d fps  |  Display set refresh: %s now  |  %s max",
+                limiterEnabled ? "ON" : "OFF", limiterTarget,
+                curHz > 0f ? String.format("%.1f Hz", curHz) : "unknown",
+                displayMaxRefreshHz > 0f ? String.format("%.1f Hz", displayMaxRefreshHz) : "unknown"));
+        Log.i(TAG, String.format(
+                "  PresentExt limit    : %s  [X Present back-pressure; 0=unlimited=fires immediately]",
+                presentExtLimit > 0 ? presentExtLimit + " fps" : "UNLIMITED (0)"));
+        Log.i(TAG, String.format(
+                "  VkSurfaceCtrl hint  : %s  [SurfaceControl setFrameRate – display HINT only, not a hard cap]",
+                vkScanoutHint > 0 ? vkScanoutHint + " fps" : "none / cleared"));
+        Log.i(TAG, "  ───────────────────────── Launch-time Env Vars ────────────────────");
+        Log.i(TAG, "  DXVK_FRAME_RATE     : " + launchDxvkFrameRate
+                + "  [DXVK internal limiter – set at Wine process launch, cannot change at runtime]");
+        Log.i(TAG, "  VKD3D_FRAME_LIMIT   : " + launchVkd3dFrameLimit
+                + "  [VKD3D-Proton DX12 limiter – set at Wine process launch, cannot change at runtime]");
+        Log.i(TAG, "  MANGOHUD_CONFIG     : " + launchMangoHudConfig
+                + "  [MangoHUD – check fps_limit inside config if set]");
+        Log.i(TAG, "  ───────────────────────── Path Notes ──────────────────────────────");
+        Log.i(TAG, "  DXVK/VKD3D games route D3D Present() → winevulkan → winex11 → X Present → PresentExtension");
+        Log.i(TAG, "  VKD3D (D3D12) frames land in [Vk compositor sink] / [VkRenderer AHB] (true for the GL and Vulkan renderers)");
+        Log.i(TAG, "  GL / virgl games  route via GLX/EGL → X Present → PresentExtension");
+        Log.i(TAG, "  Native Vulkan scanout path bypasses X Present; only SurfaceControl hint applies");
+        Log.i(TAG, "  GLRenderer has NO independent frame cap; relies solely on PresentExtension pacing");
+        Log.i(TAG, "  If PresentExtension limit=0 AND no DXVK/VKD3D env-var cap → game runs UNCAPPED");
+        Log.i(TAG, "══════════════════════════════════════════════════════════════════════");
+    }
+}
+

--- a/app/src/main/java/com/winlator/renderer/GLRenderer.java
+++ b/app/src/main/java/com/winlator/renderer/GLRenderer.java
@@ -126,6 +126,7 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
 
     @Override
     public void onDrawFrame(GL10 gl) {
+        FramePacingLogger.recordGLDrawFrame(); // [FramePacingLogger] GL renderer: one EGL swap / drawn frame
         if (toggleFullscreen) {
             fullscreen = !fullscreen;
             toggleFullscreen = false;

--- a/app/src/main/java/com/winlator/renderer/VulkanRenderer.java
+++ b/app/src/main/java/com/winlator/renderer/VulkanRenderer.java
@@ -449,9 +449,11 @@ public class VulkanRenderer implements WindowManager.OnWindowModificationListene
                         nativeScanoutSetBuffer(nativeHandle, ahbPtr,
                             rx, ry, pixmap.width, pixmap.height, fenceFd);
                         g.lock();
+                        FramePacingLogger.recordVkContentAHB(true); // [FramePacingLogger] Vulkan zero-copy scanout present (X Present direct)
                     } else {
                         nativeUpdateWindowContentAHB(nativeHandle, targetId, ahbPtr,
                             pixmap.width, pixmap.height, rx, ry);
+                        FramePacingLogger.recordVkContentAHB(false); // [FramePacingLogger] Vulkan AHB compositor present (X Present direct)
                     }
                     return;
                 }
@@ -460,6 +462,7 @@ public class VulkanRenderer implements WindowManager.OnWindowModificationListene
                     short s = g.getStride() > 0 ? g.getStride() : pixmap.width;
                     nativeUpdateWindowContent(nativeHandle, targetId, vd,
                         pixmap.width, pixmap.height, s, rx, ry);
+                    FramePacingLogger.recordVkContentPixels(); // [FramePacingLogger] Vulkan software pixel blit (X Present direct, virtual data)
                     return;
                 }
             }
@@ -468,11 +471,13 @@ public class VulkanRenderer implements WindowManager.OnWindowModificationListene
             short stride = (short)(buf.capacity() / (pixmap.height * 4));
             nativeUpdateWindowContent(nativeHandle, targetId, buf,
                 pixmap.width, pixmap.height, stride, rx, ry);
+            FramePacingLogger.recordVkContentPixels(); // [FramePacingLogger] Vulkan software pixel blit (X Present direct, raw buffer)
         }
     }
 
     @Override
     public void onUpdateWindowContent(Window window) {
+        FramePacingLogger.recordVkUpdate(); // [FramePacingLogger] Vulkan compositor sink invoked (ALL non-direct sources)
         if (hudRef != null) hudRef.update();
         final long handle;
         synchronized (lock) { handle = nativeHandle; }
@@ -500,6 +505,7 @@ public class VulkanRenderer implements WindowManager.OnWindowModificationListene
                         nativeScanoutSetBuffer(handle, ahbPtr,
                             rx, ry, drawable.width, drawable.height, fenceFd);
                         g.lock();
+                        FramePacingLogger.recordVkContentAHB(true); // [FramePacingLogger] Vulkan zero-copy scanout present
                         boolean delivered = nativeIsGameFrameDelivered(handle);
                         if (!xRenderingPausedForScanout && !wasDelivered && delivered) {
                             xServer.setRenderingEnabled(false);
@@ -508,6 +514,7 @@ public class VulkanRenderer implements WindowManager.OnWindowModificationListene
                     } else if (!scanoutNow) {
                         nativeUpdateWindowContentAHB(handle, drawableId, ahbPtr,
                             drawable.width, drawable.height, rx, ry);
+                        FramePacingLogger.recordVkContentAHB(false); // [FramePacingLogger] Vulkan AHB compositor present
                     }
                     return;
                 }
@@ -516,6 +523,7 @@ public class VulkanRenderer implements WindowManager.OnWindowModificationListene
                     short s = g.getStride() > 0 ? g.getStride() : drawable.width;
                     nativeUpdateWindowContent(handle, drawableId, vd,
                         drawable.width, drawable.height, s, rx, ry);
+                    FramePacingLogger.recordVkContentPixels(); // [FramePacingLogger] Vulkan software pixel blit (virtual data)
                     return;
                 }
             }
@@ -524,6 +532,7 @@ public class VulkanRenderer implements WindowManager.OnWindowModificationListene
             short stride = (short)(buf.capacity() / (drawable.height * 4));
             nativeUpdateWindowContent(handle, drawableId, buf,
                 drawable.width, drawable.height, stride, rx, ry);
+            FramePacingLogger.recordVkContentPixels(); // [FramePacingLogger] Vulkan software pixel blit (raw buffer)
         }
     }
 
@@ -812,6 +821,7 @@ public class VulkanRenderer implements WindowManager.OnWindowModificationListene
     public int getFpsLimit() { return fpsLimit; }
     public void setFpsLimit(int limit) {
         this.fpsLimit = limit;
+        FramePacingLogger.updateVkScanoutHint(limit); // [FramePacingLogger] Vulkan SurfaceControl frame-rate hint changed
         if (android.os.Build.VERSION.SDK_INT >= 30 && scanoutGameSC != null) {
             float targetFps = limit > 0 ? (float)limit
                 : xServerView.getDisplay() != null

--- a/app/src/main/java/com/winlator/widget/FrameRating.java
+++ b/app/src/main/java/com/winlator/widget/FrameRating.java
@@ -76,6 +76,10 @@ public class FrameRating extends FrameLayout implements Runnable {
                     minFPS = currentFPS;
                 }
 
+                // [FramePacingLogger] Feed the authoritative on-screen FPS (same value
+                // the Performance HUD shows) into the frame-pacing report.
+                com.winlator.renderer.FramePacingLogger.updateMeasuredFps(lastFPS, getAvgFPS());
+
                 lastReadingTime = time;
             }
 

--- a/app/src/main/java/com/winlator/xenvironment/components/VortekRendererComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/VortekRendererComponent.java
@@ -145,6 +145,7 @@ public class VortekRendererComponent extends EnvironmentComponent implements Con
             synchronized (drawable.renderLock) {
                 drawable.forceUpdate();
             }
+            com.winlator.renderer.FramePacingLogger.recordVortekPresent(); // [FramePacingLogger] Vortek native frame pushed into the active renderer
         }
     }
 

--- a/app/src/main/java/com/winlator/xserver/extensions/PresentExtension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/PresentExtension.java
@@ -69,6 +69,7 @@ public class PresentExtension implements Extension {
 
     public void setFrameRateLimit(int limit) {
         this.frameRateLimit = Math.max(0, limit);
+        com.winlator.renderer.FramePacingLogger.updatePresentExtLimit(this.frameRateLimit); // [FramePacingLogger] X Present back-pressure cap changed
     }
 
     public void close() {
@@ -298,11 +299,13 @@ public class PresentExtension implements Extension {
                 if (window.attributes.isMapped()) {
                     asr.onUpdateWindowContent(window);
                 }
+                com.winlator.renderer.FramePacingLogger.recordXPresent(true, false); // [FramePacingLogger] X Present → SurfaceFlinger (FLIP/scanout)
                 if (targetFps > 0) scheduleIdleNotify(window, pixmap, serial, idleFence, targetFps, vr);
                 else sendIdleNotify(window, pixmap, serial, idleFence);
             } else if (vr != null && window.attributes.isMapped()) {
                 sendCompleteNotify(window, serial, Kind.PIXMAP, Mode.COPY, ust, msc);
                 vr.onUpdateWindowContentDirect(window, pixmap.drawable, xOff, yOff);
+                com.winlator.renderer.FramePacingLogger.recordXPresent(false, true); // [FramePacingLogger] X Present → Vulkan compositor (COPY)
                 if (targetFps > 0) scheduleIdleNotify(window, pixmap, serial, idleFence, targetFps, vr);
                 else sendIdleNotify(window, pixmap, serial, idleFence);
             } else {
@@ -310,6 +313,7 @@ public class PresentExtension implements Extension {
                 content.copyArea((short)0, (short)0, xOff, yOff,
                         pixmap.drawable.width, pixmap.drawable.height, pixmap.drawable);
                 sendCompleteNotify(window, serial, Kind.PIXMAP, Mode.COPY, ust, msc);
+                com.winlator.renderer.FramePacingLogger.recordXPresent(false, true); // [FramePacingLogger] X Present → GL renderer (COPY)
                 if (targetFps > 0) scheduleIdleNotify(window, pixmap, serial, idleFence, targetFps, vr);
                 else sendIdleNotify(window, pixmap, serial, idleFence);
             }


### PR DESCRIPTION


## Description
Created FramPacingLogger.java for debugging

Added frame logging every 10sec that can be enabled by using GN_FRAME_LOG = 1 for debug purposes in container settings

Anchored the logger into every frame-producing, frame-pacing, and frame-limiting path. All edits outside FramePacingLogger.java are purely additive logging anchors

The frame report will show how frames are getting output and which rendering path is being used

## Recording
<img width="2272" height="1474" alt="Captura de ecrã 2026-06-28 155057" src="https://github.com/user-attachments/assets/4f76b78c-bef9-4c42-87c8-b1fa418f3237" />

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new frame pacing diagnostics logger that reports frame sources, limits, and on-screen FPS every 10s to logcat. This helps debug judder and understand which rendering path is active; opt-in via GN_FRAME_LOG=1.

- **New Features**
  - Added `com.winlator.renderer.FramePacingLogger` with a 10s report (tag: "FramePacing", 10s initial delay).
  - Anchors added in `PresentExtension`, `VulkanRenderer`, `GLRenderer`, `ASurfaceRenderer`, `VortekRendererComponent`, `FrameRating`, and `XServerScreen` (purely additive).
  - Reports include per-path counts (X Present scanout/copy, Vulkan scanout/AHB/pixels, SurfaceFlinger GPU/CPU, GL draws), skipped frames, on-screen FPS (HUD), display Hz vs present rate, active limiters (QuickMenu, PresentExtension, SurfaceControl hint), and launch-time env vars (DXVK/VKD3D/MangoHUD) plus wrapper/driver versions.

- **Migration**
  - Set GN_FRAME_LOG=1 in the container’s Environment Variables and launch a game.
  - View logs via logcat filter "FramePacing".
  - Logger mirrors QuickMenu FPS limiter changes and auto-resets/disables on session end.

<sup>Written for commit 7c39b3d4f7d6e0cf2a1214912a860d02c642c7fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

