### PR TITLE
fix: Fix controller focus not being acquired on screen entry

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/downloads/DownloadsScreen.kt
@@ -370,6 +370,11 @@ private fun DownloadsTabRow(
     onSectionSelected: (DownloadsSection) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val focusRequesters = remember {
+        sections.associateWith { FocusRequester() }
+    }
+    var requestedInitialFocus by remember { mutableStateOf(false) }
+
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -384,6 +389,7 @@ private fun DownloadsTabRow(
                 modifier = Modifier
                     .weight(1f)
                     .clip(RoundedCornerShape(16.dp))
+                    .focusRequester(focusRequesters.getValue(section))
                     .selectable(
                         selected = isSelected,
                         onClick = { onSectionSelected(section) },
@@ -422,6 +428,20 @@ private fun DownloadsTabRow(
                         color = if (isSelected) accentColor else MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
+            }
+        }
+    }
+
+    LaunchedEffect(selectedSection, requestedInitialFocus) {
+        if (requestedInitialFocus) return@LaunchedEffect
+        val focusRequester = focusRequesters.getValue(selectedSection)
+        repeat(3) {
+            try {
+                focusRequester.requestFocus()
+                requestedInitialFocus = true
+                return@LaunchedEffect
+            } catch (_: Exception) {
+                delay(80)
             }
         }
     }

--- a/app/src/main/java/app/gamenative/ui/screen/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/downloads/DownloadsScreen.kt
@@ -353,12 +353,13 @@ private fun DownloadsSidebar(
         val focusRequester = focusRequesters.getValue(selectedSection)
         repeat(3) {
             try {
-                focusRequester.requestFocus()
-                requestedInitialFocus = true
-                return@LaunchedEffect
+                if (focusRequester.requestFocus()) {
+                    requestedInitialFocus = true
+                    return@LaunchedEffect
+                }
             } catch (_: Exception) {
-                delay(80)
             }
+            delay(80)
         }
     }
 }
@@ -437,12 +438,13 @@ private fun DownloadsTabRow(
         val focusRequester = focusRequesters.getValue(selectedSection)
         repeat(3) {
             try {
-                focusRequester.requestFocus()
-                requestedInitialFocus = true
-                return@LaunchedEffect
+                if (focusRequester.requestFocus()) {
+                    requestedInitialFocus = true
+                    return@LaunchedEffect
+                }
             } catch (_: Exception) {
-                delay(80)
             }
+            delay(80)
         }
     }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -132,6 +132,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import kotlin.math.roundToInt
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -594,8 +595,16 @@ internal fun AppScreenContent(
         scrollState.animateScrollTo(0)
     }
 
-    LaunchedEffect(Unit) {
-        playButtonFocusRequester.requestFocus()
+    LaunchedEffect(displayInfo.appId) {
+        // Node may not be placed on the first frame, and requestFocus() returns false until it is;
+        // retry until it takes so the controller lands on Play (re-runs when switching games).
+        repeat(5) {
+            try {
+                if (playButtonFocusRequester.requestFocus()) return@LaunchedEffect
+            } catch (_: IllegalStateException) {
+            }
+            delay(32)
+        }
     }
 
     // Button state calculations (needed by key event handler)

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -352,6 +352,8 @@ private fun LibraryScreenContent(
     // buttons would otherwise light up for ~100ms and then lose focus).
     var tabBarHasFocus by remember { mutableStateOf(false) }
     var lastBootstrapAtMs by remember { mutableLongStateOf(0L) }
+    // One-shot guard so initial-entry focus is requested only once and doesn't fight the tab-change effect.
+    var didInitialContentFocus by remember { mutableStateOf(false) }
 
     fun firstVisibleContentIndex(): Int {
         val lastIndex = state.appInfoList.lastIndex
@@ -612,6 +614,22 @@ private fun LibraryScreenContent(
         }
 
         previousAppCount = currentCount
+    }
+
+    // Focus content on first entry once the library has loaded (one-shot).
+    LaunchedEffect(state.appInfoList.isNotEmpty()) {
+        if (!didInitialContentFocus &&
+            state.appInfoList.isNotEmpty() &&
+            selectedAppId == null &&
+            !isSystemMenuOpen &&
+            !state.isOptionsPanelOpen &&
+            !state.isSearching
+        ) {
+            didInitialContentFocus = true
+            // Brief delay to let the list lay out before requesting focus.
+            kotlinx.coroutines.delay(150)
+            requestContentFocusOrDefer(targetListIndex = 0)
+        }
     }
 
     // Restore focus when System Menu or Options Panel closes

--- a/app/src/main/java/app/gamenative/ui/screen/library/RecommendedGameScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/RecommendedGameScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -52,6 +53,7 @@ import androidx.compose.ui.layout.ContentScale
 import app.gamenative.R
 import app.gamenative.data.RecommendedGame
 import app.gamenative.ui.screen.library.components.VideoHero
+import app.gamenative.ui.util.requestInitialFocus
 import app.gamenative.PrefManager
 import com.posthog.PostHog
 import com.skydoves.landscapist.ImageOptions
@@ -67,6 +69,7 @@ internal fun RecommendedGameScreen(
 ) {
     val context = LocalContext.current
     val scrollState = rememberScrollState()
+    val focusRequester = remember { FocusRequester() }
 
     val media = remember(game) {
         val list = mutableListOf<Pair<Boolean, String>>()
@@ -399,7 +402,9 @@ internal fun RecommendedGameScreen(
                         val browserIntent = Intent(Intent.ACTION_VIEW, game.affiliateUrl.toUri())
                         context.startActivity(browserIntent)
                     },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .requestInitialFocus(focusRequester),
                     shape = RoundedCornerShape(12.dp),
                 ) {
                     Icon(

--- a/app/src/main/java/app/gamenative/ui/screen/login/TwoFactorAuthScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/login/TwoFactorAuthScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.delay
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -130,8 +131,15 @@ private fun TwoFactorTextField(
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    LaunchedEffect(true) {
-        focusRequester.requestFocus()
+    LaunchedEffect(Unit) {
+        // Node may not be placed on the first frame; retry until requestFocus() takes.
+        repeat(5) {
+            try {
+                if (focusRequester.requestFocus()) return@LaunchedEffect
+            } catch (_: IllegalStateException) {
+            }
+            delay(32)
+        }
     }
 
     Column(modifier = Modifier.fillMaxWidth()) {

--- a/app/src/main/java/app/gamenative/ui/screen/login/UserLoginScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/login/UserLoginScreen.kt
@@ -617,8 +617,16 @@ private fun CredentialsForm(
     val usernameFocusRequester = remember { FocusRequester() }
 
     // Focus the username field on entry so the first controller/D-pad press is not wasted.
+    // Retry: the field may not be attached on the first frame.
     LaunchedEffect(Unit) {
-        runCatching { usernameFocusRequester.requestFocus() }
+        repeat(5) {
+            try {
+                usernameFocusRequester.requestFocus()
+                return@LaunchedEffect
+            } catch (_: IllegalStateException) {
+                delay(32)
+            }
+        }
     }
 
     Column(

--- a/app/src/main/java/app/gamenative/ui/screen/login/UserLoginScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/login/UserLoginScreen.kt
@@ -616,6 +616,11 @@ private fun CredentialsForm(
     val passwordFocusRequester = remember { FocusRequester() }
     val usernameFocusRequester = remember { FocusRequester() }
 
+    // Focus the username field on entry so the first controller/D-pad press is not wasted.
+    LaunchedEffect(Unit) {
+        runCatching { usernameFocusRequester.requestFocus() }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth(),

--- a/app/src/main/java/app/gamenative/ui/screen/login/UserLoginScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/login/UserLoginScreen.kt
@@ -621,11 +621,10 @@ private fun CredentialsForm(
     LaunchedEffect(Unit) {
         repeat(5) {
             try {
-                usernameFocusRequester.requestFocus()
-                return@LaunchedEffect
+                if (usernameFocusRequester.requestFocus()) return@LaunchedEffect
             } catch (_: IllegalStateException) {
-                delay(32)
             }
+            delay(32)
         }
     }
 

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -58,6 +59,7 @@ import app.gamenative.PrefManager
 import app.gamenative.R
 import app.gamenative.enums.AppTheme
 import app.gamenative.ui.theme.PluviaTheme
+import app.gamenative.ui.util.requestInitialFocus
 import com.materialkolor.PaletteStyle
 
 @Composable
@@ -231,6 +233,7 @@ private fun BackButton(
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
+    val focusRequester = remember { FocusRequester() }
 
     val scale by animateFloatAsState(
         targetValue = if (isFocused) 1.1f else 1f,
@@ -268,6 +271,7 @@ private fun BackButton(
                     )
                 },
             )
+            .requestInitialFocus(focusRequester)
             .selectable(
                 selected = isFocused,
                 interactionSource = interactionSource,

--- a/app/src/main/java/app/gamenative/ui/util/FocusModifiers.kt
+++ b/app/src/main/java/app/gamenative/ui/util/FocusModifiers.kt
@@ -20,14 +20,14 @@ fun Modifier.requestInitialFocus(
 ): Modifier {
     LaunchedEffect(focusRequester, enabled) {
         if (!enabled) return@LaunchedEffect
-        // Node may not be placed on the first frame; retry briefly until requestFocus() succeeds.
+        // Node may not be placed on the first frame, and requestFocus() returns false when the
+        // request is not honored yet; retry until it actually takes.
         repeat(5) {
             try {
-                focusRequester.requestFocus()
-                return@LaunchedEffect
+                if (focusRequester.requestFocus()) return@LaunchedEffect
             } catch (_: IllegalStateException) {
-                delay(32)
             }
+            delay(32)
         }
     }
     return this.focusRequester(focusRequester)

--- a/app/src/main/java/app/gamenative/ui/util/FocusModifiers.kt
+++ b/app/src/main/java/app/gamenative/ui/util/FocusModifiers.kt
@@ -1,0 +1,34 @@
+package app.gamenative.ui.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import kotlinx.coroutines.delay
+
+/**
+ * Attaches [focusRequester] and requests focus once laid out, so a freshly opened screen already
+ * has a focused element. Apply BEFORE `.focusable()`/`.selectable()`/`.clickable()`.
+ *
+ * [enabled] gates the request; focus is (re)requested each time it becomes `true`.
+ */
+@Composable
+fun Modifier.requestInitialFocus(
+    focusRequester: FocusRequester,
+    enabled: Boolean = true,
+): Modifier {
+    LaunchedEffect(enabled) {
+        if (!enabled) return@LaunchedEffect
+        // Node may not be placed on the first frame; retry briefly until requestFocus() succeeds.
+        repeat(5) {
+            try {
+                focusRequester.requestFocus()
+                return@LaunchedEffect
+            } catch (_: IllegalStateException) {
+                delay(32)
+            }
+        }
+    }
+    return this.focusRequester(focusRequester)
+}

--- a/app/src/main/java/app/gamenative/ui/util/FocusModifiers.kt
+++ b/app/src/main/java/app/gamenative/ui/util/FocusModifiers.kt
@@ -18,7 +18,7 @@ fun Modifier.requestInitialFocus(
     focusRequester: FocusRequester,
     enabled: Boolean = true,
 ): Modifier {
-    LaunchedEffect(enabled) {
+    LaunchedEffect(focusRequester, enabled) {
         if (!enabled) return@LaunchedEffect
         // Node may not be placed on the first frame; retry briefly until requestFocus() succeeds.
         repeat(5) {


### PR DESCRIPTION
## Description

On most screens, opening them with a controller left nothing focused, so the first D-pad/A press did nothing — you had to press once "into the void" before anything reacted.

This adds a small reusable `Modifier.requestInitialFocus()` helper and uses it to focus a sensible first element on entry:
- Settings → the back button
- Login → the username field
- Recommended game → the primary action button
- Library → the content list, once it has loaded
- Downloads → the portrait tab row (landscape already did this via the sidebar)

The helper retries focus a few times because the node isn't always laid out on the first frame.

## Recording
<!-- TODO: short clip showing focus landing on screen entry -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing controller focus on screen entry so the first D‑pad/A press works immediately. Adds a reusable `Modifier.requestInitialFocus()` that requests focus after layout and retries until it succeeds.

- **Bug Fixes**
  - Added `Modifier.requestInitialFocus()` (attaches `FocusRequester`; retries until `requestFocus()` returns true; effect keyed on requester/enabled).
  - Settings: Back button gets initial focus.
  - Login: Username and 2FA fields auto-focus with retry.
  - Library: One‑shot content list focus after load; game detail Play button auto‑focus on entry and when switching games (retry).
  - Recommended Game: Primary action button auto-focus.
  - Downloads: Auto-focus the portrait tab row; sidebar/tab focus now retry until success.

<sup>Written for commit 289ff51d8a68da79efbdd1e36cf1a6467c47abc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved initial keyboard/controller focus across key screens, including Downloads tabs/sections, Library content, Login (username + 2FA), Settings (back button), Recommended Game (Buy), and Library play button after switching games.
  * Added a reusable “request initial focus” helper for consistent, timed focus behavior.
* **Bug Fixes**
  * Enhanced focus reliability with bounded retries and brief delays, ensuring focus is applied when UI elements appear.
  * Reduced mis-focus by gating initial focus until relevant views are ready and inactive overlays/search/detail states aren’t blocking input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->