### PR TITLE
fix: prevent audio resume when exiting from QuickMenu that caused ANR

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1190,7 +1190,11 @@ fun XServerScreen(
                 )
                 imeInputReceiver?.hideKeyboard()
                 // Resume processes before exiting so they can receive SIGTERM cleanly.
-                forceResumeIfSuspended()
+                // Don't resume audio to avoid resume->suspend race condition causing ANR.
+                if (PluviaApp.isOverlayPaused && !neverSuspend) {
+                    PluviaApp.xEnvironment?.resumeGameProcesses()
+                }
+                clearOverlayPauseState()
                 exit(xServerView!!.getxServer().winHandler, frameRating, currentAppInfo, container, appId, onExit, navigateBack)
                 true
             }

--- a/app/src/main/java/com/winlator/xenvironment/XEnvironment.java
+++ b/app/src/main/java/com/winlator/xenvironment/XEnvironment.java
@@ -83,14 +83,10 @@ public class XEnvironment implements Iterable<EnvironmentComponent> {
     }
 
     public void onPause() {
-        GuestProgramLauncherComponent guestProgramLauncherComponent = getComponent(GuestProgramLauncherComponent.class);
-        if (guestProgramLauncherComponent != null) guestProgramLauncherComponent.suspendProcess();
-        GlibcProgramLauncherComponent glibcProgramLauncherComponent = getComponent(GlibcProgramLauncherComponent.class);
-        if (glibcProgramLauncherComponent != null) glibcProgramLauncherComponent.suspendProcess();
-        BionicProgramLauncherComponent bionicProgramLauncherComponent = getComponent(BionicProgramLauncherComponent.class);
-        if (bionicProgramLauncherComponent != null) bionicProgramLauncherComponent.suspendProcess();
+        // Pause game processes FIRST
+        pauseGameProcesses();
 
-        // Pause audio components
+        // Then pause audio components
         PulseAudioComponent pulseAudioComponent = getComponent(PulseAudioComponent.class);
         if (pulseAudioComponent != null) pulseAudioComponent.pause();
         ALSAServerComponent alsaServerComponent = getComponent(ALSAServerComponent.class);
@@ -105,6 +101,19 @@ public class XEnvironment implements Iterable<EnvironmentComponent> {
         if (alsaServerComponent != null) alsaServerComponent.resume();
 
         // Then resume game processes
+        resumeGameProcesses();
+    }
+
+    public void pauseGameProcesses() {
+        GuestProgramLauncherComponent guestProgramLauncherComponent = getComponent(GuestProgramLauncherComponent.class);
+        if (guestProgramLauncherComponent != null) guestProgramLauncherComponent.suspendProcess();
+        GlibcProgramLauncherComponent glibcProgramLauncherComponent = getComponent(GlibcProgramLauncherComponent.class);
+        if (glibcProgramLauncherComponent != null) glibcProgramLauncherComponent.suspendProcess();
+        BionicProgramLauncherComponent bionicProgramLauncherComponent = getComponent(BionicProgramLauncherComponent.class);
+        if (bionicProgramLauncherComponent != null) bionicProgramLauncherComponent.suspendProcess();
+    }
+
+    public void resumeGameProcesses() {
         GuestProgramLauncherComponent guestProgramLauncherComponent = getComponent(GuestProgramLauncherComponent.class);
         if (guestProgramLauncherComponent != null) guestProgramLauncherComponent.resumeProcess();
         GlibcProgramLauncherComponent glibcProgramLauncherComponent = getComponent(GlibcProgramLauncherComponent.class);


### PR DESCRIPTION
## Description
Previously, audio components still resuming when exiting from QuickMenu, it may cause ANR when using pulseaudio.
Preventing it to resume from exit, could safely stop the component to avoid ANR.

## Recording
No

## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent audio from resuming when exiting QuickMenu to eliminate ANR with PulseAudio caused by a resume→suspend race. Also enforces a safe pause/resume order between game processes and audio.

- **Bug Fixes**
  - Exit path: skip audio resume; only call `resumeGameProcesses()` when overlay is paused and `neverSuspend` is false; then `clearOverlayPauseState()`.
  - `XEnvironment`: pause game processes first, then audio on pause; resume audio first, then processes on resume. Extracted `pauseGameProcesses()` and `resumeGameProcesses()` for reuse.

<sup>Written for commit a71cf97310e175299423fa58037e80d29f763c3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Exit game” flow so game processes are only resumed when needed before quitting, reducing unnecessary state changes.
  * Fixed pause and resume behavior so game processes are handled more consistently alongside audio when the app is backgrounded or restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->