### PR TITLE
fix: GOG cloud save upload to prevent redundant transfers

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
@@ -231,9 +231,12 @@ class GOGCloudSavesManager(
                 // Upload files that don't exist remotely
                 filesToUpload.addAll(classifier.notExistingRemotely)
 
-                if (filesToUpload.isNotEmpty()) {
-                    Timber.tag("GOG-CloudSaves").i("Smart upload: ${filesToUpload.size} file(s) changed since last sync (out of ${localFiles.size} total)")
-                    filesToUpload.forEach { file ->
+                // Deduplicate by relativePath (new files can appear in both lists)
+                val uniqueFilesToUpload = filesToUpload.distinctBy { it.relativePath }
+
+                if (uniqueFilesToUpload.isNotEmpty()) {
+                    Timber.tag("GOG-CloudSaves").i("Smart upload: ${uniqueFilesToUpload.size} file(s) changed since last sync (out of ${localFiles.size} total)")
+                    uniqueFilesToUpload.forEach { file ->
                         uploadFile(credentials.userId, clientId, dirname, file, credentials.accessToken)
                     }
                 } else {

--- a/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
@@ -640,13 +640,25 @@ class GOGCloudSavesManager(
                 val localFile = FileUtils.resolveCaseInsensitive(syncDir, file.relativePath)
                 localFile.parentFile?.mkdirs()
 
+                // Write file content
                 FileOutputStream(localFile).use { fos ->
                     fos.write(bytes)
                 }
 
-                // Preserve timestamp if available
-                file.updateTimestamp?.let { timestamp ->
-                    localFile.setLastModified(timestamp * 1000)
+                // Preserve cloud timestamp (must be done after closing the stream)
+                file.updateTimestamp?.let { cloudTimestamp ->
+                    val cloudMillis = cloudTimestamp * 1000
+                    val success = localFile.setLastModified(cloudMillis)
+                    if (success) {
+                        val actualMillis = localFile.lastModified()
+                        if (actualMillis == cloudMillis) {
+                            Timber.tag("GOG-CloudSaves").d("Preserved cloud timestamp for ${file.relativePath}: $cloudTimestamp seconds")
+                        } else {
+                            Timber.tag("GOG-CloudSaves").w("Timestamp mismatch for ${file.relativePath}: set $cloudMillis but got $actualMillis")
+                        }
+                    } else {
+                        Timber.tag("GOG-CloudSaves").w("Failed to set timestamp for ${file.relativePath}")
+                    }
                 }
 
                 Timber.tag("GOG-CloudSaves").i("Successfully downloaded: ${file.relativePath}")

--- a/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
@@ -223,6 +223,16 @@ class GOGCloudSavesManager(
             if (preferredAction == "upload" && localFiles.isNotEmpty()) {
                 // Use classifier to intelligently determine which files need uploading
                 val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTimestamp)
+
+                // Don't clobber the cloud on an automatic exit upload. If the cloud is newer
+                // (DOWNLOAD) or both sides changed (CONFLICT), skip and leave the timestamp
+                // untouched — the next launch detects the conflict and prompts the user to resolve it.
+                val action = classifier.determineAction()
+                if (action == SyncAction.DOWNLOAD || action == SyncAction.CONFLICT) {
+                    Timber.tag("GOG-CloudSaves").w("Skipping upload: cloud changed since last sync (action=$action), deferring to launch conflict prompt")
+                    return@withContext lastSyncTimestamp
+                }
+
                 val filesToUpload = mutableListOf<SyncFile>()
 
                 // Upload files that were updated locally since last sync
@@ -346,6 +356,53 @@ class GOGCloudSavesManager(
         } catch (e: Exception) {
             Timber.tag("GOG-CloudSaves").e(e, "Sync failed: ${e.message}")
             return@withContext 0L
+        }
+    }
+
+    /**
+     * Conflict timestamps for a save location, in milliseconds (for display).
+     */
+    data class ConflictInfo(
+        val localTimestamp: Long,
+        val remoteTimestamp: Long
+    )
+
+    /**
+     * Detect whether a save location is in conflict (both local and cloud changed since the last
+     * sync) WITHOUT uploading or downloading anything. Returns null when there is no conflict, or
+     * on any error (fail open so the regular sync still runs).
+     */
+    suspend fun detectConflict(
+        localPath: String,
+        dirname: String,
+        clientId: String,
+        clientSecret: String,
+        lastSyncTimestamp: Long = 0
+    ): ConflictInfo? = withContext(Dispatchers.IO) {
+        try {
+            val syncDir = File(localPath)
+            if (!syncDir.exists()) return@withContext null
+
+            val localFiles = scanLocalFiles(syncDir)
+            if (localFiles.isEmpty()) return@withContext null // nothing local => no conflict
+
+            val credentials = GOGAuthManager.getGameCredentials(context, clientId, clientSecret).getOrNull()
+                ?: return@withContext null
+            val cloudFiles = getCloudFiles(credentials.userId, clientId, dirname, credentials.accessToken)
+                ?: return@withContext null
+            if (cloudFiles.none { !it.isDeleted }) return@withContext null // nothing in cloud => no conflict
+
+            val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTimestamp)
+            if (classifier.determineAction() != SyncAction.CONFLICT) return@withContext null
+
+            // updateTimestamp is stored in seconds; convert to millis for display.
+            val localTs = localFiles.mapNotNull { it.updateTimestamp }.maxOrNull() ?: 0L
+            val remoteTs = cloudFiles.filter { !it.isDeleted }.mapNotNull { it.updateTimestamp }.maxOrNull() ?: 0L
+            Timber.tag("GOG-CloudSaves").i("Conflict detected for '$dirname' (local: $localTs, remote: $remoteTs)")
+            ConflictInfo(localTimestamp = localTs * 1000, remoteTimestamp = remoteTs * 1000)
+        } catch (e: Exception) {
+            Timber.tag("GOG-CloudSaves").e(e, "Conflict detection failed for '$dirname': ${e.message}")
+            null
         }
     }
 

--- a/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
@@ -220,6 +220,16 @@ class GOGCloudSavesManager(
                 return@withContext currentTimestamp()
             }
 
+            // Explicit "keep local" choice from the conflict dialog: force-upload every local file so
+            // local wins, bypassing the conflict guard on the plain "upload" path below.
+            if (preferredAction == "forceupload" && localFiles.isNotEmpty()) {
+                Timber.tag("GOG-CloudSaves").i("Forcing upload of ${localFiles.size} file(s) (user requested)")
+                localFiles.forEach { file ->
+                    uploadFile(credentials.userId, clientId, dirname, file, credentials.accessToken)
+                }
+                return@withContext currentTimestamp()
+            }
+
             if (preferredAction == "upload" && localFiles.isNotEmpty()) {
                 // Use classifier to intelligently determine which files need uploading
                 val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTimestamp)

--- a/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
@@ -221,9 +221,23 @@ class GOGCloudSavesManager(
             }
 
             if (preferredAction == "upload" && localFiles.isNotEmpty()) {
-                Timber.tag("GOG-CloudSaves").i("Forcing upload of ${localFiles.size} file(s) (user requested)")
-                localFiles.forEach { file ->
-                    uploadFile(credentials.userId, clientId, dirname, file, credentials.accessToken)
+                // Use classifier to intelligently determine which files need uploading
+                val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTimestamp)
+                val filesToUpload = mutableListOf<SyncFile>()
+
+                // Upload files that were updated locally since last sync
+                filesToUpload.addAll(classifier.updatedLocal)
+
+                // Upload files that don't exist remotely
+                filesToUpload.addAll(classifier.notExistingRemotely)
+
+                if (filesToUpload.isNotEmpty()) {
+                    Timber.tag("GOG-CloudSaves").i("Smart upload: ${filesToUpload.size} file(s) changed since last sync (out of ${localFiles.size} total)")
+                    filesToUpload.forEach { file ->
+                        uploadFile(credentials.userId, clientId, dirname, file, credentials.accessToken)
+                    }
+                } else {
+                    Timber.tag("GOG-CloudSaves").i("Smart upload: No files changed since last sync, skipping upload")
                 }
                 return@withContext currentTimestamp()
             }

--- a/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
@@ -241,6 +241,7 @@ class GOGCloudSavesManager(
                     }
                 } else {
                     Timber.tag("GOG-CloudSaves").i("Smart upload: No files changed since last sync, skipping upload")
+                    return@withContext lastSyncTimestamp
                 }
                 return@withContext currentTimestamp()
             }

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -658,12 +658,13 @@ class GOGService : Service() {
                 val game = instance.gogManager.getGameFromDbById(gameId.toString()) ?: return@withContext null
                 val saveLocations = instance.gogManager.getSaveDirectoryPath(context, appId, game.title)
                     ?: return@withContext null
+                val manager = GOGCloudSavesManager(context)
 
                 for (location in saveLocations) {
                     if (location.clientSecret.isEmpty()) continue
                     val timestamp = instance.gogManager
                         .getCloudSaveSyncTimestamp(appId, location.name).toLongOrNull() ?: 0L
-                    val conflict = GOGCloudSavesManager(context).detectConflict(
+                    val conflict = manager.detectConflict(
                         clientId = location.clientId,
                         clientSecret = location.clientSecret,
                         localPath = location.location,

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -564,39 +564,49 @@ class GOGService : Service() {
                                 preferredAction = preferredAction,
                             )
 
-                            if (newTimestamp > 0) {
-                                // Success - store new timestamp
-                                instance.gogManager.setCloudSaveSyncTimestamp(appId, location.name, newTimestamp.toString())
-                                Timber.tag("GOG").d("[Cloud Saves] Updated timestamp for '${location.name}': $newTimestamp")
+                            if (newTimestamp != timestamp) {
+                                if (newTimestamp > 0) {
+                                    // Success - store new timestamp
+                                    instance.gogManager.setCloudSaveSyncTimestamp(appId, location.name, newTimestamp.toString())
+                                    Timber.tag("GOG").d("[Cloud Saves] Updated timestamp for '${location.name}': $newTimestamp")
 
-                                // Log the save files in the directory after sync
-                                try {
-                                    val saveDir = java.io.File(location.location)
-                                    if (saveDir.exists() && saveDir.isDirectory) {
-                                        val files = saveDir.listFiles()
-                                        if (files != null && files.isNotEmpty()) {
-                                            val fileList = files.joinToString(", ") { it.name }
-                                            Timber.tag("GOG").i("[Cloud Saves] [$preferredAction] Files in '${location.name}': $fileList (${files.size} files)")
+                                    // Log the save files in the directory after sync
+                                    try {
+                                        val saveDir = java.io.File(location.location)
+                                        if (saveDir.exists() && saveDir.isDirectory) {
+                                            val files = saveDir.listFiles()
+                                            if (files != null && files.isNotEmpty()) {
+                                                val fileList = files.joinToString(", ") { it.name }
+                                                Timber.tag("GOG")
+                                                    .i("[Cloud Saves] [$preferredAction] Files in '${location.name}': $fileList (${files.size} files)")
 
-                                            // Log detailed file info
-                                            files.forEach { file ->
-                                                val size = if (file.isFile) "${file.length()} bytes" else "directory"
-                                                Timber.tag("GOG").d("[Cloud Saves] [$preferredAction]   - ${file.name} ($size)")
+                                                // Log detailed file info
+                                                files.forEach { file ->
+                                                    val size = if (file.isFile) "${file.length()} bytes" else "directory"
+                                                    Timber.tag("GOG").d("[Cloud Saves] [$preferredAction]   - ${file.name} ($size)")
+                                                }
+                                            } else {
+                                                Timber.tag("GOG")
+                                                    .w("[Cloud Saves] [$preferredAction] Directory '${location.name}' is empty at: ${location.location}")
                                             }
                                         } else {
-                                            Timber.tag("GOG").w("[Cloud Saves] [$preferredAction] Directory '${location.name}' is empty at: ${location.location}")
+                                            Timber.tag("GOG")
+                                                .w("[Cloud Saves] [$preferredAction] Directory not found: ${location.location}")
                                         }
-                                    } else {
-                                        Timber.tag("GOG").w("[Cloud Saves] [$preferredAction] Directory not found: ${location.location}")
+                                    } catch (e: Exception) {
+                                        Timber.tag("GOG").e(e, "[Cloud Saves] Failed to list files in directory: ${location.location}")
                                     }
-                                } catch (e: Exception) {
-                                    Timber.tag("GOG").e(e, "[Cloud Saves] Failed to list files in directory: ${location.location}")
-                                }
 
-                                Timber.tag("GOG").i("[Cloud Saves] Successfully synced save location '${location.name}' for game $gameId")
+                                    Timber.tag("GOG")
+                                        .i("[Cloud Saves] Successfully synced save location '${location.name}' for game $gameId")
+                                } else {
+                                    Timber.tag("GOG")
+                                        .e("[Cloud Saves] Failed to sync save location '${location.name}' for game $gameId (timestamp: $newTimestamp)")
+                                    allSucceeded = false
+                                }
                             } else {
-                                Timber.tag("GOG").e("[Cloud Saves] Failed to sync save location '${location.name}' for game $gameId (timestamp: $newTimestamp)")
-                                allSucceeded = false
+                                Timber.tag("GOG").i("[Cloud Saves] No save changes found for $appId")
+                                return@withContext true
                             }
                         } catch (e: CancellationException) {
                             throw e

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -643,17 +643,26 @@ class GOGService : Service() {
         /**
          * Check every save location for a conflict (both local and cloud changed since the last
          * sync) WITHOUT uploading or downloading anything. Returns the first conflicting location's
-         * timestamps (millis), or null if there is no conflict. Does not take the sync lock so it
-         * can run before the real sync.
+         * timestamps (millis), or null if there is no conflict.
+         *
+         * Takes the per-app sync lock (startSync/endSync) for the duration of the read so it never
+         * observes a half-synced snapshot: a concurrent syncSaves mutates local files, remote
+         * metadata, and the stored timestamp, any of which would otherwise yield a wrong result.
+         * If a sync is already running for this app, skips detection and returns null — that sync
+         * reconciles state, and a real conflict surfaces on a later launch.
          */
         suspend fun detectCloudSaveConflict(
             context: Context,
             appId: String,
         ): GogConflict? = withContext(Dispatchers.IO) {
-            try {
-                val instance = getInstance() ?: return@withContext null
-                if (!GOGAuthManager.hasStoredCredentials(context)) return@withContext null
+            val instance = getInstance() ?: return@withContext null
+            if (!GOGAuthManager.hasStoredCredentials(context)) return@withContext null
 
+            if (!instance.gogManager.startSync(appId)) {
+                Timber.tag("GOG").d("[Cloud Saves] Sync already in progress for $appId, skipping conflict detection")
+                return@withContext null
+            }
+            try {
                 val gameId = ContainerUtils.extractGameIdFromContainerId(appId)
                 val game = instance.gogManager.getGameFromDbById(gameId.toString()) ?: return@withContext null
                 val saveLocations = instance.gogManager.getSaveDirectoryPath(context, appId, game.title)
@@ -682,6 +691,8 @@ class GOGService : Service() {
             } catch (e: Exception) {
                 Timber.tag("GOG").e(e, "[Cloud Saves] Conflict detection failed for $appId")
                 null
+            } finally {
+                instance.gogManager.endSync(appId)
             }
         }
     }

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -634,6 +634,55 @@ class GOGService : Service() {
                 return@withContext false
             }
         }
+
+        data class GogConflict(
+            val localTimestamp: Long,
+            val remoteTimestamp: Long,
+        )
+
+        /**
+         * Check every save location for a conflict (both local and cloud changed since the last
+         * sync) WITHOUT uploading or downloading anything. Returns the first conflicting location's
+         * timestamps (millis), or null if there is no conflict. Does not take the sync lock so it
+         * can run before the real sync.
+         */
+        suspend fun detectCloudSaveConflict(
+            context: Context,
+            appId: String,
+        ): GogConflict? = withContext(Dispatchers.IO) {
+            try {
+                val instance = getInstance() ?: return@withContext null
+                if (!GOGAuthManager.hasStoredCredentials(context)) return@withContext null
+
+                val gameId = ContainerUtils.extractGameIdFromContainerId(appId)
+                val game = instance.gogManager.getGameFromDbById(gameId.toString()) ?: return@withContext null
+                val saveLocations = instance.gogManager.getSaveDirectoryPath(context, appId, game.title)
+                    ?: return@withContext null
+
+                for (location in saveLocations) {
+                    if (location.clientSecret.isEmpty()) continue
+                    val timestamp = instance.gogManager
+                        .getCloudSaveSyncTimestamp(appId, location.name).toLongOrNull() ?: 0L
+                    val conflict = GOGCloudSavesManager(context).detectConflict(
+                        clientId = location.clientId,
+                        clientSecret = location.clientSecret,
+                        localPath = location.location,
+                        dirname = location.name,
+                        lastSyncTimestamp = timestamp,
+                    )
+                    if (conflict != null) {
+                        Timber.tag("GOG").i("[Cloud Saves] Conflict in '${location.name}' for $appId")
+                        return@withContext GogConflict(conflict.localTimestamp, conflict.remoteTimestamp)
+                    }
+                }
+                null
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.tag("GOG").e(e, "[Cloud Saves] Conflict detection failed for $appId")
+                null
+            }
+        }
     }
 
     private lateinit var notificationHelper: NotificationHelper

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -606,7 +606,6 @@ class GOGService : Service() {
                                 }
                             } else {
                                 Timber.tag("GOG").i("[Cloud Saves] No save changes found for $appId")
-                                return@withContext true
                             }
                         } catch (e: CancellationException) {
                             throw e

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1825,18 +1825,50 @@ fun preLaunchApp(
             } else {
                 Timber.tag("GOG").i("[Cloud Saves] GOG Game detected for $appId — syncing cloud saves before launch")
 
-                // Sync cloud saves (download latest saves before playing)
-                Timber.tag("GOG").d("[Cloud Saves] Starting pre-game download sync for $appId")
-                val syncSuccess = app.gamenative.service.gog.GOGService.syncCloudSaves(
+                // Map an explicit user choice (from the conflict dialog) to a forced sync direction.
+                val gogPreferredAction = when (preferredSave) {
+                    SaveLocation.Local -> "upload" // "Keep local" -> push local to cloud
+                    SaveLocation.Remote -> "download" // "Keep remote" -> pull cloud down
+                    SaveLocation.None -> null
+                }
+
+                // Initial launch (no choice yet): detect a conflict and prompt before syncing.
+                if (gogPreferredAction == null) {
+                    val conflict = GOGService.detectCloudSaveConflict(context, appId)
+                    if (conflict != null) {
+                        Timber.tag("GOG").i("[Cloud Saves] Conflict detected for $appId — prompting user")
+                        val localDate = Date(conflict.localTimestamp).toString()
+                        val remoteDate = Date(conflict.remoteTimestamp).toString()
+                        setLoadingDialogVisible(false)
+                        setMessageDialogState(
+                            MessageDialogState(
+                                visible = true,
+                                type = DialogType.SYNC_CONFLICT,
+                                title = context.getString(R.string.main_save_conflict_title),
+                                message = context.getString(R.string.main_save_conflict_message, localDate, remoteDate),
+                                dismissBtnText = context.getString(R.string.main_keep_local),
+                                confirmBtnText = context.getString(R.string.main_keep_remote),
+                            ),
+                        )
+                        // Wait for the user; the dialog handlers re-enter preLaunchApp with a SaveLocation.
+                        return@launch
+                    }
+                }
+
+                // No conflict, or the user already chose a side: perform the sync.
+                val action = gogPreferredAction ?: "none"
+                Timber.tag("GOG").d("[Cloud Saves] Starting pre-game sync for $appId (action: $action)")
+                val syncSuccess = GOGService.syncCloudSaves(
                     context = context,
                     appId = appId,
+                    preferredAction = action,
                 )
 
                 if (!syncSuccess) {
-                    Timber.tag("GOG").w("[Cloud Saves] Download sync failed for $appId, proceeding with launch anyway")
+                    Timber.tag("GOG").w("[Cloud Saves] Pre-game sync failed for $appId, proceeding with launch anyway")
                     // Don't block launch on sync failure - log warning and continue
                 } else {
-                    Timber.tag("GOG").i("[Cloud Saves] Download sync completed successfully for $appId")
+                    Timber.tag("GOG").i("[Cloud Saves] Pre-game sync completed successfully for $appId")
                 }
             }
 

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1827,7 +1827,7 @@ fun preLaunchApp(
 
                 // Map an explicit user choice (from the conflict dialog) to a forced sync direction.
                 val gogPreferredAction = when (preferredSave) {
-                    SaveLocation.Local -> "upload" // "Keep local" -> push local to cloud
+                    SaveLocation.Local -> "forceupload" // "Keep local" -> force local up, past the conflict guard
                     SaveLocation.Remote -> "download" // "Keep remote" -> pull cloud down
                     SaveLocation.None -> null
                 }

--- a/app/src/test/java/app/gamenative/service/gog/GOGCloudSavesManagerTest.kt
+++ b/app/src/test/java/app/gamenative/service/gog/GOGCloudSavesManagerTest.kt
@@ -310,4 +310,54 @@ class GOGCloudSavesManagerTest {
         // instead of currentTimestamp() to signal no changes occurred
         // This allows the caller to detect: newTimestamp == lastSyncTimestamp means no changes
     }
+
+    @Test
+    fun downloaded_files_should_preserve_cloud_timestamp() {
+        // Critical: When downloading files from cloud, the local file's modification time
+        // must be set to match the cloud file's timestamp. This ensures:
+        // 1. Future syncs correctly detect which version is newer
+        // 2. Files downloaded from cloud don't immediately appear as "locally modified"
+        // 3. Timestamp-based conflict detection works correctly
+
+        val cloudFile = GOGCloudSavesManager.CloudFile(
+            relativePath = "save.sav",
+            md5Hash = "abc123",
+            updateTime = "2026-01-01T00:00:00Z",
+            updateTimestamp = 1500L // seconds (UTC epoch)
+        )
+
+        // After download, the local file's lastModified() should be set to:
+        val expectedLocalMillis = cloudFile.updateTimestamp!! * 1000
+        assertEquals(1500000L, expectedLocalMillis)
+
+        // Simulate what happens after download: create a local file representation
+        val downloadedFile = GOGCloudSavesManager.SyncFile(
+            relativePath = cloudFile.relativePath,
+            absolutePath = "/path/save.sav",
+            md5Hash = cloudFile.md5Hash,
+            updateTime = cloudFile.updateTime,
+            updateTimestamp = cloudFile.updateTimestamp // Should match cloud timestamp
+        )
+
+        // Verify timestamps match (both in seconds)
+        assertEquals(cloudFile.updateTimestamp, downloadedFile.updateTimestamp)
+
+        // Test scenario: After downloading, if we sync again with the same lastSyncTime,
+        // both local and cloud will have timestamp > lastSyncTime
+        val lastSyncTime = 1000L
+        val classifier = classifyFiles(listOf(downloadedFile), listOf(cloudFile), lastSyncTime)
+
+        // Both files have timestamp 1500L > lastSyncTime 1000L, so both are "updated"
+        assertEquals(1, classifier.updatedLocal.size)
+        assertEquals(1, classifier.updatedCloud.size)
+
+        // This results in CONFLICT action
+        assertEquals(GOGCloudSavesManager.SyncAction.CONFLICT, classifier.determineAction())
+
+        // However, the CONFLICT resolution logic compares timestamps and finds they're equal,
+        // so neither will be uploaded/downloaded (see syncSaves CONFLICT handling at lines 275-287)
+
+        // The key is: after a successful download that preserves timestamps, the NEXT sync
+        // should update lastSyncTimestamp to 1500L, preventing this conflict on future syncs
+    }
 }

--- a/app/src/test/java/app/gamenative/service/gog/GOGCloudSavesManagerTest.kt
+++ b/app/src/test/java/app/gamenative/service/gog/GOGCloudSavesManagerTest.kt
@@ -282,4 +282,32 @@ class GOGCloudSavesManagerTest {
         assertEquals(1, uniqueFilesToUpload.size)
         assertEquals("new.sav", uniqueFilesToUpload[0].relativePath)
     }
+
+    @Test
+    fun smart_upload_returns_original_timestamp_when_no_files_changed() {
+        // When no files have changed since last sync, should return the original timestamp
+        // This signals to the caller that no sync occurred and timestamp should not be updated
+        val lastSyncTime = 1000L
+        val localFiles = listOf(
+            GOGCloudSavesManager.SyncFile("save1.sav", "/path/save1.sav", "hash1", "2026-01-01T00:00:00Z", 500L),
+            GOGCloudSavesManager.SyncFile("save2.sav", "/path/save2.sav", "hash2", "2026-01-01T00:00:00Z", 800L)
+        )
+        val cloudFiles = listOf(
+            GOGCloudSavesManager.CloudFile("save1.sav", "hash1", "2026-01-01T00:00:00Z", 500L),
+            GOGCloudSavesManager.CloudFile("save2.sav", "hash2", "2026-01-01T00:00:00Z", 800L)
+        )
+
+        val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTime)
+        val filesToUpload = mutableListOf<GOGCloudSavesManager.SyncFile>()
+        filesToUpload.addAll(classifier.updatedLocal)
+        filesToUpload.addAll(classifier.notExistingRemotely)
+        val uniqueFilesToUpload = filesToUpload.distinctBy { it.relativePath }
+
+        // No files should be uploaded
+        assertEquals(0, uniqueFilesToUpload.size)
+
+        // When uniqueFilesToUpload is empty, the implementation should return lastSyncTimestamp
+        // instead of currentTimestamp() to signal no changes occurred
+        // This allows the caller to detect: newTimestamp == lastSyncTimestamp means no changes
+    }
 }

--- a/app/src/test/java/app/gamenative/service/gog/GOGCloudSavesManagerTest.kt
+++ b/app/src/test/java/app/gamenative/service/gog/GOGCloudSavesManagerTest.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.mock
+import java.lang.reflect.Method
 
 class GOGCloudSavesManagerTest {
     private val context: Context = mock()
@@ -49,5 +51,235 @@ class GOGCloudSavesManagerTest {
         assertEquals(1, files!!.size)
         assertEquals("save-1.sav", files.single().relativePath)
         assertEquals(1_775_162_040L, files.single().updateTimestamp)
+    }
+
+    // Helper to access private classifyFiles method
+    private fun classifyFiles(
+        localFiles: List<GOGCloudSavesManager.SyncFile>,
+        cloudFiles: List<GOGCloudSavesManager.CloudFile>,
+        timestamp: Long
+    ): GOGCloudSavesManager.SyncClassifier {
+        val method: Method = GOGCloudSavesManager::class.java.getDeclaredMethod(
+            "classifyFiles",
+            List::class.java,
+            List::class.java,
+            Long::class.java
+        )
+        method.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return method.invoke(manager, localFiles, cloudFiles, timestamp) as GOGCloudSavesManager.SyncClassifier
+    }
+
+    @Test
+    fun classifyFiles_identifies_files_updated_locally_after_last_sync() {
+        val lastSyncTime = 1000L
+        val localFiles = listOf(
+            GOGCloudSavesManager.SyncFile(
+                relativePath = "save1.sav",
+                absolutePath = "/path/save1.sav",
+                md5Hash = "hash1",
+                updateTime = "2026-01-01T00:00:00Z",
+                updateTimestamp = 1500L // Modified after last sync
+            ),
+            GOGCloudSavesManager.SyncFile(
+                relativePath = "save2.sav",
+                absolutePath = "/path/save2.sav",
+                md5Hash = "hash2",
+                updateTime = "2026-01-01T00:00:00Z",
+                updateTimestamp = 500L // Modified before last sync
+            )
+        )
+        val cloudFiles = listOf(
+            GOGCloudSavesManager.CloudFile("save1.sav", "hash1", "2026-01-01T00:00:00Z", 800L),
+            GOGCloudSavesManager.CloudFile("save2.sav", "hash2", "2026-01-01T00:00:00Z", 500L)
+        )
+
+        val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTime)
+
+        assertEquals(1, classifier.updatedLocal.size)
+        assertEquals("save1.sav", classifier.updatedLocal[0].relativePath)
+        assertEquals(1500L, classifier.updatedLocal[0].updateTimestamp)
+    }
+
+    @Test
+    fun classifyFiles_identifies_files_not_existing_remotely() {
+        val localFiles = listOf(
+            GOGCloudSavesManager.SyncFile("save1.sav", "/path/save1.sav", "hash1", "2026-01-01T00:00:00Z", 1000L),
+            GOGCloudSavesManager.SyncFile("save2.sav", "/path/save2.sav", "hash2", "2026-01-01T00:00:00Z", 1000L)
+        )
+        val cloudFiles = listOf(
+            GOGCloudSavesManager.CloudFile("save1.sav", "hash1", "2026-01-01T00:00:00Z", 1000L)
+        )
+
+        val classifier = classifyFiles(localFiles, cloudFiles, 0L)
+
+        assertEquals(1, classifier.notExistingRemotely.size)
+        assertEquals("save2.sav", classifier.notExistingRemotely[0].relativePath)
+    }
+
+    @Test
+    fun classifyFiles_identifies_files_updated_in_cloud_after_last_sync() {
+        val lastSyncTime = 1000L
+        val localFiles = listOf(
+            GOGCloudSavesManager.SyncFile("save1.sav", "/path/save1.sav", "hash1", "2026-01-01T00:00:00Z", 500L)
+        )
+        val cloudFiles = listOf(
+            GOGCloudSavesManager.CloudFile("save1.sav", "hash1", "2026-01-01T00:00:00Z", 1500L) // Modified after last sync
+        )
+
+        val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTime)
+
+        assertEquals(1, classifier.updatedCloud.size)
+        assertEquals("save1.sav", classifier.updatedCloud[0].relativePath)
+    }
+
+    @Test
+    fun classifyFiles_identifies_files_not_existing_locally() {
+        val localFiles = listOf(
+            GOGCloudSavesManager.SyncFile("save1.sav", "/path/save1.sav", "hash1", "2026-01-01T00:00:00Z", 1000L)
+        )
+        val cloudFiles = listOf(
+            GOGCloudSavesManager.CloudFile("save1.sav", "hash1", "2026-01-01T00:00:00Z", 1000L),
+            GOGCloudSavesManager.CloudFile("save2.sav", "hash2", "2026-01-01T00:00:00Z", 1000L)
+        )
+
+        val classifier = classifyFiles(localFiles, cloudFiles, 0L)
+
+        assertEquals(1, classifier.notExistingLocally.size)
+        assertEquals("save2.sav", classifier.notExistingLocally[0].relativePath)
+    }
+
+    @Test
+    fun classifyFiles_skips_deleted_cloud_files() {
+        val localFiles = emptyList<GOGCloudSavesManager.SyncFile>()
+        val cloudFiles = listOf(
+            GOGCloudSavesManager.CloudFile("save1.sav", "aadd86936a80ee8a369579c3926f1b3c", "2026-01-01T00:00:00Z", 1000L) // Deletion marker
+        )
+
+        val classifier = classifyFiles(localFiles, cloudFiles, 0L)
+
+        assertEquals(0, classifier.notExistingLocally.size)
+        assertEquals(0, classifier.updatedCloud.size)
+    }
+
+    @Test
+    fun syncClassifier_determineAction_returns_upload_when_only_local_updated() {
+        val lastSyncTime = 1000L
+        val localFiles = listOf(
+            GOGCloudSavesManager.SyncFile("save1.sav", "/path/save1.sav", "hash1", "2026-01-01T00:00:00Z", 1500L)
+        )
+        val cloudFiles = listOf(
+            GOGCloudSavesManager.CloudFile("save1.sav", "hash1", "2026-01-01T00:00:00Z", 500L)
+        )
+
+        val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTime)
+        val action = classifier.determineAction()
+
+        assertEquals(GOGCloudSavesManager.SyncAction.UPLOAD, action)
+    }
+
+    @Test
+    fun syncClassifier_determineAction_returns_download_when_only_cloud_updated() {
+        val lastSyncTime = 1000L
+        val localFiles = listOf(
+            GOGCloudSavesManager.SyncFile("save1.sav", "/path/save1.sav", "hash1", "2026-01-01T00:00:00Z", 500L)
+        )
+        val cloudFiles = listOf(
+            GOGCloudSavesManager.CloudFile("save1.sav", "hash1", "2026-01-01T00:00:00Z", 1500L)
+        )
+
+        val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTime)
+        val action = classifier.determineAction()
+
+        assertEquals(GOGCloudSavesManager.SyncAction.DOWNLOAD, action)
+    }
+
+    @Test
+    fun syncClassifier_determineAction_returns_conflict_when_both_updated() {
+        val lastSyncTime = 1000L
+        val localFiles = listOf(
+            GOGCloudSavesManager.SyncFile("save1.sav", "/path/save1.sav", "hash1", "2026-01-01T00:00:00Z", 1500L)
+        )
+        val cloudFiles = listOf(
+            GOGCloudSavesManager.CloudFile("save1.sav", "hash1", "2026-01-01T00:00:00Z", 1500L)
+        )
+
+        val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTime)
+        val action = classifier.determineAction()
+
+        assertEquals(GOGCloudSavesManager.SyncAction.CONFLICT, action)
+    }
+
+    @Test
+    fun syncClassifier_determineAction_returns_none_when_nothing_updated() {
+        val lastSyncTime = 1000L
+        val localFiles = listOf(
+            GOGCloudSavesManager.SyncFile("save1.sav", "/path/save1.sav", "hash1", "2026-01-01T00:00:00Z", 500L)
+        )
+        val cloudFiles = listOf(
+            GOGCloudSavesManager.CloudFile("save1.sav", "hash1", "2026-01-01T00:00:00Z", 500L)
+        )
+
+        val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTime)
+        val action = classifier.determineAction()
+
+        assertEquals(GOGCloudSavesManager.SyncAction.NONE, action)
+    }
+
+    @Test
+    fun smart_upload_should_only_include_updated_and_new_files() {
+        // Simulates the smart upload logic: only files modified after last sync + new files
+        val lastSyncTime = 1000L
+        val localFiles = listOf(
+            GOGCloudSavesManager.SyncFile("unchanged.sav", "/path/unchanged.sav", "hash1", "2026-01-01T00:00:00Z", 500L),
+            GOGCloudSavesManager.SyncFile("modified.sav", "/path/modified.sav", "hash2", "2026-01-01T00:00:00Z", 1500L),
+            GOGCloudSavesManager.SyncFile("new.sav", "/path/new.sav", "hash3", "2026-01-01T00:00:00Z", 1200L)
+        )
+        val cloudFiles = listOf(
+            GOGCloudSavesManager.CloudFile("unchanged.sav", "hash1", "2026-01-01T00:00:00Z", 500L),
+            GOGCloudSavesManager.CloudFile("modified.sav", "hash2_old", "2026-01-01T00:00:00Z", 800L)
+        )
+
+        val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTime)
+        val filesToUpload = mutableListOf<GOGCloudSavesManager.SyncFile>()
+        filesToUpload.addAll(classifier.updatedLocal)
+        filesToUpload.addAll(classifier.notExistingRemotely)
+
+        // Deduplicate by relativePath (files can appear in both lists)
+        val uniqueFilesToUpload = filesToUpload.distinctBy { it.relativePath }
+
+        assertEquals(2, uniqueFilesToUpload.size)
+        assertTrue(uniqueFilesToUpload.any { it.relativePath == "modified.sav" })
+        assertTrue(uniqueFilesToUpload.any { it.relativePath == "new.sav" })
+        assertTrue(uniqueFilesToUpload.none { it.relativePath == "unchanged.sav" })
+    }
+
+    @Test
+    fun smart_upload_deduplicates_new_files_appearing_in_both_lists() {
+        // New files modified after last sync appear in BOTH updatedLocal and notExistingRemotely
+        // This test verifies they are only uploaded once
+        val lastSyncTime = 1000L
+        val localFiles = listOf(
+            GOGCloudSavesManager.SyncFile("new.sav", "/path/new.sav", "hash1", "2026-01-01T00:00:00Z", 1500L)
+        )
+        val cloudFiles = emptyList<GOGCloudSavesManager.CloudFile>()
+
+        val classifier = classifyFiles(localFiles, cloudFiles, lastSyncTime)
+
+        // Verify the file appears in both lists
+        assertEquals(1, classifier.updatedLocal.size)
+        assertEquals(1, classifier.notExistingRemotely.size)
+        assertEquals("new.sav", classifier.updatedLocal[0].relativePath)
+        assertEquals("new.sav", classifier.notExistingRemotely[0].relativePath)
+
+        // Simulate the upload logic with deduplication
+        val filesToUpload = mutableListOf<GOGCloudSavesManager.SyncFile>()
+        filesToUpload.addAll(classifier.updatedLocal)
+        filesToUpload.addAll(classifier.notExistingRemotely)
+        val uniqueFilesToUpload = filesToUpload.distinctBy { it.relativePath }
+
+        // Should only upload once
+        assertEquals(1, uniqueFilesToUpload.size)
+        assertEquals("new.sav", uniqueFilesToUpload[0].relativePath)
     }
 }


### PR DESCRIPTION
## Description
Previously, a preferred "upload" action would unconditionally re-upload all local save files, even if they hadn't changed since the last sync. This led to inefficient and unnecessary data transfers, and the timestamps are also force updated, particularly after game sessions or application restarts.

This change introduces a smart classification mechanism to identify only local files that have been updated or are new, ensuring that only essential changes are uploaded to the GOG cloud.

## Recording
N/A

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make GOG cloud save sync smarter and safer: upload only changed files, detect conflicts before launch with a prompt, skip exit uploads when the cloud is newer or in conflict, reuse one manager for checks, preserve cloud timestamps on downloads, and lock conflict detection to avoid race conditions.

- **New Features**
  - Detect conflicts before launch and prompt to keep local or remote; the choice applies immediately (force upload or download).

- **Bug Fixes**
  - Smart upload: only changed/missing files and deduplicate by `relativePath`.
  - Preserve cloud timestamps on downloaded files to prevent re-uploads and false conflicts.
  - “No changes” returns the original timestamp and other locations continue; exit uploads skip when cloud is newer or in conflict.
  - Conflict dialog: “Keep local” now forces upload so local wins; “Keep remote” downloads.
  - Conflict detection runs under the per-app sync lock; if a sync is in progress, detection skips to prevent spurious prompts.

<sup>Written for commit 5c2d74cc8b3f921791d717738ea5b118e090295a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud save syncing with “smart upload” to send only locally updated or newly created files, avoiding unnecessary re-uploads.
  * Prevents duplicate uploads by deduplicating smart-upload candidates by file path.
  * Refined sync outcome handling so locations with “no changes” no longer mark the overall sync as failed.
* **New Features**
  * Added cloud-save conflict detection and a pre-launch conflict dialog that lets users resolve local vs remote differences.
* **Tests**
  * Expanded coverage for sync classification, smart-upload candidate selection/deduplication, and “no files changed” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->