### PR TITLE
fix: cut FPS count from CPU images by half on SurfaceFlinger renderer

### DIFF
--- a/app/src/main/java/com/winlator/renderer/ASurfaceRenderer.java
+++ b/app/src/main/java/com/winlator/renderer/ASurfaceRenderer.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ASurfaceRenderer implements WindowManager.OnWindowModificationListener,
@@ -134,7 +135,7 @@ public class ASurfaceRenderer implements WindowManager.OnWindowModificationListe
     }
 
     private int pendingPresentSerial = 0;
-    private int skipFPSCount = 0;
+    private AtomicInteger skipFPSCount = new AtomicInteger(0);
     public void setPendingPresentSerial(int serial) {
         pendingPresentSerial = serial;
     }
@@ -261,7 +262,7 @@ public class ASurfaceRenderer implements WindowManager.OnWindowModificationListe
                 return;
             }
         }
-        skipFPSCount = 0;
+        skipFPSCount.set(0);
         surfaceInitialized = nativeInit(surface, xServer.screenInfo.width, xServer.screenInfo.height);
         if (surfaceInitialized) {
             NATIVE_CONTEXT_GENERATION.incrementAndGet();
@@ -304,7 +305,7 @@ public class ASurfaceRenderer implements WindowManager.OnWindowModificationListe
             nativeDestroy();
             surfaceInitialized = false;
         }
-        skipFPSCount = 0;
+        skipFPSCount.set(0);
         windowSurfaces.clear();
         cachedDesktopDst = null;
     }
@@ -466,11 +467,11 @@ public class ASurfaceRenderer implements WindowManager.OnWindowModificationListe
                     int acquireFence = g.consumeAcquireFence();
                     // Disable swap R/B in cpu path as it is handled with drawable
                     nativeSetWindowBuffer(windowId, ahbPtr, acquireFence, 0, 0, g, g.getLastUsedSlot(), sfCompatMode);
-                    if (hudRef != null && skipFPSCount >= 1) {
+                    if (hudRef != null && skipFPSCount.get() >= 1) {
                         hudRef.update();
-                        skipFPSCount = 0;
+                        skipFPSCount.set(0);
                     } else {
-                        skipFPSCount++;
+                        skipFPSCount.incrementAndGet();
                     }
                 }
             }

--- a/app/src/main/java/com/winlator/renderer/ASurfaceRenderer.java
+++ b/app/src/main/java/com/winlator/renderer/ASurfaceRenderer.java
@@ -3,9 +3,8 @@ package com.winlator.renderer;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.os.Build;
 import android.view.Surface;
-import android.view.SurfaceControl;
+
 import app.gamenative.R;
 import android.graphics.Rect;
 import timber.log.Timber;
@@ -135,6 +134,7 @@ public class ASurfaceRenderer implements WindowManager.OnWindowModificationListe
     }
 
     private int pendingPresentSerial = 0;
+    private int skipFPSCount = 0;
     public void setPendingPresentSerial(int serial) {
         pendingPresentSerial = serial;
     }
@@ -261,6 +261,7 @@ public class ASurfaceRenderer implements WindowManager.OnWindowModificationListe
                 return;
             }
         }
+        skipFPSCount = 0;
         surfaceInitialized = nativeInit(surface, xServer.screenInfo.width, xServer.screenInfo.height);
         if (surfaceInitialized) {
             NATIVE_CONTEXT_GENERATION.incrementAndGet();
@@ -303,6 +304,7 @@ public class ASurfaceRenderer implements WindowManager.OnWindowModificationListe
             nativeDestroy();
             surfaceInitialized = false;
         }
+        skipFPSCount = 0;
         windowSurfaces.clear();
         cachedDesktopDst = null;
     }
@@ -464,7 +466,12 @@ public class ASurfaceRenderer implements WindowManager.OnWindowModificationListe
                     int acquireFence = g.consumeAcquireFence();
                     // Disable swap R/B in cpu path as it is handled with drawable
                     nativeSetWindowBuffer(windowId, ahbPtr, acquireFence, 0, 0, g, g.getLastUsedSlot(), sfCompatMode);
-                    if (hudRef != null) hudRef.update();
+                    if (hudRef != null && skipFPSCount >= 1) {
+                        hudRef.update();
+                        skipFPSCount = 0;
+                    } else {
+                        skipFPSCount++;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description
fix fps counter for OpenGL games or when using DRI3 disabled

## Recording

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated FPS in the SurfaceFlinger renderer’s CPU-image path by updating the HUD every other frame. Restores accurate FPS for OpenGL games and when DRI3 is disabled.

- **Bug Fixes**
  - Use a thread-safe `AtomicInteger` skip counter and update the HUD only every second CPU frame to prevent double-counting.
  - Reset the counter on surface create/destroy to avoid stale state.

<sup>Written for commit 1cce41e088042442354bf1bdb7bda0cd3b1c715b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary CPU scanout HUD refreshes by throttling updates, improving rendering smoothness and performance in some cases.
  * Correctly resets the HUD refresh throttling state when the rendering surface is created or destroyed, helping prevent stale or inconsistent on-screen updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->