### PR TITLE
Added changes to make app more navigable by controller

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/NoExtractOutlinedTextField.kt
+++ b/app/src/main/java/app/gamenative/ui/component/NoExtractOutlinedTextField.kt
@@ -11,7 +11,13 @@ import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.InterceptPlatformTextInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
@@ -63,6 +69,30 @@ fun NoExtractOutlinedTextField(
         ?: if (singleLine) KeyboardActions(onDone = { focusManager.clearFocus() })
         else KeyboardActions.Default
 
+    // A focused Compose text field swallows D-pad up/down (for cursor movement),
+    // which traps controller focus on the field. In a single-line field up/down are
+    // never used for editing, so intercept them *before* the field and turn them into
+    // focus moves, letting a gamepad navigate past the field. Left/right (cursor) and
+    // typing are untouched.
+    val gamepadModifier = if (singleLine) {
+        modifier.onPreviewKeyEvent { event ->
+            if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+            when (event.key) {
+                Key.DirectionUp -> {
+                    focusManager.moveFocus(FocusDirection.Up)
+                    true
+                }
+                Key.DirectionDown -> {
+                    focusManager.moveFocus(FocusDirection.Down)
+                    true
+                }
+                else -> false
+            }
+        }
+    } else {
+        modifier
+    }
+
     InterceptPlatformTextInput(
         interceptor = { request, nextHandler ->
             val modifiedRequest = PlatformTextInputMethodRequest { outAttributes ->
@@ -77,7 +107,7 @@ fun NoExtractOutlinedTextField(
         OutlinedTextField(
             value = value,
             onValueChange = onValueChange,
-            modifier = modifier,
+            modifier = gamepadModifier,
             enabled = enabled,
             readOnly = readOnly,
             textStyle = textStyle,

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -60,6 +61,13 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringArrayResource
@@ -1245,8 +1253,33 @@ fun ContainerConfigDialog(
                         stringResource(R.string.container_config_tab_drives),
                         stringResource(R.string.container_config_tab_advanced)
                     )
+
+                    // Let controller shoulder buttons cycle through the tabs: R1/R2
+                    // forward, L1/L2 back (both wrap). The handler lives on the content
+                    // container (not a focusable wrapper, which would break up/down
+                    // traversal), so it fires whenever focus is anywhere in the tabs or
+                    // content below.
+                    val firstTabFocusRequester = remember { FocusRequester() }
+                    // Seed focus onto the first tab when the dialog opens so the gamepad
+                    // can navigate immediately instead of needing a button press first.
+                    LaunchedEffect(Unit) { runCatching { firstTabFocusRequester.requestFocus() } }
+
                     Column(
                         modifier = Modifier
+                            .onPreviewKeyEvent { event ->
+                                if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                                when (event.key) {
+                                    Key.ButtonR1, Key.ButtonR2 -> {
+                                        selectedTab = (selectedTab + 1) % tabs.size
+                                        true
+                                    }
+                                    Key.ButtonL1, Key.ButtonL2 -> {
+                                        selectedTab = (selectedTab - 1 + tabs.size) % tabs.size
+                                        true
+                                    }
+                                    else -> false
+                                }
+                            }
                             .padding(
                                 top = PaddingUtils.statusBarAwarePadding().calculateTopPadding() + paddingValues.calculateTopPadding(),
                                 bottom = 32.dp + paddingValues.calculateBottomPadding(),
@@ -1261,6 +1294,11 @@ fun ContainerConfigDialog(
                                     selected = selectedTab == index,
                                     onClick = { selectedTab = index },
                                     text = { Text(text = label) },
+                                    modifier = if (index == 0) {
+                                        Modifier.focusRequester(firstTabFocusRequester)
+                                    } else {
+                                        Modifier
+                                    },
                                 )
                             }
                         }
@@ -1384,7 +1422,20 @@ internal fun ExecutablePathDropdown(
             },
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(),
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                // A focused text field also swallows the center/enter (gamepad A) key,
+                // so the anchor never opens via controller. Intercept it here and toggle
+                // the menu. (Up/down focus-escape is handled in NoExtractOutlinedTextField.)
+                .onPreviewKeyEvent { event ->
+                    if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                    when (event.key) {
+                        Key.DirectionCenter, Key.Enter, Key.NumPadEnter, Key.Spacebar, Key.ButtonA -> {
+                            expanded = !expanded
+                            true
+                        }
+                        else -> false
+                    }
+                },
             singleLine = true
         )
 

--- a/app/src/main/java/app/gamenative/ui/component/settings/SettingsListDropdown.kt
+++ b/app/src/main/java/app/gamenative/ui/component/settings/SettingsListDropdown.kt
@@ -24,6 +24,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -57,11 +59,18 @@ fun SettingsListDropdown(
     var isDropdownExpanded by remember { mutableStateOf(false) }
     val selectedText = if (value >= 0 && value < items.size) items[value] else fallbackDisplay
 
+    // Keep a handle on the anchor tile so we can return focus to it when the menu
+    // closes. Without this, dismissing the popup leaves focus cleared and D-pad /
+    // controller navigation has nowhere to go.
+    val focusRequester = remember { FocusRequester() }
+
     SettingsTileScaffold(
-        modifier = Modifier.clickable(
-            enabled = enabled,
-            onClick = { isDropdownExpanded = true },
-        ).then(modifier),
+        modifier = Modifier
+            .focusRequester(focusRequester)
+            .clickable(
+                enabled = enabled,
+                onClick = { isDropdownExpanded = true },
+            ).then(modifier),
         enabled = enabled,
         title = title,
         subtitle = {
@@ -93,7 +102,10 @@ fun SettingsListDropdown(
     ) {
         DropdownMenu(
             expanded = isDropdownExpanded,
-            onDismissRequest = { isDropdownExpanded = false },
+            onDismissRequest = {
+                isDropdownExpanded = false
+                focusRequester.requestFocus()
+            },
         ) {
             items.forEachIndexed { index, text ->
                 val isMuted = itemMuted?.getOrNull(index) == true
@@ -108,6 +120,7 @@ fun SettingsListDropdown(
                     onClick = {
                         onItemSelected(index)
                         isDropdownExpanded = false
+                        focusRequester.requestFocus()
                     },
                 )
             }

--- a/app/src/main/java/app/gamenative/ui/component/settings/SettingsListDropdownSearchable.kt
+++ b/app/src/main/java/app/gamenative/ui/component/settings/SettingsListDropdownSearchable.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -22,8 +23,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -34,8 +43,10 @@ import com.alorma.compose.settings.ui.base.internal.LocalSettingsGroupEnabled
 import com.alorma.compose.settings.ui.base.internal.SettingsTileColors
 import com.alorma.compose.settings.ui.base.internal.SettingsTileDefaults
 import com.alorma.compose.settings.ui.base.internal.SettingsTileScaffold
-import androidx.compose.material3.TextField
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.res.stringResource
 import app.gamenative.R
 
@@ -58,6 +69,16 @@ fun SettingsListDropdownSearchable(
 ) {
     var isDropdownExpanded by remember { mutableStateOf(false) }
 
+    // Keep a handle on the anchor tile so we can return focus to it when the menu
+    // closes. Without this, dismissing the popup leaves focus cleared and D-pad /
+    // controller navigation has nowhere to go.
+    val focusRequester = remember { FocusRequester() }
+
+    // Focus handle for the first item in the list. On a controller we seed focus
+    // here (not the search field) so D-pad down immediately walks the drivers and
+    // the soft keyboard never pops up. Touch users can still tap the search field.
+    val listFocusRequester = remember { FocusRequester() }
+
     // 🔥 NEW: search state
     var query by remember { mutableStateOf("") }
 
@@ -72,6 +93,7 @@ fun SettingsListDropdownSearchable(
 
     SettingsTileScaffold(
         modifier = Modifier
+            .focusRequester(focusRequester)
             .clickable(
                 enabled = enabled,
                 onClick = {
@@ -111,20 +133,55 @@ fun SettingsListDropdownSearchable(
     ) {
         DropdownMenu(
             expanded = isDropdownExpanded,
-            onDismissRequest = { isDropdownExpanded = false },
+            onDismissRequest = {
+                isDropdownExpanded = false
+                focusRequester.requestFocus()
+            },
         ) {
 
-            TextField(
+            // When the menu opens, land focus on the first item rather than the
+            // search field so a controller can scroll the list right away (and the
+            // soft keyboard stays down). Re-seed if the filter empties the current row.
+            LaunchedEffect(isDropdownExpanded) {
+                if (isDropdownExpanded) {
+                    runCatching { listFocusRequester.requestFocus() }
+                }
+            }
+
+            OutlinedTextField(
                 value = query,
                 onValueChange = { query = it },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(8.dp),
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                    // D-pad down from the search field jumps to the first result. We
+                    // request the item's focus directly (rather than moveFocus, which
+                    // leaked focus to the screen behind the popup); leaving the field
+                    // also drops the soft keyboard so there's nothing left to dismiss.
+                    .onPreviewKeyEvent { event ->
+                        if (event.type == KeyEventType.KeyDown && event.key == Key.DirectionDown) {
+                            runCatching { listFocusRequester.requestFocus() }
+                            true
+                        } else {
+                            false
+                        }
+                    },
                 placeholder = { Text(text = stringResource(R.string.settings_interface_settingslistdropdownsearchable_searchlabel)) },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Filled.Search,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
                 singleLine = true,
+                shape = RoundedCornerShape(12.dp),
+                // Don't pop the soft keyboard when the field merely gains focus
+                // (e.g. D-pad / controller navigation). It still shows on tap.
+                keyboardOptions = KeyboardOptions.Default.copy(showKeyboardOnFocus = false),
             )
 
-            filteredItems.forEach { (index, text) ->
+            filteredItems.forEachIndexed { position, (index, text) ->
                 val isMuted = itemMuted?.getOrNull(index) == true
                 val textColor = if (isMuted) {
                     MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
@@ -132,11 +189,17 @@ fun SettingsListDropdownSearchable(
                     MaterialTheme.colorScheme.onSurface
                 }
                 DropdownMenuItem(
+                    modifier = if (position == 0) {
+                        Modifier.focusRequester(listFocusRequester)
+                    } else {
+                        Modifier
+                    },
                     enabled = enabled,
                     text = { Text(text = text, color = textColor) },
                     onClick = {
                         onItemSelected(index)
                         isDropdownExpanded = false
+                        focusRequester.requestFocus()
                     },
                 )
             }

--- a/app/src/main/java/app/gamenative/ui/component/settings/SettingsMultiListDropdown.kt
+++ b/app/src/main/java/app/gamenative/ui/component/settings/SettingsMultiListDropdown.kt
@@ -26,6 +26,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -62,11 +64,18 @@ fun SettingsMultiListDropdown(
     var isDropdownExpanded by remember { mutableStateOf(false) }
     val selectedText = if (values.isNotEmpty()) values.map { items[it] }.joinToString(", ") else fallbackDisplay
 
+    // Keep a handle on the anchor tile so we can return focus to it when the menu
+    // closes. Without this, dismissing the popup leaves focus cleared and D-pad /
+    // controller navigation has nowhere to go.
+    val focusRequester = remember { FocusRequester() }
+
     SettingsTileScaffold(
-        modifier = Modifier.clickable(
-            enabled = enabled,
-            onClick = { isDropdownExpanded = true },
-        ).then(modifier),
+        modifier = Modifier
+            .focusRequester(focusRequester)
+            .clickable(
+                enabled = enabled,
+                onClick = { isDropdownExpanded = true },
+            ).then(modifier),
         enabled = enabled,
         title = title,
         subtitle = {
@@ -98,7 +107,10 @@ fun SettingsMultiListDropdown(
     ) {
         DropdownMenu(
             expanded = isDropdownExpanded,
-            onDismissRequest = { isDropdownExpanded = false },
+            onDismissRequest = {
+                isDropdownExpanded = false
+                focusRequester.requestFocus()
+            },
         ) {
             items.forEachIndexed { index, text ->
                 DropdownMenuItem(


### PR DESCRIPTION
## Description
Made app esp edit container more navigable by controller alone

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves controller navigation across the container editor and settings menus. D‑pad and shoulder buttons now work consistently, and focus is preserved when menus open/close.

- **New Features**
  - Single-line text fields: D‑pad Up/Down now move focus instead of trapping it.
  - ContainerConfigDialog: L1/L2/R1/R2 cycle tabs; focus starts on the first tab.
  - Dropdowns: A/Enter/Space toggle anchors even when a field is focused; focus returns to the tile after selection/dismiss (`MenuAnchorType.PrimaryNotEditable` for the executable path input).
  - Searchable dropdown: focus starts on the first result, D‑pad Down from the search jumps to the list, and the keyboard doesn’t auto-open on focus.

<sup>Written for commit 1cfb95065f917af799c931e072c8a300270d12bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved controller and keyboard navigation across dropdowns, tabs, and text fields.
  * Added smoother focus movement in dialogs and settings lists, including better behavior when menus open and close.

* **Bug Fixes**
  * Fixed cases where focus could be lost after dismissing a dropdown.
  * Enabled D-pad and shoulder-button navigation to move through controls more reliably.
  * Updated searchable dropdown behavior so focus lands in the expected place after opening or selecting items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->