### PR TITLE
Added default turnip driver for A12 devices

### DIFF
--- a/app/src/main/java/app/gamenative/utils/BestConfigService.kt
+++ b/app/src/main/java/app/gamenative/utils/BestConfigService.kt
@@ -213,6 +213,10 @@ object BestConfigService {
      *
      * - Adreno 6xx requires DXVK 1.11.1-sarek (newer DXVK 2.x is incompatible).
      * - Adreno 8 Elite Gen 5 (84x/85x) requires the MrPurple T26 driver.
+     * - Adreno A12 requires the A12-fix Turnip driver.
+     *
+     * The override is skipped when the matched GPU is the same family (e.g. an
+     * exact A12 match), so a server-provided exact-GPU config is left untouched.
      */
     private fun applyGpuFamilyOverrides(
         context: Context,
@@ -236,6 +240,13 @@ object BestConfigService {
             kvs.put("version", "Turnip Adreno Driver T26 (@Mr_Purple_666)")
             filteredJson.put("graphicsDriverConfig", kvs.toString())
             filteredJson.put("graphicsDriverVersion", "Turnip Adreno Driver T26 (@Mr_Purple_666)")
+        }
+
+        if (GPUInformation.isAdrenoA12(context) && !matched.matches(Regex(".*adreno.*\\ba12\\b.*"))) {
+            val kvs = KeyValueSet(filteredJson.optString("graphicsDriverConfig", ""))
+            kvs.put("version", ContainerUtils.WRAPPER_ADRENO_A12)
+            filteredJson.put("graphicsDriverConfig", kvs.toString())
+            filteredJson.put("graphicsDriverVersion", ContainerUtils.WRAPPER_ADRENO_A12)
         }
 
         return filteredJson

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -38,9 +38,10 @@ object ContainerUtils {
     const val WRAPPER_TURNIP_CAPABLE = "Turnip v26.2.0 R4"
     const val WRAPPER_ADRENO_8ELITE_GEN5 = "Turnip Adreno Driver T26 (@Mr_Purple_666)"
     const val WRAPPER_ADRENO_8ELITE = "Turnip Gen8 V30"
+    const val WRAPPER_ADRENO_A12 = "Turnip v26.1.0 A12 Fix"
 
     val wrapperDriverDefaults: List<String> =
-        listOf(WRAPPER_TURNIP_CAPABLE, WRAPPER_ADRENO_8ELITE_GEN5, WRAPPER_ADRENO_8ELITE)
+        listOf(WRAPPER_TURNIP_CAPABLE, WRAPPER_ADRENO_8ELITE_GEN5, WRAPPER_ADRENO_8ELITE, WRAPPER_ADRENO_A12)
 
     fun setContainerDefaults(context: Context) {
         // Override default driver and DXVK version based on Turnip capability
@@ -51,6 +52,15 @@ object ContainerUtils {
             DefaultVersion.DXVK = if (GPUInformation.isAdreno6xx(context)) "1.11.1-sarek" else "2.4.1-gplasync"
             DefaultVersion.VKD3D = "2.14.1"
             DefaultVersion.WRAPPER = WRAPPER_TURNIP_CAPABLE
+            DefaultVersion.STEAM_TYPE = Container.STEAM_TYPE_NORMAL
+            DefaultVersion.ASYNC_CACHE = "1"
+        } else if (GPUInformation.isAdrenoA12(context)) {
+            DefaultVersion.VARIANT = Container.BIONIC
+            DefaultVersion.WINE_VERSION = "proton-10.0-arm64ec-2"
+            DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
+            DefaultVersion.DXVK = "2.4.1-gplasync"
+            DefaultVersion.VKD3D = "2.14.1"
+            DefaultVersion.WRAPPER = WRAPPER_ADRENO_A12
             DefaultVersion.STEAM_TYPE = Container.STEAM_TYPE_NORMAL
             DefaultVersion.ASYNC_CACHE = "1"
         } else if (GPUInformation.isAdreno8EliteGen5(context)) {

--- a/app/src/main/java/com/winlator/core/GPUInformation.java
+++ b/app/src/main/java/com/winlator/core/GPUInformation.java
@@ -169,6 +169,16 @@ public abstract class GPUInformation {
         return r.contains("adreno") && r.matches(".*\\b8(4[0-9]|5[0-9])\\b.*");
     }
 
+    /**
+     * Detects the Adreno A12 family (e.g. renderer "Adreno (TM) A12").
+     * A12 is a distinct family from the numeric 8-Elite parts (84x/85x), so its
+     * alphanumeric model token cannot collide with the numeric family regexes.
+     */
+    public static boolean isAdrenoA12(Context context) {
+        String r = getRenderer(context).toLowerCase(Locale.ENGLISH);
+        return r.contains("adreno") && r.matches(".*\\ba12\\b.*");
+    }
+
     public static boolean isTurnipCapable(Context context) {
         String r = getRenderer(context).toLowerCase(Locale.ENGLISH);
         // match “adreno 610…699” or “adreno 710…799”

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,14 @@
 {
   "version": 1,
-  "updatedAt": "2026-01-26",
+  "updatedAt": "2026-06-30",
   "items": {
     "driver": [
+      {
+        "id": "Turnip v26.1.0 A12 Fix",
+        "name": "Turnip_v26.1.0_A12Fix",
+        "url": "https://downloads.gamenative.app/drivers/Turnip_v26.1.0_A12Fix.zip",
+        "variant": "bionic"
+      },
       {
         "id": "turnip26.0.0_R8",
         "name": "turnip26.0.0_R8",


### PR DESCRIPTION
## Description
Added turnip support for A12 GPU (Retroid Pocket Classic)

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds default Turnip A12-fix driver and detection for Adreno A12 devices (e.g., Retroid Pocket Classic) to improve compatibility. Also adds override logic that won’t replace an exact A12 server config.

- **New Features**
  - Added `GPUInformation.isAdrenoA12` renderer detection.
  - Set A12 defaults in `ContainerUtils`: Bionic, Proton 10 arm64ec-2, DXVK 2.4.1-gplasync, VKD3D 2.14.1, wrapper `Turnip v26.1.0 A12 Fix`, normal Steam, async cache on.
  - Applied family override in `BestConfigService` to use the A12-fix wrapper when A12 is detected and the matched config isn’t an exact A12.

- **Dependencies**
  - Added `Turnip v26.1.0 A12 Fix` to `manifest.json` with download URL.

<sup>Written for commit 40d7a0bfab124949b5242295e9b6785c77b09f82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Adreno A12 devices with updated default graphics and driver settings.
  * Introduced a new recommended driver option for Adreno A12 users.

* **Bug Fixes**
  * Improved GPU detection so devices in the Adreno A12 family are handled more accurately.
  * Updated override behavior to avoid applying mismatched graphics settings on supported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->