### PR TITLE
Added back delete container for installed games

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/ContainerStorageManagerDialog.kt
@@ -711,8 +711,8 @@ private fun StorageEntryCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
-            val canRemoveOrphanContainer = entry.hasContainer && !entry.canUninstallGame
-            if (canMoveToExternal || canMoveToInternal || entry.canUninstallGame || canRemoveOrphanContainer) {
+            val canRemoveContainer = entry.hasContainer
+            if (canMoveToExternal || canMoveToInternal || entry.canUninstallGame || canRemoveContainer) {
                 Spacer(modifier = Modifier.height(14.dp))
                 FlowRow(
                     modifier = Modifier.fillMaxWidth(),
@@ -749,7 +749,7 @@ private fun StorageEntryCard(
                             contentColor = MaterialTheme.colorScheme.onErrorContainer,
                         )
                     }
-                    if (canRemoveOrphanContainer) {
+                    if (canRemoveContainer) {
                         StorageActionButton(
                             text = stringResource(R.string.container_storage_remove_button),
                             icon = Icons.Default.Delete,


### PR DESCRIPTION
## Description
@Catpotatos requested it :)

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the Delete Container button in the Storage Manager dialog for any entry with a container, including installed games. Previously it only showed for orphan containers.

<sup>Written for commit f141e92867f8b7c42a3d6ff0a2117df740565044. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated storage container actions so the **Remove** option is available whenever a container exists.
  - Entries that support **Uninstall** can now also show **Remove** at the same time, making cleanup options more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->