### PR TITLE
fix: Optimize GOG and EPIC download

### DIFF
--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -1275,7 +1275,7 @@ class EpicDownloadManager @Inject constructor(
         }
 
         if (isRoot) {
-            val totalSize = calculateTotalSize(dir)
+            val totalSize = calculateDirectorySize(dir)
             val fileCount = countFiles(dir)
             Timber.tag("Epic").i("=== Summary ===")
             Timber.tag("Epic").i("Total files: $fileCount")
@@ -1294,15 +1294,6 @@ class EpicDownloadManager @Inject constructor(
             bytes < 1024 * 1024 * 1024 -> "%.2f MB".format(bytes / (1024.0 * 1024.0))
             else -> "%.2f GB".format(bytes / (1024.0 * 1024.0 * 1024.0))
         }
-    }
-
-    /**
-     * Calculate total size of a directory recursively
-     */
-    private fun calculateTotalSize(dir: File): Long {
-        if (!dir.exists()) return 0
-        if (dir.isFile) return dir.length()
-        return dir.listFiles()?.sumOf { calculateTotalSize(it) } ?: 0
     }
 
     /**

--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -1027,7 +1027,15 @@ class EpicDownloadManager @Inject constructor(
 
                 val chunksAdded = mutableListOf<String>()
 
-                files.forEach { file ->
+                // Sort files by total chunk usage (lowest first) - files with less-shared chunks complete faster and free cache sooner
+                val sortedFiles = files.sortedBy { file ->
+                    file.chunkParts.sumOf { chunk ->
+                        chunkUsageCounts[chunk.guidStr]?.get() ?: 0
+                    }
+                }
+                Timber.tag("EPIC").d("Processing ${sortedFiles.size} files sorted by chunk usage (least shared first)")
+
+                sortedFiles.forEach { file ->
                     if (!downloadInfo.isActive()) {
                         Timber.tag("EPIC").w("Download cancelled during file iteration")
                         return@launch
@@ -1075,7 +1083,19 @@ class EpicDownloadManager @Inject constructor(
                     return@withContext Result.failure(Exception("Download cancelled"))
                 }
 
-                Timber.tag("EPIC").d("Waiting for $currentPendingChunks pending chunks to complete")
+                // Calculate storage usage stats
+                // Note: chunkCacheDir is inside installDir, so we need to calculate separately to avoid double-counting
+                val chunkCacheSize = calculateDirectorySize(chunkCacheDir)
+                val totalInstallDirSize = calculateDirectorySize(installDir)
+                val installedFilesSize = totalInstallDirSize - chunkCacheSize // Exclude cache from installed files
+
+                Timber.tag("EPIC").d(
+                    """Waiting for $currentPendingChunks pending chunks
+                    |  Cache: ${chunkCacheSize / 1_000_000}MB
+                    |  Game files: ${installedFilesSize / 1_000_000}MB
+                    |  Total disk: ${totalInstallDirSize / 1_000_000}MB
+                    """.trimMargin()
+                )
 
                 if (currentPendingChunks == lastPendingChunks) {
                     samePendingChunksAttempts++
@@ -1097,8 +1117,8 @@ class EpicDownloadManager @Inject constructor(
                     samePendingChunksAttempts = 0
                 }
 
-                // Wait for 1 second to recheck
-                delay(1000)
+                // Wait for 5 seconds to recheck (not too quick due to added stats causing IO)
+                delay(5000)
 
                 currentPendingChunks = pendingChunks.get()
             }
@@ -1292,5 +1312,32 @@ class EpicDownloadManager @Inject constructor(
         if (!dir.exists()) return 0
         if (dir.isFile) return 1
         return dir.listFiles()?.sumOf { countFiles(it) } ?: 0
+    }
+
+    /**
+     * Total size under [directory]. Symlinks are skipped to avoid double-counting.
+     */
+    private fun calculateDirectorySize(directory: File): Long {
+        var size = 0L
+        try {
+            if (!directory.exists() || !directory.isDirectory) {
+                return 0L
+            }
+
+            val files = directory.listFiles() ?: return 0L
+            for (file in files) {
+                if (java.nio.file.Files.isSymbolicLink(file.toPath())) {
+                    continue
+                }
+                size += if (file.isDirectory) {
+                    calculateDirectorySize(file)
+                } else {
+                    file.length()
+                }
+            }
+        } catch (e: Exception) {
+            Timber.tag("Epic").w(e, "Error calculating directory size for ${directory.name}")
+        }
+        return size
     }
 }

--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -880,6 +880,9 @@ class EpicDownloadManager @Inject constructor(
             val downloadedChunkIds = newKeySet<String>()
             val pendingChunks = AtomicInteger(chunkQueue.size)
 
+            // Calculate total expected installed size once (sum of all file sizes)
+            val totalExpectedSize = files.sumOf { it.fileSize }
+
             chunkQueue.forEach { chunkInfo ->
                 chunkUsageCounts[chunkInfo.guidStr] = AtomicInteger(
                     files.sumOf { file -> file.chunkParts.count { chunk -> chunk.guidStr == chunkInfo.guidStr } }
@@ -1083,17 +1086,14 @@ class EpicDownloadManager @Inject constructor(
                     return@withContext Result.failure(Exception("Download cancelled"))
                 }
 
-                // Calculate storage usage stats
-                // Note: chunkCacheDir is inside installDir, so we need to calculate separately to avoid double-counting
+                // Calculate storage usage stats (only scan cache dir, not entire install dir)
                 val chunkCacheSize = calculateDirectorySize(chunkCacheDir)
-                val totalInstallDirSize = calculateDirectorySize(installDir)
-                val installedFilesSize = totalInstallDirSize - chunkCacheSize // Exclude cache from installed files
 
                 Timber.tag("EPIC").d(
                     """Waiting for $currentPendingChunks pending chunks
                     |  Cache: ${chunkCacheSize / 1_000_000}MB
-                    |  Game files: ${installedFilesSize / 1_000_000}MB
-                    |  Total disk: ${totalInstallDirSize / 1_000_000}MB
+                    |  Game files: ${totalExpectedSize / 1_000_000}MB
+                    |  Total disk: ${(chunkCacheSize + totalExpectedSize) / 1_000_000}MB
                     """.trimMargin()
                 )
 

--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -984,7 +984,15 @@ class GOGDownloadManager @Inject constructor(
 
                 val chunksAdded = mutableListOf<String>()
 
-                files.forEach { file ->
+                // Sort files by total chunk usage (lowest first) - files with less-shared chunks complete faster and free cache sooner
+                val sortedFiles = files.sortedBy { file ->
+                    file.chunks.sumOf { chunk ->
+                        chunkUsageCounts[chunk.compressedMd5]?.get() ?: 0
+                    }
+                }
+                Timber.tag("GOG").d("Processing ${sortedFiles.size} files sorted by chunk usage (least shared first)")
+
+                sortedFiles.forEach { file ->
                     if (!downloadInfo.isActive()) {
                         Timber.tag("GOG").w("Download cancelled during file iteration")
                         return@launch
@@ -1029,7 +1037,19 @@ class GOGDownloadManager @Inject constructor(
                     return@withContext Result.failure(Exception("Download cancelled"))
                 }
 
-                Timber.tag("GOG").d("Waiting for $currentPendingChunks pending chunks to complete")
+                // Calculate storage usage stats
+                // Note: chunkCacheDir is inside installDir, so we need to calculate separately to avoid double-counting
+                val chunkCacheSize = calculateDirectorySize(chunkCacheDir)
+                val totalInstallDirSize = calculateDirectorySize(installDir)
+                val installedFilesSize = totalInstallDirSize - chunkCacheSize // Exclude cache from installed files
+
+                Timber.tag("GOG").d(
+                    """Waiting for $currentPendingChunks pending chunks
+                    |  Cache: ${chunkCacheSize / 1_000_000}MB
+                    |  Game files: ${installedFilesSize / 1_000_000}MB
+                    |  Total disk: ${totalInstallDirSize / 1_000_000}MB
+                    """.trimMargin()
+                )
 
                 if (currentPendingChunks == lastPendingChunks) {
                     samePendingChunksAttempts++
@@ -1051,8 +1071,8 @@ class GOGDownloadManager @Inject constructor(
                     samePendingChunksAttempts = 0
                 }
 
-                // Wait for 1 second to recheck
-                delay(1000)
+                // Wait for 5 seconds to recheck (not too quick due to added stats causing IO)
+                delay(5000)
 
                 currentPendingChunks = pendingChunks.get()
             }
@@ -1426,7 +1446,7 @@ class GOGDownloadManager @Inject constructor(
                     ?: return@withContext Result.failure(Exception("Empty response for chunk $chunkMd5"))
 
                 val md = MessageDigest.getInstance("MD5")
-                val buffer = ByteArray(256 * 1024) // 256KB
+                val buffer = ByteArray(64 * 1024) // 64KB - reduced from 256KB to minimize memory pressure during parallel downloads
                 var lastProgressEmitAt = System.currentTimeMillis()
 
                 if (tempChunkFile.exists()) tempChunkFile.delete()
@@ -1513,34 +1533,15 @@ class GOGDownloadManager @Inject constructor(
                 )
             }
 
-            // Read compressed data
-            val compressedBytes = chunkFile.readBytes()
-
-            // Decompress chunk
-            val decompressedBytes = decompressChunk(compressedBytes, chunk)
-            if (decompressedBytes.isFailure) {
-                return@withContext Result.failure(
-                    decompressedBytes.exceptionOrNull()
-                        ?: Exception("Failed to decompress chunk ${chunk.compressedMd5}"),
-                )
-            }
-
-            val data = decompressedBytes.getOrThrow()
-
-            // Verify decompressed MD5
-            val actualMd5 = calculateMd5(data)
-            if (actualMd5 != chunk.md5) {
-                return@withContext Result.failure(
-                    Exception("Decompressed MD5 mismatch for chunk: expected ${chunk.md5}, got $actualMd5"),
-                )
-            }
-
             val writeOffset = file.chunks.take(chunkIndex).sumOf { it.size }
 
-            // Write decompressed chunk at specific file offset using RandomAccessFile
-            RandomAccessFile(outputFile.path, "rw").use { randomAccessFile ->
-                randomAccessFile.seek(writeOffset)
-                randomAccessFile.write(data)
+            // Decompress directly to file while calculating MD5
+            val decompressResult = decompressChunkToFile(chunkFile, chunk, outputFile, writeOffset)
+            if (decompressResult.isFailure) {
+                return@withContext Result.failure(
+                    decompressResult.exceptionOrNull()
+                        ?: Exception("Failed to decompress chunk ${chunk.compressedMd5}"),
+                )
             }
 
             // Verify final file hash if provided
@@ -1554,6 +1555,9 @@ class GOGDownloadManager @Inject constructor(
                     // Move the log here for files finally assembled
                     Timber.tag("GOG").v("Assembled: ${file.path} (${outputFile.length()} bytes)")
                 }
+            } else {
+                // For md5 is null, likely it does not need to decompress, need to show log here
+                Timber.tag("GOG").v("Assembled: ${file.path} (${outputFile.length()} bytes)")
             }
 
             Result.success(outputFile)
@@ -1564,62 +1568,107 @@ class GOGDownloadManager @Inject constructor(
     }
 
     /**
-     * Decompress a GOG chunk using zlib
+     * Decompress a GOG chunk directly to file using zlib, streaming to avoid large memory allocations.
+     * Calculates MD5 while decompressing and writes directly to the target file at the specified offset.
      *
-     * GOG chunks are compressed with zlib
-     * If chunk.compressedSize is null, data is uncompressed
-     *
-     * @param compressedBytes Compressed chunk data
+     * @param chunkFile Compressed chunk file
      * @param chunk Chunk metadata
-     * @return Decompressed data
+     * @param outputFile Target file to write decompressed data
+     * @param writeOffset Offset in the output file to write at
+     * @return Result indicating success or failure
      */
-    private fun decompressChunk(compressedBytes: ByteArray, chunk: FileChunk): Result<ByteArray> {
+    private fun decompressChunkToFile(
+        chunkFile: File,
+        chunk: FileChunk,
+        outputFile: File,
+        writeOffset: Long,
+    ): Result<Unit> {
         return try {
-            // If no compressed size specified, data is already uncompressed
-            if (chunk.compressedSize == null) {
-                return Result.success(compressedBytes)
-            }
+            val md5Digest = MessageDigest.getInstance("MD5")
+            var totalBytesWritten = 0L
 
-            // Decompress using zlib
-            val inflater = Inflater()
-            try {
-                inflater.setInput(compressedBytes)
-                val outputStream = ByteArrayOutputStream(chunk.size.toInt())
-                val buffer = ByteArray(8192)
+            RandomAccessFile(outputFile.path, "rw").use { raf ->
+                raf.seek(writeOffset)
 
-                while (!inflater.finished()) {
-                    val count = inflater.inflate(buffer)
-                    if (count > 0) {
-                        outputStream.write(buffer, 0, count)
-                    } else {
-                        // No bytes produced - check if we need more input or a dictionary
-                        if (inflater.needsInput()) {
-                            throw java.io.IOException(
-                                "Incomplete zlib data: decompression requires more input but none available"
-                            )
-                        } else if (inflater.needsDictionary()) {
-                            throw java.io.IOException(
-                                "Zlib data requires a preset dictionary which is not supported"
-                            )
+                // If no compressed size specified, data is already uncompressed
+                if (chunk.compressedSize == null) {
+                    chunkFile.inputStream().use { input ->
+                        val buffer = ByteArray(8192)
+                        var bytesRead: Int
+                        while (input.read(buffer).also { bytesRead = it } != -1) {
+                            md5Digest.update(buffer, 0, bytesRead)
+                            raf.write(buffer, 0, bytesRead)
+                            totalBytesWritten += bytesRead
                         }
-                        // If neither condition is true, inflater is still processing internally
-                        // Continue loop, but this should be rare
+                    }
+                } else {
+                    // Decompress using zlib and stream directly to file
+                    val inflater = Inflater()
+                    try {
+                        chunkFile.inputStream().buffered().use { input ->
+                            val inputBuffer = ByteArray(8192)
+                            val outputBuffer = ByteArray(8192)
+                            var inputBytesRead: Int
+
+                            while (input.read(inputBuffer).also { inputBytesRead = it } != -1) {
+                                inflater.setInput(inputBuffer, 0, inputBytesRead)
+
+                                while (!inflater.needsInput() && !inflater.finished()) {
+                                    val count = inflater.inflate(outputBuffer)
+                                    if (count > 0) {
+                                        md5Digest.update(outputBuffer, 0, count)
+                                        raf.write(outputBuffer, 0, count)
+                                        totalBytesWritten += count
+                                    } else {
+                                        if (inflater.needsDictionary()) {
+                                            throw java.io.IOException(
+                                                "Zlib data requires a preset dictionary which is not supported"
+                                            )
+                                        }
+                                        break
+                                    }
+                                }
+                            }
+
+                            // Finish any remaining data
+                            while (!inflater.finished()) {
+                                val count = inflater.inflate(outputBuffer)
+                                if (count > 0) {
+                                    md5Digest.update(outputBuffer, 0, count)
+                                    raf.write(outputBuffer, 0, count)
+                                    totalBytesWritten += count
+                                } else {
+                                    if (inflater.needsInput()) {
+                                        throw java.io.IOException(
+                                            "Incomplete zlib data: decompression requires more input but none available"
+                                        )
+                                    }
+                                    break
+                                }
+                            }
+                        }
+                    } finally {
+                        inflater.end()
                     }
                 }
-
-                val decompressed = outputStream.toByteArray()
-
-                // Verify size matches expected
-                if (decompressed.size.toLong() != chunk.size) {
-                    return Result.failure(
-                        Exception("Decompressed size mismatch: expected ${chunk.size}, got ${decompressed.size}"),
-                    )
-                }
-
-                Result.success(decompressed)
-            } finally {
-                inflater.end()
             }
+
+            // Verify size matches expected
+            if (totalBytesWritten != chunk.size) {
+                return Result.failure(
+                    Exception("Decompressed size mismatch: expected ${chunk.size}, got $totalBytesWritten"),
+                )
+            }
+
+            // Verify decompressed MD5
+            val actualMd5 = md5Digest.digest().joinToString("") { "%02x".format(it) }
+            if (actualMd5 != chunk.md5) {
+                return Result.failure(
+                    Exception("Decompressed MD5 mismatch for chunk: expected ${chunk.md5}, got $actualMd5"),
+                )
+            }
+
+            Result.success(Unit)
         } catch (e: Exception) {
             Timber.tag("GOG").e(e, "Failed to decompress chunk ${chunk.compressedMd5}")
             Result.failure(e)

--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -1577,7 +1577,7 @@ class GOGDownloadManager @Inject constructor(
      * @param writeOffset Offset in the output file to write at
      * @return Result indicating success or failure
      */
-    private fun decompressChunkToFile(
+    internal fun decompressChunkToFile(
         chunkFile: File,
         chunk: FileChunk,
         outputFile: File,

--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -816,6 +816,9 @@ class GOGDownloadManager @Inject constructor(
             val chunkAttempts = ConcurrentHashMap<String, AtomicInteger>()
             val pendingChunks = AtomicInteger(chunkHashes.size)
 
+            // Calculate total expected installed size once (sum of all file sizes)
+            val totalExpectedSize = files.sumOf { file -> file.chunks.sumOf { it.size } }
+
             chunkHashes.forEach { chunkMd5 ->
                 chunkUsageCounts[chunkMd5] = AtomicInteger(
                     files.sumOf { file -> file.chunks.count { chunk -> chunk.compressedMd5 == chunkMd5 } }
@@ -1037,17 +1040,14 @@ class GOGDownloadManager @Inject constructor(
                     return@withContext Result.failure(Exception("Download cancelled"))
                 }
 
-                // Calculate storage usage stats
-                // Note: chunkCacheDir is inside installDir, so we need to calculate separately to avoid double-counting
+                // Calculate storage usage stats (only scan cache dir, not entire install dir)
                 val chunkCacheSize = calculateDirectorySize(chunkCacheDir)
-                val totalInstallDirSize = calculateDirectorySize(installDir)
-                val installedFilesSize = totalInstallDirSize - chunkCacheSize // Exclude cache from installed files
 
                 Timber.tag("GOG").d(
                     """Waiting for $currentPendingChunks pending chunks
                     |  Cache: ${chunkCacheSize / 1_000_000}MB
-                    |  Game files: ${installedFilesSize / 1_000_000}MB
-                    |  Total disk: ${totalInstallDirSize / 1_000_000}MB
+                    |  Game files: ${totalExpectedSize / 1_000_000}MB
+                    |  Total disk: ${(chunkCacheSize + totalExpectedSize) / 1_000_000}MB
                     """.trimMargin()
                 )
 

--- a/app/src/test/java/app/gamenative/service/gog/GOGDownloadManagerTest.kt
+++ b/app/src/test/java/app/gamenative/service/gog/GOGDownloadManagerTest.kt
@@ -314,4 +314,255 @@ class GOGDownloadManagerTest {
             productId = null,
         )
     }
+
+    // ===== Chunk Decompression Tests =====
+
+    @Test
+    fun decompressChunkToFile_compressedChunk_writesCorrectly() {
+        val tempDir = Files.createTempDirectory("gog-chunk-test").toFile()
+
+        // Arrange: Create compressed chunk
+        val originalData = "Hello World! This is test data for compression.".toByteArray()
+        val compressedData = compressTestData(originalData)
+        val chunkFile = File(tempDir, "chunk.bin")
+        chunkFile.writeBytes(compressedData)
+
+        val outputFile = File(tempDir, "output.bin")
+        val chunk = app.gamenative.service.gog.api.FileChunk(
+            compressedMd5 = "test-md5",
+            md5 = calculateTestMd5(originalData),
+            size = originalData.size.toLong(),
+            compressedSize = compressedData.size.toLong()
+        )
+
+        // Act
+        val result = testDecompressChunkToFile(chunkFile, chunk, outputFile, 0)
+
+        // Assert
+        assertTrue("Decompression should succeed", result.isSuccess)
+        assertTrue("Output file should exist", outputFile.exists())
+        assertEquals("Output size should match", originalData.size.toLong(), outputFile.length())
+        assertEquals("Content should match", originalData.decodeToString(), outputFile.readBytes().decodeToString())
+
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun decompressChunkToFile_uncompressedChunk_copiesDirectly() {
+        val tempDir = Files.createTempDirectory("gog-chunk-test").toFile()
+
+        // Arrange: Create uncompressed chunk (compressedSize = null)
+        val originalData = "Uncompressed data".toByteArray()
+        val chunkFile = File(tempDir, "chunk.bin")
+        chunkFile.writeBytes(originalData)
+
+        val outputFile = File(tempDir, "output.bin")
+        val chunk = app.gamenative.service.gog.api.FileChunk(
+            compressedMd5 = "test-md5",
+            md5 = calculateTestMd5(originalData),
+            size = originalData.size.toLong(),
+            compressedSize = null // Indicates uncompressed
+        )
+
+        // Act
+        val result = testDecompressChunkToFile(chunkFile, chunk, outputFile, 0)
+
+        // Assert
+        assertTrue("Copy should succeed", result.isSuccess)
+        assertTrue("Output file should exist", outputFile.exists())
+        assertEquals("Output size should match", originalData.size.toLong(), outputFile.length())
+        assertEquals("Content should match", originalData.decodeToString(), outputFile.readBytes().decodeToString())
+
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun decompressChunkToFile_nonZeroOffset_writesAtCorrectPosition() {
+        val tempDir = Files.createTempDirectory("gog-chunk-test").toFile()
+
+        // Arrange: Pre-create file with some data
+        val existingData = "AAAA".toByteArray()
+        val newData = "BBBB".toByteArray()
+        val compressedNewData = compressTestData(newData)
+
+        val outputFile = File(tempDir, "output.bin")
+        java.io.RandomAccessFile(outputFile.path, "rw").use {
+            it.setLength(8) // Pre-allocate 8 bytes
+            it.write(existingData) // Write first 4 bytes
+        }
+
+        val chunkFile = File(tempDir, "chunk.bin")
+        chunkFile.writeBytes(compressedNewData)
+
+        val chunk = app.gamenative.service.gog.api.FileChunk(
+            compressedMd5 = "test-md5",
+            md5 = calculateTestMd5(newData),
+            size = newData.size.toLong(),
+            compressedSize = compressedNewData.size.toLong()
+        )
+
+        // Act: Write at offset 4
+        val result = testDecompressChunkToFile(chunkFile, chunk, outputFile, 4)
+
+        // Assert
+        assertTrue("Decompression should succeed", result.isSuccess)
+        val finalContent = outputFile.readBytes()
+        assertEquals("First 4 bytes should be unchanged", "AAAA", finalContent.sliceArray(0..3).decodeToString())
+        assertEquals("Next 4 bytes should be new data", "BBBB", finalContent.sliceArray(4..7).decodeToString())
+
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun decompressChunkToFile_sizeMismatch_fails() {
+        val tempDir = Files.createTempDirectory("gog-chunk-test").toFile()
+
+        // Arrange: Compressed data with wrong expected size
+        val originalData = "Short".toByteArray()
+        val compressedData = compressTestData(originalData)
+        val chunkFile = File(tempDir, "chunk.bin")
+        chunkFile.writeBytes(compressedData)
+
+        val outputFile = File(tempDir, "output.bin")
+        val actualMd5 = calculateTestMd5(originalData)
+        val chunk = app.gamenative.service.gog.api.FileChunk(
+            compressedMd5 = "test-md5",
+            md5 = actualMd5, // Correct MD5 so size check is reached
+            size = 999L, // Wrong expected size
+            compressedSize = compressedData.size.toLong()
+        )
+
+        // Act
+        val result = testDecompressChunkToFile(chunkFile, chunk, outputFile, 0)
+
+        // Assert
+        assertTrue("Should fail on size mismatch", result.isFailure)
+        val errorMsg = result.exceptionOrNull()?.message ?: ""
+        assertTrue("Error should mention size mismatch, got: $errorMsg", errorMsg.contains("size", ignoreCase = true))
+
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun decompressChunkToFile_md5Mismatch_fails() {
+        val tempDir = Files.createTempDirectory("gog-chunk-test").toFile()
+
+        // Arrange: Valid compressed data but wrong MD5
+        val originalData = "Test data".toByteArray()
+        val compressedData = compressTestData(originalData)
+        val chunkFile = File(tempDir, "chunk.bin")
+        chunkFile.writeBytes(compressedData)
+
+        val outputFile = File(tempDir, "output.bin")
+        val chunk = app.gamenative.service.gog.api.FileChunk(
+            compressedMd5 = "test-md5",
+            md5 = "wrong-md5-hash", // Wrong MD5
+            size = originalData.size.toLong(),
+            compressedSize = compressedData.size.toLong()
+        )
+
+        // Act
+        val result = testDecompressChunkToFile(chunkFile, chunk, outputFile, 0)
+
+        // Assert
+        assertTrue("Should fail on MD5 mismatch", result.isFailure)
+        assertTrue("Error should mention MD5", result.exceptionOrNull()?.message?.contains("MD5", ignoreCase = true) == true)
+
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun decompressChunkToFile_emptyMd5_failsValidation() {
+        val tempDir = Files.createTempDirectory("gog-chunk-test").toFile()
+
+        // Arrange: Compressed chunk with empty MD5 string
+        val originalData = "Test data".toByteArray()
+        val compressedData = compressTestData(originalData)
+        val chunkFile = File(tempDir, "chunk.bin")
+        chunkFile.writeBytes(compressedData)
+
+        val outputFile = File(tempDir, "output.bin")
+        val chunk = app.gamenative.service.gog.api.FileChunk(
+            compressedMd5 = "test-md5",
+            md5 = "", // Empty MD5 still validates (won't match actual hash)
+            size = originalData.size.toLong(),
+            compressedSize = compressedData.size.toLong()
+        )
+
+        // Act
+        val result = testDecompressChunkToFile(chunkFile, chunk, outputFile, 0)
+
+        // Assert
+        assertTrue("Should fail because empty MD5 doesn't match actual hash", result.isFailure)
+        assertTrue("Error should mention MD5", result.exceptionOrNull()?.message?.contains("MD5", ignoreCase = true) == true)
+
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun decompressChunkToFile_corruptedZlibData_fails() {
+        val tempDir = Files.createTempDirectory("gog-chunk-test").toFile()
+
+        // Arrange: Invalid zlib data
+        val corruptedData = byteArrayOf(0x78.toByte(), 0x9C.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte())
+        val chunkFile = File(tempDir, "chunk.bin")
+        chunkFile.writeBytes(corruptedData)
+
+        val outputFile = File(tempDir, "output.bin")
+        val chunk = app.gamenative.service.gog.api.FileChunk(
+            compressedMd5 = "test-md5",
+            md5 = "any-md5",
+            size = 100L,
+            compressedSize = corruptedData.size.toLong()
+        )
+
+        // Act
+        val result = testDecompressChunkToFile(chunkFile, chunk, outputFile, 0)
+
+        // Assert
+        assertTrue("Should fail on corrupted data", result.isFailure)
+
+        tempDir.deleteRecursively()
+    }
+
+    // Helper functions for chunk decompression tests
+
+    private fun compressTestData(data: ByteArray): ByteArray {
+        val deflater = java.util.zip.Deflater()
+        try {
+            deflater.setInput(data)
+            deflater.finish()
+
+            val buffer = ByteArray(data.size * 2 + 100)
+            var totalCompressed = 0
+
+            while (!deflater.finished()) {
+                val count = deflater.deflate(buffer, totalCompressed, buffer.size - totalCompressed)
+                totalCompressed += count
+                if (count == 0 && !deflater.finished()) {
+                    throw IllegalStateException("Deflater stuck")
+                }
+            }
+
+            return buffer.copyOf(totalCompressed)
+        } finally {
+            deflater.end()
+        }
+    }
+
+    private fun calculateTestMd5(data: ByteArray): String {
+        val digest = java.security.MessageDigest.getInstance("MD5")
+        val hash = digest.digest(data)
+        return hash.joinToString("") { "%02x".format(it) }
+    }
+
+    private fun testDecompressChunkToFile(
+        chunkFile: File,
+        chunk: app.gamenative.service.gog.api.FileChunk,
+        outputFile: File,
+        writeOffset: Long
+    ): Result<Unit> {
+        // Now that decompressChunkToFile is internal, we can call it directly
+        return manager.decompressChunkToFile(chunkFile, chunk, outputFile, writeOffset)
+    }
 }


### PR DESCRIPTION
## Description

### For GOG:
Refactors GOG chunk assembly to stream decompression directly to files, significantly reducing memory pressure during large downloads and parallel operations.

Other improvements include:
* Sorts files by chunk usage to prioritize less-shared chunks and free cache sooner.
* Reduces buffer size for chunk downloads to further minimize memory.
* Adds detailed disk usage logging for better monitoring.
* Increases the download loop recheck delay to account for new disk IO operations.

### For EPIC:
* Sorts files by total chunk usage to prioritize less-shared chunks and free cache sooner.
* Adds detailed disk usage logging for better visibility during downloads.
* Increases download loop recheck delay to accommodate new disk I/O from stats calculation.

## Recording
GOG logs
```
GOG                      D  Waiting for 10157 pending chunks
                              Cache: 83MB
                              Game files: 57405MB
                              Total disk: 57489MB
GOG                      D  Waiting for 10119 pending chunks
                              Cache: 83MB
                              Game files: 57405MB
                              Total disk: 57489MB
```

GPIC logs
```
EPIC                     D  Waiting for 604 pending chunks
                              Cache: 1MB
                              Game files: 2374MB
                              Total disk: 2376MB
EPIC                     D  Waiting for 552 pending chunks
                              Cache: 1MB
                              Game files: 2374MB
                              Total disk: 2376MB
```

## Type of Change
- [ ] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize GOG and Epic downloads to cut memory use and reduce I/O during large installs. GOG now streams zlib decompression directly into files with MD5 and size checks; both providers prioritize less‑shared chunks and show cache-based disk stats without scanning the install dir.

- **Refactors**
  - GOGDownloadManager
    - Stream zlib decompression directly to the target file with on-the-fly MD5 and size verification.
    - Sort files by total chunk usage (least shared first).
    - Reduce chunk download buffer from 256KB to 64KB.
    - Log cache/game/total disk usage (scan cache dir only; precompute expected game size); increase recheck delay to 5s.
    - Log assembled files even when `md5` is missing.
    - Add unit tests for `decompressChunkToFile` (compressed/uncompressed, non-zero offsets, size/MD5 mismatch, corrupted data).
  - EpicDownloadManager
    - Sort files by total chunk usage (least shared first).
    - Log cache/game/total disk usage using `calculateDirectorySize` (scan cache dir only; skip symlinks; precompute expected game size); increase recheck delay to 5s.

<sup>Written for commit 69f14d01a4d1a1999747d6bc1b685e7082154baa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of Changes

* **New Features**
  * None

* **Bug Fixes**
  * Streamlined chunk decompression to write directly into the destination file while validating decompressed size and MD5.
  * Improved assembly behavior when file checksum information is missing by skipping file-level MD5 verification.

* **Improvements**
  * Prioritized least-shared chunks for pre-allocation and streaming.
  * Updated pending-wait handling to report cache size, expected installed size, total disk usage, and use a longer recheck interval.

* **Tests**
  * Added decompression-to-file coverage for compressed/uncompressed chunks, offsets, size/MD5 mismatches, empty MD5, and corrupted data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->