### PR TITLE
feat: Manage game downloads with a centralized queue

### DIFF
--- a/app/src/main/java/app/gamenative/data/DownloadInfo.kt
+++ b/app/src/main/java/app/gamenative/data/DownloadInfo.kt
@@ -50,8 +50,29 @@ data class DownloadInfo(
     private var currentStatusMessage: String = ""
     private val postInstallSyncing = MutableStateFlow(false)
 
+    private var wasAutoPaused: Boolean = false
+    private var autoResumeCallback: (() -> Unit)? = null
+
+    // For GameDownloadQueue integration
+    private var queueGameSource: GameSource? = null
+    private var queueGameId: String? = null
+
     fun cancel() {
         cancel("Cancelled by user")
+    }
+
+    fun pause(message: String = "Paused", autoPaused: Boolean = false) {
+        persistProgressSnapshot()
+        setActive(false)
+        setPostInstallSyncing(false)
+        resetSpeedTracking()
+        wasAutoPaused = autoPaused
+        downloadJob?.cancel(CancellationException(message))
+
+        // If user manually paused (not auto-paused), unregister from queue to resume next download
+        if (!autoPaused && queueGameSource != null && queueGameId != null) {
+            app.gamenative.service.GameDownloadQueue.unregisterDownload(queueGameSource!!, queueGameId!!)
+        }
     }
 
     fun failedToDownload() {
@@ -64,6 +85,12 @@ data class DownloadInfo(
         setActive(false)
         setPostInstallSyncing(false)
         resetSpeedTracking()
+
+        // Unregister from queue to resume next download
+        if (queueGameSource != null && queueGameId != null) {
+            app.gamenative.service.GameDownloadQueue.unregisterDownload(queueGameSource!!, queueGameId!!)
+        }
+
         // The snapshot write hits the (possibly saturated) install volume and the
         // job cancel cascades through many continuations; callers include UI click
         // handlers on the main thread, so both must run off it (ANR otherwise).
@@ -196,6 +223,29 @@ data class DownloadInfo(
         if (!active) {
             resetSpeedTracking()
         }
+    }
+
+    fun wasAutoPaused(): Boolean = wasAutoPaused
+
+    fun setAutoResumeCallback(callback: () -> Unit) {
+        autoResumeCallback = callback
+    }
+
+    fun triggerAutoResume() {
+        if (wasAutoPaused) {
+            wasAutoPaused = false
+            autoResumeCallback?.invoke()
+            autoResumeCallback = null
+        }
+    }
+
+    /**
+     * Set the queue identifiers for this download.
+     * This allows the DownloadInfo to unregister itself from the queue when paused/cancelled.
+     */
+    fun setQueueIdentifiers(gameSource: GameSource, gameId: String) {
+        queueGameSource = gameSource
+        queueGameId = gameId
     }
 
     fun isActive(): Boolean = isActive

--- a/app/src/main/java/app/gamenative/service/GameDownloadQueue.kt
+++ b/app/src/main/java/app/gamenative/service/GameDownloadQueue.kt
@@ -1,0 +1,135 @@
+package app.gamenative.service
+
+import android.content.Context
+import app.gamenative.data.DownloadInfo
+import app.gamenative.data.GameSource
+import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Centralized queue for managing downloads across all game services.
+ * Ensures only one download is active at a time across Steam, Epic, GOG, and Amazon.
+ */
+object GameDownloadQueue {
+
+    data class DownloadEntry(
+        val gameSource: GameSource,
+        val gameId: String,
+        val downloadInfo: DownloadInfo
+    )
+
+    /**
+     * Listener interface for services to handle resume requests.
+     */
+    interface ResumeListener {
+        fun onResumeRequested(gameSource: GameSource, gameId: String)
+    }
+
+    private val activeDownloads = ConcurrentHashMap<String, DownloadEntry>()
+    private val resumeListeners = ConcurrentHashMap<GameSource, ResumeListener>()
+
+    private fun makeKey(gameSource: GameSource, gameId: String): String {
+        return "${gameSource.name}_$gameId"
+    }
+
+    /**
+     * Register a resume listener for a specific game source.
+     * Each service should register its own listener to handle resume requests.
+     */
+    fun registerResumeListener(gameSource: GameSource, listener: ResumeListener) {
+        resumeListeners[gameSource] = listener
+        Timber.i("[GameDownloadQueue] Registered resume listener for $gameSource")
+    }
+
+    /**
+     * Unregister a resume listener for a specific game source.
+     */
+    fun unregisterResumeListener(gameSource: GameSource) {
+        resumeListeners.remove(gameSource)
+        Timber.i("[GameDownloadQueue] Unregistered resume listener for $gameSource")
+    }
+
+    /**
+     * Register a new download. This will auto-pause all other active downloads.
+     */
+    fun registerDownload(
+        gameSource: GameSource,
+        gameId: String,
+        downloadInfo: DownloadInfo
+    ) {
+        val key = makeKey(gameSource, gameId)
+
+        // Set queue identifiers on the DownloadInfo so it can unregister itself
+        downloadInfo.setQueueIdentifiers(gameSource, gameId)
+
+        // Auto-pause all other active downloads
+        activeDownloads.forEach { (existingKey, entry) ->
+            if (existingKey != key && entry.downloadInfo.isActive()) {
+                Timber.i("[GameDownloadQueue] Auto-pausing ${entry.gameSource} download for ${entry.gameId}")
+                entry.downloadInfo.pause(message = "Paused for new download", autoPaused = true)
+            }
+        }
+
+        // Register the new download
+        activeDownloads[key] = DownloadEntry(gameSource, gameId, downloadInfo)
+        Timber.i("[GameDownloadQueue] Registered ${gameSource} download for $gameId")
+    }
+
+    /**
+     * Unregister a download when it completes or is cancelled.
+     * Automatically resumes the next paused download if available.
+     */
+    fun unregisterDownload(gameSource: GameSource, gameId: String) {
+        val key = makeKey(gameSource, gameId)
+        activeDownloads.remove(key)
+        Timber.i("[GameDownloadQueue] Unregistered ${gameSource} download for $gameId")
+
+        // Auto-resume the first paused download (if any)
+        val nextDownload = activeDownloads.values.firstOrNull { entry ->
+            entry.downloadInfo.wasAutoPaused()
+        }
+
+        if (nextDownload != null) {
+            Timber.i("[GameDownloadQueue] Auto-resuming ${nextDownload.gameSource} download for ${nextDownload.gameId}")
+            val listener = resumeListeners[nextDownload.gameSource]
+            if (listener != null) {
+                nextDownload.downloadInfo.setAutoResumeCallback {
+                    listener.onResumeRequested(nextDownload.gameSource, nextDownload.gameId)
+                }
+                nextDownload.downloadInfo.triggerAutoResume()
+            } else {
+                Timber.w("[GameDownloadQueue] No resume listener registered for ${nextDownload.gameSource}")
+            }
+        }
+    }
+
+    /**
+     * Get all currently active downloads across all services.
+     */
+    fun getActiveDownloads(): Map<String, DownloadEntry> {
+        return HashMap(activeDownloads)
+    }
+
+    /**
+     * Get the count of active downloads.
+     */
+    fun getActiveDownloadCount(): Int {
+        return activeDownloads.count { it.value.downloadInfo.isActive() }
+    }
+
+    /**
+     * Check if a specific download is registered.
+     */
+    fun isDownloadRegistered(gameSource: GameSource, gameId: String): Boolean {
+        val key = makeKey(gameSource, gameId)
+        return activeDownloads.containsKey(key)
+    }
+
+    /**
+     * Get download info for a specific game.
+     */
+    fun getDownloadInfo(gameSource: GameSource, gameId: String): DownloadInfo? {
+        val key = makeKey(gameSource, gameId)
+        return activeDownloads[key]?.downloadInfo
+    }
+}

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1943,6 +1943,13 @@ class SteamService : Service(), IChallengeUrlChanged {
                 val chunkStagingRedirectDir = File(DownloadService.baseCacheDirPath, "depot_chunks/$appId")
                     .takeIf { !appDirPath.startsWith(DownloadService.baseDataDirPath) }
 
+                // Register with centralized queue and auto-pause other downloads
+                GameDownloadQueue.registerDownload(
+                    gameSource = GameSource.STEAM,
+                    gameId = appId.toString(),
+                    downloadInfo = di
+                )
+
                 val downloadJob = instance!!.scope.launch {
                     try {
                         if (isUpdateOrVerify) {
@@ -2216,6 +2223,9 @@ class SteamService : Service(), IChallengeUrlChanged {
 
                         // Remove the downloading app info
                         instance?.downloadingAppInfoDao?.deleteApp(appId)
+
+                        // Unregister from queue (will auto-resume next paused download)
+                        GameDownloadQueue.unregisterDownload(GameSource.STEAM, appId.toString())
                     } catch (e: CancellationException) {
                         Timber.d(e, "Download canceled for app $appId")
                         throw e
@@ -3573,6 +3583,17 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
 
+        // Register resume listener with GameDownloadQueue
+        GameDownloadQueue.registerResumeListener(GameSource.STEAM, object : GameDownloadQueue.ResumeListener {
+            override fun onResumeRequested(gameSource: GameSource, gameId: String) {
+                val appId = gameId.toIntOrNull() ?: return
+                Timber.i("[SteamService] Resume requested for app $appId")
+                scope.launch {
+                    downloadApp(appId)
+                }
+            }
+        })
+
         // clear stale download records (completed games) but keep interrupted ones (preserves DLC selection)
         scope.launch {
             for (record in downloadingAppInfoDao.getAll()) {
@@ -3747,6 +3768,9 @@ class SteamService : Service(), IChallengeUrlChanged {
         notificationHelper.cancel()
 
         connectivityManager.unregisterNetworkCallback(networkCallback)
+
+        // Unregister resume listener from GameDownloadQueue
+        GameDownloadQueue.unregisterResumeListener(GameSource.STEAM)
 
         scope.launch { stop() }
     }

--- a/app/src/main/java/app/gamenative/service/amazon/AmazonService.kt
+++ b/app/src/main/java/app/gamenative/service/amazon/AmazonService.kt
@@ -14,6 +14,7 @@ import app.gamenative.data.GameSource
 import app.gamenative.db.dao.AmazonGameDao
 import app.gamenative.enums.Marker
 import app.gamenative.events.AndroidEvent
+import app.gamenative.service.GameDownloadQueue
 import app.gamenative.service.NotificationHelper
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.ExecutableSelectionUtils
@@ -468,6 +469,13 @@ class AmazonService : Service() {
                 AndroidEvent.DownloadStatusChanged(game.appId, true)
             )
 
+            // Register with centralized queue and auto-pause other downloads
+            GameDownloadQueue.registerDownload(
+                gameSource = GameSource.AMAZON,
+                gameId = productId,
+                downloadInfo = downloadInfo
+            )
+
             val job = instance.serviceScope.launch {
                 try {
                     val result = instance.amazonDownloadManager.downloadGame(
@@ -485,6 +493,9 @@ class AmazonService : Service() {
                         PluviaApp.events.emitJava(
                             AndroidEvent.LibraryInstallStatusChanged(game.appId, GameSource.AMAZON)
                         )
+
+                        // Unregister from queue (will auto-resume next paused download)
+                        GameDownloadQueue.unregisterDownload(GameSource.AMAZON, productId)
                     } else {
                         val error = result.exceptionOrNull()
                         Timber.tag("Amazon").e(error, "Download failed for $productId")
@@ -793,6 +804,23 @@ class AmazonService : Service() {
         super.onCreate()
         instance = this
         PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
+
+        // Register resume listener with GameDownloadQueue
+        GameDownloadQueue.registerResumeListener(GameSource.AMAZON, object : GameDownloadQueue.ResumeListener {
+            override fun onResumeRequested(gameSource: GameSource, gameId: String) {
+                Timber.tag("Amazon").i("[AmazonService] Resume requested for product $gameId")
+                serviceScope.launch {
+                    val game = amazonManager.getGameById(gameId)
+                    if (game != null) {
+                        val installPath = game.installPath.ifBlank {
+                            AmazonConstants.getGameInstallPath(applicationContext, game.title)
+                        }
+                        downloadGame(applicationContext, gameId, installPath)
+                    }
+                }
+            }
+        })
+
         PluviaApp.events.emit(AndroidEvent.ServiceReady)
         Timber.i("[Amazon] Service created")
     }
@@ -856,6 +884,10 @@ class AmazonService : Service() {
         serviceScope.cancel()
         stopForeground(STOP_FOREGROUND_REMOVE)
         notificationHelper.cancel(NotificationHelper.NOTIFICATION_ID_AMAZON)
+
+        // Unregister resume listener from GameDownloadQueue
+        GameDownloadQueue.unregisterResumeListener(GameSource.AMAZON)
+
         instance = null
         super.onDestroy()
         Timber.i("[Amazon] Service destroyed")

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -15,6 +15,8 @@ import app.gamenative.utils.MarkerUtils
 import app.gamenative.enums.Marker
 import app.gamenative.events.AndroidEvent
 import app.gamenative.PluviaApp
+import app.gamenative.data.GameSource
+import app.gamenative.service.GameDownloadQueue
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.service.NotificationHelper
 import com.winlator.container.Container
@@ -437,6 +439,13 @@ class EpicService : Service() {
             downloadInfo.setActive(true)
             instance.notifierOrNull?.trackDownload(downloadInfo, game.title ?: "", NotificationHelper.NOTIFICATION_ID_EPIC)
 
+            // Register with centralized queue and auto-pause other downloads
+            GameDownloadQueue.registerDownload(
+                gameSource = GameSource.EPIC,
+                gameId = appId.toString(),
+                downloadInfo = downloadInfo
+            )
+
             // Start download in background
             val job = instance.scope.launch {
                 try {
@@ -485,6 +494,9 @@ class EpicService : Service() {
                         SnackbarManager.show("Download completed successfully!")
                         downloadInfo.setProgress(1.0f)
                         downloadInfo.setActive(false)
+
+                        // Unregister from queue (will auto-resume next paused download)
+                        GameDownloadQueue.unregisterDownload(GameSource.EPIC, appId.toString())
                     } else {
                         val error = result.exceptionOrNull()
                         Timber.e(error, "[Download] Failed for game $gameId")
@@ -642,6 +654,26 @@ class EpicService : Service() {
         // Initialize notification helper for foreground service
         notificationHelper = NotificationHelper(applicationContext)
         PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
+
+        // Register resume listener with GameDownloadQueue
+        GameDownloadQueue.registerResumeListener(GameSource.EPIC, object : GameDownloadQueue.ResumeListener {
+            override fun onResumeRequested(gameSource: GameSource, gameId: String) {
+                val appId = gameId.toIntOrNull() ?: return
+                Timber.tag("Epic").i("[EpicService] Resume requested for app $appId")
+                scope.launch {
+                    val game = epicManager.getGameById(appId)
+                    if (game != null) {
+                        val installPath = game.installPath.ifBlank {
+                            EpicConstants.getGameInstallPath(applicationContext, game.appName)
+                        }
+                        val container = ContainerUtils.getOrCreateContainer(applicationContext, "EPIC_$appId")
+                        val language = ContainerUtils.toContainerData(container).language
+                        downloadGame(applicationContext, appId, emptyList(), installPath, language)
+                    }
+                }
+            }
+        })
+
         PluviaApp.events.emit(AndroidEvent.ServiceReady)
     }
 
@@ -742,6 +774,10 @@ class EpicService : Service() {
         scope.cancel() // Cancel any ongoing operations
         stopForeground(STOP_FOREGROUND_REMOVE)
         notificationHelper.cancel(NotificationHelper.NOTIFICATION_ID_EPIC)
+
+        // Unregister resume listener from GameDownloadQueue
+        GameDownloadQueue.unregisterResumeListener(GameSource.EPIC)
+
         instance = null
     }
 

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -12,6 +12,8 @@ import app.gamenative.data.LaunchInfo
 import app.gamenative.data.LibraryItem
 import app.gamenative.events.AndroidEvent
 import app.gamenative.PluviaApp
+import app.gamenative.data.GameSource
+import app.gamenative.service.GameDownloadQueue
 import app.gamenative.ui.util.SnackbarManager
 import app.gamenative.service.NotificationHelper
 import app.gamenative.utils.ContainerUtils
@@ -365,6 +367,13 @@ class GOGService : Service() {
             instance.activeDownloads[gameId] = downloadInfo
             instance.notifierOrNull?.trackDownload(downloadInfo, "", NotificationHelper.NOTIFICATION_ID_GOG)
 
+            // Register with centralized queue and auto-pause other downloads
+            GameDownloadQueue.registerDownload(
+                gameSource = GameSource.GOG,
+                gameId = gameId,
+                downloadInfo = downloadInfo
+            )
+
             // Launch download in service scope so it runs independently
             val job = instance.scope.launch {
                 try {
@@ -419,6 +428,9 @@ class GOGService : Service() {
                         SnackbarManager.show("Download completed successfully!")
                         downloadInfo.setProgress(1.0f)
                         downloadInfo.setActive(false)
+
+                        // Unregister from queue (will auto-resume next paused download)
+                        GameDownloadQueue.unregisterDownload(GameSource.GOG, gameId)
                     }
                 } catch (e: CancellationException) {
                     downloadInfo.setPostInstallSyncing(false)
@@ -733,6 +745,25 @@ class GOGService : Service() {
         // Initialize notification helper for foreground service
         notificationHelper = NotificationHelper(applicationContext)
         PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
+
+        // Register resume listener with GameDownloadQueue
+        GameDownloadQueue.registerResumeListener(GameSource.GOG, object : GameDownloadQueue.ResumeListener {
+            override fun onResumeRequested(gameSource: GameSource, gameId: String) {
+                Timber.i("[GOGService] Resume requested for game $gameId")
+                scope.launch {
+                    val game = gogManager.getGameFromDbById(gameId)
+                    if (game != null) {
+                        val installPath = game.installPath.ifBlank {
+                            GOGConstants.getGameInstallPath(game.title)
+                        }
+                        val container = ContainerUtils.getOrCreateContainer(applicationContext, "GOG_$gameId")
+                        val language = ContainerUtils.toContainerData(container).language
+                        downloadGame(applicationContext, gameId, installPath, language)
+                    }
+                }
+            }
+        })
+
         PluviaApp.events.emit(AndroidEvent.ServiceReady)
     }
 
@@ -833,6 +864,10 @@ class GOGService : Service() {
         scope.cancel() // Cancel any ongoing operations
         stopForeground(STOP_FOREGROUND_REMOVE)
         notificationHelper.cancel(NotificationHelper.NOTIFICATION_ID_GOG)
+
+        // Unregister resume listener from GameDownloadQueue
+        GameDownloadQueue.unregisterResumeListener(GameSource.GOG)
+
         instance = null
     }
 


### PR DESCRIPTION
## Description
Introduces a global download management system to ensure only one game download is active across all integrated services (Steam, Epic, GOG, Amazon) at any given time.

This improves resource management and user experience by:
- Automatically pausing other active downloads when a new download is initiated.
- Automatically resuming the next available paused download once the current active download completes or is paused / cancelled.

## Recording
N/A

## Type of Change
- [ ] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a global download queue so only one game download runs at a time across Steam, Epic, GOG, and Amazon. It auto-pauses other active downloads and resumes the next paused one when the current download completes, is paused, or is cancelled.

- New Features
  - Added `app.gamenative.service.GameDownloadQueue` with register/unregister APIs, per-source resume listeners, and helpers (active count, lookup); registering a download auto-pauses others, and unregistering resumes the next auto-paused one.
  - Integrated with `SteamService`, `EpicService`, `GOGService`, and `AmazonService`: downloads register on start and unregister on completion/cancel; services add/remove resume listeners on create/destroy to resume paused downloads. Updated `app.gamenative.data.DownloadInfo` to track auto-paused state, store queue IDs, support an auto-resume callback, and self-unregister on manual pause/cancel to advance the queue.

<sup>Written for commit 0192ff24756270b2813a83fad8d9094543dadb60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



