### PR TITLE
Bumped version, fixed ALSA ANR

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,7 +64,7 @@ android {
         buildConfigField("boolean", "XR_BUILD", "false")
         buildConfigField("boolean", "MODERN_XR", "false")
 
-        versionCode = 14
+        versionCode = 19
         versionName = "1.1.0"
 
         buildConfigField("boolean", "GOLD", "false")

--- a/app/src/main/java/com/winlator/alsaserver/ALSAClient.java
+++ b/app/src/main/java/com/winlator/alsaserver/ALSAClient.java
@@ -176,12 +176,13 @@ public class ALSAClient {
             do {
                 try {
                     int bytesWritten = this.audioTrack.write(data, data.remaining(), 0);
-                    if (bytesWritten < 0) {
+                    if (bytesWritten <= 0) {
                         break;
                     } else {
                         increaseBufferSizeIfUnderrunOccurs();
                     }
                 } catch (Exception e) {
+                    break;
                 }
             } while (data.position() != data.limit());
             this.position += data.position();

--- a/app/src/main/java/com/winlator/xenvironment/components/ALSAServerComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/ALSAServerComponent.java
@@ -41,6 +41,12 @@ public class ALSAServerComponent extends EnvironmentComponent {
     public void stop() {
         XConnectorEpoll xConnectorEpoll = this.connector;
         if (xConnectorEpoll != null) {
+            for (int i = 0; i < xConnectorEpoll.getConnectedClientsCount(); i++) {
+                com.winlator.xconnector.Client client = xConnectorEpoll.getConnectedClientAt(i);
+                if (client != null && client.getTag() instanceof ALSAClient) {
+                    ((ALSAClient) client.getTag()).stop();
+                }
+            }
             xConnectorEpoll.stop();
             this.connector = null;
         }


### PR DESCRIPTION
## Description
Bumped version, fixed ALSA ANR

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ALSA-related ANR by breaking on write failures and stopping active clients during server shutdown. Also bumps `versionCode` to 19.

- **Bug Fixes**
  - `ALSAClient.writeDataToTrack`: break when `AudioTrack.write` returns <= 0 or throws, preventing tight loop/ANR.
  - `ALSAServerComponent.stop`: iterates `XConnectorEpoll` clients and calls `ALSAClient.stop()` before shutting down the connector.

<sup>Written for commit ccc6757d1b528cf08c2cafbb5dc6ee94d055c79b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio streaming reliability by handling write failures and no-progress writes more safely.
  * Ensured active audio clients are stopped cleanly when the audio server is shut down, reducing stuck playback or connection issues.

* **Chores**
  * Updated the app version number for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->