### PR TITLE
Add an animated focus ring across the library and in-game UI

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/AccentActionRow.kt
+++ b/app/src/main/java/app/gamenative/ui/component/AccentActionRow.kt
@@ -1,0 +1,101 @@
+package app.gamenative.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * Tappable action row: an [accentColor]-tinted icon, a title, and the shared [focusRing].
+ */
+@Composable
+fun AccentActionRow(
+    title: String,
+    icon: ImageVector,
+    accentColor: Color,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val shape = RoundedCornerShape(14.dp)
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 2.dp)
+            .clip(shape)
+            .background(
+                if (isFocused) {
+                    Brush.horizontalGradient(
+                        colors = listOf(
+                            accentColor.copy(alpha = 0.16f),
+                            accentColor.copy(alpha = 0.08f),
+                        ),
+                    )
+                } else {
+                    Brush.horizontalGradient(
+                        colors = listOf(
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.18f),
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.10f),
+                        ),
+                    )
+                },
+            )
+            .focusRing(interactionSource, shape, width = 2.dp)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                role = Role.Button,
+                onClick = onClick,
+            )
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(accentColor.copy(alpha = if (isFocused) 0.24f else 0.16f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = accentColor,
+                modifier = Modifier.size(22.dp),
+            )
+        }
+
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = if (isFocused) FontWeight.SemiBold else FontWeight.Medium,
+        )
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/component/FocusRing.kt
+++ b/app/src/main/java/app/gamenative/ui/component/FocusRing.kt
@@ -1,0 +1,123 @@
+package app.gamenative.ui.component
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Colored focus ring: a sweep gradient border whose colors rotate around the element while
+ * [interactionSource] is focused (D-pad / controller). Shared by LibraryGridCard, InfoCard, etc.
+ *
+ * Only the colors move; the shape stays put. The static stroke acts as a mask that the rotating
+ * gradient is painted through, clipped to [shape] so the outer edge stays flush with the element.
+ *
+ * Pass the element's clickable [interactionSource] so focus is tracked, and apply this after the
+ * clip/background so the border draws on top. [durationMillis] is one full rotation.
+ */
+@Composable
+fun Modifier.focusRing(
+    interactionSource: InteractionSource,
+    shape: Shape,
+    width: Dp = 4.dp,
+    durationMillis: Int = 5000,
+): Modifier {
+    val focused by interactionSource.collectIsFocusedAsState()
+
+    // The Animatable and its driver are created unconditionally (stable remember slots), so the slot
+    // count doesn't change between focused/unfocused and the ring can't flicker on recompose (the
+    // earlier bug on frequently-recomposing elements like the tab-bar buttons). The spin runs only
+    // while focused; losing focus cancels the effect and snaps back to 0, so an unfocused ring
+    // schedules no animation frames (an always-on InfiniteTransition would keep ticking per frame).
+    val angle = remember { Animatable(0f) }
+    LaunchedEffect(focused) {
+        if (focused) {
+            angle.animateTo(
+                targetValue = 360f,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(durationMillis, easing = LinearEasing),
+                    repeatMode = RepeatMode.Restart,
+                ),
+            )
+        } else {
+            angle.snapTo(0f)
+        }
+    }
+
+    if (!focused) return this
+
+    // First == last so the sweep loops seamlessly. Only blue (tertiary) and purple (primary);
+    // secondary is a near-black gray and would show as a dark band in the ring.
+    val colors = listOf(
+        MaterialTheme.colorScheme.primary,
+        MaterialTheme.colorScheme.tertiary,
+        MaterialTheme.colorScheme.primary,
+    )
+    val strokePx = with(LocalDensity.current) { width.toPx() }
+
+    return drawWithCache {
+        // Rebuilt only when the size changes.
+        val outline = shape.createOutline(size, layoutDirection, this)
+        val bounds = Rect(Offset.Zero, size)
+        val center = bounds.center
+        val sweep = Brush.sweepGradient(colors, center)
+        // Allocate the layer Paint once per cache build (size change), not once per frame.
+        val layerPaint = Paint()
+        val clipPath = Path().apply {
+            when (val o = outline) {
+                is Outline.Rectangle -> addRect(o.rect)
+                is Outline.Rounded -> addRoundRect(o.roundRect)
+                is Outline.Generic -> addPath(o.path)
+            }
+        }
+
+        onDrawWithContent {
+            drawContent()
+            // Reading angle here keeps the animation in the draw phase, off recomposition.
+            val canvas = drawContext.canvas
+            canvas.saveLayer(bounds, layerPaint)
+
+            // Keep the ring's outer edge flush with the element.
+            canvas.clipPath(clipPath)
+
+            // Stroke at 2x width; the clipped-off outer half leaves an inward border of `width`.
+            drawOutline(outline, color = Color.Black, style = Stroke(strokePx * 2f))
+
+            // Paint the gradient only over the stroke. Oversized circle covers any rotation.
+            rotate(angle.value, pivot = center) {
+                drawCircle(
+                    brush = sweep,
+                    radius = size.maxDimension,
+                    blendMode = BlendMode.SrcIn,
+                )
+            }
+
+            canvas.restore()
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -1218,24 +1218,6 @@ private fun QuickMenuCloseButton(
     Box(
         modifier = modifier
             .size(44.dp)
-            .then(
-                if (isFocused) {
-                    Modifier.border(
-                        BorderStroke(
-                            2.dp,
-                            Brush.verticalGradient(
-                                colors = listOf(
-                                    MaterialTheme.colorScheme.primary,
-                                    MaterialTheme.colorScheme.tertiary,
-                                ),
-                            ),
-                        ),
-                        shape,
-                    )
-                } else {
-                    Modifier
-                }
-            )
             .clip(shape)
             .background(
                 if (isFocused) {
@@ -1244,6 +1226,7 @@ private fun QuickMenuCloseButton(
                     Color.Transparent
                 },
             )
+            .focusRing(interactionSource, shape, width = 2.dp)
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
@@ -1282,24 +1265,6 @@ private fun QuickMenuTabButton(
     Box(
         modifier = modifier
             .size(56.dp)
-            .then(
-                if (isFocused) {
-                    Modifier.border(
-                        BorderStroke(
-                            2.dp,
-                            Brush.verticalGradient(
-                                colors = listOf(
-                                    MaterialTheme.colorScheme.primary,
-                                    MaterialTheme.colorScheme.tertiary,
-                                ),
-                            ),
-                        ),
-                        shape,
-                    )
-                } else {
-                    Modifier
-                }
-            )
             .clip(shape)
             .background(
                 when {
@@ -1308,6 +1273,7 @@ private fun QuickMenuTabButton(
                     else -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
                 },
             )
+            .focusRing(interactionSource, shape, width = 2.dp)
             .then(
                 if (focusRequester != null) {
                     Modifier.focusRequester(focusRequester)
@@ -1970,24 +1936,6 @@ private fun QuickMenuItemRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .then(
-                if (isFocused && isEnabled) {
-                    Modifier.border(
-                        BorderStroke(
-                            2.dp,
-                            Brush.verticalGradient(
-                                colors = listOf(
-                                    MaterialTheme.colorScheme.primary,
-                                    MaterialTheme.colorScheme.tertiary,
-                                ),
-                            ),
-                        ),
-                        shape,
-                    )
-                } else {
-                    Modifier
-                }
-            )
             .clip(shape)
             .then(
                 if (isFocused && isEnabled) {
@@ -1999,6 +1947,13 @@ private fun QuickMenuItemRow(
                             ),
                         ),
                     )
+                } else {
+                    Modifier
+                }
+            )
+            .then(
+                if (isEnabled) {
+                    Modifier.focusRing(interactionSource, shape, width = 2.dp)
                 } else {
                     Modifier
                 }

--- a/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
@@ -407,7 +407,7 @@ fun GLScreenEffectsTabContent(
 
         Spacer(modifier = Modifier.height(20.dp))
 
-        ScreenEffectActionRow(
+        AccentActionRow(
             title = stringResource(R.string.screen_effects_reset),
             icon = Icons.Default.RestartAlt,
             accentColor = PluviaTheme.colors.accentPurple,
@@ -646,7 +646,7 @@ fun ScreenEffectsTabContent(
 
         Spacer(modifier = Modifier.height(20.dp))
 
-        ScreenEffectActionRow(
+        AccentActionRow(
             title = stringResource(R.string.screen_effects_reset),
             icon = Icons.Default.RestartAlt,
             accentColor = PluviaTheme.colors.accentPurple,
@@ -916,7 +916,7 @@ fun ScreenEffectsPanel(
 
                     Spacer(modifier = Modifier.height(20.dp))
 
-                    ScreenEffectActionRow(
+                    AccentActionRow(
                         title = stringResource(R.string.screen_effects_reset),
                         icon = Icons.Default.RestartAlt,
                         accentColor = PluviaTheme.colors.accentPurple,
@@ -1343,83 +1343,6 @@ private fun ScreenEffectRadioIndicator(selected: Boolean, accentColor: Color) {
                     .background(accentColor),
             )
         }
-    }
-}
-
-@Composable
-private fun ScreenEffectActionRow(
-    title: String,
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    accentColor: Color,
-    onClick: () -> Unit,
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isFocused by interactionSource.collectIsFocusedAsState()
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 2.dp)
-            .clip(RoundedCornerShape(14.dp))
-            .background(
-                if (isFocused) {
-                    Brush.horizontalGradient(
-                        colors = listOf(
-                            accentColor.copy(alpha = 0.16f),
-                            accentColor.copy(alpha = 0.08f),
-                        ),
-                    )
-                } else {
-                    Brush.horizontalGradient(
-                        colors = listOf(
-                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.18f),
-                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.10f),
-                        ),
-                    )
-                },
-            )
-            .then(
-                if (isFocused) {
-                    Modifier.border(
-                        width = 2.dp,
-                        color = accentColor.copy(alpha = 0.7f),
-                        shape = RoundedCornerShape(14.dp),
-                    )
-                } else {
-                    Modifier
-                },
-            )
-            .selectable(
-                selected = isFocused,
-                interactionSource = interactionSource,
-                indication = null,
-                onClick = onClick,
-            )
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(CircleShape)
-                .background(accentColor.copy(alpha = if (isFocused) 0.24f else 0.16f)),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = accentColor,
-                modifier = Modifier.size(22.dp),
-            )
-        }
-
-        Text(
-            text = title,
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurface,
-            fontWeight = if (isFocused) FontWeight.SemiBold else FontWeight.Medium,
-        )
     }
 }
 

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -113,6 +112,7 @@ import app.gamenative.service.SteamService
 import app.gamenative.ui.component.GamepadAction
 import app.gamenative.ui.component.GamepadActionBar
 import app.gamenative.ui.component.GamepadButton
+import app.gamenative.ui.component.focusRing
 import app.gamenative.ui.component.LoadingScreen
 import app.gamenative.ui.data.AppMenuOption
 import app.gamenative.ui.data.GameDisplayInfo
@@ -212,22 +212,7 @@ private fun PrimaryActionButton(
             .background(
                 if (enabled) buttonColor else buttonColor.copy(alpha = 0.5f),
             )
-            .then(
-                if (isFocused) {
-                    Modifier.border(
-                        2.dp,
-                        Brush.verticalGradient(
-                            colors = listOf(
-                                MaterialTheme.colorScheme.primary,
-                                MaterialTheme.colorScheme.tertiary,
-                            ),
-                        ),
-                        RoundedCornerShape(8.dp),
-                    )
-                } else {
-                    Modifier
-                },
-            )
+            .focusRing(interactionSource, RoundedCornerShape(8.dp), width = 2.dp)
             .focusRequester(focusRequester)
             .selectable(
                 selected = isFocused,
@@ -337,22 +322,7 @@ private fun ActionIconButton(
                     Color.White.copy(alpha = 0.1f)
                 },
             )
-            .then(
-                if (isFocused) {
-                    Modifier.border(
-                        2.dp,
-                        Brush.verticalGradient(
-                            colors = listOf(
-                                MaterialTheme.colorScheme.primary,
-                                MaterialTheme.colorScheme.tertiary,
-                            ),
-                        ),
-                        RoundedCornerShape(8.dp),
-                    )
-                } else {
-                    Modifier
-                },
-            )
+            .focusRing(interactionSource, RoundedCornerShape(8.dp), width = 2.dp)
             .selectable(
                 selected = isFocused,
                 interactionSource = interactionSource,
@@ -383,6 +353,7 @@ private fun InfoCard(
     focusableForNavigation: Boolean = false,
 ) {
     var isFocused by remember { mutableStateOf(false) }
+    val interactionSource = remember { MutableInteractionSource() }
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
     val scope = rememberCoroutineScope()
     val cardModifier = if (focusableForNavigation) {
@@ -394,23 +365,8 @@ private fun InfoCard(
                     scope.launch { bringIntoViewRequester.bringIntoView() }
                 }
             }
-            .focusable()
-            .then(
-                if (isFocused) {
-                    Modifier.border(
-                        2.dp,
-                        Brush.verticalGradient(
-                            colors = listOf(
-                                MaterialTheme.colorScheme.primary,
-                                MaterialTheme.colorScheme.tertiary,
-                            ),
-                        ),
-                        RoundedCornerShape(16.dp),
-                    )
-                } else {
-                    Modifier
-                },
-            )
+            .focusable(interactionSource = interactionSource)
+            .focusRing(interactionSource, RoundedCornerShape(16.dp), width = 2.dp)
     } else {
         modifier
     }

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -331,6 +331,10 @@ private fun LibraryScreenContent(
     var previousAppCount by remember { mutableIntStateOf(state.appInfoList.size) }
     var controllerBootstrapNeeded by remember { mutableStateOf(true) }
     var rootHasFocus by remember { mutableStateOf(false) }
+    // True while focus lives in the top tab bar. The delayed focus-restoration effects below must
+    // not yank focus back to the grid when the user has moved up into the tab bar (the action
+    // buttons would otherwise light up for ~100ms and then lose focus).
+    var tabBarHasFocus by remember { mutableStateOf(false) }
     var lastBootstrapAtMs by remember { mutableLongStateOf(0L) }
 
     fun firstVisibleContentIndex(): Int {
@@ -494,6 +498,9 @@ private fun LibraryScreenContent(
         // Brief delay to let list populate after tab change
         kotlinx.coroutines.delay(150)
 
+        // The user may have moved focus up into the tab bar during the delay; don't yank it back.
+        if (tabBarHasFocus) return@LaunchedEffect
+
         if (state.appInfoList.isEmpty()) {
             // Empty tab - focus root so bumpers still work
             requestRootFocusSafe()
@@ -570,10 +577,10 @@ private fun LibraryScreenContent(
         val listBecameNonEmpty = previousAppCount == 0 && currentCount > 0
         val listBecameEmpty = previousAppCount > 0 && currentCount == 0
 
-        if (listBecameNonEmpty && selectedAppId == null && !isSystemMenuOpen && !state.isOptionsPanelOpen && !state.isSearching) {
+        if (listBecameNonEmpty && selectedAppId == null && !isSystemMenuOpen && !state.isOptionsPanelOpen && !state.isSearching && !tabBarHasFocus) {
             requestContentFocusOrDefer()
         }
-        if (listBecameEmpty && selectedAppId == null && !isSystemMenuOpen && !state.isOptionsPanelOpen && !state.isSearching) {
+        if (listBecameEmpty && selectedAppId == null && !isSystemMenuOpen && !state.isOptionsPanelOpen && !state.isSearching && !tabBarHasFocus) {
             // Empty tabs can drop focused children; re-anchor focus at the root so bumper nav keeps working.
             requestRootFocusSafe()
         }
@@ -615,6 +622,7 @@ private fun LibraryScreenContent(
             state.appInfoList.isNotEmpty() &&
             controllerBootstrapNeeded &&
             !rootHasFocus &&
+            !tabBarHasFocus &&
             (now - lastBootstrapAtMs) > 250L
     }
     val canNavigateTabsWithoutFocus: () -> Boolean = {
@@ -735,7 +743,10 @@ private fun LibraryScreenContent(
                         !isSystemMenuOpen &&
                         !state.isSearching &&
                         state.appInfoList.isNotEmpty() &&
-                        controllerBootstrapNeeded
+                        controllerBootstrapNeeded &&
+                        // Don't pull focus to the grid while the user is on the tab bar (D-pad
+                        // up/left/right and analog nudges aren't consumed by the bar otherwise).
+                        !tabBarHasFocus
 
                     when (keyCode) {
                         // Navigation keys should bootstrap focus even before any item is selected.
@@ -983,7 +994,16 @@ private fun LibraryScreenContent(
                         onNextTab = onNextTab,
                         modifier = Modifier
                             .align(Alignment.TopCenter)
-                            .fillMaxWidth(),
+                            .fillMaxWidth()
+                            .onFocusChanged { focusState ->
+                                tabBarHasFocus = focusState.hasFocus
+                                // Cancel any deferred grid-focus so the retry loop can't pull focus
+                                // back off a tab-bar button the user just landed on.
+                                if (focusState.hasFocus) {
+                                    pendingGridFocusRequest = false
+                                    pendingCarouselFocusRequest = false
+                                }
+                            },
                     )
                 }
             }

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryGridCard.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryGridCard.kt
@@ -58,6 +58,7 @@ import app.gamenative.data.GameSource
 import app.gamenative.data.LibraryItem
 import app.gamenative.ui.component.CompatibilityBadge
 import app.gamenative.ui.component.GameStatsRow
+import app.gamenative.ui.component.focusRing
 import app.gamenative.ui.data.GameCardStats
 import app.gamenative.ui.enums.PaneType
 import app.gamenative.ui.theme.PluviaTheme
@@ -119,27 +120,22 @@ internal fun GridViewCard(
     } else {
         Modifier
     }
-    val focusBorderBrush = Brush.verticalGradient(
-        colors = listOf(
-            MaterialTheme.colorScheme.primary,
-            MaterialTheme.colorScheme.tertiary,
-        ),
-    )
+    val cardShape = RoundedCornerShape(12.dp)
+    val interactionSource = remember { MutableInteractionSource() }
+    val isItemFocused by interactionSource.collectIsFocusedAsState()
+
+    LaunchedEffect(isItemFocused) {
+        onFocusChanged(isItemFocused)
+        if (isItemFocused) onFocus()
+    }
 
     Box(
         modifier = modifier
             .padding(vertical = 4.dp)
             .scale(scale)
-            .then(focusHaloModifier),
+            .then(focusHaloModifier)
+            .focusRing(interactionSource, cardShape),
     ) {
-        val interactionSource = remember { MutableInteractionSource() }
-        val isItemFocused by interactionSource.collectIsFocusedAsState()
-
-        LaunchedEffect(isItemFocused) {
-            onFocusChanged(isItemFocused)
-            if (isItemFocused) onFocus()
-        }
-
         Card(
             modifier = Modifier
                 .fillMaxWidth()
@@ -149,12 +145,11 @@ internal fun GridViewCard(
                     interactionSource = interactionSource,
                     indication = null,
                 ),
-            shape = RoundedCornerShape(12.dp),
+            shape = cardShape,
             colors = CardDefaults.cardColors(
                 containerColor = Color.Transparent,
             ),
             border = when {
-                isFocused -> BorderStroke(2.dp, focusBorderBrush)
                 appInfo.isRecommended -> BorderStroke(
                     1.dp,
                     MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListCard.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListCard.kt
@@ -35,7 +35,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -47,6 +46,7 @@ import app.gamenative.data.LibraryItem
 import app.gamenative.service.SteamService
 import app.gamenative.ui.component.CompatibilityBadge
 import app.gamenative.ui.component.GameStatsRow
+import app.gamenative.ui.component.focusRing
 import app.gamenative.ui.data.GameCardStats
 import app.gamenative.ui.util.ListItemImage
 import app.gamenative.utils.CustomGameScanner
@@ -77,16 +77,22 @@ internal fun ListViewCard(
         if (isItemFocused) onFocus()
     }
 
-    Card(
+    val shape = RoundedCornerShape(14.dp)
+    Box(
         modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
-            .clickable(
-                onClick = onClick,
-                interactionSource = interactionSource,
-                indication = null,
-            ),
-        shape = RoundedCornerShape(14.dp),
+            .focusRing(interactionSource, shape),
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(
+                    onClick = onClick,
+                    interactionSource = interactionSource,
+                    indication = null,
+                ),
+            shape = shape,
         colors = CardDefaults.cardColors(
             containerColor = if (isFocused) {
                 MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.25f)
@@ -95,15 +101,6 @@ internal fun ListViewCard(
             },
         ),
         border = when {
-            isFocused -> BorderStroke(
-                2.dp,
-                Brush.horizontalGradient(
-                    colors = listOf(
-                        MaterialTheme.colorScheme.primary,
-                        MaterialTheme.colorScheme.tertiary,
-                    ),
-                ),
-            )
             appInfo.isRecommended -> BorderStroke(
                 1.dp,
                 MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
@@ -202,6 +199,7 @@ internal fun ListViewCard(
                 )
             }
         }
+    }
     }
 }
 

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryTabBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryTabBar.kt
@@ -6,8 +6,6 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.border
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -17,6 +15,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -41,10 +40,9 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.onPreviewKeyEvent
@@ -60,6 +58,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import app.gamenative.BuildConfig
 import app.gamenative.R
+import app.gamenative.ui.component.focusRing
 import app.gamenative.ui.enums.LibraryTab
 import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.ui.util.WindowWidthClass
@@ -216,24 +215,6 @@ private fun CompactLibraryTabBar(
                                 tabPositions[index] = coordinates.positionInParent().x
                                 tabWidths[index] = coordinates.size.width.toFloat()
                             }
-                            .then(
-                                if (isTabFocused) {
-                                    Modifier.border(
-                                        BorderStroke(
-                                            2.dp,
-                                            Brush.verticalGradient(
-                                                colors = listOf(
-                                                    MaterialTheme.colorScheme.primary,
-                                                    MaterialTheme.colorScheme.tertiary,
-                                                ),
-                                            ),
-                                        ),
-                                        RoundedCornerShape(16.dp),
-                                    )
-                                } else {
-                                    Modifier
-                                },
-                            )
                             .clip(RoundedCornerShape(16.dp))
                             .background(
                                 when {
@@ -242,6 +223,7 @@ private fun CompactLibraryTabBar(
                                     else -> Color.Transparent
                                 },
                             )
+                            .focusRing(tabInteractionSource, RoundedCornerShape(16.dp), width = 2.dp)
                             .selectable(
                                 selected = isSelected,
                                 interactionSource = tabInteractionSource,
@@ -310,24 +292,6 @@ private fun CompactIconButton(
     Box(
         modifier = modifier
             .size(36.dp)
-            .then(
-                if (isFocused) {
-                    Modifier.border(
-                        BorderStroke(
-                            2.dp,
-                            Brush.verticalGradient(
-                                colors = listOf(
-                                    MaterialTheme.colorScheme.primary,
-                                    MaterialTheme.colorScheme.tertiary,
-                                ),
-                            ),
-                        ),
-                        CircleShape,
-                    )
-                } else {
-                    Modifier
-                },
-            )
             .clip(CircleShape)
             .background(
                 if (isFocused) {
@@ -336,6 +300,7 @@ private fun CompactIconButton(
                     MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
                 },
             )
+            .focusRing(interactionSource, CircleShape, width = 2.dp)
             .selectable(
                 selected = false,
                 interactionSource = interactionSource,
@@ -560,26 +525,16 @@ private fun IconActionButton(
 
     Box(
         modifier = modifier
-            .scale(scale)
+            // Both the focus scale and alpha go in a SINGLE graphicsLayer above the ring. Previously
+            // .scale (above) and .alpha (below) were two separate animating layers sandwiching the
+            // focusRing draw node, which made the ring flicker off ~100ms after focus. One stable
+            // layer wrapping clip/background/focusRing fixes it.
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+                this.alpha = alpha
+            }
             .size(44.dp)
-            .then(
-                if (isFocused) {
-                    Modifier.border(
-                        BorderStroke(
-                            2.dp,
-                            Brush.verticalGradient(
-                                colors = listOf(
-                                    MaterialTheme.colorScheme.primary,
-                                    MaterialTheme.colorScheme.tertiary,
-                                ),
-                            ),
-                        ),
-                        CircleShape,
-                    )
-                } else {
-                    Modifier
-                },
-            )
             .clip(CircleShape)
             .background(
                 brush = Brush.radialGradient(
@@ -596,13 +551,15 @@ private fun IconActionButton(
                     },
                 ),
             )
+            .focusRing(interactionSource, CircleShape, width = 2.dp)
             .selectable(
-                selected = isFocused,
+                // These are actions, not toggles; feeding isFocused back as `selected` caused an
+                // extra recomposition on every focus change.
+                selected = false,
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = onClick,
-            )
-            .alpha(alpha),
+            ),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
@@ -648,25 +605,12 @@ private fun TabItem(
 
     Box(
         modifier = modifier
-            .then(
-                if (isFocused) {
-                    Modifier.border(
-                        BorderStroke(
-                            2.dp,
-                            Brush.verticalGradient(
-                                colors = listOf(
-                                    MaterialTheme.colorScheme.primary,
-                                    MaterialTheme.colorScheme.tertiary,
-                                ),
-                            ),
-                        ),
-                        RoundedCornerShape(20.dp),
-                    )
-                } else {
-                    Modifier
-                },
-            )
+            // Min height = the sliding pill's height (40.dp) so the focus ring outlines the same
+            // 40dp-tall, 20dp-radius capsule the user sees. Uses heightIn (not a fixed height) so the
+            // label can grow at large accessibility font scales instead of being clipped.
+            .heightIn(min = 40.dp)
             .clip(RoundedCornerShape(20.dp))
+            .focusRing(interactionSource, RoundedCornerShape(20.dp), width = 2.dp)
             .onGloballyPositioned { coordinates ->
                 onPositioned(
                     coordinates.positionInParent().x,
@@ -679,7 +623,7 @@ private fun TabItem(
                 indication = null,
                 onClick = onClick,
             )
-            .padding(horizontal = 20.dp, vertical = 10.dp),
+            .padding(horizontal = 20.dp),
         contentAlignment = Alignment.Center,
     ) {
         Text(


### PR DESCRIPTION
## What
Replaces the static gradient focus borders with a rotating sweep-gradient ring that highlights the focused element when navigating with a controller or D-pad. It only animates while focused, so unfocused elements schedule no frames.

## Where
- Library grid and list cards
- Library tab bar
- Game page action buttons and info cards
- In-game quick menu
- In-game screen effects panel rows

## Notes
The card ring is drawn on each card's outer box rather than the Material Card itself, since the card's own background would otherwise cover it.

Before:
https://github.com/user-attachments/assets/ea2855df-2c8d-4da5-87ad-7ff363544a4e

After:
https://github.com/user-attachments/assets/4bea6134-0470-4cea-821d-968151034a74

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an animated sweep‑gradient focus ring across the library and in‑game UI, replacing static borders. It runs only while focused and removes focus flicker and tab‑bar focus yanks.

- **New Features**
  - Introduced `Modifier.focusRing(...)` in `FocusRing.kt` for a rotating sweep‑gradient border; configurable shape and width; animation runs only while focused.
  - Applied to library grid/list cards (ring draws on the outer container), library tab bar (aligned to the 40dp pill), game page primary/action buttons and info cards, in‑game quick menu, and screen effects rows via `AccentActionRow`.

- **Bug Fixes**
  - Eliminated focus‑ring flicker by keeping a stable transition and gating only the draw; unfocused elements don’t animate.
  - Fixed tab‑bar issues: removed icon flicker by applying focus scale and alpha in one `graphicsLayer`, and prevented grid focus from pulling back while the tab bar is focused by tracking `tabBarHasFocus` and canceling deferred focus requests.

<sup>Written for commit 0220307f23259054b6a34e295260b4b9827376ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an accented action row component with improved clickable button layout and focus-tinted visuals.
  * Introduced a shared, animated focus ring for consistent focus highlighting.
* **UI Improvements**
  * Updated library cards, tab bars, quick menu controls, and screen actions to use the unified focus ring styling.
  * Refined tab navigation so focus doesn’t jump unexpectedly between the tab bar and content.
  * Updated library and screen effect reset controls to match the new accent action row appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->