### PR TITLE
apply gmem automatically for adreno 710, 720, 732 to reduce glitches

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -5097,6 +5097,13 @@ private suspend fun extractGraphicsDriverFiles(
         envVars.put("GALLIUM_DRIVER", "zink")
         envVars.put("LIBGL_KOPPER_DISABLE", "true")
 
+        if (currentWrapperVersion.lowercase(Locale.getDefault()).contains("turnip")
+            && GPUInformation.isAdreno710_720_732(context)) {
+            var tuDebug = envVars.get("TU_DEBUG").replace("sysmem", "gmem")
+            if (!tuDebug.contains("gmem")) tuDebug = (if (tuDebug.isEmpty()) "" else "$tuDebug,") + "gmem"
+            envVars.put("TU_DEBUG", tuDebug)
+        }
+
         // 1. Get the main WRAPPER selection (e.g., "Wrapper-v2") from the class field.
         val mainWrapperSelection: String = graphicsDriver
 


### PR DESCRIPTION
## Description
Add TU_DEBUG gmem to make turnip work on 710, 720, 732 adreno devices

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically enable GMEM for Adreno 710/720/732 when using Turnip to reduce rendering glitches. Updates the `TU_DEBUG` env var during driver setup.

- **Bug Fixes**
  - Detect Turnip wrapper and Adreno 710/720/732, then replace `sysmem` with `gmem` in `TU_DEBUG`.
  - If `TU_DEBUG` lacks `gmem`, append it to ensure GMEM is active.

<sup>Written for commit d22900916b8aee18204642aa17e0c62cacc35d7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

