### PR TITLE
Fall back to English depots for unavailable languages

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -932,11 +932,14 @@ class SteamService : Service(), IChallengeUrlChanged {
             hasSteamUnlockedBranch: Boolean = false,
         ): Map<Int, DepotInfo> {
             val dlcAppIdsWithSingleDepots = getDlcAppIdsWithSingleDepot(depots)
-            val eligible = eligibleDepots(depots, preferredLanguage, ownedDlc, licensedDepotIds)
+            val effectiveLanguage = SteamUtils.effectiveDepotLanguage(
+                depots, preferredLanguage, ownedDlc, licensedDepotIds, hasSteamUnlockedBranch,
+            )
+            val eligible = eligibleDepots(depots, effectiveLanguage, ownedDlc, licensedDepotIds)
             val has64Bit = eligible.any { it.osArch == OSArch.Arch64 }
             val hasNonDeckWin = eligible.any { !it.steamDeck && it.isWindowsCompatible }
             return depots.filter { (_, depot) ->
-                filterForDownloadableDepots(depot, has64Bit, hasNonDeckWin, preferredLanguage,
+                filterForDownloadableDepots(depot, has64Bit, hasNonDeckWin, effectiveLanguage,
                     ownedDlc, licensedDepotIds,
                     dlcAppIdsWithSingleDepots = dlcAppIdsWithSingleDepots
                 )
@@ -1005,18 +1008,25 @@ class SteamService : Service(), IChallengeUrlChanged {
             val map = getMainAppDepots(appId, preferredLanguage).toMutableMap()
 
             // parent app's arch applies to DLC arch selection
-            val has64Bit = eligibleDepots(appInfo.depots, preferredLanguage, ownedDlc, licensedDepots)
+            val mainLanguage = SteamUtils.effectiveDepotLanguage(
+                appInfo.depots, preferredLanguage, ownedDlc, licensedDepots, hasSteamUnlockedBranch,
+            )
+            val has64Bit = eligibleDepots(appInfo.depots, mainLanguage, ownedDlc, licensedDepots)
                 .any { it.osArch == OSArch.Arch64 }
 
             val indirectDlcApps = getDownloadableDlcAppsOf(appId).orEmpty()
             indirectDlcApps.forEach { dlcApp ->
                 val dlcAppIdsWithSingleDepots = getDlcAppIdsWithSingleDepot(dlcApp.depots)
                 val dlcLicensedDepots = getLicensedDepotIds(dlcApp.id)
-                val dlcEligible = eligibleDepots(dlcApp.depots, preferredLanguage, null, dlcLicensedDepots)
+                // Resolve the DLC's own language too, so DLC that omits the container language installs.
+                val dlcLanguage = SteamUtils.effectiveDepotLanguage(
+                    dlcApp.depots, preferredLanguage, null, dlcLicensedDepots, hasSteamUnlockedBranch,
+                )
+                val dlcEligible = eligibleDepots(dlcApp.depots, dlcLanguage, null, dlcLicensedDepots)
                 val dlcHasNonDeckWin = dlcEligible.any { !it.steamDeck && it.isWindowsCompatible }
                 dlcApp.depots
                     .filter { (_, depot) ->
-                        filterForDownloadableDepots(depot, has64Bit, dlcHasNonDeckWin, preferredLanguage,
+                        filterForDownloadableDepots(depot, has64Bit, dlcHasNonDeckWin, dlcLanguage,
                             null, dlcLicensedDepots, hasSteamUnlockedBranch,
                             dlcAppIdsWithSingleDepots = dlcAppIdsWithSingleDepots
                         )

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -12,6 +12,7 @@ import app.gamenative.data.SteamApp
 import app.gamenative.enums.LoginResult
 import app.gamenative.enums.Marker
 import app.gamenative.enums.SpecialGameSaveMapping
+import app.gamenative.enums.SteamRealm
 import app.gamenative.events.SteamEvent
 import app.gamenative.service.SteamService
 import app.gamenative.service.SteamService.Companion.getAppDirName
@@ -99,6 +100,46 @@ object SteamUtils {
         // DL size should always be smaller than installSize.
         val hasSaneDownload = manifest.download > 0L && manifest.download <= manifest.size
         return if (hasSaneDownload) manifest.download else manifest.size
+    }
+
+    /**
+     * The language [depots] should be filtered by: the requested one when the app ships an
+     * installable depot in it, otherwise English, otherwise any language it ships. Used for both the
+     * base game and its DLC so a title that omits the container's language still resolves instead of
+     * yielding zero depots. Untagged (neutral) depots pass the language filter regardless.
+     */
+    fun effectiveDepotLanguage(
+        depots: Map<Int, DepotInfo>,
+        preferredLanguage: String,
+        ownedDlc: Map<Int, DepotInfo>?,
+        licensedDepotIds: Set<Int>?,
+        hasSteamUnlockedBranch: Boolean = false,
+    ): String {
+        // A depot installs once its language is chosen if it passes every check except language
+        // and arch. Arch is left out because it is a per-language preference, not a gate.
+        fun DepotInfo.installableInItsLanguage(): Boolean {
+            val isDlc = dlcAppId != SteamService.INVALID_APP_ID
+            val hasContent = manifests.isNotEmpty() || sharedInstall ||
+                (hasSteamUnlockedBranch && encryptedManifests.isNotEmpty())
+            val ownedIfDlc = !isDlc || ownedDlc == null || ownedDlc.containsKey(depotId)
+            val licensedIfBaseGame = isDlc || systemDefined ||
+                licensedDepotIds == null || depotId in licensedDepotIds
+            // Mirror the SteamChina realm gate in filterForDownloadableDepots, or we could pick a
+            // language only the final pass drops and lose the real fallback.
+            return isWindowsCompatible && realm != SteamRealm.SteamChina &&
+                hasContent && ownedIfDlc && licensedIfBaseGame
+        }
+
+        // Base-game depots only, so an owned in-app DLC's language can't steer the base game.
+        // Untagged depots are the neutral build and pass the language filter regardless.
+        val availableLanguages = depots.values
+            .filter { it.dlcAppId == SteamService.INVALID_APP_ID && it.language.isNotEmpty() && it.installableInItsLanguage() }
+            .mapTo(mutableSetOf()) { it.language }
+        return when {
+            preferredLanguage in availableLanguages -> preferredLanguage
+            "english" in availableLanguages -> "english"
+            else -> availableLanguages.firstOrNull() ?: preferredLanguage
+        }
     }
 
     internal val http = Net.http.newBuilder()

--- a/app/src/test/java/app/gamenative/utils/SteamUtilsDepotLanguageTest.kt
+++ b/app/src/test/java/app/gamenative/utils/SteamUtilsDepotLanguageTest.kt
@@ -1,0 +1,185 @@
+package app.gamenative.utils
+
+import app.gamenative.data.DepotInfo
+import app.gamenative.data.ManifestInfo
+import app.gamenative.enums.OS
+import app.gamenative.enums.OSArch
+import app.gamenative.enums.SteamRealm
+import app.gamenative.service.SteamService
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.EnumSet
+
+class SteamUtilsDepotLanguageTest {
+
+    private fun depot(
+        depotId: Int = 1,
+        language: String = "",
+        manifests: Map<String, ManifestInfo> = mapOf("public" to manifest()),
+        encryptedManifests: Map<String, ManifestInfo> = emptyMap(),
+        sharedInstall: Boolean = false,
+        osList: EnumSet<OS> = EnumSet.of(OS.windows),
+        dlcAppId: Int = SteamService.INVALID_APP_ID,
+        systemDefined: Boolean = false,
+        realm: SteamRealm = SteamRealm.Unknown,
+    ) = DepotInfo(
+        depotId = depotId,
+        dlcAppId = dlcAppId,
+        depotFromApp = 0,
+        sharedInstall = sharedInstall,
+        osList = osList,
+        osArch = OSArch.Arch64,
+        manifests = manifests,
+        encryptedManifests = encryptedManifests,
+        language = language,
+        realm = realm,
+        systemDefined = systemDefined,
+    )
+
+    private fun manifest() = ManifestInfo(name = "public", gid = 1L, size = 1000L, download = 800L)
+
+    // Insertion order preserved so first-available fallback is deterministic.
+    private fun depotsOf(vararg depots: DepotInfo) =
+        depots.associateByTo(LinkedHashMap()) { it.depotId }
+
+    private fun resolve(
+        depots: Map<Int, DepotInfo>,
+        preferred: String,
+        ownedDlc: Map<Int, DepotInfo>? = null,
+        licensedDepotIds: Set<Int>? = null,
+        hasSteamUnlockedBranch: Boolean = false,
+    ) = SteamUtils.effectiveDepotLanguage(depots, preferred, ownedDlc, licensedDepotIds, hasSteamUnlockedBranch)
+
+    // -- Priority 1: requested language wins when available --
+
+    @Test
+    fun `returns requested language when the app ships it`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "english"),
+            depot(depotId = 2, language = "french"),
+            depot(depotId = 3, language = "german"),
+        )
+        assertEquals("french", resolve(depots, "french"))
+    }
+
+    // -- Priority 2: fall back to English --
+
+    @Test
+    fun `falls back to english when requested language is absent`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "english"),
+            depot(depotId = 2, language = "german"),
+        )
+        assertEquals("english", resolve(depots, "french"))
+    }
+
+    // -- Priority 3: fall back to the first language the app ships --
+
+    @Test
+    fun `falls back to the only available language when neither requested nor english exist`() {
+        val depots = depotsOf(depot(depotId = 1, language = "german"))
+        assertEquals("german", resolve(depots, "french"))
+    }
+
+    @Test
+    fun `falls back to the first available language when neither requested nor english exist`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "schinese"),
+            depot(depotId = 2, language = "japanese"),
+        )
+        assertEquals("schinese", resolve(depots, "french"))
+    }
+
+    // -- Untagged (neutral) depots are ignored by the fallback pool --
+
+    @Test
+    fun `keeps preferred language when the app only ships untagged depots`() {
+        val depots = depotsOf(depot(depotId = 1, language = ""))
+        assertEquals("french", resolve(depots, "french"))
+    }
+
+    @Test
+    fun `untagged depot does not become the fallback`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = ""),
+            depot(depotId = 2, language = "german"),
+        )
+        assertEquals("german", resolve(depots, "french"))
+    }
+
+    // -- Only base-game depots steer the language --
+
+    @Test
+    fun `dlc depot language does not steer the base game`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "german"),
+            depot(depotId = 2, language = "french", dlcAppId = 4242),
+        )
+        // french lives only on the DLC depot, so it is excluded and german wins.
+        assertEquals("german", resolve(depots, "french"))
+    }
+
+    // -- A depot must be installable to count as an available language --
+
+    @Test
+    fun `encrypted-only language is ignored without a steam-unlocked branch`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "english"),
+            depot(
+                depotId = 2,
+                language = "french",
+                manifests = emptyMap(),
+                encryptedManifests = mapOf("public" to manifest()),
+            ),
+        )
+        assertEquals("english", resolve(depots, "french", hasSteamUnlockedBranch = false))
+    }
+
+    @Test
+    fun `encrypted-only language counts when the steam-unlocked branch is present`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "english"),
+            depot(
+                depotId = 2,
+                language = "french",
+                manifests = emptyMap(),
+                encryptedManifests = mapOf("public" to manifest()),
+            ),
+        )
+        assertEquals("french", resolve(depots, "french", hasSteamUnlockedBranch = true))
+    }
+
+    @Test
+    fun `non-windows language is ignored`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "english"),
+            depot(depotId = 2, language = "french", osList = EnumSet.of(OS.linux)),
+        )
+        assertEquals("english", resolve(depots, "french"))
+    }
+
+    @Test
+    fun `steamchina realm language is ignored`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "english"),
+            depot(depotId = 2, language = "french", realm = SteamRealm.SteamChina),
+        )
+        assertEquals("english", resolve(depots, "french"))
+    }
+
+    @Test
+    fun `unlicensed base-game language is ignored`() {
+        val depots = depotsOf(
+            depot(depotId = 100, language = "french"),
+            depot(depotId = 101, language = "english"),
+        )
+        assertEquals("english", resolve(depots, "french", licensedDepotIds = setOf(101)))
+    }
+
+    // -- No installable tagged depot at all --
+
+    @Test
+    fun `returns preferred language when there are no depots`() {
+        assertEquals("french", resolve(emptyMap(), "french"))
+    }
+}


### PR DESCRIPTION
## Description
Some owned games show **0 B** download and disk size and can't be installed. Example: appId 1150690 on a **French** container.

The cause is depot language selection. That game ships one full Windows depot **per language** (English, Simplified Chinese, Japanese, Korean) with no language-neutral build. `filterForDownloadableDepots` drops every non-DLC depot whose `language` doesn't match the container language, and none of them is French, so **all depots are filtered out**: zero downloadable depots, hence 0 B and no install.

Fix: added `SteamUtils.effectiveDepotLanguage`, which picks the language to filter by from what the app actually ships an installable depot in — the requested one, else English (Steam's default), else any language it offers. Depot resolution filters by that effective language instead of the raw container language.

The helper lives in `SteamUtils` so both the base game (`resolveDownloadableDepots`) and each DLC (`getDownloadableDepots`) resolve their own language independently, so we don't pull wrong-language files for a DLC. It only pools tagged base-game depots when choosing the fallback, so an owned in-app DLC can't steer the base game's language, and untagged (neutral) depots pass the language filter unconditionally and are ignored by the pool, so they resolve regardless. Games that already offer the requested language are unaffected.

Result: the French container now resolves the English depot for 1150690 and shows a real size / can install. Any game shipping per-language depots without the user's language is fixed the same way, base game and DLC alike.

## Recording

| Before | After |
| :---: | :---: |
| <img width="1080" height="2340" alt="Screenshot_20260710_141605_GameNative" src="https://github.com/user-attachments/assets/9efe76ae-001f-424a-bea8-0d5bf189b870" /> | <img width="1080" height="2340" alt="Screenshot_20260710_141307_GameNative" src="https://github.com/user-attachments/assets/b0afc3f3-769d-45da-9ec2-eef719f6ad6a" /> |

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fall back to English (or another shipped language) when a game’s container language isn’t available in Windows depots, so base games and DLC show real sizes and install instead of 0 B.

- **Bug Fixes**
  - Resolve an effective depot language via `SteamUtils.effectiveDepotLanguage` from installable base‑game Windows depots: requested → `english` → first available; neutral depots don’t steer; DLC depots don’t steer the base game; arch ignored; exclude `SteamChina`; encrypted manifests count only with a Steam‑unlocked branch; respect licensing and DLC ownership.
  - Apply that language in eligibility and filtering for the main app and each DLC, fixing titles missing the container language; added unit tests for priorities and edge cases.

<sup>Written for commit 71681056d0a4ae44399c52b3bc4eaceba31fa557. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved depot download language selection by deriving the most effective, currently installable base-game language rather than relying solely on the preferred language.
  * Enhanced fallback behavior to choose a suitable language when the preferred option isn’t available or eligible for download.
  * Updated DLC depot filtering so each DLC uses its own effective language, improving compatibility and reducing missing or failed DLC downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
