### PR TITLE
fix: Prevent ANRs by executing PulseAudio operations on background thread

### DIFF
--- a/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
@@ -13,6 +13,8 @@ import com.winlator.xenvironment.XEnvironment;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import timber.log.Timber;
@@ -45,6 +47,8 @@ public class PulseAudioComponent extends EnvironmentComponent {
     private byte performanceMode = 1;
     private final AtomicBoolean isPaused = new AtomicBoolean(false);
     private boolean lowLatency = false;
+
+    private final ExecutorService pauseResumeExecutor = Executors.newSingleThreadExecutor();
 
     public PulseAudioComponent(UnixSocketConfig socketConfig, boolean lowLatency) {
         this.socketConfig = socketConfig;
@@ -105,7 +109,7 @@ public class PulseAudioComponent extends EnvironmentComponent {
     }
 
     public void pause() {
-        new Thread(() -> {
+        pauseResumeExecutor.execute(() -> {
             synchronized (lock) {
                 if (!isPaused.get() && isServerRunning()) {
                     Timber.tag("PulseAudioComponent").d("Pausing...");
@@ -117,11 +121,11 @@ public class PulseAudioComponent extends EnvironmentComponent {
                     Timber.tag("PulseAudioComponent").d("Audio paused");
                 }
             }
-        }).start();
+        });
     }
 
     public void resume() {
-        new Thread(() -> {
+        pauseResumeExecutor.execute(() -> {
             synchronized (lock) {
                 if (isPaused.get()) {
                     Timber.tag("PulseAudioComponent").d("Resuming...");
@@ -137,7 +141,7 @@ public class PulseAudioComponent extends EnvironmentComponent {
                     }
                 }
             }
-        }).start();
+        });
     }
 
     public boolean isServerRunning() {

--- a/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
@@ -105,35 +105,39 @@ public class PulseAudioComponent extends EnvironmentComponent {
     }
 
     public void pause() {
-        synchronized (lock) {
-            if (!isPaused.get() && isServerRunning()) {
-                Timber.tag("PulseAudioComponent").d("Pausing...");
+        new Thread(() -> {
+            synchronized (lock) {
+                if (!isPaused.get() && isServerRunning()) {
+                    Timber.tag("PulseAudioComponent").d("Pausing...");
 
-                // Suspend sink and set isPaused together immediately
-                isPaused.set(true);
-                updateSink(true);
+                    // Suspend sink and set isPaused together immediately
+                    isPaused.set(true);
+                    updateSink(true);
 
-                Timber.tag("PulseAudioComponent").d("Audio paused");
+                    Timber.tag("PulseAudioComponent").d("Audio paused");
+                }
             }
-        }
+        }).start();
     }
 
     public void resume() {
-        synchronized (lock) {
-            if (isPaused.get()) {
-                Timber.tag("PulseAudioComponent").d("Resuming...");
+        new Thread(() -> {
+            synchronized (lock) {
+                if (isPaused.get()) {
+                    Timber.tag("PulseAudioComponent").d("Resuming...");
 
-                if (isServerRunning()) {
-                    // Set isPaused immediately
-                    isPaused.set(false);
-                    updateSink(false);
+                    if (isServerRunning()) {
+                        // Set isPaused immediately
+                        isPaused.set(false);
+                        updateSink(false);
 
-                    Timber.tag("PulseAudioComponent").d("Audio resumed");
-                } else {
-                    start();
+                        Timber.tag("PulseAudioComponent").d("Audio resumed");
+                    } else {
+                        start();
+                    }
                 }
             }
-        }
+        }).start();
     }
 
     public boolean isServerRunning() {


### PR DESCRIPTION
## Description
Moves the PulseAudio `pause()` and `resume()` methods to a dedicated background thread. This ensures that potentially blocking operations, such as `updateSink()`, do not block the main application thread, thereby mitigating Application Not Responding (ANR) errors.

## Recording
N/A

## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move PulseAudio pause/resume to a dedicated single-threaded background executor to prevent ANRs from blocking `updateSink()` and keep the UI responsive during audio state changes.

- **Bug Fixes**
  - Use `Executors.newSingleThreadExecutor()` to run `pause()`/`resume()` off the main thread and serialize operations.
  - Keep `lock` synchronization; update `isPaused` and call `updateSink()` together for consistent state.
  - On resume, start the server if it isn’t running.

<sup>Written for commit c08780389f4872e75b4a4d64fd18004abebe52f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pause and resume handling so audio state changes happen more reliably in the background.
  * Reduced the chance of the app freezing or lagging when suspending or restoring audio.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->