### PR TITLE
Fix Rain World Workshop mod activation

### DIFF
--- a/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
@@ -35,6 +35,7 @@ object GameFixesRegistry {
         STEAM_Fix_22370,
         STEAM_Fix_22380,
         STEAM_Fix_22490,
+        STEAM_Fix_312520,
         STEAM_Fix_413150,
         STEAM_Fix_413420,
         STEAM_Fix_752580,

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_312520.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_312520.kt
@@ -26,8 +26,9 @@ val STEAM_Fix_312520: KeyedGameFix = object : KeyedGameFix {
         var changed = false
         val envVars = EnvVars(container.envVars)
         val dllOverrides = envVars.get("WINEDLLOVERRIDES")
-        if (!hasWinHttpOverride(dllOverrides)) {
-            envVars.put("WINEDLLOVERRIDES", appendWinHttpOverride(dllOverrides))
+        val requiredDllOverrides = ensureWinHttpOverride(dllOverrides)
+        if (requiredDllOverrides != dllOverrides) {
+            envVars.put("WINEDLLOVERRIDES", requiredDllOverrides)
             container.envVars = envVars.toString()
             changed = true
         }
@@ -54,13 +55,24 @@ val STEAM_Fix_312520: KeyedGameFix = object : KeyedGameFix {
     }
 }
 
-private fun appendWinHttpOverride(value: String): String =
-    value.trim().takeIf { it.isNotEmpty() }
-        ?.let { "$it;$RAIN_WORLD_WINHTTP_OVERRIDE" }
-        ?: RAIN_WORLD_WINHTTP_OVERRIDE
+private fun ensureWinHttpOverride(value: String): String {
+    val parts = value.trim().split(';', ' ').filter { it.isNotBlank() }
+    val winHttpParts = parts.filter { overridePartContainsWinHttp(it) }
+    if (winHttpParts.size == 1 && winHttpParts.single().equals(RAIN_WORLD_WINHTTP_OVERRIDE, ignoreCase = true)) {
+        return value
+    }
 
-private fun hasWinHttpOverride(value: String): Boolean =
-    value.split(';', ' ')
-        .map { it.substringBefore('=').split(',') }
-        .flatten()
-        .any { it.equals("winhttp", ignoreCase = true) }
+    return (parts.mapNotNull { part ->
+        val dllNames = part.substringBefore('=').split(',')
+        val keptDllNames = dllNames.filterNot { it.equals("winhttp", ignoreCase = true) }
+        when {
+            keptDllNames.size == dllNames.size -> part
+            keptDllNames.isEmpty() -> null
+            part.contains('=') -> keptDllNames.joinToString(",") + part.substring(part.indexOf('='))
+            else -> keptDllNames.joinToString(",")
+        }
+    } + RAIN_WORLD_WINHTTP_OVERRIDE).joinToString(";")
+}
+
+private fun overridePartContainsWinHttp(part: String): Boolean =
+    part.substringBefore('=').split(',').any { it.equals("winhttp", ignoreCase = true) }

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_312520.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_312520.kt
@@ -36,7 +36,7 @@ val STEAM_Fix_312520: KeyedGameFix = object : KeyedGameFix {
         val userRegFile = File(container.rootDir, ".wine/user.reg")
         if (!userRegFile.isFile) {
             userRegFile.parentFile?.mkdirs()
-            userRegFile.writeText("REGEDIT4\n")
+            userRegFile.writeText("WINE REGISTRY Version 2\n\n")
         }
         WineRegistryEditor(userRegFile).use { editor ->
             editor.setCreateKeyIfNotExist(true)

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_312520.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_312520.kt
@@ -1,0 +1,66 @@
+package app.gamenative.gamefixes
+
+import android.content.Context
+import app.gamenative.data.GameSource
+import com.winlator.container.Container
+import com.winlator.core.WineRegistryEditor
+import com.winlator.core.envvars.EnvVars
+import java.io.File
+import timber.log.Timber
+
+private const val RAIN_WORLD_DLL_OVERRIDES_KEY =
+    "Software\\Wine\\AppDefaults\\RainWorld.exe\\DllOverrides"
+private const val RAIN_WORLD_WINHTTP_OVERRIDE = "winhttp=native,builtin"
+
+val STEAM_Fix_312520: KeyedGameFix = object : KeyedGameFix {
+    override val gameSource = GameSource.STEAM
+    override val gameId = "312520"
+
+    override fun apply(
+        context: Context,
+        gameId: String,
+        installPath: String,
+        installPathWindows: String,
+        container: Container,
+    ): Boolean = try {
+        var changed = false
+        val envVars = EnvVars(container.envVars)
+        val dllOverrides = envVars.get("WINEDLLOVERRIDES")
+        if (!hasWinHttpOverride(dllOverrides)) {
+            envVars.put("WINEDLLOVERRIDES", appendWinHttpOverride(dllOverrides))
+            container.envVars = envVars.toString()
+            changed = true
+        }
+
+        val userRegFile = File(container.rootDir, ".wine/user.reg")
+        if (!userRegFile.isFile) {
+            userRegFile.parentFile?.mkdirs()
+            userRegFile.writeText("REGEDIT4\n")
+        }
+        WineRegistryEditor(userRegFile).use { editor ->
+            editor.setCreateKeyIfNotExist(true)
+            val existing = editor.getStringValue(RAIN_WORLD_DLL_OVERRIDES_KEY, "winhttp", "")
+            if (existing != "native,builtin") {
+                editor.setStringValue(RAIN_WORLD_DLL_OVERRIDES_KEY, "winhttp", "native,builtin")
+                changed = true
+            }
+        }
+
+        if (changed) container.saveData()
+        true
+    } catch (e: Exception) {
+        Timber.tag("GameFixes").e(e, "Failed to apply Rain World Doorstop DLL override")
+        false
+    }
+}
+
+private fun appendWinHttpOverride(value: String): String =
+    value.trim().takeIf { it.isNotEmpty() }
+        ?.let { "$it;$RAIN_WORLD_WINHTTP_OVERRIDE" }
+        ?: RAIN_WORLD_WINHTTP_OVERRIDE
+
+private fun hasWinHttpOverride(value: String): Boolean =
+    value.split(';', ' ')
+        .map { it.substringBefore('=').split(',') }
+        .flatten()
+        .any { it.equals("winhttp", ignoreCase = true) }

--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -71,6 +71,9 @@ import java.util.concurrent.atomic.AtomicInteger
 object WorkshopManager {
 
     private const val TAG = "WorkshopManager"
+    private const val RAIN_WORLD_APP_ID = 312520
+    private const val RAIN_WORLD_MODS_PATH = "RainWorld_Data/StreamingAssets/mods"
+    private const val RAIN_WORLD_ENABLED_MODS_PATH = "RainWorld_Data/StreamingAssets/enabledMods.txt"
     private const val MAX_PAGES = 50
     private const val PAGE_SIZE = 100
     private var workshopTypesPatched = false
@@ -1329,6 +1332,9 @@ object WorkshopManager {
         // Clean up installed mod entries (symlinks/copies) in the game tree
         // before deleting the content dir, so isOurSymlink checks still work.
         if (gameRootDir != null) {
+            if (gameId == RAIN_WORLD_APP_ID) {
+                cleanupRainWorldWorkshopMods(gameRootDir, workshopDir)
+            }
             cleanupInstalledModEntries(gameRootDir, workshopDir, winePrefix, gameName)
         }
 
@@ -2411,7 +2417,12 @@ object WorkshopManager {
         // When the user has set a custom mod folder, symlink all workshop
         // items into that directory. mods.json is still populated for games
         // that use ISteamUGC. All automatic detection is bypassed.
-        val hasManualModPath = workshopModPath.isNotEmpty()
+        val effectiveWorkshopModPath = if (appId == RAIN_WORLD_APP_ID) {
+            File(gameRootDir, RAIN_WORLD_MODS_PATH).absolutePath
+        } else {
+            workshopModPath
+        }
+        val hasManualModPath = effectiveWorkshopModPath.isNotEmpty()
         val ignoreManualModPath =
             compatibilityOverride?.ignoreManualModPath == true || useMetadataOnly
         val useManualModPath = hasManualModPath && !ignoreManualModPath
@@ -2421,7 +2432,7 @@ object WorkshopManager {
             )
         }
         if (useManualModPath) {
-            val targetDir = File(workshopModPath)
+            val targetDir = File(effectiveWorkshopModPath)
 
             // ── Clean ALL workshop symlinks from every possible location ─────
             // When switching from one manual path to another (e.g. LocalLow→Local),
@@ -2489,6 +2500,11 @@ object WorkshopManager {
             // ── Create fresh symlinks in the chosen target ──────────────────
             try {
                 if (!targetDir.isDirectory) targetDir.mkdirs()
+                val previousRainWorldWorkshopIds = if (appId == RAIN_WORLD_APP_ID) {
+                    workshopSymlinkNames(targetDir, workshopContentDir)
+                } else {
+                    emptySet()
+                }
                 // Clean the target itself (in case of stale entries)
                 cleanWorkshopSymlinksFrom(targetDir).also {
                     // The helper skips targetCanonical, so clean it explicitly
@@ -2509,11 +2525,37 @@ object WorkshopManager {
                         }
                     }
                 }
-                // Create fresh symlinks
-                modDirs.forEach { itemDir ->
-                    val linkPath = targetDir.toPath().resolve(itemDir.name)
-                    if (!Files.exists(linkPath)) {
-                        Files.createSymbolicLink(linkPath, itemDir.toPath())
+                if (appId == RAIN_WORLD_APP_ID) {
+                    val enabledRainWorldIds = mutableListOf<String>()
+                    val orderByItemId = items.mapIndexed { index, item ->
+                        item.publishedFileId.toString() to index
+                    }.toMap()
+                    val rainWorldNamesByDir = modDirs.associateWith { rainWorldModId(it) ?: it.name }
+
+                    modDirs.forEach { itemDir ->
+                        val linkName = rainWorldNamesByDir[itemDir] ?: itemDir.name
+                        enabledRainWorldIds += linkName
+                        val linkPath = targetDir.toPath().resolve(linkName)
+                        if (!Files.exists(linkPath)) {
+                            Files.createSymbolicLink(linkPath, itemDir.toPath())
+                        }
+                    }
+                    syncRainWorldEnabledMods(
+                        gameRootDir,
+                        enabledRainWorldIds
+                            .distinct()
+                            .sortedBy { id ->
+                                val sourceDir = modDirs.firstOrNull { rainWorldModId(it) == id || it.name == id }
+                                orderByItemId[sourceDir?.name] ?: Int.MAX_VALUE
+                            },
+                        previousRainWorldWorkshopIds,
+                    )
+                } else {
+                    modDirs.forEach { itemDir ->
+                        val linkPath = targetDir.toPath().resolve(itemDir.name)
+                        if (!Files.exists(linkPath)) {
+                            Files.createSymbolicLink(linkPath, itemDir.toPath())
+                        }
                     }
                 }
                 Timber.tag(TAG).i(
@@ -3195,7 +3237,7 @@ object WorkshopManager {
         // When the user has a manual mod path inside the game tree, skip
         // cleaning symlinks in that directory — they were just created above.
         val manualTargetCanonical = if (useManualModPath) {
-            runCatching { File(workshopModPath).canonicalPath }.getOrElse { workshopModPath }
+            runCatching { File(effectiveWorkshopModPath).canonicalPath }.getOrElse { effectiveWorkshopModPath }
         } else ""
         gameRootDir.walkTopDown().maxDepth(6).forEach { entry ->
             if (!Files.isSymbolicLink(entry.toPath())) return@forEach
@@ -3774,6 +3816,70 @@ object WorkshopManager {
             compatibilityOverride = compatibilityOverride,
             bionicSteam = bionicSteam,
         )
+    }
+
+    private fun rainWorldModId(itemDir: File): String? =
+        runCatching {
+            JSONObject(File(itemDir, "modinfo.json").readText(Charsets.UTF_8).trimStart('\uFEFF'))
+                .optString("id")
+                .trim()
+                .takeIf { it.isNotEmpty() }
+        }.getOrNull()
+
+    private fun cleanupRainWorldWorkshopMods(gameRootDir: File, workshopContentDir: File) {
+        val modsDir = File(gameRootDir, RAIN_WORLD_MODS_PATH)
+        val managedIds = workshopSymlinkNames(modsDir, workshopContentDir)
+        modsDir.listFiles()?.forEach { entry ->
+            if (entry.name in managedIds) {
+                runCatching { Files.deleteIfExists(entry.toPath()) }
+            }
+        }
+        syncRainWorldEnabledMods(gameRootDir, emptyList(), managedIds)
+    }
+
+    private fun syncRainWorldEnabledMods(
+        gameRootDir: File,
+        activeWorkshopIds: List<String>,
+        previousWorkshopIds: Set<String>,
+    ) {
+        val enabledModsFile = File(gameRootDir, RAIN_WORLD_ENABLED_MODS_PATH)
+        val activeIdSet = activeWorkshopIds.toSet()
+        val preservedIds = if (enabledModsFile.isFile) {
+            enabledModsFile.readLines()
+                .map { it.trim() }
+                .filter { it.isNotEmpty() && it !in previousWorkshopIds && it !in activeIdSet }
+        } else {
+            emptyList()
+        }
+        val nextIds = (preservedIds + activeWorkshopIds).distinct()
+        if (nextIds.isEmpty()) {
+            enabledModsFile.delete()
+        } else {
+            enabledModsFile.parentFile?.mkdirs()
+            enabledModsFile.writeText(nextIds.joinToString("\n", postfix = "\n"))
+        }
+    }
+
+    private fun workshopSymlinkNames(targetDir: File, workshopContentDir: File): Set<String> =
+        targetDir.listFiles()
+            ?.filter { isWorkshopContentSymlink(it, workshopContentDir) }
+            ?.mapTo(mutableSetOf()) { it.name }
+            ?: emptySet()
+
+    private fun isWorkshopContentSymlink(entry: File, workshopContentDir: File): Boolean {
+        if (!Files.isSymbolicLink(entry.toPath())) return false
+        return runCatching {
+            val linkTarget = Files.readSymbolicLink(entry.toPath())
+            val resolved = if (linkTarget.isAbsolute) {
+                linkTarget
+            } else {
+                entry.toPath().parent.resolve(linkTarget)
+            }
+            val resolvedPath = runCatching { resolved.toRealPath().toString() }
+                .getOrElse { resolved.normalize().toAbsolutePath().toString() }
+            resolvedPath.contains("workshop/content/") ||
+                resolvedPath.startsWith(workshopContentDir.absolutePath)
+        }.getOrDefault(false)
     }
 
     /**

--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -2531,12 +2531,20 @@ object WorkshopManager {
                         item.publishedFileId.toString() to index
                     }.toMap()
                     val rainWorldNamesByDir = modDirs.associateWith { rainWorldModId(it) ?: it.name }
+                    val orderByRainWorldId = linkedMapOf<String, Int>()
+                    rainWorldNamesByDir.forEach { (dir, id) ->
+                        orderByRainWorldId.putIfAbsent(id, orderByItemId[dir.name] ?: Int.MAX_VALUE)
+                    }
 
                     modDirs.forEach { itemDir ->
                         val linkName = rainWorldNamesByDir[itemDir] ?: itemDir.name
                         enabledRainWorldIds += linkName
                         val linkPath = targetDir.toPath().resolve(linkName)
-                        if (!Files.exists(linkPath)) {
+                        val linkFile = linkPath.toFile()
+                        if (isWorkshopContentSymlink(linkFile, workshopContentDir)) {
+                            Files.deleteIfExists(linkPath)
+                        }
+                        if (!Files.exists(linkPath, LinkOption.NOFOLLOW_LINKS)) {
                             Files.createSymbolicLink(linkPath, itemDir.toPath())
                         }
                     }
@@ -2544,10 +2552,7 @@ object WorkshopManager {
                         gameRootDir,
                         enabledRainWorldIds
                             .distinct()
-                            .sortedBy { id ->
-                                val sourceDir = modDirs.firstOrNull { rainWorldModId(it) == id || it.name == id }
-                                orderByItemId[sourceDir?.name] ?: Int.MAX_VALUE
-                            },
+                            .sortedBy { id -> orderByRainWorldId[id] ?: Int.MAX_VALUE },
                         previousRainWorldWorkshopIds,
                     )
                 } else {


### PR DESCRIPTION
﻿## Description
Fixes Rain World Workshop mods showing up in Remix but not actually working in-game.

This places Rain World Workshop mods in `RainWorld_Data/StreamingAssets/mods`, names the symlinks using each mod’s `modinfo.json` id, and keeps `enabledMods.txt` synced.

Also applies Rain World’s `winhttp` Doorstop override before launch so the mod loader can start correctly.


## Recording

https://drive.google.com/file/d/1bYpK4WeOLR2KgEw2o6g_h_N59ylnqQeC/view?usp=drivesdk

## Type of Change
- [X] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Rain World Workshop mods not activating in-game. Symlinks go to the right folder, the enabled list stays in sync, and a `winhttp` override (with a valid Wine registry header) ensures the mod loader starts.

- Bug Fixes
  - Link Workshop mods to `RainWorld_Data/StreamingAssets/mods` (ignores custom mod path) and name links by each mod’s `modinfo.json` `id`.
  - Sync `RainWorld_Data/StreamingAssets/enabledMods.txt`; preserve non-Workshop entries; clean/update on uninstall or link changes; order by subscription.
  - Add Steam game fix `STEAM_312520`: set `WINEDLLOVERRIDES` and Wine registry `winhttp=native,builtin`; create the registry file if missing with the correct header.

<sup>Written for commit 99fb552e53efe1d7e38cc05ef714fe7b7f5717d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Steam game fix for Rain World that updates Wine networking overrides and ensures the required Wine registry file exists.

* **Bug Fixes**
  * Improved Rain World Steam workshop cleanup to better remove workshop-related mod links and resynchronize `enabledMods.txt`.
  * Enhanced Rain World manual mod symlink handling by using the effective mods path, naming links from each mod’s ID, and protecting them from later cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->