### PR TITLE
fix: Prevent ANRs by consolidating PulseAudio operations

### DIFF
--- a/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
@@ -42,13 +42,12 @@ public class PulseAudioComponent extends EnvironmentComponent {
     private final UnixSocketConfig socketConfig;
     private final String SINK_NAME = "AAudioSink";
 
-    private final Object lock = new Object();
     private float volume = 1.0f;
     private byte performanceMode = 1;
     private final AtomicBoolean isPaused = new AtomicBoolean(false);
     private boolean lowLatency = false;
 
-    private final ExecutorService pauseResumeExecutor = Executors.newSingleThreadExecutor();
+    private final ExecutorService singleThreadExecutor = Executors.newSingleThreadExecutor();
 
     public PulseAudioComponent(UnixSocketConfig socketConfig, boolean lowLatency) {
         this.socketConfig = socketConfig;
@@ -83,62 +82,53 @@ public class PulseAudioComponent extends EnvironmentComponent {
 
     @Override
     public void start() {
-        Timber.tag("PulseAudioComponent").d("Starting...");
-        synchronized (lock) {
+        singleThreadExecutor.execute(() -> {
+            Timber.tag("PulseAudioComponent").d("Starting...");
             if (!isServerRunning()) {
                 killAllPulseAudioProcesses();
                 startPulseAudio();
                 isPaused.set(false);
             }
-        }
+        });
     }
 
     @Override
     public void stop() {
-        Timber.tag("PulseAudioComponent").d("Stopping...");
-        synchronized (lock) {
-            // Stop sink here
-            updateSink(true);
-
-            isPaused.set(false);
-
+        singleThreadExecutor.execute(() -> {
+            Timber.tag("PulseAudioComponent").d("Stopping...");
             killAllPulseAudioProcesses();
-
+            isPaused.set(false);
             Timber.tag("PulseAudioComponent").d("Stopped PulseAudio server");
-        }
+        });
     }
 
     public void pause() {
-        pauseResumeExecutor.execute(() -> {
-            synchronized (lock) {
-                if (!isPaused.get() && isServerRunning()) {
-                    Timber.tag("PulseAudioComponent").d("Pausing...");
+        singleThreadExecutor.execute(() -> {
+            if (!isPaused.get() && isServerRunning()) {
+                Timber.tag("PulseAudioComponent").d("Pausing...");
 
-                    // Suspend sink and set isPaused together immediately
-                    isPaused.set(true);
-                    updateSink(true);
+                // Suspend sink and set isPaused together immediately
+                isPaused.set(true);
+                updateSink(true);
 
-                    Timber.tag("PulseAudioComponent").d("Audio paused");
-                }
+                Timber.tag("PulseAudioComponent").d("Audio paused");
             }
         });
     }
 
     public void resume() {
-        pauseResumeExecutor.execute(() -> {
-            synchronized (lock) {
-                if (isPaused.get()) {
-                    Timber.tag("PulseAudioComponent").d("Resuming...");
+        singleThreadExecutor.execute(() -> {
+            if (isPaused.get()) {
+                Timber.tag("PulseAudioComponent").d("Resuming...");
 
-                    if (isServerRunning()) {
-                        // Set isPaused immediately
-                        isPaused.set(false);
-                        updateSink(false);
+                if (isServerRunning()) {
+                    // Set isPaused immediately
+                    isPaused.set(false);
+                    updateSink(false);
 
-                        Timber.tag("PulseAudioComponent").d("Audio resumed");
-                    } else {
-                        start();
-                    }
+                    Timber.tag("PulseAudioComponent").d("Audio resumed");
+                } else {
+                    start();
                 }
             }
         });


### PR DESCRIPTION
## Description
Moves all PulseAudio lifecycle control methods (`start`, `stop`, `pause`, `resume`) to a single-threaded executor. This ensures that all potentially blocking operations are executed off the main thread, further mitigating Application Not Responding (ANR) errors. The use of a single executor also simplifies concurrency management by making explicit `synchronized` blocks unnecessary for these operations.

## Recording
N/A

## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates PulseAudio lifecycle operations into a single-thread executor to keep blocking work off the main thread and prevent ANRs. Simplifies concurrency by removing locks and unifying pause/resume handling.

- **Bug Fixes**
  - Route `start`, `stop`, `pause`, `resume` through `singleThreadExecutor`.
  - Remove `lock` and the separate `pauseResumeExecutor`.
  - Run sink updates and process kills on the executor; set `isPaused` consistently.

<sup>Written for commit 361c2d7d7d18d887ff16f830904750b6c769dc94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of audio server start, stop, pause, and resume actions.
  * Reduced issues caused by rapid or overlapping lifecycle changes, helping audio state stay in sync more consistently.
  * Stopping now more cleanly shuts down audio processes before clearing the paused state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->