### PR TITLE
fix: Shut down PulseAudio executor on component stop

### DIFF
--- a/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
@@ -100,6 +100,7 @@ public class PulseAudioComponent extends EnvironmentComponent {
             isPaused.set(false);
             Timber.tag("PulseAudioComponent").d("Stopped PulseAudio server");
         });
+        singleThreadExecutor.shutdown();
     }
 
     public void pause() {


### PR DESCRIPTION
## Description
The `singleThreadExecutor` was introduced to handle PulseAudio operations off the main thread. This change ensures that the executor is properly shut down when the PulseAudio component stops, releasing its resources and preventing potential thread leaks.

## Recording
N/A

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shut down the PulseAudio single-thread executor on component stop to free resources and prevent thread leaks. Calls `singleThreadExecutor.shutdown()` in `stop()`.

<sup>Written for commit 4afd28e78da06c42efb05b8994c8d6f57fc20d13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior for audio services so they stop cleanly when no longer needed, reducing the chance of lingering background activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->