### PR TITLE
fix: Pulseaudio Pactl Timeout handling

### DIFF
--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -250,7 +250,6 @@ public abstract class ProcessHelper {
                     Thread.currentThread().interrupt();
                 }
                 output.append("Error: Process timeout after 30 seconds");
-                return output.toString().trim();
             }
 
             try { stdoutStream.close(); } catch (IOException ignored) {}

--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -244,6 +244,11 @@ public abstract class ProcessHelper {
             boolean finished = process.waitFor(30, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
+                try {
+                    process.waitFor(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
                 output.append("Error: Process timeout after 30 seconds");
                 return output.toString().trim();
             }

--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -205,7 +205,7 @@ public abstract class ProcessHelper {
             if (BuildConfig.DEBUG) {
                 Log.d("ProcessHelper", "Executing with output: " + Arrays.toString(splitCommand(command)) + ", " + Arrays.toString(envp) + ", " + workingDir);
             }
-            
+
             ProcessBuilder pb = new ProcessBuilder(splitCommand(command));
             Map<String, String> env = pb.environment();
             env.clear();
@@ -241,11 +241,25 @@ public abstract class ProcessHelper {
             stderrDrainer.setDaemon(true);
             stderrDrainer.start();
 
-            process.waitFor();
+            boolean finished = process.waitFor(30, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                output.append("Error: Process timeout after 30 seconds");
+                return output.toString().trim();
+            }
+
             try { stdoutStream.close(); } catch (IOException ignored) {}
             try { stderrStream.close(); } catch (IOException ignored) {}
+
             stdoutDrainer.join(5_000);
+            if (stdoutDrainer.isAlive()) {
+                stdoutDrainer.interrupt();
+            }
+
             stderrDrainer.join(5_000);
+            if (stderrDrainer.isAlive()) {
+                stderrDrainer.interrupt();
+            }
 
             output.append(stdoutBuf);
             if (includeStderr) output.append(stderrBuf);

--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -241,7 +241,7 @@ public abstract class ProcessHelper {
             stderrDrainer.setDaemon(true);
             stderrDrainer.start();
 
-            boolean finished = process.waitFor(30, TimeUnit.SECONDS);
+            boolean finished = process.waitFor(5, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
                 try {
@@ -249,7 +249,7 @@ public abstract class ProcessHelper {
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
-                output.append("Error: Process timeout after 30 seconds");
+                output.append("Error: Process timeout after 5 seconds");
             }
 
             try { stdoutStream.close(); } catch (IOException ignored) {}

--- a/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
@@ -85,11 +85,9 @@ public class PulseAudioComponent extends EnvironmentComponent {
     public void start() {
         singleThreadExecutor.execute(() -> {
             Timber.tag("PulseAudioComponent").d("Starting...");
-            if (!isServerRunning()) {
-                killAllPulseAudioProcesses();
-                startPulseAudio();
-                isPaused.set(false);
-            }
+            killAllPulseAudioProcesses();
+            startPulseAudio();
+            isPaused.set(false);
         });
     }
 
@@ -106,7 +104,7 @@ public class PulseAudioComponent extends EnvironmentComponent {
     public void pause() {
         singleThreadExecutor.execute(() -> {
             if (!isPaused.get()) {
-                if (!isPauseResumeRunning.get() && isServerRunning()) {
+                if (!isPauseResumeRunning.get()) {
                     isPauseResumeRunning.set(true);
                     Timber.tag("PulseAudioComponent").d("Pausing...");
 
@@ -130,29 +128,17 @@ public class PulseAudioComponent extends EnvironmentComponent {
                     isPauseResumeRunning.set(true);
                     Timber.tag("PulseAudioComponent").d("Resuming...");
 
-                    if (isServerRunning()) {
-                        if (updateSink(false)) {
-                            isPaused.set(false);
-                            Timber.tag("PulseAudioComponent").d("Audio resumed");
-                        } else {
-                            Timber.tag("PulseAudioComponent").d("Failed to resume Audio");
-                        }
+                    if (updateSink(false)) {
+                        isPaused.set(false);
+                        Timber.tag("PulseAudioComponent").d("Audio resumed");
                     } else {
                         Timber.tag("PulseAudioComponent").d("Failed to resume Audio");
-                        start();
                     }
 
                     isPauseResumeRunning.set(false);
                 }
             }
         });
-    }
-
-    public boolean isServerRunning() {
-        final String info = execPactlCommand("info").toLowerCase(java.util.Locale.ROOT);
-        return info.contains("server name:") && (
-                !info.contains("connection failure") && !info.contains("process timeout")
-        );
     }
 
     public void setVolume(float volume) {
@@ -236,9 +222,9 @@ public class PulseAudioComponent extends EnvironmentComponent {
 
     private boolean updateSink(boolean suspend) {
         if (!suspend) {
-            return !execPactlCommand("suspend-sink " + SINK_NAME + " false").contains("process timeout");
+            return !execPactlCommand("suspend-sink " + SINK_NAME + " false").toLowerCase().contains("process timeout");
         } else {
-            return !execPactlCommand("suspend-sink " + SINK_NAME + " true").contains("process timeout");
+            return !execPactlCommand("suspend-sink " + SINK_NAME + " true").toLowerCase().contains("process timeout");
         }
     }
 

--- a/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
@@ -137,7 +137,7 @@ public class PulseAudioComponent extends EnvironmentComponent {
     public boolean isServerRunning() {
         final String info = execPactlCommand("info").toLowerCase(java.util.Locale.ROOT);
         return info.contains("server name:") && (
-                !info.contains("connection failure") || !info.contains("process timeout")
+                !info.contains("connection failure") && !info.contains("process timeout")
         );
     }
 

--- a/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
@@ -136,7 +136,9 @@ public class PulseAudioComponent extends EnvironmentComponent {
 
     public boolean isServerRunning() {
         final String info = execPactlCommand("info").toLowerCase(java.util.Locale.ROOT);
-        return info.contains("server name:") && !info.contains("connection failure");
+        return info.contains("server name:") && (
+                !info.contains("connection failure") || !info.contains("process timeout")
+        );
     }
 
     public void setVolume(float volume) {

--- a/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
@@ -44,6 +44,7 @@ public class PulseAudioComponent extends EnvironmentComponent {
 
     private float volume = 1.0f;
     private byte performanceMode = 1;
+    private final AtomicBoolean isPauseResumeRunning = new AtomicBoolean(false);
     private final AtomicBoolean isPaused = new AtomicBoolean(false);
     private boolean lowLatency = false;
 
@@ -104,14 +105,20 @@ public class PulseAudioComponent extends EnvironmentComponent {
 
     public void pause() {
         singleThreadExecutor.execute(() -> {
-            if (!isPaused.get() && isServerRunning()) {
-                Timber.tag("PulseAudioComponent").d("Pausing...");
+            if (!isPaused.get()) {
+                if (!isPauseResumeRunning.get() && isServerRunning()) {
+                    isPauseResumeRunning.set(true);
+                    Timber.tag("PulseAudioComponent").d("Pausing...");
 
-                // Suspend sink and set isPaused together immediately
-                isPaused.set(true);
-                updateSink(true);
+                    if (updateSink(true)) {
+                        isPaused.set(true);
+                        Timber.tag("PulseAudioComponent").d("Audio paused");
+                    } else {
+                        Timber.tag("PulseAudioComponent").d("Failed to pause Audio");
+                    }
 
-                Timber.tag("PulseAudioComponent").d("Audio paused");
+                    isPauseResumeRunning.set(false);
+                }
             }
         });
     }
@@ -119,16 +126,23 @@ public class PulseAudioComponent extends EnvironmentComponent {
     public void resume() {
         singleThreadExecutor.execute(() -> {
             if (isPaused.get()) {
-                Timber.tag("PulseAudioComponent").d("Resuming...");
+                if (!isPauseResumeRunning.get()) {
+                    isPauseResumeRunning.set(true);
+                    Timber.tag("PulseAudioComponent").d("Resuming...");
 
-                if (isServerRunning()) {
-                    // Set isPaused immediately
-                    isPaused.set(false);
-                    updateSink(false);
+                    if (isServerRunning()) {
+                        if (updateSink(false)) {
+                            isPaused.set(false);
+                            Timber.tag("PulseAudioComponent").d("Audio resumed");
+                        } else {
+                            Timber.tag("PulseAudioComponent").d("Failed to resume Audio");
+                        }
+                    } else {
+                        Timber.tag("PulseAudioComponent").d("Failed to resume Audio");
+                        start();
+                    }
 
-                    Timber.tag("PulseAudioComponent").d("Audio resumed");
-                } else {
-                    start();
+                    isPauseResumeRunning.set(false);
                 }
             }
         });
@@ -220,11 +234,11 @@ public class PulseAudioComponent extends EnvironmentComponent {
         return ProcessHelper.execWithOutput(workingDir + "/pactl " + command, envVars.toStringArray(), workingDir, true);
     }
 
-    private void updateSink(boolean suspend) {
+    private boolean updateSink(boolean suspend) {
         if (!suspend) {
-            execPactlCommand("suspend-sink " + SINK_NAME + " false");
+            return !execPactlCommand("suspend-sink " + SINK_NAME + " false").contains("process timeout");
         } else {
-            execPactlCommand("suspend-sink " + SINK_NAME + " true");
+            return !execPactlCommand("suspend-sink " + SINK_NAME + " true").contains("process timeout");
         }
     }
 


### PR DESCRIPTION
## Description
Introduces a 5-second timeout for processes executed via `ProcessHelper.execWithOutput` to prevent them from hanging indefinitely. If a command exceeds this timeout, the process is forcibly destroyed, and an error is reported.

This change also ensures that `stdoutDrainer` and `stderrDrainer` threads are interrupted if they do not complete within 5 seconds after the process finishes, improving resource cleanup. The PulseAudio component now correctly identifies a non-running server if the `pactl info` command times out, preventing stale states and improving overall stability.

The `updateSink` method now explicitly checks if `pactl` suspend/resume commands time out when executed via `ProcessHelper`. If a timeout occurs, the internal `isPaused` state is not updated, ensuring consistency and preventing scenarios where the component acts on a stale state. This addresses potential ANRs and instability caused by previous `ProcessHelper` timeout handling. An additional flag prevents concurrent pause/resume operations to further improve robustness.

## Recording
N/A

## Type of Change
- [ ] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortens external command timeout to 5s and simplifies PulseAudio handling to prevent ANRs. Cleans up hung processes and makes pause/resume safer by ignoring timed-out `pactl` calls.

- **Bug Fixes**
  - Added a 5s timeout in `ProcessHelper.execWithOutput`; force-kills on timeout and interrupts stdout/stderr drainers after 5s.
  - Removed `isServerRunning`; lifecycle methods avoid `pactl info` and act directly to reduce hangs.
  - Pause/resume only updates `isPaused` when `updateSink` succeeds and serializes operations to prevent desync.

<sup>Written for commit b318b0c55e789998a4be9b101cbbdeaa17a1fd81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **Bug Fixes**
  * Prevent indefinite hangs by bounding process completion to 5 seconds, forcing termination if needed, and adding explicit timeout output.
  * Improved stdout/stderr capture cleanup by closing streams earlier and time-limiting background thread joins to avoid stalled or orphaned output collection.
  * Updated PulseAudio pause/resume to avoid overlapping operations and to update pause state only when the suspend command succeeds.
  * Refreshed PulseAudio startup behavior to always restart the service, and adjusted sink update success detection to treat “process timeout” output as failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->