### PR TITLE
fix(): Fix notifications & watching due to invalid caching of the appId

### DIFF
--- a/app/src/main/java/app/gamenative/service/AchievementWatcher.kt
+++ b/app/src/main/java/app/gamenative/service/AchievementWatcher.kt
@@ -28,6 +28,7 @@ class AchievementWatcher(
     private var uploadJob: Job? = null
 
     fun start() {
+        Timber.tag("achievements").d("Achievement Watcher Started for appId=$appId")
         // Snapshot all currently earned achievements so we don't notify for
         // pre-existing unlocks when the game writes its initial achievements.json.
         for (dir in watchDirs) {

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3483,19 +3483,34 @@ private fun setupXEnvironment(
     }
 
     if (gameSource == GameSource.STEAM) {
+        Timber.tag("achievements").d("Setting up achievements for Steam appID=$appId...")
         val gameIdInt = ContainerUtils.extractGameIdFromContainerId(appId)
+        val configDirectory = gameIdInt?.let { SteamService.findSteamSettingsDir(context, it) }
         val achAppId = SteamService.cachedAchievementsAppId
-        if (gameIdInt != null && achAppId != null) {
+
+        if (gameIdInt != null && configDirectory != null) {
+            // Re-generate achievements (it should keep the already existing ones if they're there).
+            if (achAppId != gameIdInt && SteamService.isLoggedIn) {
+                try {
+                    runBlocking {
+                        SteamService.generateAchievements(gameIdInt, configDirectory)
+                    }
+                } catch (e: Exception) {
+                    Timber.tag("achievements").e(e, "Failed to refresh achievement cache for appId=$gameIdInt")
+                }
+            }
+
             val watchDirs = SteamService.getGseSaveDirs(context, gameIdInt)
-            val configDirectory = SteamService.findSteamSettingsDir(context, gameIdInt)
-            val displayNameMap = SteamService.cachedAchievements?.associate { ach ->
+            val cachedAchievements = SteamService.cachedAchievements
+                .takeIf { achAppId == gameIdInt }
+            val displayNameMap = cachedAchievements?.associate { ach ->
                 ach.name to (ach.displayName?.get(container.language)
                     ?: ach.displayName?.get("english")
                     ?: ach.name)
             } ?: emptyMap()
             val iconUrlMap = SteamService.cachedAchievements?.associate { ach ->
                 ach.name to ach.icon?.let {
-                    "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/$achAppId/$it"
+                    "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/$gameIdInt/$it"
                 }
             } ?: emptyMap()
             PluviaApp.achievementWatcher = AchievementWatcher(
@@ -3505,6 +3520,8 @@ private fun setupXEnvironment(
                 iconUrlMap = iconUrlMap,
                 configDirectory = configDirectory,
             ).also { it.start() }
+        } else {
+            Timber.tag("achievements").w("Skipping achievement watcher, no steam_settings dir found for appId=$appId")
         }
     }
 

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3486,14 +3486,16 @@ private fun setupXEnvironment(
         Timber.tag("achievements").d("Setting up achievements for Steam appID=$appId...")
         val gameIdInt = ContainerUtils.extractGameIdFromContainerId(appId)
         val configDirectory = gameIdInt?.let { SteamService.findSteamSettingsDir(context, it) }
-        val achAppId = SteamService.cachedAchievementsAppId
+        var cachedAchAppId = SteamService.cachedAchievementsAppId
 
         if (gameIdInt != null && configDirectory != null) {
             // Re-generate achievements (it should keep the already existing ones if they're there).
-            if (achAppId != gameIdInt && SteamService.isLoggedIn) {
+            if (cachedAchAppId != gameIdInt && SteamService.isLoggedIn) {
                 try {
                     runBlocking {
                         SteamService.generateAchievements(gameIdInt, configDirectory)
+                        // Update reference to new value set by generateAchievements
+                        cachedAchAppId = SteamService.cachedAchievementsAppId
                     }
                 } catch (e: Exception) {
                     Timber.tag("achievements").e(e, "Failed to refresh achievement cache for appId=$gameIdInt")
@@ -3502,7 +3504,7 @@ private fun setupXEnvironment(
 
             val watchDirs = SteamService.getGseSaveDirs(context, gameIdInt)
             val cachedAchievements = SteamService.cachedAchievements
-                .takeIf { achAppId == gameIdInt }
+                .takeIf { cachedAchAppId == gameIdInt }
             val displayNameMap = cachedAchievements?.associate { ach ->
                 ach.name to (ach.displayName?.get(container.language)
                     ?: ach.displayName?.get("english")
@@ -3510,7 +3512,7 @@ private fun setupXEnvironment(
             } ?: emptyMap()
             val iconUrlMap = SteamService.cachedAchievements?.associate { ach ->
                 ach.name to ach.icon?.let {
-                    "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/$gameIdInt/$it"
+                    "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/$cachedAchAppId/$it"
                 }
             } ?: emptyMap()
             PluviaApp.achievementWatcher = AchievementWatcher(


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

Created a fallback when the achievementAppId caching misses so it can still generate the achievements correctly so that the Watcher and its appropriate logic all works.


## Recording
<!-- Attach a short recording/GIF showing the change -->

Video of Achievements Watcher working again: 
Uploading achievements-watcher-working-again.mp4…


## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Steam achievement notifications and watching by regenerating achievements and using the refreshed `cachedAchievementsAppId` for lookups and icon URLs. Adds clear logs to aid debugging.

- **Bug Fixes**
  - Regenerates achievements when `cachedAchievementsAppId` doesn’t match the current Steam game (only when logged in), then updates the local reference after `SteamService.generateAchievements(...)`.
  - Uses `cachedAchievements` only when it matches the current game to avoid mismatched labels.
  - Builds icon URLs with the refreshed `cachedAchievementsAppId` to prevent wrong icons.
  - Requires a valid Steam settings directory before starting the watcher; skips with a warning if missing.
  - Adds debug logs for setup and `AchievementWatcher.start()` (includes appId and errors).

<sup>Written for commit 53cee2c73c3c6bcc4b0d382c83775f614814ac33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved achievement watcher startup by only enabling it when the required game ID and Steam configuration data are available.
  * Fixed achievement display details and icon URLs to consistently use the correct cached achievement set, reducing mismatches after switching games or accounts.
  * Added safer refresh behavior for cached achievements and improved logging, including warnings when achievement setup can’t be created, plus a debug log when the watcher starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->