### PR TITLE
fix: Make ProcessHelper.execWithOutput timeout configurable

### DIFF
--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -194,6 +194,10 @@ public abstract class ProcessHelper {
     //                         the main thread reads stdout. This keeps stdout clean for callers
     //                         such as SteamTokenLogin
     public static String execWithOutput(String command, String[] envp, File workingDir, boolean includeStderr) {
+        return execWithOutput(command, envp, workingDir, includeStderr, -1);
+    }
+
+    public static String execWithOutput(String command, String[] envp, File workingDir, boolean includeStderr, int timeoutSeconds) {
         StringBuilder output = new StringBuilder();
         final StringBuilder stdoutBuf = new StringBuilder();
         final StringBuilder stderrBuf = new StringBuilder();
@@ -241,15 +245,19 @@ public abstract class ProcessHelper {
             stderrDrainer.setDaemon(true);
             stderrDrainer.start();
 
-            boolean finished = process.waitFor(5, TimeUnit.SECONDS);
-            if (!finished) {
-                process.destroyForcibly();
-                try {
-                    process.waitFor(5, TimeUnit.SECONDS);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+            if (timeoutSeconds > 0) {
+                boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+                if (!finished) {
+                    process.destroyForcibly();
+                    try {
+                        process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    output.append("Error: Process timeout after 5 seconds");
                 }
-                output.append("Error: Process timeout after 5 seconds");
+            } else {
+                process.waitFor();
             }
 
             try { stdoutStream.close(); } catch (IOException ignored) {}

--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -254,7 +254,7 @@ public abstract class ProcessHelper {
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                     }
-                    output.append("Error: Process timeout after 5 seconds");
+                    output.append("Error: Process timeout after ").append(timeoutSeconds).append(" seconds");
                 }
             } else {
                 process.waitFor();

--- a/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/PulseAudioComponent.java
@@ -218,7 +218,7 @@ public class PulseAudioComponent extends EnvironmentComponent {
         envVars.put("TMPDIR", XEnvironment.getTmpDir(context));
         envVars.put("PULSE_SERVER", socketConfig.path);
 
-        return ProcessHelper.execWithOutput(workingDir + "/pactl " + command, envVars.toStringArray(), workingDir, true);
+        return ProcessHelper.execWithOutput(workingDir + "/pactl " + command, envVars.toStringArray(), workingDir, true, 5);
     }
 
     private boolean updateSink(boolean suspend) {


### PR DESCRIPTION
## Description
Generalizes external process execution timeouts by introducing a `timeoutSeconds` parameter to `ProcessHelper.execWithOutput`. This allows callers to specify a custom timeout, or disable it by passing a non-positive value.

The PulseAudio component is updated to explicitly pass a 5-second timeout for `pactl` commands, ensuring consistent handling and preventing potential hangs, building upon previous efforts to improve stability.

## Recording
N/A

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make external process timeouts configurable and apply a 5s timeout to `pactl` calls to prevent PulseAudio hangs. Callers can now override or disable timeouts via a new parameter.

- **Bug Fixes**
  - Added `timeoutSeconds` to `ProcessHelper.execWithOutput`; non-positive values wait indefinitely.
  - Only log a timeout error when a positive timeout is set; message includes the actual duration.
  - Kept existing overload for backward compatibility.
  - `PulseAudioComponent` now passes a 5s timeout for `pactl` commands.

<sup>Written for commit 23fc80deccc5a35e84dbc8aacba78b37921e0efc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process execution so commands can use configurable timeouts (or wait indefinitely when no timeout is set), with clearer timeout error reporting.
  * Reduced the chance of stalled audio-related operations by applying a controlled timeout when running `pactl` to update suspend/resume sink state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->