### PR TITLE
Allow uninstall of corruptede steam games

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -561,6 +561,7 @@ internal fun AppScreenContent(
     isDownloading: Boolean,
     downloadProgress: Float,
     hasPartialDownload: Boolean,
+    hasLeftoverInstall: Boolean = false,
     isUpdatePending: Boolean,
     downloadInfo: app.gamenative.data.DownloadInfo? = null,
     onDownloadInstallClick: () -> Unit,
@@ -948,10 +949,10 @@ internal fun AppScreenContent(
                             onClick = { optionsMenuVisible = true },
                         )
 
-                        if (isInstalled || hasPartialDownload) {
+                        if (isInstalled || hasPartialDownload || hasLeftoverInstall) {
                             ActionIconButton(
                                 icon = Icons.Default.Delete,
-                                contentDescription = if (isInstalled) stringResource(R.string.uninstall) else stringResource(R.string.delete_app),
+                                contentDescription = if (isInstalled || hasLeftoverInstall) stringResource(R.string.uninstall) else stringResource(R.string.delete_app),
                                 onClick = onDeleteDownloadClick,
                             )
                         }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -317,6 +317,15 @@ abstract class BaseAppScreen {
     }
 
     /**
+     * Check if a stale install record remains even though the game is not actually installed
+     * (e.g. its files went missing after a storage switch). Such a record blocks reinstall
+     * until it is cleaned up, so sources that can detect it should expose a delete action.
+     */
+    open fun hasLeftoverInstall(context: Context, libraryItem: LibraryItem): Boolean {
+        return false
+    }
+
+    /**
      * Check if an update is pending (synchronous version, returns false by default)
      * Override isUpdatePendingSuspend for async checks
      */
@@ -990,6 +999,9 @@ abstract class BaseAppScreen {
         var hasPartialDownloadState by remember(libraryItem.appId) {
             mutableStateOf(hasPartialDownload(context, libraryItem))
         }
+        var hasLeftoverInstallState by remember(libraryItem.appId) {
+            mutableStateOf(hasLeftoverInstall(context, libraryItem))
+        }
 
         val uiScope = rememberCoroutineScope()
 
@@ -1000,6 +1012,7 @@ abstract class BaseAppScreen {
             isDownloadingState = currentlyDownloading
             downloadProgressState = getDownloadProgress(context, libraryItem)
             hasPartialDownloadState = hasPartialDownload(context, libraryItem)
+            hasLeftoverInstallState = hasLeftoverInstall(context, libraryItem)
             if (includeUpdatePending) {
                 isUpdatePendingState = isUpdatePendingSuspend(context, libraryItem)
             }
@@ -1264,6 +1277,7 @@ abstract class BaseAppScreen {
             isDownloading = isDownloadingState,
             downloadProgress = downloadProgressState,
             hasPartialDownload = hasPartialDownloadState,
+            hasLeftoverInstall = hasLeftoverInstallState,
             isUpdatePending = isUpdatePendingState,
             downloadInfo = downloadInfo,
             onDownloadInstallClick = {

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -385,6 +385,11 @@ class SteamAppScreen : BaseAppScreen() {
         return downloadInfo?.getProgress() ?: 0f
     }
 
+    override fun hasLeftoverInstall(context: Context, libraryItem: LibraryItem): Boolean {
+        val gameId = libraryItem.gameId
+        return SteamService.getInstalledApp(gameId) != null && !SteamService.isAppInstalled(gameId)
+    }
+
     override fun hasPartialDownload(context: Context, libraryItem: LibraryItem): Boolean {
         // Use Steam's more accurate check that looks for marker files
         return SteamService.hasPartialDownload(libraryItem.gameId)
@@ -581,8 +586,8 @@ class SteamAppScreen : BaseAppScreen() {
                     dismissBtnText = context.getString(R.string.no),
                 ),
             )
-        } else if (isInstalled) {
-            // Show uninstall dialog when installed
+        } else if (isInstalled || SteamService.getInstalledApp(gameId) != null) {
+            // Show uninstall dialog when installed, or to clean up a leftover install record
             showUninstallDialog(libraryItem.appId)
         }
     }

--- a/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
@@ -722,7 +722,8 @@ object ContainerStorageManager {
             gameInstallSizeBytes = gameInstallSizeBytes,
             status = status,
             installPath = installPath,
-            canUninstallGame = status == Status.READY && gameSource != null && gameSource != GameSource.CUSTOM_GAME,
+            canUninstallGame = (status == Status.READY || status == Status.GAME_FILES_MISSING) &&
+                gameSource != null && gameSource != GameSource.CUSTOM_GAME,
             hasContainer = true,
         )
     }


### PR DESCRIPTION
## Description
Some games would get partially installed/deleted, and then the user would only see an install button which does nothing

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows uninstalling corrupted or leftover Steam installs so users can clean up broken states and reinstall. Fixes the “Install” button doing nothing after partial or removed installs.

- **Bug Fixes**
  - Detects leftover Steam installs (`SteamService.getInstalledApp()` exists while `isAppInstalled()` is false) and exposes an Uninstall action.
  - Shows the Uninstall/Delete button when installed, partially downloaded, or a leftover install is detected.
  - Enables uninstall when game files are missing by allowing `canUninstallGame` for `GAME_FILES_MISSING` in `ContainerStorageManager`.

<sup>Written for commit b58acfa70a380cf03c0abf57cf760d95ff7f7419. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting leftover installations, so uninstall/delete options can appear even when only partial app data remains.
  * Updated the uninstall flow to handle leftover install records more consistently.

* **Bug Fixes**
  * Improved delete/uninstall availability for apps with missing files or stray install metadata.
  * Refined the action icon and label so the correct uninstall option is shown in more cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->