### PR TITLE
Update lsteamclient archive names for Proton 10.0-4 variants

### DIFF
--- a/app/src/main/java/app/gamenative/utils/launchdependencies/BionicSteamAssetsDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/BionicSteamAssetsDependency.kt
@@ -46,9 +46,9 @@ object BionicSteamAssetsDependency : LaunchDependency {
     private val LSTEAMCLIENT_ARCHIVE_BY_WINE = mapOf(
         "proton-9.0-x86_64" to "lsteamclient-x86_64-proton9.tzst",
         "proton-9.0-arm64ec" to "lsteamclient-arm64ec-proton9.tzst",
-        "proton-10.0-4-x86_64-1" to "lsteamclient-x86_64.tzst",
         "proton-10.0-arm64ec-2" to "lsteamclient-arm64ec.tzst",
-        "proton-10.0-4-arm64ec-1" to "lsteamclient-arm64ec.tzst",
+        "proton-10.0-4-x86_64-1" to "lsteamclient-x86_64-proton10-4.tzst",
+        "proton-10.0-4-arm64ec-1" to "lsteamclient-arm64ec-proton10-4.tzst",
         "proton-11.0-1-x86_64-1" to "lsteamclient-x86_64-proton11.tzst",
         "proton-11.0-1-arm64ec-1" to "lsteamclient-arm64ec-proton11.tzst",
     )


### PR DESCRIPTION
## Description
Update lsteamclient archive names for Proton 10.0-4 variants

## Recording
N/A

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use version-specific `lsteamclient` archives for Proton 10.0-4 in `BionicSteamAssetsDependency`. Maps to `lsteamclient-x86_64-proton10-4.tzst` and `lsteamclient-arm64ec-proton10-4.tzst` to ensure the right assets are downloaded.

<sup>Written for commit f0941d20399b7ee4647f3a05ffd6444473b611bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

