### PR TITLE
Fix carousel focus ring: hug the card and update without scroll delay

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
@@ -283,6 +283,10 @@ internal fun LibraryCarouselPane(
         scope.launch {
             onFocusedIndexChanged(targetIndex)
             kotlinx.coroutines.delay(16)
+            try {
+                firstCarouselItemFocusRequester?.requestFocus()
+            } catch (_: IllegalStateException) {
+            }
             listState.animateScrollToItem(targetIndex)
             kotlinx.coroutines.delay(16)
             try {

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryGridCard.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryGridCard.kt
@@ -134,13 +134,13 @@ internal fun GridViewCard(
         modifier = modifier
             .padding(vertical = 4.dp)
             .scale(scale)
-            .then(focusHaloModifier)
-            .focusRing(interactionSource, cardShape),
+            .then(focusHaloModifier),
     ) {
         Card(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(aspectRatio)
+                .focusRing(interactionSource, cardShape)
                 .clickable(
                     onClick = onClick,
                     interactionSource = interactionSource,


### PR DESCRIPTION
## Description
Fixes two issues with the animated focus ring on library game cards in carousel mode:

- **Ring didn't match the card.** The ring was drawn on `GridViewCard`'s outer box. In the carousel that box is fill-sized to the item slot while the visible `Card` sizes itself via `fillMaxWidth().aspectRatio(2/3)`, so the ring didn't line up with the card. It's now drawn on the `Card` itself, so it hugs the visible bounds in every layout (grid unchanged).
- **Ring lagged when switching games.** In `navigateCarousel`, `requestFocus()` ran only after the suspending `animateScrollToItem()` completed, so the ring waited out the whole scroll animation before moving. Focus is now requested first (the ring follows immediately) and the scroll animates afterwards.

## Recording

| Before | After |
| :---: | :---: |
| <img width="2340" height="1080" alt="Screenshot_20260710_105844_GameNative" src="https://github.com/user-attachments/assets/c60f58d4-88f8-41fa-ad08-2e16f6c52173" /> | <img width="2340" height="1080" alt="Screenshot_20260710_114804_GameNative" src="https://github.com/user-attachments/assets/a74a3e0e-313f-4448-b886-b88fd57d7598" /> |

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [ ] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the carousel focus ring so it hugs the visible card and updates immediately when changing selection, without waiting for scroll and avoiding focus exceptions.

- **Bug Fixes**
  - Draw the ring on the inner `Card` instead of the outer slot so it aligns with the card’s 2:3 bounds; grid unchanged.
  - Request focus (guarded with try/catch) before animating scroll, with a small frame delay, so the ring moves right away while the list scrolls and avoids intermittent `IllegalStateException`.

<sup>Written for commit 3f33ed6310e3a202e54138d67fad1f195358fab1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus behavior when navigating the library carousel to make keyboard/remote navigation more reliable.
  * Updated focus visual rendering on library cards so the focus ring aligns consistently with the card itself.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->