### PR TITLE
Fix orphaned cloud saves (ones that were never downloaded because of offline boot)

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -488,18 +488,18 @@ object SteamAutoCloud {
             "$scheme${urlHost}$urlPath"
         }
 
-        val downloadFiles: (AppFileChangeList, CoroutineScope) -> Deferred<UserFilesDownloadResult> = { fileList, parentScope ->
+        val downloadFiles: (List<AppFileInfo>, AppFileChangeList, CoroutineScope) -> Deferred<UserFilesDownloadResult> = { filesToDownload, fileList, parentScope ->
             parentScope.async {
                 val filesDownloaded = AtomicInteger(0)
                 val bytesDownloaded = AtomicLong(0L)
-                val totalFiles = fileList.files.size
+                val totalFiles = filesToDownload.size
                 val parallelism = PrefManager.downloadSpeed.coerceAtLeast(1)
                 // A new client (and its Dispatcher thread pool) is created intentionally per sync,
                 // since cloud saves are downloaded at most once per game launch.
                 val downloadHttpClient = Net.httpForParallelDownloads(parallelism)
                 val semaphore = Semaphore(parallelism)
                 val completedFiles = AtomicInteger(0)
-                val totalRawBytes = fileList.files.sumOf { it.rawFileSize.toLong() }
+                val totalRawBytes = filesToDownload.sumOf { it.rawFileSize.toLong() }
                 // downloadedRawBytes tracks bytes as they stream in (per-chunk) for live progress.
                 // bytesDownloaded accumulates rawFileSize per completed file for final accounting.
                 val downloadedRawBytes = AtomicLong(0L)
@@ -514,7 +514,7 @@ object SteamAutoCloud {
 
                 try {
                     coroutineScope {
-                        fileList.files.map { file ->
+                        filesToDownload.map { file ->
                             async {
                                 semaphore.withPermit {
                                     val result = downloadSingleFile(
@@ -847,7 +847,7 @@ object SteamAutoCloud {
                     }.inWholeMicroseconds
 
                     microsecDownloadFiles = measureTime {
-                        val downloadInfo = downloadFiles(appFileListChange, parentScope).await()
+                        val downloadInfo = downloadFiles(appFileListChange.files, appFileListChange, parentScope).await()
                         filesDownloaded = downloadInfo.filesDownloaded
                         bytesDownloaded = downloadInfo.bytesDownloaded
                     }.inWholeMicroseconds
@@ -922,6 +922,38 @@ object SteamAutoCloud {
                         }
                     } else {
                         syncResult = SyncResult.UpdateFail
+                    }
+                }
+            }
+
+            // Download cloud files that were never synced to this device: present in the cloud
+            // manifest but absent from both disk and the pre-sync cache. An upload-only sync (e.g.
+            // Keep Local) advances our change number without downloading, orphaning cloud-only files.
+            // A file in the cache but missing from disk was deleted locally — left out of "known" on
+            // purpose so it propagates as a cloud delete rather than being resurrected. The pre-sync
+            // cachedFileList is used (not a fresh read) so an upload earlier in this sync can't hide
+            // such a delete. Callers run this only after any local upload, so a full local rescan is
+            // then the correct cache snapshot.
+            val reconcileNeverSyncedCloudFiles: (CoroutineScope) -> Deferred<Int> = { parentScope ->
+                parentScope.async {
+                    // Lowercased absolute paths, mirroring the silent-rehydrate comparison, since
+                    // Steam Cloud and wine may disagree on case.
+                    val knownKeys = (allLocalUserFiles + (cachedFileList?.userFileInfo ?: emptyList()))
+                        .map { it.getAbsPath(prefixToPath).toString().lowercase() }
+                        .toSet()
+                    val neverSynced = appFileListChange.files.filter {
+                        getFullFilePath(it, appFileListChange).toString().lowercase() !in knownKeys
+                    }
+
+                    if (neverSynced.isEmpty()) {
+                        0
+                    } else {
+                        Timber.i("Reconcile: downloading ${neverSynced.size} never-synced cloud file(s) for ${appInfo.id}")
+                        val downloadInfo = downloadFiles(neverSynced, appFileListChange, parentScope).await()
+                        filesDownloaded += downloadInfo.filesDownloaded
+                        bytesDownloaded += downloadInfo.bytesDownloaded
+                        steamInstance.fileChangeListsDao.insert(appInfo.id, getLocalUserFilesAsPrefixMap().values.flatten())
+                        downloadInfo.filesDownloaded
                     }
                 }
             }
@@ -1003,6 +1035,9 @@ object SteamAutoCloud {
                             SaveLocation.Local -> {
                                 // overwrite remote save with the local one
                                 uploadUserFiles(parentScope).await()
+                                // Keep-Local is upload-only; without this, cloud-only files this
+                                // device never had would be orphaned. Pull them down instead.
+                                reconcileNeverSyncedCloudFiles(parentScope).await()
                             }
 
                             SaveLocation.Remote -> {
@@ -1038,10 +1073,22 @@ object SteamAutoCloud {
                         Timber.i("Found local changes and no new cloud user files")
 
                         uploadUserFiles(parentScope).await()
-                    } else {
-                        Timber.i("No local changes and no new cloud user files, doing nothing...")
+                    }
 
-                        syncResult = SyncResult.UpToDate
+                    // Equal change numbers normally mean "cloud has nothing new", but an earlier
+                    // upload-only sync can leave cloud-only files that were never downloaded here.
+                    // Reconcile after any upload (the two file sets are disjoint: never-synced files
+                    // are by definition not on disk, so not local changes).
+                    val downloaded = reconcileNeverSyncedCloudFiles(parentScope).await()
+
+                    if (!hasLocalChanges) {
+                        if (downloaded > 0) {
+                            Timber.i("Downloaded $downloaded never-synced cloud file(s)")
+                            syncResult = SyncResult.Success
+                        } else {
+                            Timber.i("No local changes and no new cloud user files, doing nothing...")
+                            syncResult = SyncResult.UpToDate
+                        }
                     }
                 }.inWholeMicroseconds
             } else {

--- a/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
+++ b/app/src/test/java/app/gamenative/service/SteamAutoCloudTest.kt
@@ -2810,4 +2810,264 @@ class SteamAutoCloudTest {
             rehydratedCn!!.changeNumber,
         )
     }
+
+    // ── Reconciliation of never-synced cloud files ───────────────────────
+    // The offline-first-boot bug: an upload-only sync stamps the local change
+    // number to match the cloud's without downloading, so cloud-only files are
+    // orphaned. With equal change numbers we must still pull down any cloud file
+    // that's absent from both disk and the cache.
+
+    /** Wire up the download pipeline (Cloud metadata + HTTP) for a single cloud file's content. */
+    private fun stubSingleFileDownload(content: ByteArray) {
+        val mockDownloadInfo = mock<FileDownloadInfo>()
+        whenever(mockDownloadInfo.urlHost).thenReturn("test.example.com")
+        whenever(mockDownloadInfo.urlPath).thenReturn("/download/file1")
+        whenever(mockDownloadInfo.useHttps).thenReturn(true)
+        whenever(mockDownloadInfo.requestHeaders).thenReturn(emptyList())
+        whenever(mockDownloadInfo.fileSize).thenReturn(content.size)
+        whenever(mockDownloadInfo.rawFileSize).thenReturn(content.size)
+        whenever(mockDownloadInfo.timestamp).thenReturn(Date())
+
+        every { mockSteamCloud.clientFileDownload(any(), any()) } returns
+            CompletableFuture.completedFuture(mockDownloadInfo)
+        every { mockSteamCloud.clientFileDownload(any(), any(), any(), any(), any()) } returns
+            CompletableFuture.completedFuture(mockDownloadInfo)
+
+        val mockHttpClient = mock<OkHttpClient>()
+        every { Net.httpForParallelDownloads(any()) } returns mockHttpClient
+        val mockCall = mock<Call>()
+        whenever(mockHttpClient.newCall(any())).thenReturn(mockCall)
+        whenever(mockCall.execute()).thenReturn(
+            Response.Builder()
+                .request(okhttp3.Request.Builder().url("https://test.example.com/download/file1").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(content.toResponseBody())
+                .build(),
+        )
+
+        val mockSteamClient = mockSteamService.steamClient!!
+        val mockConfig = mock<SteamConfiguration>()
+        whenever(mockSteamClient.configuration).thenReturn(mockConfig)
+        whenever(mockConfig.httpClient).thenReturn(mockHttpClient)
+    }
+
+    private fun cloudFile(filename: String, content: ByteArray): AppFileInfo {
+        val m = mock<AppFileInfo>()
+        whenever(m.filename).thenReturn(filename)
+        whenever(m.shaFile).thenReturn(sha1(content))
+        whenever(m.pathPrefixIndex).thenReturn(0)
+        whenever(m.timestamp).thenReturn(Date())
+        whenever(m.rawFileSize).thenReturn(content.size)
+        return m
+    }
+
+    private val saveGamesPrefix = "%WinMyDocuments%/My Games/TestGame/Steam/76561198025127569/SaveGames"
+
+    // ── Equal CN, cloud has a file this device never synced → download it ──
+    @Test
+    fun equalCn_cloudHasNeverSyncedFile_downloadsAndCaches() = runBlocking {
+        val cn = 5L
+        cacheCurrentLocalFiles(cn)
+
+        val orphanContent = "cloud-only save this device never had".toByteArray()
+        val orphan = cloudFile("OrphanSaveData.sav", orphanContent)
+
+        val changeList = makeCloudFileChangeList(cn, files = listOf(orphan), pathPrefixes = listOf(saveGamesPrefix))
+        every { mockSteamCloud.getAppFileListChange(any(), any(), any()) } returns
+            CompletableFuture.completedFuture(changeList)
+        stubSingleFileDownload(orphanContent)
+
+        val testApp = db.steamAppDao().findApp(steamAppId)!!
+        val result = SteamAutoCloud.syncUserFiles(
+            appInfo = testApp,
+            clientId = clientId,
+            steamInstance = mockSteamService,
+            steamCloud = mockSteamCloud,
+            preferredSave = SaveLocation.None,
+            prefixToPath = makePrefixToPath(),
+        ).await()
+
+        assertNotNull(result)
+        assertEquals(SyncResult.Success, result!!.syncResult)
+        assertEquals("orphaned cloud file should be downloaded", 1, result.filesDownloaded)
+
+        val downloaded = File(saveFilesDir, "OrphanSaveData.sav")
+        assertTrue("never-synced cloud file must land on disk", downloaded.exists())
+        assertEquals(orphanContent.contentToString(), downloaded.readBytes().contentToString())
+
+        // change number is unchanged (cloud didn't advance), and the file is now cached
+        val cnAfter = db.appChangeNumbersDao().getByAppId(steamAppId)
+        assertEquals("change number must stay equal", cn, cnAfter!!.changeNumber)
+        val cache = db.appFileChangeListsDao().getByAppId(steamAppId)!!.userFileInfo
+        assertTrue(
+            "downloaded file must be added to the cache so it isn't re-fetched next launch",
+            cache.any { it.filename.endsWith("OrphanSaveData.sav") },
+        )
+        assertEquals("cache should now hold the 5 original files plus the downloaded one", 6, cache.size)
+    }
+
+    // ── Equal CN, cache-known file deleted from disk → stays a delete, not resurrected ──
+    @Test
+    fun equalCn_cacheKnownFileMissingFromDisk_notReDownloaded() = runBlocking {
+        val cn = 5L
+        cacheCurrentLocalFiles(cn)
+
+        // user deleted this save locally; it's still in the cache
+        val deleted = File(saveFilesDir, "SaveData_0.sav")
+        assertTrue("precondition: file exists before delete", deleted.exists())
+        deleted.delete()
+
+        // cloud still lists it. A working download stub is wired up so that if the never-synced
+        // check mis-keys the path, reconcile downloads it and the filesDownloaded assertion fails
+        // fast — rather than blocking forever on an unstubbed download future.
+        val stillInCloud = cloudFile("SaveData_0.sav", "savedata0 content".toByteArray())
+        val changeList = makeCloudFileChangeList(cn, files = listOf(stillInCloud), pathPrefixes = listOf(saveGamesPrefix))
+        every { mockSteamCloud.getAppFileListChange(any(), any(), any()) } returns
+            CompletableFuture.completedFuture(changeList)
+        stubSingleFileDownload("savedata0 content".toByteArray())
+
+        val testApp = db.steamAppDao().findApp(steamAppId)!!
+        val result = SteamAutoCloud.syncUserFiles(
+            appInfo = testApp,
+            clientId = clientId,
+            steamInstance = mockSteamService,
+            steamCloud = mockSteamCloud,
+            preferredSave = SaveLocation.None,
+            prefixToPath = makePrefixToPath(),
+        ).await()
+
+        assertNotNull(result)
+        assertEquals("locally-deleted file must not be re-downloaded", 0, result!!.filesDownloaded)
+        assertFalse("locally-deleted file must not be resurrected on disk", deleted.exists())
+    }
+
+    // ── Equal CN, cloud files already present on disk → nothing to do ──
+    @Test
+    fun equalCn_cloudFilesAlreadyOnDisk_upToDate() = runBlocking {
+        val cn = 5L
+        cacheCurrentLocalFiles(cn)
+
+        // cloud lists exactly the files already on disk. Correct path-keying means none are
+        // "never synced". A working download stub is wired up so a mis-key fails the download
+        // assertion fast instead of blocking forever on an unstubbed download future.
+        val onDisk = listOf(
+            cloudFile("AutoSaveData.sav", "autosave content".toByteArray()),
+            cloudFile("SaveData_0.sav", "savedata0 content".toByteArray()),
+            cloudFile("ContinueSaveData.sav", "continue content".toByteArray()),
+            cloudFile("SaveData_1.sav", "savedata1 content".toByteArray()),
+            cloudFile("SystemData_0.sav", "systemdata content".toByteArray()),
+        )
+        val changeList = makeCloudFileChangeList(cn, files = onDisk, pathPrefixes = listOf(saveGamesPrefix))
+        every { mockSteamCloud.getAppFileListChange(any(), any(), any()) } returns
+            CompletableFuture.completedFuture(changeList)
+        stubSingleFileDownload("autosave content".toByteArray())
+
+        val testApp = db.steamAppDao().findApp(steamAppId)!!
+        val result = SteamAutoCloud.syncUserFiles(
+            appInfo = testApp,
+            clientId = clientId,
+            steamInstance = mockSteamService,
+            steamCloud = mockSteamCloud,
+            preferredSave = SaveLocation.None,
+            prefixToPath = makePrefixToPath(),
+        ).await()
+
+        assertNotNull(result)
+        assertEquals(SyncResult.UpToDate, result!!.syncResult)
+        assertEquals("nothing to download", 0, result.filesDownloaded)
+    }
+
+    // ── Equal CN, mixed manifest: only the never-synced file is fetched (strict subset) ──
+    // Manifest has two files already on disk plus one orphan. Reconcile must download exactly
+    // the orphan and leave the on-disk files untouched — this exercises downloadFiles fetching
+    // a strict subset of the manifest, not all of it.
+    @Test
+    fun equalCn_mixedManifest_downloadsOnlyTheOrphan() = runBlocking {
+        val cn = 5L
+        cacheCurrentLocalFiles(cn)
+
+        val orphanContent = "the only cloud-only file".toByteArray()
+        // Two files that already exist on disk (from setUp) + one orphan that does not.
+        val manifest = listOf(
+            cloudFile("AutoSaveData.sav", "autosave content".toByteArray()),
+            cloudFile("SaveData_0.sav", "savedata0 content".toByteArray()),
+            cloudFile("OrphanSaveData.sav", orphanContent),
+        )
+        val changeList = makeCloudFileChangeList(cn, files = manifest, pathPrefixes = listOf(saveGamesPrefix))
+        every { mockSteamCloud.getAppFileListChange(any(), any(), any()) } returns
+            CompletableFuture.completedFuture(changeList)
+        // The download stub serves orphanContent for ANY request, so if reconcile wrongly fetched
+        // an on-disk file it would both bump filesDownloaded and overwrite that file's content.
+        stubSingleFileDownload(orphanContent)
+
+        val testApp = db.steamAppDao().findApp(steamAppId)!!
+        val result = SteamAutoCloud.syncUserFiles(
+            appInfo = testApp,
+            clientId = clientId,
+            steamInstance = mockSteamService,
+            steamCloud = mockSteamCloud,
+            preferredSave = SaveLocation.None,
+            prefixToPath = makePrefixToPath(),
+        ).await()
+
+        assertNotNull(result)
+        assertEquals(SyncResult.Success, result!!.syncResult)
+        assertEquals("exactly one (the orphan) should be downloaded", 1, result.filesDownloaded)
+
+        // orphan pulled down with its own content
+        val orphan = File(saveFilesDir, "OrphanSaveData.sav")
+        assertTrue("orphan must be downloaded", orphan.exists())
+        assertEquals(orphanContent.contentToString(), orphan.readBytes().contentToString())
+
+        // the two already-present files must be left exactly as they were (not re-fetched/overwritten)
+        assertEquals(
+            "AutoSaveData.sav must not be re-fetched",
+            "autosave content",
+            File(saveFilesDir, "AutoSaveData.sav").readText(),
+        )
+        assertEquals(
+            "SaveData_0.sav must not be re-fetched",
+            "savedata0 content",
+            File(saveFilesDir, "SaveData_0.sav").readText(),
+        )
+    }
+
+    // ── Root cause: Keep Local must still pull down cloud-only files, not orphan them ──
+    @Test
+    fun keepLocal_downloadsNeverSyncedCloudFiles() = runBlocking {
+        // db cleared (fresh) + local files exist + cloud ahead → conflict; user picks Keep Local
+        db.appChangeNumbersDao().deleteByAppId(steamAppId)
+        db.appFileChangeListsDao().deleteByAppId(steamAppId)
+        assertTrue("precondition: local save files exist", saveFilesDir.listFiles()!!.isNotEmpty())
+
+        val orphanContent = "PC-only save the phone never had".toByteArray()
+        val orphan = cloudFile("CloudOnlySaveData.sav", orphanContent)
+        val changeList = makeCloudFileChangeList(5, files = listOf(orphan), pathPrefixes = listOf(saveGamesPrefix))
+        every { mockSteamCloud.getAppFileListChange(any(), any(), any()) } returns
+            CompletableFuture.completedFuture(changeList)
+        stubSingleFileDownload(orphanContent)
+
+        val testApp = db.steamAppDao().findApp(steamAppId)!!
+        val result = SteamAutoCloud.syncUserFiles(
+            appInfo = testApp,
+            clientId = clientId,
+            steamInstance = mockSteamService,
+            steamCloud = mockSteamCloud,
+            preferredSave = SaveLocation.Local,
+            prefixToPath = makePrefixToPath(),
+        ).await()
+
+        assertNotNull(result)
+        assertEquals(SyncResult.Success, result!!.syncResult)
+        assertTrue("local saves should upload", result.uploadsCompleted)
+        assertTrue("local saves should upload", result.filesUploaded > 0)
+        assertEquals("cloud-only file must be pulled down, not orphaned", 1, result.filesDownloaded)
+        assertTrue(
+            "cloud-only file must land on disk",
+            File(saveFilesDir, "CloudOnlySaveData.sav").exists(),
+        )
+    }
+
 }


### PR DESCRIPTION


## Description
If a game was launched first offline, not all files will be downloaded. Then because of cloud sync, those files are never downloaded. Download anything that's on the cloud but not local.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes orphaned cloud saves after an offline first boot or upload-only sync. We now download cloud files that aren’t on disk and not in the pre-sync cache.

- **Bug Fixes**
  - Added a reconcile step that compares the cloud manifest to local disk + cached files (case-insensitive) and downloads only “never-synced” files.
  - Runs after “Keep Local” conflict resolution and when change numbers are equal, so cloud-only files aren’t missed.
  - Preserves local deletions by excluding cache-known-but-missing files, and updates the cache after successful downloads.
  - Added tests for equal change numbers, Keep Local flow, and mixed manifests.

- **Refactors**
  - `downloadFiles` now accepts a subset list of files, enabling selective downloads instead of fetching the entire change list.

<sup>Written for commit 458c295d0e6d0404d9b0b5fd8380d8163c5985de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud sync now downloads files present in the cloud but never previously synchronized.
  * Prevents deleted, cache-known files from being restored unexpectedly.
  * Downloads only missing files when cloud and local versions are otherwise aligned.
  * Preserves local changes while still retrieving cloud-only files during “Keep local” resolution.
  * Correctly reports synchronization status after newly discovered files are downloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->