### PR TITLE
Fixed intermittent failing build action on GH

### DIFF
--- a/.github/workflows/app-release-signed.yml
+++ b/.github/workflows/app-release-signed.yml
@@ -11,10 +11,15 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch:
 
+concurrency:
+  group: android-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@v4
@@ -83,6 +88,9 @@ jobs:
         cp app/build/outputs/bundle/legacyRelease/app-legacy-release.aab app-release.aab
         cp app/build/outputs/bundle/modernRelease/app-modern-release.aab app-modern-release.aab
         cp app/build/outputs/bundle/legacyXrRelease/app-legacyXr-release.aab app-legacy-xr-release.aab
+
+    - name: Stop Gradle daemon to free memory
+      run: ./gradlew --stop
 
     - name: Extract APKs from Bundles
       run: |


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [ ] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized the Android release GitHub Action by preventing overlapping runs, adding a job timeout, and freeing memory after builds to reduce intermittent failures.

- **Bug Fixes**
  - Added concurrency group `android-ci-${{ github.ref }}` with cancel-in-progress to avoid overlapping builds per ref.
  - Set `timeout-minutes: 45` on the `ubuntu-latest` job to stop hung runs.
  - Stopped the Gradle daemon (`./gradlew --stop`) after bundling to free memory before APK extraction.

<sup>Written for commit 42c41811ea5f01b6ca77fb7e89a007ec4fd8dbdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Android release workflow reliability by canceling superseded runs on the same branch.
  * Added a 45-minute maximum duration to prevent stalled builds from running indefinitely.
  * Preserved APK extraction, signing, artifact publishing, and release notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->