### PR TITLE
fix(): PICs improvements and reduce memory pressure

### DIFF
--- a/app/src/main/java/app/gamenative/data/SteamLicenseForPics.kt
+++ b/app/src/main/java/app/gamenative/data/SteamLicenseForPics.kt
@@ -1,0 +1,10 @@
+package app.gamenative.data
+
+import androidx.room.ColumnInfo
+
+// Slimmed down type for retrieving licences for processing.
+data class SteamLicenseForPics(
+    val packageId: Int,
+    @ColumnInfo("access_token")
+    val accessToken: Long,
+)

--- a/app/src/main/java/app/gamenative/db/dao/SteamLicenseDao.kt
+++ b/app/src/main/java/app/gamenative/db/dao/SteamLicenseDao.kt
@@ -7,6 +7,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
 import app.gamenative.data.SteamLicense
+import app.gamenative.data.SteamLicenseForPics
 import kotlin.math.min
 
 val SQLITE_MAX_VARS = 999
@@ -28,6 +29,9 @@ interface SteamLicenseDao {
 
     @Query("SELECT * FROM steam_license")
     suspend fun getAllLicenses(): List<SteamLicense>
+
+    @Query("SELECT packageId, access_token FROM steam_license")
+    suspend fun getLicensesForPics(): List<SteamLicenseForPics>
 
     @Query("SELECT * FROM steam_license WHERE packageId = :packageId")
     suspend fun findLicense(packageId: Int): SteamLicense?

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -27,6 +27,7 @@ import app.gamenative.data.GameSource
 import app.gamenative.data.LaunchInfo
 import app.gamenative.data.OwnedGames
 import app.gamenative.data.PostSyncInfo
+import app.gamenative.data.SteamLicenseForPics
 import app.gamenative.data.SteamApp
 import app.gamenative.data.SteamControllerConfigDetail
 import app.gamenative.data.SteamFriend
@@ -4137,7 +4138,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                 // Chunk the input to reduce memory pressures for very large items.
                 licenses = callback.licenseList
                 cachedLicenseDao.deleteAll()
-                callback.licenseList.chunked(500).forEach { chunk ->
+                callback.licenseList.chunked(MAX_PICS_BUFFER).forEach { chunk ->
                     cachedLicenseDao.insertAll(
                         chunk.map { license ->
                             CachedLicense(licenseJson = LicenseSerializer.serializeLicense(license))
@@ -4176,22 +4177,26 @@ class SteamService : Service(), IChallengeUrlChanged {
 
                 if (licensesToAdd.isNotEmpty()) {
                     Timber.i("Adding ${licensesToAdd.size} licenses")
-                    licensesToAdd.chunked(500).forEach { chunk ->
+                    licensesToAdd.chunked(MAX_PICS_BUFFER).forEach { chunk ->
                         licenseDao.insertAll(chunk)
                     }
                 }
 
+                Timber.i("Finished adding ${licensesToAdd.size} licenses")
+
                 val licensesToRemove = licenseDao.findStaleLicences(
                     packageIds = callback.licenseList.map { it.packageID },
                 )
+
                 if (licensesToRemove.isNotEmpty()) {
                     Timber.i("Removing ${licensesToRemove.size} (stale) licenses")
                     val packageIds = licensesToRemove.map { it.packageId }
                     licenseDao.deleteStaleLicenses(packageIds)
                 }
 
+                Timber.i("Getting licences from DB")
                 // Get PICS information with the current license database.
-                licenseDao.getAllLicenses()
+                licenseDao.getLicensesForPics()
                     .map { PICSRequest(it.packageId, it.accessToken) }
                     .chunked(MAX_PICS_BUFFER)
                     .forEach { chunk ->

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -4194,7 +4194,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                     licenseDao.deleteStaleLicenses(packageIds)
                 }
 
-                Timber.i("Getting licences from DB")
+                Timber.i("Getting licenses from DB")
                 // Get PICS information with the current license database.
                 licenseDao.getLicensesForPics()
                     .map { PICSRequest(it.packageId, it.accessToken) }


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

- Reduced size of grabbing licences from the DB via a smaller licence grab
- Match chunking of the queries to the batch size for pics to avoid overflow

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts memory use and stabilizes PICS requests by fetching only the needed license fields and matching chunk sizes to the PICS batch size.

- **Performance**
  - Added `SteamLicenseForPics` and `getLicensesForPics()` to select only `packageId` and `access_token`.
  - Aligned chunking to `MAX_PICS_BUFFER` for caching, inserts, and PICS requests (replaces hardcoded 500).
  - Switched PICS request generation to use `getLicensesForPics()` and added clearer progress logs to reduce memory pressure on large libraries.

<sup>Written for commit be8a4b1ef842d37972deb9bcc83837b8d883dbe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved Steam license processing by handling records in controlled batches.
  * Reduced loaded data for image-related license handling by only fetching required fields.
* **Reliability**
  * Added clearer progress logging around Steam license insert operations and refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->