### PR TITLE
Fix Steam collections failing to load

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -23,6 +23,9 @@
 # Needed for release build
 -keep class in.dragonbra.javasteam.** { *; }
 
+# UnifiedService subclasses are built via reflection in SteamUnifiedMessages.createService; keep their ctor.
+-keep class * extends in.dragonbra.javasteam.steam.handlers.steamunifiedmessages.UnifiedService { *; }
+
 -keep class org.spongycastle.**
 -dontwarn org.spongycastle.jce.provider.X509LDAPCertStoreSpi
 -dontwarn org.spongycastle.x509.util.LDAPStoreHelper

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -4070,53 +4070,68 @@ class SteamService : Service(), IChallengeUrlChanged {
      */
     internal suspend fun fetchSteamCollections() {
         val client = steamClient
-        // Remember who we fetched for, so a slow RPC can't write one account's collections into another.
         val fetchSteamId = client?.steamID?.convertToUInt64()
+        // Same login + account as when we started, so a slow RPC can't cross accounts.
+        fun sameSession() = isLoggedIn && steamClient?.steamID?.convertToUInt64() == fetchSteamId
         val um = client?.getHandler<SteamUnifiedMessages>()
         if (um == null) {
             Timber.tag("SteamCollections").w("UnifiedMessages handler unavailable; cannot fetch collections")
             return
         }
-        try {
-            val request = SteammessagesCloudconfigstoreSteamclient.CCloudConfigStore_Download_Request.newBuilder()
-                .addVersions(
-                    SteammessagesCloudconfigstoreSteamclient.CCloudConfigStore_NamespaceVersion.newBuilder()
-                        .setEnamespace(1) // user collections namespace
-                        .setVersion(0L), // 0 = full download
-                )
-                .build()
-
-            // A registered service is required: JavaSteam routes ServiceMethodResponse packets by
-            // service name, so the generic sendMessage alone never receives the reply.
-            val service = um.createService(CloudConfigStoreService::class.java)
-            val job = service.download(request)
-            // The fetch fires during the post-login burst (PICS for the whole library), so give the
-            // response generous headroom beyond the default job timeout.
-            job.timeout = 60_000L
-            val response = job.toFuture().await()
-
-            val body = response.body.build()
-            val rawEntries = body.dataList.flatMap { ns ->
-                ns.entriesList.map { entry ->
-                    SteamCollectionParser.RawEntry(
-                        key = entry.key,
-                        value = entry.value,
-                        isDeleted = entry.isDeleted,
-                    )
-                }
-            }
-
-            val parsed = SteamCollectionParser.parse(rawEntries)
-            Timber.tag("SteamCollections").i(
-                "Fetched ${parsed.collections.size} Steam collections " +
-                    "(${parsed.skippedDynamicCount} dynamic skipped)",
-            )
-            // Drop the result if we logged out or switched accounts while the RPC was in flight.
-            if (isLoggedIn && steamClient?.steamID?.convertToUInt64() == fetchSteamId) {
-                SteamCollectionRepository.update(parsed)
-            }
+        // A registered service is required: JavaSteam routes ServiceMethodResponse packets by
+        // service name, so the generic sendMessage alone never receives the reply.
+        val service = try {
+            um.createService(CloudConfigStoreService::class.java)
         } catch (t: Throwable) {
-            Timber.tag("SteamCollections").e(t, "Failed to fetch Steam collections; keeping cached snapshot")
+            Timber.tag("SteamCollections").e(t, "Cannot create CloudConfigStore service; keeping cached snapshot")
+            return
+        }
+
+        val request = SteammessagesCloudconfigstoreSteamclient.CCloudConfigStore_Download_Request.newBuilder()
+            .addVersions(
+                SteammessagesCloudconfigstoreSteamclient.CCloudConfigStore_NamespaceVersion.newBuilder()
+                    .setEnamespace(1) // user collections namespace
+                    .setVersion(0L), // 0 = full download
+            )
+            .build()
+
+        // Reply can be starved or dropped during the post-login PICS burst; retry with backoff.
+        val backoffsMs = longArrayOf(3_000L, 8_000L, 20_000L)
+        val maxAttempts = backoffsMs.size + 1
+        repeat(maxAttempts) { attempt ->
+            if (!sameSession()) return
+            try {
+                val job = service.download(request)
+                job.timeout = 30_000L
+                val response = job.toFuture().await()
+
+                val body = response.body.build()
+                val rawEntries = body.dataList.flatMap { ns ->
+                    ns.entriesList.map { entry ->
+                        SteamCollectionParser.RawEntry(
+                            key = entry.key,
+                            value = entry.value,
+                            isDeleted = entry.isDeleted,
+                        )
+                    }
+                }
+
+                val parsed = SteamCollectionParser.parse(rawEntries)
+                Timber.tag("SteamCollections").i(
+                    "Fetched ${parsed.collections.size} Steam collections " +
+                        "(${parsed.skippedDynamicCount} dynamic skipped) on attempt ${attempt + 1}",
+                )
+                if (sameSession()) SteamCollectionRepository.update(parsed)
+                return
+            } catch (t: Throwable) {
+                val lastAttempt = attempt == maxAttempts - 1
+                Timber.tag("SteamCollections").w(
+                    t,
+                    "Steam collections fetch attempt ${attempt + 1}/$maxAttempts failed" +
+                        if (lastAttempt) "; keeping cached snapshot" else "; retrying",
+                )
+                if (!lastAttempt) delay(backoffsMs[attempt])
+            }
         }
     }
 

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -4123,6 +4123,8 @@ class SteamService : Service(), IChallengeUrlChanged {
                 )
                 if (sameSession()) SteamCollectionRepository.update(parsed)
                 return
+            } catch (e: CancellationException) {
+                throw e
             } catch (t: Throwable) {
                 val lastAttempt = attempt == maxAttempts - 1
                 Timber.tag("SteamCollections").w(


### PR DESCRIPTION
Some users reported their Steam collections never loading (or sitting on the loading state indefinitely). Two separate causes.

### 1. Release builds stripped a reflection-only constructor
`SteamUnifiedMessages.createService` instantiates `CloudConfigStoreService` reflectively. R8 can't see that call, so in minified builds it dropped the `(SteamUnifiedMessages)` constructor — `createService` then threw `NoSuchMethodException` and the fetch bailed straight to the cached snapshot. Debug builds aren't minified, which is why it never showed up in testing.

Fix: keep the constructor for `UnifiedService` subclasses (the existing `in.dragonbra.javasteam.**` rule covers JavaSteam's own generated services, but not app-side stubs like this one).

### 2. The fetch was one-shot with no retry
Collections are fetched once, at login, right as the whole-library PICS burst goes out. If that reply is starved or dropped, nothing recovered it until the next login — so collections stayed empty/stuck.

Fix: retry with backoff (3s / 8s / 20s, 30s per attempt) and bail cleanly if the account changes mid-flight.

#1 is release-only; #2 can bite any build under load. Verified on a release build — collections populate after login.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Steam collections getting stuck on loading by preserving reflective service constructors in release builds and adding a backoff-based retry that respects cancellation after login.

- **Bug Fixes**
  - Keep constructors for classes extending `in.dragonbra.javasteam.steam.handlers.steamunifiedmessages.UnifiedService` so `SteamUnifiedMessages.createService(CloudConfigStoreService)` works in minified builds.
  - Retry the collections download with backoff (3s, 8s, 20s; 30s timeout/attempt), rethrow `CancellationException`, and drop results if the account/session changes mid-flight.

<sup>Written for commit 4f3821099c32c692636bccc93343db203b8d6cc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading Steam collections during slow or failed network requests.
  * Prevented outdated collection data from replacing current data after logout or account switching by ensuring updates only apply to the active session.
  * Added automatic retries with increasing delays for temporary service failures.
  * Preserved cached collections when refreshed data can’t be retrieved.
* **Chores**
  * Improved release-build compatibility by preserving dynamically created Steam message services from being removed or obfuscated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->