### PR TITLE
Restore controller profile mappings for player 1

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1453,7 +1453,7 @@ fun XServerScreen(
             if (isGamepad) {
                 val winHandler = xServerView!!.getxServer().winHandler
                 val assignedSlot = ControllerManager.getInstance().getSlotForDevice(it.event.device.id)
-                if (assignedSlot >= 0) {
+                if (assignedSlot > 0) {
                     handled = winHandler.onKeyEvent(it.event)
                 } else {
                     winHandler.setCurrentController(it.event.device.id)
@@ -1505,7 +1505,7 @@ fun XServerScreen(
             if (isGamepad && it.event != null) {
                 val winHandler = xServerView!!.getxServer().winHandler
                 val assignedSlot = ControllerManager.getInstance().getSlotForDevice(it.event.device.id)
-                if (assignedSlot >= 0) {
+                if (assignedSlot > 0) {
                     handled = winHandler.onGenericMotionEvent(it.event)
                 } else {
                     winHandler.setCurrentController(it.event.device.id)


### PR DESCRIPTION
## Description
The multicontroller change routed any device with an assigned slot straight to WinHandler's raw XInput passthrough, skipping PhysicalControllerHandler and InputControlsView. Since ControllerManager now auto-assigns every connected controller on hotplug, that applied to single-controller setups too, so custom mapping profiles stopped working entirely.

Gate the passthrough on slot > 0 instead. Player 1 goes back through the profile chain; players 2-4 keep the passthrough path, which is all they can use today anyway since ControlsProfile holds a single shared GamepadState.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.
