### PR TITLE
feat: add default screen size detection and 960p screen size option (e.g. retroid pocket nova)

### DIFF
--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -1,6 +1,10 @@
 package app.gamenative
 
+import android.hardware.display.DisplayManager
+import android.os.Build
 import android.os.StrictMode
+import android.util.DisplayMetrics
+import android.view.Display
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -267,23 +271,21 @@ class PluviaApp : SplitCompatApplication() {
 
         fun getDefaultScreenSize(): String {
             return try {
-                val windowManager = instance.getSystemService(WINDOW_SERVICE) as? android.view.WindowManager
-                if (windowManager != null) {
-                    val width: Int
-                    val height: Int
+                val displayManager = instance.getSystemService(DISPLAY_SERVICE) as? DisplayManager
+                val display = displayManager?.getDisplay(Display.DEFAULT_DISPLAY)
+                if (display != null) {
+                    val width : Int
+                    val height : Int
 
-                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-                        // API 30+ - Use WindowMetrics
-                        val windowMetrics = windowManager.currentWindowMetrics
-                        val bounds = windowMetrics.bounds
-                        width = bounds.width()
-                        height = bounds.height()
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        val mode = display.mode
+                        width = mode.physicalWidth
+                        height = mode.physicalHeight
                     } else {
                         // API < 30 - Use deprecated Display API
+                        val displayMetrics = DisplayMetrics()
                         @Suppress("DEPRECATION")
-                        val displayMetrics = android.util.DisplayMetrics()
-                        @Suppress("DEPRECATION")
-                        windowManager.defaultDisplay.getRealMetrics(displayMetrics)
+                        display.getMetrics(displayMetrics)
                         width = displayMetrics.widthPixels
                         height = displayMetrics.heightPixels
                     }

--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -288,7 +288,7 @@ class PluviaApp : SplitCompatApplication() {
                         // API < 30 - Use deprecated Display API
                         val displayMetrics = DisplayMetrics()
                         @Suppress("DEPRECATION")
-                        display.getMetrics(displayMetrics)
+                        display.getRealMetrics(displayMetrics)
                         width = displayMetrics.widthPixels
                         height = displayMetrics.heightPixels
                     }

--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -205,6 +205,7 @@ class PluviaApp : SplitCompatApplication() {
         internal var onDestinationChangedListener: NavChangedListener? = null
 
         private lateinit var instance: PluviaApp
+        private var cachedDefaultScreenSize: String? = null
 
         // TODO: find a way to make this saveable, this is terrible (leak that memory baby)
         internal var xEnvironment: XEnvironment? = null
@@ -270,6 +271,8 @@ class PluviaApp : SplitCompatApplication() {
         fun isManualSuspendMode(): Boolean = activeSuspendPolicy.equals(Container.SUSPEND_POLICY_MANUAL, ignoreCase = true)
 
         fun getDefaultScreenSize(): String {
+            cachedDefaultScreenSize?.let { return it }
+
             return try {
                 val displayManager = instance.getSystemService(DISPLAY_SERVICE) as? DisplayManager
                 val display = displayManager?.getDisplay(Display.DEFAULT_DISPLAY)
@@ -298,17 +301,23 @@ class PluviaApp : SplitCompatApplication() {
                     // 16:10 = 1.6
                     // 16:9 = 1.77
 
-                    when {
+                    val result = when {
                         aspectRatio < 1.5f -> Container.DEFAULT_SCREEN_SIZE_4_3  // 4:3 aspect ratio devices
                         aspectRatio < 1.7f -> Container.DEFAULT_SCREEN_SIZE_16_10  // 16:10 aspect ratio devices
                         else -> Container.DEFAULT_SCREEN_SIZE_16_9  // 16:9 and wider aspect ratio devices
                     }
+                    cachedDefaultScreenSize = result
+                    result
                 } else {
-                    Container.DEFAULT_SCREEN_SIZE_16_9  // Fallback to default
+                    val fallback = Container.DEFAULT_SCREEN_SIZE_16_9  // Fallback to default
+                    cachedDefaultScreenSize = fallback
+                    fallback
                 }
             } catch (e: Exception) {
                 Timber.e(e, "Failed to get device screen size")
-                Container.DEFAULT_SCREEN_SIZE_16_9  // Fallback to default
+                val fallback = Container.DEFAULT_SCREEN_SIZE_16_9  // Fallback to default
+                cachedDefaultScreenSize = fallback
+                fallback
             }
         }
     }

--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -51,6 +51,7 @@ class PluviaApp : SplitCompatApplication() {
 
     override fun onCreate() {
         super.onCreate()
+        instance = this
 
         preloadSystemLibraries()
 
@@ -199,6 +200,8 @@ class PluviaApp : SplitCompatApplication() {
         val events: EventDispatcher = EventDispatcher()
         internal var onDestinationChangedListener: NavChangedListener? = null
 
+        private lateinit var instance: PluviaApp
+
         // TODO: find a way to make this saveable, this is terrible (leak that memory baby)
         internal var xEnvironment: XEnvironment? = null
         internal var xServerView: XServerRendererView? = null
@@ -262,6 +265,50 @@ class PluviaApp : SplitCompatApplication() {
 
         fun isManualSuspendMode(): Boolean = activeSuspendPolicy.equals(Container.SUSPEND_POLICY_MANUAL, ignoreCase = true)
 
+        fun getDefaultScreenSize(): String {
+            return try {
+                val windowManager = instance.getSystemService(WINDOW_SERVICE) as? android.view.WindowManager
+                if (windowManager != null) {
+                    val width: Int
+                    val height: Int
+
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                        // API 30+ - Use WindowMetrics
+                        val windowMetrics = windowManager.currentWindowMetrics
+                        val bounds = windowMetrics.bounds
+                        width = bounds.width()
+                        height = bounds.height()
+                    } else {
+                        // API < 30 - Use deprecated Display API
+                        @Suppress("DEPRECATION")
+                        val displayMetrics = android.util.DisplayMetrics()
+                        @Suppress("DEPRECATION")
+                        windowManager.defaultDisplay.getRealMetrics(displayMetrics)
+                        width = displayMetrics.widthPixels
+                        height = displayMetrics.heightPixels
+                    }
+
+                    // Calculate aspect ratio (always use landscape orientation for calculation)
+                    val aspectRatio = maxOf(width, height).toFloat() / minOf(width, height).toFloat()
+
+                    // Aspect ratio thresholds:
+                    // 4:3 = 1.33
+                    // 16:10 = 1.6
+                    // 16:9 = 1.77
+
+                    when {
+                        aspectRatio < 1.5f -> Container.DEFAULT_SCREEN_SIZE_4_3  // 4:3 aspect ratio devices
+                        aspectRatio < 1.7f -> Container.DEFAULT_SCREEN_SIZE_16_10  // 16:10 aspect ratio devices
+                        else -> Container.DEFAULT_SCREEN_SIZE_16_9  // 16:9 and wider aspect ratio devices
+                    }
+                } else {
+                    Container.DEFAULT_SCREEN_SIZE_16_9  // Fallback to default
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to get device screen size")
+                Container.DEFAULT_SCREEN_SIZE_16_9  // Fallback to default
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -166,7 +166,7 @@ object PrefManager {
     /* Container Default Settings */
     private val SCREEN_SIZE = stringPreferencesKey("screen_size")
     var screenSize: String
-        get() = getPref(SCREEN_SIZE, Container.DEFAULT_SCREEN_SIZE)
+        get() = getPref(SCREEN_SIZE, PluviaApp.getDefaultScreenSize())
         set(value) {
             setPref(SCREEN_SIZE, value)
         }

--- a/app/src/main/java/app/gamenative/ui/data/XServerState.kt
+++ b/app/src/main/java/app/gamenative/ui/data/XServerState.kt
@@ -1,6 +1,7 @@
 package app.gamenative.ui.data
 
 import androidx.compose.runtime.saveable.mapSaver
+import app.gamenative.PluviaApp
 import com.winlator.container.Container
 import com.winlator.core.DXVKHelper
 import com.winlator.core.KeyValueSet
@@ -10,7 +11,7 @@ data class XServerState(
     var winStarted: Boolean = false,
     val dxwrapper: String = Container.DEFAULT_DXWRAPPER,
     val dxwrapperConfig: KeyValueSet? = null,
-    val screenSize: String = Container.DEFAULT_SCREEN_SIZE,
+    val screenSize: String = PluviaApp.getDefaultScreenSize(),
     val wineInfo: WineInfo = WineInfo.MAIN_WINE_VERSION,
     val graphicsDriver: String = Container.DEFAULT_GRAPHICS_DRIVER,
     val graphicsDriverVersion: String = "",

--- a/app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt
+++ b/app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt
@@ -260,7 +260,7 @@ object IntentLaunchManager {
 
         return ContainerData(
             name = override.name.ifEmpty { base.name },
-            screenSize = if (override.screenSize != PluviaApp.getDefaultScreenSize()) {
+            screenSize = if (override.screenSize != base.screenSize) {
                 override.screenSize
             } else {
                 base.screenSize

--- a/app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt
+++ b/app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt
@@ -2,6 +2,7 @@ package app.gamenative.utils
 
 import android.content.Context
 import android.content.Intent
+import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
 import app.gamenative.data.GameSource
 import com.winlator.container.Container
@@ -189,7 +190,7 @@ object IntentLaunchManager {
         // Only include non-default values to avoid overriding existing container settings
         val config = ContainerData(
             name = if (json.has("name")) json.getString("name") else "",
-            screenSize = if (json.has("screenSize")) json.getString("screenSize") else Container.DEFAULT_SCREEN_SIZE,
+            screenSize = if (json.has("screenSize")) json.getString("screenSize") else PluviaApp.getDefaultScreenSize(),
             envVars = if (json.has("envVars")) json.getString("envVars") else Container.DEFAULT_ENV_VARS,
             graphicsDriver = if (json.has("graphicsDriver")) json.getString("graphicsDriver") else Container.DEFAULT_GRAPHICS_DRIVER,
             graphicsDriverVersion = if (json.has("graphicsDriverVersion")) json.getString("graphicsDriverVersion") else "",
@@ -259,7 +260,7 @@ object IntentLaunchManager {
 
         return ContainerData(
             name = override.name.ifEmpty { base.name },
-            screenSize = if (override.screenSize != Container.DEFAULT_SCREEN_SIZE) {
+            screenSize = if (override.screenSize != PluviaApp.getDefaultScreenSize()) {
                 override.screenSize
             } else {
                 base.screenSize

--- a/app/src/main/java/com/winlator/container/Container.java
+++ b/app/src/main/java/com/winlator/container/Container.java
@@ -36,7 +36,9 @@ public class Container {
     public static final String DEFAULT_EXTERNAL_DISPLAY_MODE = EXTERNAL_DISPLAY_MODE_OFF;
 
     public static final String DEFAULT_ENV_VARS = "WRAPPER_MAX_IMAGE_COUNT=0 ZINK_DESCRIPTORS=lazy ZINK_DEBUG=compact,deck_emu MESA_SHADER_CACHE_DISABLE=false MESA_SHADER_CACHE_MAX_SIZE=512MB mesa_glthread=true WINEESYNC=1 MESA_VK_WSI_PRESENT_MODE=mailbox TU_DEBUG=noconform VKD3D_SHADER_MODEL=6_0 PULSE_LATENCY_MSEC=144";
-    public static final String DEFAULT_SCREEN_SIZE = "1280x720";
+    public static final String DEFAULT_SCREEN_SIZE_16_9 = "1280x720";
+    public static final String DEFAULT_SCREEN_SIZE_16_10 = "1280x800";
+    public static final String DEFAULT_SCREEN_SIZE_4_3 = "1280x960";
     public static final String DEFAULT_GRAPHICS_DRIVER = DefaultVersion.DEFAULT_GRAPHICS_DRIVER;
     public static final String DEFAULT_AUDIO_DRIVER = "pulseaudio";
     public static final String DEFAULT_EMULATOR = "FEXCore";
@@ -75,7 +77,7 @@ public class Container {
     public static final byte MAX_DRIVE_LETTERS = 8;
     public final String id;
     private String name;
-    private String screenSize = DEFAULT_SCREEN_SIZE;
+    private String screenSize = DEFAULT_SCREEN_SIZE_16_9;
     private String envVars = DEFAULT_ENV_VARS;
     private String graphicsDriver = DEFAULT_GRAPHICS_DRIVER;
     private String dxwrapper = DEFAULT_DXWRAPPER;

--- a/app/src/main/java/com/winlator/container/ContainerData.kt
+++ b/app/src/main/java/com/winlator/container/ContainerData.kt
@@ -1,6 +1,7 @@
 package com.winlator.container
 
 import androidx.compose.runtime.saveable.mapSaver
+import app.gamenative.PluviaApp
 import com.winlator.box86_64.Box86_64Preset
 import com.winlator.core.DefaultVersion
 import com.winlator.core.WineInfo
@@ -11,7 +12,7 @@ import kotlin.String
 
 data class ContainerData(
     val name: String = "",
-    val screenSize: String = Container.DEFAULT_SCREEN_SIZE,
+    val screenSize: String = PluviaApp.getDefaultScreenSize(),
     val envVars: String = Container.DEFAULT_ENV_VARS,
     val graphicsDriver: String = Container.DEFAULT_GRAPHICS_DRIVER,
     val graphicsDriverVersion: String = "",

--- a/app/src/main/java/com/winlator/container/ContainerManager.java
+++ b/app/src/main/java/com/winlator/container/ContainerManager.java
@@ -98,7 +98,7 @@ public class ContainerManager {
     public Future<Container> createDefaultContainerFuture(WineInfo wineInfo, String containerId) {
         String name = "container_" + containerId;
         Log.d("XServerScreen", "Creating container $name");
-        String screenSize = Container.DEFAULT_SCREEN_SIZE;
+        String screenSize = Container.DEFAULT_SCREEN_SIZE_16_9;
         String envVars = Container.DEFAULT_ENV_VARS;
         String graphicsDriver = Container.DEFAULT_GRAPHICS_DRIVER;
         String dxwrapper = Container.DEFAULT_DXWRAPPER;

--- a/app/src/main/java/com/winlator/container/ContainerManager.java
+++ b/app/src/main/java/com/winlator/container/ContainerManager.java
@@ -95,52 +95,6 @@ public class ContainerManager {
     public Future<Container> createContainerFuture(String containerId, final JSONObject data) {
         return Executors.newSingleThreadExecutor().submit(() -> createContainer(containerId, data));
     }
-    public Future<Container> createDefaultContainerFuture(WineInfo wineInfo, String containerId) {
-        String name = "container_" + containerId;
-        Log.d("XServerScreen", "Creating container $name");
-        String screenSize = Container.DEFAULT_SCREEN_SIZE_16_9;
-        String envVars = Container.DEFAULT_ENV_VARS;
-        String graphicsDriver = Container.DEFAULT_GRAPHICS_DRIVER;
-        String dxwrapper = Container.DEFAULT_DXWRAPPER;
-        String dxwrapperConfig = "";
-        String audioDriver = Container.DEFAULT_AUDIO_DRIVER;
-        String wincomponents = Container.DEFAULT_WINCOMPONENTS;
-        String drives = "";
-        Boolean showFPS = false;
-        String cpuList = Container.getFallbackCPUList();
-        String cpuListWoW64 = Container.getFallbackCPUListWoW64();
-        Boolean wow64Mode = WineInfo.isMainWineVersion(wineInfo.identifier());
-        // Boolean wow64Mode = false;
-        Byte startupSelection = Container.STARTUP_SELECTION_ESSENTIAL;
-        String box86Preset = Box86_64Preset.COMPATIBILITY;
-        String box64Preset = Box86_64Preset.COMPATIBILITY;
-        String desktopTheme = WineThemeManager.DEFAULT_DESKTOP_THEME;
-
-        JSONObject data = new JSONObject();
-        try {
-            data.put("name", name);
-            data.put("screenSize", screenSize);
-            data.put("envVars", envVars);
-            data.put("cpuList", cpuList);
-            data.put("cpuListWoW64", cpuListWoW64);
-            data.put("graphicsDriver", graphicsDriver);
-            data.put("dxwrapper", dxwrapper);
-            data.put("dxwrapperConfig", dxwrapperConfig);
-            data.put("audioDriver", audioDriver);
-            data.put("wincomponents", wincomponents);
-            data.put("drives", drives);
-            data.put("showFPS", showFPS);
-            data.put("wow64Mode", wow64Mode);
-            data.put("startupSelection", startupSelection);
-            data.put("box86Preset", box86Preset);
-            data.put("box64Preset", box64Preset);
-            data.put("desktopTheme", desktopTheme);
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        }
-
-        return createContainerFuture(containerId, data);
-    }
 
     public void duplicateContainerAsync(Container container, Runnable callback) {
         final Handler handler = new Handler();

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -10,6 +10,7 @@
         <item>1024x768 (4:3)</item>
         <item>1280x720 (16:9)</item>
         <item>1280x800 (16:10)</item>
+        <item>1280x960 (4:3)</item>
         <item>1280x1024 (5:4)</item>
         <item>1366x768 (16:9)</item>
         <item>1440x900 (16:10)</item>


### PR DESCRIPTION
## Description
feat: add 960p default screen size (e.g. retroid pocket nova)

## Recording
<img width="1280" height="960" alt="Screenshot_20260717_120030" src="https://github.com/user-attachments/assets/e5339eb5-ec82-47bb-b649-2b045c2d53a0" />


## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 1280x960 (4:3) and auto-detect the default screen size via `DisplayManager` with a `getRealMetrics` fallback and caching. Apply the detected aspect ratio to defaults for preferences, new containers, XServer state, imports, and launches (4:3, 16:10, or 16:9; 16:9 fallback), and fix config merging so screen-size overrides are respected — improving support for 960p handhelds like the Retroid Pocket Nova.

- **Refactors**
  - Removed unused `createDefaultContainerFuture` in `ContainerManager`.

<sup>Written for commit 425e8d1bd1f0019b17ae4e4b3a03f733a78c1771. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added **1280×960 (4:3)** as a selectable screen resolution option.

* **Improved Defaults**
  * Default screen-size is now chosen automatically based on the device’s display characteristics, selecting the closest aspect ratio (**16:9**, **16:10**, or **4:3**).
  * This improved default is applied consistently across new containers, saved settings, and configuration parsing, with a safe fallback when display details can’t be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->