### PR TITLE
Fix GOG cloud saves for Galaxy SDK games (e.g. Tainted Grail)

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGCloudSavesManager.kt
@@ -516,8 +516,10 @@ class GOGCloudSavesManager(
 
             Timber.tag("GOG").d("[Cloud Saves]   Examining item $i: name='$name', dirname='$dirname'")
 
-            if (name.isNotEmpty() && hash.isNotEmpty() && name.startsWith("$dirname/")) {
-                val relativePath = name.removePrefix("$dirname/")
+            // Empty dirname (Galaxy SDK fallback) => no namespace prefix; every object is ours.
+            val matchesDir = dirname.isEmpty() || name.startsWith("$dirname/")
+            if (name.isNotEmpty() && hash.isNotEmpty() && matchesDir) {
+                val relativePath = if (dirname.isEmpty()) name else name.removePrefix("$dirname/")
                 files.add(
                     CloudFile(
                         relativePath = relativePath,
@@ -559,7 +561,8 @@ class GOGCloudSavesManager(
 
             Timber.tag("GOG-CloudSaves").i("Uploading: ${file.relativePath} (${fileSize} bytes)")
 
-            val url = "$CLOUD_STORAGE_BASE_URL/v1/$userId/$clientId/$dirname/${file.relativePath}"
+            val objectPath = if (dirname.isEmpty()) file.relativePath else "$dirname/${file.relativePath}"
+            val url = "$CLOUD_STORAGE_BASE_URL/v1/$userId/$clientId/$objectPath"
 
             // GOG stores saves gzip-compressed. Match the Galaxy/gogdl protocol: send the gzipped
             // bytes with Content-Encoding: gzip and an Etag of the compressed MD5, otherwise other
@@ -615,7 +618,8 @@ class GOGCloudSavesManager(
         try {
             Timber.tag("GOG-CloudSaves").i("Downloading: ${file.relativePath}")
 
-            val url = "$CLOUD_STORAGE_BASE_URL/v1/$userId/$clientId/$dirname/${file.relativePath}"
+            val objectPath = if (dirname.isEmpty()) file.relativePath else "$dirname/${file.relativePath}"
+            val url = "$CLOUD_STORAGE_BASE_URL/v1/$userId/$clientId/$objectPath"
 
             val request = Request.Builder()
                 .url(url)

--- a/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
@@ -1043,8 +1043,16 @@ class GOGManager @Inject constructor(
 
                 val locationsArray = cloudStorage.optJSONArray("locations")
                 if (locationsArray == null || locationsArray.length() == 0) {
-                    Timber.tag("GOG").d("[Cloud Saves] No save locations configured for game $gameId")
-                    return@withContext null
+                    // Cloud is enabled but GOG declares no filesystem locations: the game syncs saves
+                    // through the Galaxy SDK IStorage API, which mirrors them to a fixed local path.
+                    // gogdl/Heroic skip these games; fall back to that path and let the existing sync
+                    // (conflict prompt included) run. Empty name => list the whole bucket unfiltered.
+                    Timber.tag("GOG").i("[Cloud Saves] Enabled with no locations for game $gameId — using Galaxy SDK storage fallback")
+                    val fallback = GOGCloudSavesLocationTemplate(
+                        "",
+                        "%LOCALAPPDATA%/GOG.com/Galaxy/Applications/$clientId/Storage/Shared/Files",
+                    )
+                    return@withContext Triple(clientId, clientSecret, listOf(fallback))
                 }
                 Timber.tag("GOG").d("[Cloud Saves] Found ${locationsArray.length()} location(s) in config")
 

--- a/app/src/test/java/app/gamenative/service/gog/GOGCloudSavesManagerTest.kt
+++ b/app/src/test/java/app/gamenative/service/gog/GOGCloudSavesManagerTest.kt
@@ -53,6 +53,37 @@ class GOGCloudSavesManagerTest {
         assertEquals(1_775_162_040L, files.single().updateTimestamp)
     }
 
+    @Test
+    fun parseCloudFilesResponse_empty_dirname_returns_all_files_without_prefix_stripping() {
+        // Galaxy SDK fallback (e.g. Tainted Grail): remote-config declares no locations, so the
+        // fallback location syncs with an empty dirname — the whole bucket is ours and each object
+        // name is already the path relative to Storage/Shared/Files, with no namespace prefix.
+        val files = manager.parseCloudFilesResponse(
+            """
+            [
+              {
+                "name": "Saved/AutoSave_0/Gameplay.data",
+                "hash": "abc123",
+                "last_modified": "2026-04-02T20:34:00.123456+00:00"
+              },
+              {
+                "name": "Saved/PlayerPrefs.data",
+                "hash": "def456",
+                "last_modified": "2026-04-02T21:00:00+00:00"
+              }
+            ]
+            """.trimIndent(),
+            "",
+        )
+
+        assertNotNull(files)
+        assertEquals(2, files!!.size)
+        assertEquals(
+            setOf("Saved/AutoSave_0/Gameplay.data", "Saved/PlayerPrefs.data"),
+            files.map { it.relativePath }.toSet(),
+        )
+    }
+
     // Helper to access private classifyFiles method
     private fun classifyFiles(
         localFiles: List<GOGCloudSavesManager.SyncFile>,


### PR DESCRIPTION
## Problem

GOG games that sync saves through the Galaxy SDK `IStorage` API (e.g. Tainted Grail: The Fall of Avalon) report cloud saves as `enabled` in remote-config but return an **empty `locations` array** — GOG does not declare a filesystem path because the running game/Galaxy client handles it. As a result `getSaveDirectoryPath` returned `null`, pre-launch sync logged "cloud saves not supported", and nothing ever synced. gogdl and Heroic skip these games for the same reason.

## Fix

When cloud storage is `enabled` but no `locations` are declared, fall back to the fixed Galaxy storage path:

```
%LOCALAPPDATA%/GOG.com/Galaxy/Applications/<clientId>/Storage/Shared/Files
```

and sync it with an **empty dirname**, so the whole cloud bucket is listed unfiltered and each object name maps directly onto a file under that path (no namespace prefix). The existing conflict-prompt and timestamp classification are untouched, so a populated cloud still prompts before overwriting local saves.

Only games with empty `locations` take this path; location-based games are unchanged.

## Verification

Tested on-device (Odin 3) with Tainted Grail:
- Fallback triggers, resolves the real `Storage/Shared/Files` path, lists the (empty) bucket, and uploads all four save files.
- Confirmed against GOG's REST API that the bucket is populated with objects named `Saved/PlayerPrefs.data`, `Saved/AutoSave_0/{Gameplay,MetaData,Prologue_Jail}.data` — i.e. relative to `Shared/Files` with no prefix, matching what the empty-dirname path expects.
- Added a unit test covering the empty-dirname listing (`parseCloudFilesResponse` returns all objects with nested paths intact, no prefix stripping).

Desktop-to-device download (the end user's goal) shares the same object naming and should work symmetrically; that direction still wants confirmation against a bucket populated by desktop Galaxy.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables cloud save sync for GOG games that use the Galaxy SDK `IStorage` API (e.g., Tainted Grail). When cloud is enabled but `locations` is empty, we fall back to the Galaxy storage path and sync the whole bucket.

- **Bug Fixes**
  - Fallback to `%LOCALAPPDATA%/GOG.com/Galaxy/Applications/<clientId>/Storage/Shared/Files` with an empty dirname.
  - Adjust list/upload/download to handle empty dirname (no prefix; build `objectPath` accordingly).
  - Only applies when `locations` is empty; location-based games unchanged.
  - Add unit test to verify empty-dirname parsing returns all objects unmodified.

<sup>Written for commit fd605e79e9e803bf5091bdb3f26a207ca84c47e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GOG cloud-save handling when no directory namespace is provided.
  * Corrected cloud-save uploads and downloads to use the proper storage paths.
  * Added a fallback save location when cloud saves are enabled but no locations are configured.
  * Preserved complete file paths when processing cloud-save listings without a namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->