### PR TITLE
Update build descriptions and compatibility mode string

### DIFF
--- a/.github/workflows/app-release-signed.yml
+++ b/.github/workflows/app-release-signed.yml
@@ -180,5 +180,5 @@ jobs:
           --arg modern "$MODERN_URL" \
           --arg legacyXr "$LEGACY_XR_URL" \
           --arg changes "$CHANGELOG" \
-          '{content: "**New Android build**\nStandard Build (Recommended): \($legacy)\nPlay Store Build (Android 11+ — built for the latest Android, so **no security warning** about an outdated target. No D drive access and no custom game support; glibc not supported, external storage location moved.): \($modern)\nQuest/VR Build (sideload only — legacy storage with all-files access and D drive support, forced landscape): \($legacyXr)\n\nChanges:\n\($changes)"}')
+          '{content: "**New Android build**\nRegular Build (Recommended): \($legacy)\nModern Build (Play Store, features stripped): \($modern)\nXR Build (for Quest): \($legacyXr)\n\nChanges:\n\($changes)"}')
         curl -H 'Content-Type: application/json' -d "$payload" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -73,12 +73,11 @@ jobs:
           yes | "$SDKMANAGER" --install "build-tools;34.0.0"
 
       - name: Build with Gradle
-        run: ./gradlew :app:bundleLegacyRelease :app:bundleModernRelease :app:bundleLegacyXrRelease
+        run: ./gradlew :app:bundleLegacyRelease :app:bundleLegacyXrRelease
 
       - name: Stage bundles
         run: |
           cp app/build/outputs/bundle/legacyRelease/app-legacy-release.aab app-release.aab
-          cp app/build/outputs/bundle/modernRelease/app-modern-release.aab app-modern-release.aab
           cp app/build/outputs/bundle/legacyXrRelease/app-legacyXr-release.aab app-legacy-xr-release.aab
 
       - name: Extract APKs from Bundles
@@ -88,11 +87,6 @@ jobs:
             --output=app-release.apks \
             --mode=universal
           unzip -o app-release.apks universal.apk
-          java -jar tools/bundletool-all-1.17.2.jar build-apks \
-            --bundle=app-modern-release.aab \
-            --output=app-modern-release.apks \
-            --mode=universal
-          unzip -p app-modern-release.apks universal.apk > universal-modern.apk
           java -jar tools/bundletool-all-1.17.2.jar build-apks \
             --bundle=app-legacy-xr-release.aab \
             --output=app-legacy-xr-release.apks \
@@ -117,7 +111,7 @@ jobs:
           if [ ! -d "$BUILD_TOOLS_DIR" ]; then
             BUILD_TOOLS_DIR="${ANDROID_SDK_ROOT}/build-tools/34.0.0"
           fi
-          for apk in universal.apk universal-modern.apk universal-legacy-xr.apk; do
+          for apk in universal.apk universal-legacy-xr.apk; do
             "${BUILD_TOOLS_DIR}/apksigner" sign \
               --lineage app/keystores/prod-debug.lineage \
               --ks app/keystores/keystore \
@@ -139,7 +133,6 @@ jobs:
           name: universal-apk
           path: |
             universal.apk
-            universal-modern.apk
             universal-legacy-xr.apk
 
   release:
@@ -157,7 +150,6 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           mv universal.apk "gamenative-$TAG.apk"
-          mv universal-modern.apk "gamenative-$TAG-modern.apk"
           mv universal-legacy-xr.apk "gamenative-$TAG-legacy-xr.apk"
 
       - name: Create GitHub Release
@@ -170,12 +162,10 @@ jobs:
           append_body: true
           body: |
             ## Downloads
-            - **`gamenative-${{ github.ref_name }}.apk`** — Standard build (Android 8–14). Recommended for most users.
-            - **`gamenative-${{ github.ref_name }}-modern.apk`** — Play Store build (Android 11+). Built for the latest Android, so **no security warning** about an outdated target. No D drive access and no custom game support; glibc not supported, external storage location moved.
-            - **`gamenative-${{ github.ref_name }}-legacy-xr.apk`** — Quest/VR sideload build. Legacy storage with all-files access and D drive support, forced landscape. Sideload only (not for the store).
+            - **`gamenative-${{ github.ref_name }}.apk`** — Standard build. Recommended for most users.
+            - **`gamenative-${{ github.ref_name }}-legacy-xr.apk`** — XR build for Quest headsets.
           files: |
             gamenative-${{ github.ref_name }}.apk
-            gamenative-${{ github.ref_name }}-modern.apk
             gamenative-${{ github.ref_name }}-legacy-xr.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -536,7 +536,7 @@
     <string name="dx_wrapper">DX-wrapper</string>
     <string name="display_renderer">Display-renderer</string>
     <string name="sf_compat_mode">Kompatibilitetstilstand</string>
-    <string name="sf_compat_mode_description">Slå fra for bedre ydeevne. Lad være tændt for at rette omvendte farver.</string>
+    <string name="sf_compat_mode_description">Slå fra for bedre ydeevne. Lad være tændt for at rette omvendte farver og forhindre nedbrud.</string>
     <string name="vkd3d_feature_level">VKD3D Feature Level</string>
     <string name="use_dri3">Brug DRI3</string>
     <string name="use_dri3_description">Deaktivering kan løse grafiske fejl på nogle enheder</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -676,7 +676,7 @@
     <string name="dx_wrapper">DX-Wrapper</string>
     <string name="display_renderer">Display-Renderer</string>
     <string name="sf_compat_mode">Kompatibilitätsmodus</string>
-    <string name="sf_compat_mode_description">Zum Verbessern der Leistung ausschalten. Eingeschaltet lassen, um invertierte Farben zu korrigieren.</string>
+    <string name="sf_compat_mode_description">Zum Verbessern der Leistung ausschalten. Eingeschaltet lassen, um invertierte Farben zu korrigieren und Abstürze zu verhindern.</string>
     <string name="vkd3d_feature_level">VKD3D-Featurelevel</string>
     <string name="use_dri3">DRI3 verwenden</string>
     <string name="use_dri3_description">Deaktivieren kann Grafikprobleme auf manchen Geräten beheben</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -745,7 +745,7 @@
     <string name="dx_wrapper">Wrapper de DX</string>
     <string name="display_renderer">Renderizador de pantalla</string>
     <string name="sf_compat_mode">Modo de compatibilidad</string>
-    <string name="sf_compat_mode_description">Desactívalo para mejorar el rendimiento. Mantenlo activado para corregir los colores invertidos.</string>
+    <string name="sf_compat_mode_description">Desactívalo para mejorar el rendimiento. Mantenlo activado para corregir los colores invertidos y evitar cierres inesperados.</string>
     <string name="vkd3d_feature_level">Feature Level de VKD3D</string>
     <string name="use_dri3">Usar DRI3</string>
     <string name="use_dri3_description">Desactivarlo puede corregir fallos gráficos en algunos dispositivos.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -700,7 +700,7 @@
     <string name="dx_wrapper">Wrapper DX</string>
     <string name="display_renderer">Rendu d\'affichage</string>
     <string name="sf_compat_mode">Mode de compatibilité</string>
-    <string name="sf_compat_mode_description">Désactivez pour de meilleures performances. Gardez activé pour corriger les couleurs inversées.</string>
+    <string name="sf_compat_mode_description">Désactivez pour de meilleures performances. Gardez activé pour corriger les couleurs inversées et éviter les plantages.</string>
     <string name="vkd3d_feature_level">Niveau de fonctionnalité VKD3D</string>
     <string name="use_dri3">Utiliser DRI3</string>
     <string name="use_dri3_description">Désactiver peut corriger les problèmes graphiques sur certains appareils</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -700,7 +700,7 @@
     <string name="dx_wrapper">Wrapper DX</string>
     <string name="display_renderer">Display Renderer</string>
     <string name="sf_compat_mode">Modalità compatibilità</string>
-    <string name="sf_compat_mode_description">Disattiva per prestazioni migliori. Mantieni attivo per correggere i colori invertiti.</string>
+    <string name="sf_compat_mode_description">Disattiva per prestazioni migliori. Mantieni attivo per correggere i colori invertiti e prevenire arresti anomali.</string>
     <string name="vkd3d_feature_level">Livello Funzionalità VKD3D</string>
     <string name="use_dri3">Usa DRI3</string>
     <string name="use_dri3_description">Disabilitare può correggere glitch grafici su alcuni dispositivi</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -710,7 +710,7 @@
     <string name="dx_wrapper">DXラッパー</string>
     <string name="display_renderer">ディスプレイレンダラー</string>
     <string name="sf_compat_mode">互換モード</string>
-    <string name="sf_compat_mode_description">オフにするとパフォーマンスが向上します。色の反転を修正するにはオンのままにします。</string>
+    <string name="sf_compat_mode_description">オフにするとパフォーマンスが向上します。色の反転を修正し、クラッシュを防ぐにはオンのままにします。</string>
     <string name="vkd3d_feature_level">VKD3D 機能レベル</string>
     <string name="use_dri3">DRI3 を使用する</string>
     <string name="use_dri3_description">無効にすると、一部のデバイスでのグラフィックの不具合が修正される場合があります</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -704,7 +704,7 @@
     <string name="dx_wrapper">DX Wrapper</string>
     <string name="display_renderer">디스플레이 렌더러</string>
     <string name="sf_compat_mode">호환 모드</string>
-    <string name="sf_compat_mode_description">성능 향상을 위해 끄세요. 색상 반전을 수정하려면 켜 두세요.</string>
+    <string name="sf_compat_mode_description">성능 향상을 위해 끄세요. 색상 반전을 수정하고 충돌을 방지하려면 켜 두세요.</string>
     <string name="vkd3d_feature_level">VKD3D 기능 수준</string>
     <string name="use_dri3">DRI3 사용</string>
     <string name="use_dri3_description">비활성화하면 일부 장치에서 그래픽 결함이 수정될 수 있습니다</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -709,7 +709,7 @@
     <string name="dx_wrapper">Wrapper DX</string>
     <string name="display_renderer">Renderer wyświetlania</string>
     <string name="sf_compat_mode">Tryb zgodności</string>
-    <string name="sf_compat_mode_description">Wyłącz dla lepszej wydajności. Włącz, aby naprawić odwrócone kolory.</string>
+    <string name="sf_compat_mode_description">Wyłącz dla lepszej wydajności. Włącz, aby naprawić odwrócone kolory i zapobiec awariom.</string>
     <string name="vkd3d_feature_level">Poziom funkcji VKD3D</string>
     <string name="use_dri3">Użyj DRI3</string>
     <string name="use_dri3_description">Wyłączenie może naprawić błędy graficzne na niektórych urządzeniach</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -536,7 +536,7 @@
     <string name="dx_wrapper">DX Wrapper</string>
     <string name="display_renderer">Renderizador da Tela</string>
     <string name="sf_compat_mode">Modo de Compatibilidade</string>
-    <string name="sf_compat_mode_description">Desative para melhor desempenho. Mantenha ativado para corrigir cores invertidas.</string>
+    <string name="sf_compat_mode_description">Desative para melhor desempenho. Mantenha ativado para corrigir cores invertidas e evitar travamentos.</string>
     <string name="vkd3d_feature_level">Nível de recurso do VKD3D</string>
     <string name="use_dri3">Usar DRI3</string>
     <string name="use_dri3_description">Desabilitar pode corrigir glitches gráficos em alguns dispositivos</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -701,7 +701,7 @@
 	<string name="dx_wrapper">Wrapper DX</string>
     <string name="display_renderer">Renderer de afișaj</string>
     <string name="sf_compat_mode">Mod de compatibilitate</string>
-    <string name="sf_compat_mode_description">Dezactivează pentru performanță mai bună. Lasă activat pentru a corecta culorile inversate.</string>
+    <string name="sf_compat_mode_description">Dezactivează pentru performanță mai bună. Lasă activat pentru a corecta culorile inversate și a preveni blocările.</string>
 	<string name="vkd3d_feature_level">Nivel funcțional VKD3D</string>
 	<string name="use_dri3">Folosește DRI3</string>
 	<string name="use_dri3_description">Dezactivarea poate rezolva artefacte grafice pe unele dispozitive</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -337,7 +337,7 @@
     <string name="dx_wrapper">DX обёртка</string>
     <string name="display_renderer">Рендерер отображения</string>
     <string name="sf_compat_mode">Режим совместимости</string>
-    <string name="sf_compat_mode_description">Отключите для повышения производительности. Включите, чтобы исправить инвертированные цвета.</string>
+    <string name="sf_compat_mode_description">Отключите для повышения производительности. Включите, чтобы исправить инвертированные цвета и предотвратить сбои.</string>
     <string name="dxvk_version">Версия DXVK</string>
     <string name="edit">Редактировать</string>
     <string name="edit_controls">Редактировать экранный контроллер</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -695,7 +695,7 @@
     <string name="dx_wrapper">DX Wrapper</string>
     <string name="display_renderer">Рендерер відображення</string>
     <string name="sf_compat_mode">Режим сумісності</string>
-    <string name="sf_compat_mode_description">Вимкніть для кращої продуктивності. Увімкніть, щоб виправити інвертовані кольори.</string>
+    <string name="sf_compat_mode_description">Вимкніть для кращої продуктивності. Увімкніть, щоб виправити інвертовані кольори та запобігти збоям.</string>
     <string name="vkd3d_feature_level">Рівень функцій VKD3D</string>
     <string name="use_dri3">Використовувати DRI3</string>
     <string name="use_dri3_description">Вимкнення параметра може виправити графічні проблеми на деяких пристроях</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -685,7 +685,7 @@
     <string name="image_cache_size">图像缓存大小</string>
     <string name="dx_wrapper">DX 封装器</string>
     <string name="sf_compat_mode">兼容模式</string>
-    <string name="sf_compat_mode_description">关闭以提升性能。开启以修正颜色反转。</string>
+    <string name="sf_compat_mode_description">关闭以提升性能。开启以修正颜色反转并防止崩溃。</string>
     <string name="vkd3d_feature_level">VKD3D 功能级别</string>
     <string name="use_dri3">使用 DRI3</string>
     <string name="use_dri3_description">在某些设备上禁用此功能或许能修复图形故障</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -687,7 +687,7 @@
     <string name="image_cache_size">圖像快取大小</string>
     <string name="dx_wrapper">DX Wrapper</string>
     <string name="sf_compat_mode">相容模式</string>
-    <string name="sf_compat_mode_description">關閉以提升效能。開啟以修正顏色反轉。</string>
+    <string name="sf_compat_mode_description">關閉以提升效能。開啟以修正顏色反轉並防止當機。</string>
     <string name="vkd3d_feature_level">VKD3D Feature Level</string>
     <string name="use_dri3">使用 DRI3</string>
     <string name="use_dri3_description">在某些裝置上停用此功能或許能修復圖形故障</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -824,7 +824,7 @@
     <string name="dx_wrapper">DX Wrapper</string>
     <string name="display_renderer">Display Renderer</string>
     <string name="sf_compat_mode">Compatibility Mode</string>
-    <string name="sf_compat_mode_description">Turn off for better performance. Keep on to fix inverted colors.</string>
+    <string name="sf_compat_mode_description">Turn off for better performance. Keep on to fix inverted colors and prevent crashes.</string>
     <string name="vkd3d_feature_level">VKD3D Feature Level</string>
     <string name="use_dri3">Use DRI3</string>
     <string name="use_dri3_description">Disabling may fix graphical glitches on some devices</string>


### PR DESCRIPTION
## Description
Three string/build-metadata cleanups:

- The Compatibility Mode toggle description said keeping it on only fixes inverted colors — it also prevents crashes. Updated the English string and all 14 translations to say so.
- Tagged releases no longer build or publish the modern APK. The release notes previously described the XR build as having "all-files access and D drive support", implying the standard build lacked those; the notes are now just "Standard build (recommended)" and "XR build for Quest headsets".
- The nightly Discord message had overly long build descriptions — now just Regular (Recommended), Modern (Play Store, features stripped), and XR (for Quest).

## Recording
N/A — text/CI changes only.

## Type of Change
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the Compatibility Mode toggle to note it also prevents crashes, updated in English and all 14 translated locales. Simplifies release outputs and messaging: tagged releases no longer include the modern build, release notes now list “Standard build (recommended)” and “XR build for Quest headsets,” and nightly Discord labels are shortened to “Regular (Recommended),” “Modern (Play Store, features stripped),” and “XR (for Quest).”

<sup>Written for commit dde46e085e2c44cb263d698e93f5b6b328f4d291. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Updates**
  - Tagged releases now provide standard and legacy XR APKs; the modern APK is no longer included.
  - Release notifications use shorter, clearer build labels.

- **Documentation**
  - Updated compatibility mode guidance across supported languages to explain that enabling it can correct inverted colors and help prevent crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->