### PR TITLE
Install missing Proton build for custom games at launch

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1664,28 +1664,27 @@ fun preLaunchApp(
             }
         }
 
-        // download any manifest components (wine/proton, dxvk, etc.) missing from config
-        if (ContainerUtils.supportsKnownConfigAutoApply(gameSource)) {
-            try {
-                val configJson = Json.parseToJsonElement(container.containerJson).jsonObject
-                val missingRequests = BestConfigService.resolveMissingManifestInstallRequests(
-                    context, configJson, "exact_gpu_match",
-                )
-                for (request in missingRequests) {
-                    setLoadingMessage(context.getString(R.string.main_downloading_entry, request.entry.name))
-                    try {
-                        ManifestInstaller.installManifestEntry(
-                            context, request.entry, request.isDriver, request.contentType,
-                        ) { progress -> setLoadingProgress(progress.coerceIn(0f, 1f)) }
-                    } catch (e: Exception) {
-                        Timber.e(e, "Failed to install ${request.entry.name}, continuing")
-                    }
+        // download any manifest components (wine/proton, dxvk, etc.) the container's config
+        // references but that aren't installed yet — all sources, including custom games
+        try {
+            val configJson = Json.parseToJsonElement(container.containerJson).jsonObject
+            val missingRequests = BestConfigService.resolveMissingManifestInstallRequests(
+                context, configJson, "exact_gpu_match",
+            )
+            for (request in missingRequests) {
+                setLoadingMessage(context.getString(R.string.main_downloading_entry, request.entry.name))
+                try {
+                    ManifestInstaller.installManifestEntry(
+                        context, request.entry, request.isDriver, request.contentType,
+                    ) { progress -> setLoadingProgress(progress.coerceIn(0f, 1f)) }
+                } catch (e: Exception) {
+                    Timber.e(e, "Failed to install ${request.entry.name}, continuing")
                 }
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to install manifest components")
-                setLoadingDialogVisible(false)
-                return@launch
             }
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to install manifest components")
+            setLoadingDialogVisible(false)
+            return@launch
         }
 
         // Check if this is a Custom Game and validate executable selection before installing components


### PR DESCRIPTION
## Description

Custom games wouldn't launch on the current default build (Proton 10). The default `wineVersion` is `proton-10.0-arm64ec-2`, which isn't bundled and has to be downloaded as a manifest component. The launch-time step that downloads missing manifest components (Proton/Wine/DXVK/VKD3D/etc.) referenced by a container's config was gated behind `ContainerUtils.supportsKnownConfigAutoApply(gameSource)`, which returns `false` for custom games. The only other launch dependency that installs a Proton build, `BionicDefaultProtonDependency`, only handles `proton-9.0-*`. So for a custom game neither path ever provisioned the Proton 10 build, and launch failed.

This drops the `supportsKnownConfigAutoApply` gate at that call site so the step runs for every source. It only installs components the container's own config already references (`resolveMissingManifestInstallRequests` reads the container's `wineVersion`/`containerVariant` from its own JSON) and no-ops when nothing is missing, so Steam/GOG/Epic/Amazon behavior is unchanged.

I intentionally did **not** flip `supportsKnownConfigAutoApply` to include custom games: that same flag also gates a server-recommended best-config lookup at container creation (`ContainerUtils.kt:819`), which should stay off for custom games. Decoupling at the call site keeps that behavior off while fixing the install.

## Type of Change
- [x] Bug fix

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted.
- [x] This change aligns with the current project scope (core functionality, stability, or performance).
- [ ] I have attached a recording of the change.
- [ ] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom game launches by auto-installing missing manifest components at start. This ensures `proton-10.0-arm64ec-2` and related parts are provisioned when referenced by the container config.

- **Bug Fixes**
  - Removed the source gate so the manifest install step runs for all sources, using the container’s own config.
  - Kept server best-config auto-apply disabled for custom games; other sources no-op when nothing is missing.

<sup>Written for commit ba2e8be0bc36b50fbd4487fabce31274f41bd8c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game launching by ensuring missing required components are installed before launch.
  * Added progress updates during component installation.
  * Launch attempts now stop cleanly when required component setup fails, with loading indicators dismissed appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->