### PR TITLE
Fix wrong install language for games with English in the neutral depot (e.g. KOTOR)

### DIFF
--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -104,15 +104,9 @@ object SteamUtils {
 
     /**
      * The language [depots] should be filtered by: the requested one when the app ships an
-     * installable depot in it, otherwise the language of an installable neutral build, otherwise
-     * English, otherwise any language it ships. Used for both the base game and its DLC so a title
-     * that omits the container's language still resolves instead of yielding zero depots.
-     *
-     * Untagged (neutral) depots pass the language filter for any language, so when the app ships one
-     * the requested language always resolves to the neutral build (e.g. KOTOR keeps English in the
-     * untagged content depot and tags only its French/German/Italian/Spanish localizations). The
-     * fall back to a different shipped language only kicks in when there is no neutral depot, i.e.
-     * the requested language would otherwise install nothing.
+     * installable depot in it, otherwise English, otherwise any language it ships. Used for both the
+     * base game and its DLC so a title that omits the container's language still resolves instead of
+     * yielding zero depots. Untagged (neutral) depots pass the language filter regardless.
      */
     fun effectiveDepotLanguage(
         depots: Map<Int, DepotInfo>,
@@ -142,12 +136,9 @@ object SteamUtils {
         val availableLanguages = installableBaseGameDepots
             .filter { it.language.isNotEmpty() }
             .mapTo(mutableSetOf()) { it.language }
-        // A neutral depot is the language-agnostic build and installs for any requested language.
         val hasNeutralDepot = installableBaseGameDepots.any { it.language.isEmpty() }
         return when {
             preferredLanguage in availableLanguages -> preferredLanguage
-            // The neutral build already satisfies the request; don't force a different localization
-            // depot on top of it.
             hasNeutralDepot -> preferredLanguage
             "english" in availableLanguages -> "english"
             else -> availableLanguages.firstOrNull() ?: preferredLanguage

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -104,9 +104,15 @@ object SteamUtils {
 
     /**
      * The language [depots] should be filtered by: the requested one when the app ships an
-     * installable depot in it, otherwise English, otherwise any language it ships. Used for both the
-     * base game and its DLC so a title that omits the container's language still resolves instead of
-     * yielding zero depots. Untagged (neutral) depots pass the language filter regardless.
+     * installable depot in it, otherwise the language of an installable neutral build, otherwise
+     * English, otherwise any language it ships. Used for both the base game and its DLC so a title
+     * that omits the container's language still resolves instead of yielding zero depots.
+     *
+     * Untagged (neutral) depots pass the language filter for any language, so when the app ships one
+     * the requested language always resolves to the neutral build (e.g. KOTOR keeps English in the
+     * untagged content depot and tags only its French/German/Italian/Spanish localizations). The
+     * fall back to a different shipped language only kicks in when there is no neutral depot, i.e.
+     * the requested language would otherwise install nothing.
      */
     fun effectiveDepotLanguage(
         depots: Map<Int, DepotInfo>,
@@ -131,12 +137,18 @@ object SteamUtils {
         }
 
         // Base-game depots only, so an owned in-app DLC's language can't steer the base game.
-        // Untagged depots are the neutral build and pass the language filter regardless.
-        val availableLanguages = depots.values
-            .filter { it.dlcAppId == SteamService.INVALID_APP_ID && it.language.isNotEmpty() && it.installableInItsLanguage() }
+        val installableBaseGameDepots = depots.values
+            .filter { it.dlcAppId == SteamService.INVALID_APP_ID && it.installableInItsLanguage() }
+        val availableLanguages = installableBaseGameDepots
+            .filter { it.language.isNotEmpty() }
             .mapTo(mutableSetOf()) { it.language }
+        // A neutral depot is the language-agnostic build and installs for any requested language.
+        val hasNeutralDepot = installableBaseGameDepots.any { it.language.isEmpty() }
         return when {
             preferredLanguage in availableLanguages -> preferredLanguage
+            // The neutral build already satisfies the request; don't force a different localization
+            // depot on top of it.
+            hasNeutralDepot -> preferredLanguage
             "english" in availableLanguages -> "english"
             else -> availableLanguages.firstOrNull() ?: preferredLanguage
         }

--- a/app/src/test/java/app/gamenative/utils/SteamUtilsDepotLanguageTest.kt
+++ b/app/src/test/java/app/gamenative/utils/SteamUtilsDepotLanguageTest.kt
@@ -104,15 +104,11 @@ class SteamUtilsDepotLanguageTest {
             depot(depotId = 1, language = ""),
             depot(depotId = 2, language = "german"),
         )
-        // The neutral depot installs regardless of language, so requesting french resolves to the
-        // neutral build rather than being forced into german.
         assertEquals("french", resolve(depots, "french"))
     }
 
     @Test
     fun `kotor layout keeps english against tagged-only localizations`() {
-        // KOTOR (app 32370): English lives in the untagged content depot; only French/German/
-        // Italian/Spanish are tagged. Requesting english must not fall back to a localization.
         val depots = depotsOf(
             depot(depotId = 32371, language = ""),
             depot(depotId = 32372, language = "french"),
@@ -121,7 +117,6 @@ class SteamUtilsDepotLanguageTest {
             depot(depotId = 32375, language = "spanish"),
         )
         assertEquals("english", resolve(depots, "english"))
-        // A tagged language it does ship still wins.
         assertEquals("german", resolve(depots, "german"))
     }
 

--- a/app/src/test/java/app/gamenative/utils/SteamUtilsDepotLanguageTest.kt
+++ b/app/src/test/java/app/gamenative/utils/SteamUtilsDepotLanguageTest.kt
@@ -90,7 +90,7 @@ class SteamUtilsDepotLanguageTest {
         assertEquals("schinese", resolve(depots, "french"))
     }
 
-    // -- Untagged (neutral) depots are ignored by the fallback pool --
+    // -- A neutral (untagged) depot satisfies any requested language, so no fallback fires --
 
     @Test
     fun `keeps preferred language when the app only ships untagged depots`() {
@@ -99,12 +99,30 @@ class SteamUtilsDepotLanguageTest {
     }
 
     @Test
-    fun `untagged depot does not become the fallback`() {
+    fun `neutral depot keeps preferred language instead of forcing another localization`() {
         val depots = depotsOf(
             depot(depotId = 1, language = ""),
             depot(depotId = 2, language = "german"),
         )
-        assertEquals("german", resolve(depots, "french"))
+        // The neutral depot installs regardless of language, so requesting french resolves to the
+        // neutral build rather than being forced into german.
+        assertEquals("french", resolve(depots, "french"))
+    }
+
+    @Test
+    fun `kotor layout keeps english against tagged-only localizations`() {
+        // KOTOR (app 32370): English lives in the untagged content depot; only French/German/
+        // Italian/Spanish are tagged. Requesting english must not fall back to a localization.
+        val depots = depotsOf(
+            depot(depotId = 32371, language = ""),
+            depot(depotId = 32372, language = "french"),
+            depot(depotId = 32373, language = "german"),
+            depot(depotId = 32374, language = "italian"),
+            depot(depotId = 32375, language = "spanish"),
+        )
+        assertEquals("english", resolve(depots, "english"))
+        // A tagged language it does ship still wins.
+        assertEquals("german", resolve(depots, "german"))
     }
 
     // -- Only base-game depots steer the language --


### PR DESCRIPTION
## Description

Fixes a language regression from #1659 (shipped in 1.1.1). KOTOR (and other titles like it) was installing/running in the wrong language.

`SteamUtils.effectiveDepotLanguage` builds its "available languages" set from **language-tagged depots only**, then falls back to the first shipped language when the requested one is absent. That breaks games that keep English (the default) in the **untagged neutral depot** and tag only their non-English localizations — the fallback forces one of those localizations on top of the neutral English build.

KOTOR (app 32370) is exactly this shape per [SteamDB](https://steamdb.info/app/32370/depots/):
- `32371` — untagged/neutral content depot (English lives here) — 3.36 GiB
- `32372` French, `32373` German, `32374` Italian, `32375` Spanish — the only tagged depots

With the default `containerLanguage="english"`, `effectiveDepotLanguage` found no `english` tag, fell through to the first tagged language (`french`), and `getDownloadableDepots` then pulled the neutral English content **plus** the French localization depot — so the game ran in French.

**Fix:** a neutral depot installs regardless of requested language, so the request is always satisfiable via that build. Return the preferred language whenever an installable neutral base-game depot exists; only fall back to another shipped language when there is none (i.e. the request would otherwise install nothing). Users who explicitly request a shipped tagged language (german/french/etc.) still get it.

This is not KOTOR-specific — it fixes any Steam title that keeps its default/English content in the neutral depot and tags only non-English localizations, a common layout for older games.

## Recording
<!-- N/A — depot-selection logic; covered by unit tests below -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

## Notes for reviewer
- Updated `SteamUtilsDepotLanguageTest`: the old `untagged depot does not become the fallback` case encoded the buggy behavior (expected `german` to be forced) — it's rewritten to expect the preferred language, and a `kotor layout` test covering the exact 32371 + F/G/I/S shape was added. Full `SteamUtilsDepotLanguageTest` class passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wrong install language for games that keep English in a neutral (untagged) depot, like KOTOR. `SteamUtils.effectiveDepotLanguage` now treats a neutral depot as satisfying any requested language and returns the preferred language instead of falling back to a tagged localization.

- **Bug Fixes**
  - Check installable base-game depots and keep the requested language when a neutral depot exists.
  - Only fall back to another shipped language if no neutral depot is available.
  - Updated tests: fixed neutral-depot expectation and added a KOTOR-style layout test.

- **Refactors**
  - Removed added comments.

<sup>Written for commit 99d7fa42b6667db34f495a09a53d6fca64cd0c02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved depot language selection when games provide neutral/untagged base-game depots.
  * The requested/preferred language is now preserved when a neutral depot can satisfy it, avoiding unnecessary fallback to another language.
  * Refined handling for specific depot layouts (including English via untagged depots) and updated tests to match the corrected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->