### PR TITLE
Default non-Adreno devices to Wrapper-gamenative driver

### DIFF
--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -86,7 +86,8 @@ object ContainerUtils {
         } else {
             DefaultVersion.VARIANT = Container.BIONIC
             DefaultVersion.WINE_VERSION = "proton-10.0-arm64ec-2"
-            DefaultVersion.DEFAULT_GRAPHICS_DRIVER = "Wrapper"
+            DefaultVersion.DEFAULT_GRAPHICS_DRIVER =
+                if (GPUInformation.isAdrenoGPU(context)) "Wrapper" else "Wrapper-gamenative"
             DefaultVersion.DXVK = "async-1.10.3"
             DefaultVersion.VKD3D = "2.14.1"
             DefaultVersion.STEAM_TYPE = Container.STEAM_TYPE_LIGHT


### PR DESCRIPTION
## What

For **newly created containers on non-Adreno GPUs** (Mali, Xclipse, etc.), the default graphics driver is now `Wrapper-gamenative` instead of `Wrapper`.

## Why

`ContainerUtils.setContainerDefaults()` is the authoritative place that picks the default driver. Its first four branches all require an Adreno renderer string (`isTurnipCapable`, `isAdrenoA12`, `isAdreno8EliteGen5`, `isAdreno8Elite`), so **every non-Adreno GPU already falls into the final `else` branch**. That branch previously hard-coded `Wrapper` for all devices.

The change gates the driver on `GPUInformation.isAdrenoGPU(context)`:

```kotlin
DefaultVersion.DEFAULT_GRAPHICS_DRIVER =
    if (GPUInformation.isAdrenoGPU(context)) "Wrapper" else "Wrapper-gamenative"
```

This flips non-Adreno devices to `Wrapper-gamenative` while preserving existing behavior for the older non-Turnip Adreno parts (e.g. Adreno 5xx) that also land in this branch. It uses the exact same `DefaultVersion.DEFAULT_GRAPHICS_DRIVER` assignment mechanism the code already relies on for `Wrapper`, and `"Wrapper-gamenative"` matches both the dropdown label and the runtime `equals("wrapper-gamenative", ...)` checks.

## Notes for reviewers

- **Scope is fresh containers only.** Existing containers keep whatever driver they already saved — there is no migration rewriting `graphicsDriver`.
- The `else` branch does not set `DefaultVersion.WRAPPER`, so the wrapper/Turnip **version** stays at the class default (`System`). If `Wrapper-gamenative` on non-Adreno needs a specific bundled version, that would be a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default non-Adreno GPUs now default to the Wrapper-gamenative graphics driver for new containers. Adreno devices keep the existing Wrapper default.

- **Migration**
  - Applies only to newly created containers; existing containers keep their current driver.
  - Driver is chosen via GPU detection (`GPUInformation.isAdrenoGPU(context)`); wrapper/Turnip version remains the class default.

<sup>Written for commit 2b37f8830e81aaea7ac01ffec7b9dd425b1c4dc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graphics driver selection for devices using Adreno GPUs.
  * Other devices now receive the appropriate GameNative graphics driver configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->