### PR TITLE
Show the selected branch's size in the download manager dialog

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/GameManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GameManagerDialog.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.window.DialogProperties
 import app.gamenative.BuildConfig
 import app.gamenative.R
 import app.gamenative.data.DepotInfo
+import app.gamenative.data.ManifestInfo
 import app.gamenative.service.SteamService
 import app.gamenative.service.SteamService.Companion.INVALID_APP_ID
 import app.gamenative.ui.component.LoadingScreen
@@ -165,6 +166,13 @@ fun GameManagerDialog(
         return "DLC ${depotInfo.dlcAppId}"
     }
 
+    val selectedBranch = branch ?: installedApp?.branch ?: "public"
+
+    fun manifestFor(depot: DepotInfo): ManifestInfo? =
+        depot.manifests[selectedBranch]
+            ?: depot.encryptedManifests[selectedBranch]
+            ?: depot.manifests["public"]
+
     fun getSizeInfo(dlcAppId: Int): Pair<String, String> {
         if (dlcAppId == INVALID_APP_ID || dlcAppId == gameId) {
             val depotsForBaseGame = downloadableDepots.filter { (_, depot) ->
@@ -172,10 +180,10 @@ fun GameManagerDialog(
             }
 
             val installBytes = depotsForBaseGame.values.sumOf {
-                it.manifests["public"]?.size ?: 0
+                manifestFor(it)?.size ?: 0
             }
             val downloadBytes = depotsForBaseGame.values.sumOf {
-                SteamUtils.getDownloadBytes(it.manifests["public"])
+                SteamUtils.getDownloadBytes(manifestFor(it))
             }
 
             return Pair(
@@ -189,10 +197,10 @@ fun GameManagerDialog(
         }
 
         val installBytes = depotsForDlc.values.sumOf {
-            it.manifests["public"]?.size ?: 0
+            manifestFor(it)?.size ?: 0
         }
         val downloadBytes = depotsForDlc.values.sumOf {
-            SteamUtils.getDownloadBytes(it.manifests["public"])
+            SteamUtils.getDownloadBytes(manifestFor(it))
         }
 
         return Pair(
@@ -208,7 +216,7 @@ fun GameManagerDialog(
             downloadableDepots
                 .filter { (_, depot) ->
                     depot.dlcAppId == INVALID_APP_ID
-                }.values.sumOf { it.manifests["public"]?.size ?: 0 }
+                }.values.sumOf { manifestFor(it)?.size ?: 0 }
         } else {
             0L
         }
@@ -218,7 +226,7 @@ fun GameManagerDialog(
                 .filter { (_, depot) ->
                     depot.dlcAppId == INVALID_APP_ID
                 }.values.sumOf {
-                    SteamUtils.getDownloadBytes(it.manifests["public"])
+                    SteamUtils.getDownloadBytes(manifestFor(it))
                 }
         } else {
             0L
@@ -228,14 +236,14 @@ fun GameManagerDialog(
             .filter { (_, depot) ->
                 selectedAppIds[depot.dlcAppId] == true && enabledAppIds[depot.dlcAppId] == true
             }
-            .values.sumOf { it.manifests["public"]?.size ?: 0 }
+            .values.sumOf { manifestFor(it)?.size ?: 0 }
 
         val selectedDownloadBytes = downloadableDepots
             .filter { (_, depot) ->
                 selectedAppIds[depot.dlcAppId] == true && enabledAppIds[depot.dlcAppId] == true
             }
             .values.sumOf {
-                SteamUtils.getDownloadBytes(it.manifests["public"])
+                SteamUtils.getDownloadBytes(manifestFor(it))
             }
 
         return InstallSizeInfo(


### PR DESCRIPTION
## Description

When installing a branch without installing the game first, the download manager dialog showed the size of the public branch instead of the selected one.

The branch was already plumbed into `GameManagerDialog` and used for the actual `downloadApp` call — so the branch text and the download itself were correct. Only the size math was wrong: all four computations (base-game row, per-DLC row, and the base/selected pairs in `getInstallSizeInfo()` that feed the total) looked up `manifests["public"]` unconditionally.

Each depot's manifest is now resolved the same way the download path already does at `SteamService.kt:1263` and `SteamService.kt:1819`:

1. `manifests[branch]`
2. `encryptedManifests[branch]` — private, password-unlocked branches keep their manifest here, so without this they'd fall through to the public size and the bug would persist for exactly those branches.
3. `manifests["public"]` — most DLC and language depots only ever publish a public manifest; only base-game depots differ per branch. Keying purely on branch would make those sum to `0` (`getDownloadBytes(null)` returns 0 silently) and under-report instead.

Not touched, but related: `SteamAppScreen.kt:1022-1027` computes sizes for the older `INSTALL_APP_PENDING` dialog keyed on `getInstalledApp(gameId)?.branch` with no `encryptedManifests` fallback. That path only runs for already-installed apps, so it isn't this bug, but it would under-report for a game installed on a private branch. Happy to fold that in if reviewers want it here rather than separately.

## Recording

Not attached — this is a text-only change to a computed size in an existing dialog, and reproducing it needs a game with a beta branch on a real device.

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the download manager dialog to show the selected branch’s size instead of always using the public branch. Each depot now resolves its manifest by selected branch, then encrypted branch, then public, so base‑game and DLC totals match what will be downloaded.

<sup>Written for commit 7b0c365c90725e79be978d18fc643d0178cd493b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation and download size calculations for games and downloadable content.
  * Size estimates now reflect the selected or installed branch when available.
  * Added fallback handling to provide accurate estimates when branch-specific or encrypted manifests are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->