### PR TITLE
fix: symlink proton files instead of copying to avoid storage increment on every single container

### DIFF
--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/VcRedistStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/VcRedistStep.kt
@@ -48,6 +48,59 @@ private val vcRedistMap: Map<String, String> = mapOf(
 object VcRedistStep : PreInstallStep {
     override val marker: Marker = Marker.VCREDIST_INSTALLED
 
+    val system32Dlls = listOf(
+        "msvcp60.dll",
+        "msvcp70.dll",
+        "msvcp71.dll",
+        "msvcp80.dll",
+        "msvcr80.dll",
+        "msvcp90.dll",
+        "msvcr90.dll",
+        "msvcp100.dll",
+        "msvcr100.dll",
+        "msvcp110.dll",
+        "msvcr110.dll",
+        "vccorlib110.dll",
+        "msvcp120.dll",
+        "msvcr120.dll",
+        "vccorlib120.dll",
+        "msvcp140.dll",
+        "msvcp140_1.dll",
+        "msvcp140_2.dll",
+        "msvcp140_atomic_wait.dll",
+        "msvcp140_codecvt_ids.dll",
+        "vcruntime140.dll",
+        "vcruntime140_1.dll",
+        "vccorlib140.dll",
+        "concrt140.dll"
+    )
+
+    val syswow64Dlls = listOf(
+        "msvcp60.dll",
+        "msvcp70.dll",
+        "msvcp71.dll",
+        "msvcp80.dll",
+        "msvcr80.dll",
+        "msvcp90.dll",
+        "msvcr90.dll",
+        "msvcp100.dll",
+        "msvcr100.dll",
+        "msvcp110.dll",
+        "msvcr110.dll",
+        "vccorlib110.dll",
+        "msvcp120.dll",
+        "msvcr120.dll",
+        "vccorlib120.dll",
+        "msvcp140.dll",
+        "msvcp140_1.dll",
+        "msvcp140_2.dll",
+        "msvcp140_atomic_wait.dll",
+        "msvcp140_codecvt_ids.dll",
+        "vcruntime140.dll",
+        "vccorlib140.dll",
+        "concrt140.dll"
+    )
+
     override fun appliesTo(
         container: Container,
         gameSource: GameSource,

--- a/app/src/main/java/com/winlator/container/ContainerManager.java
+++ b/app/src/main/java/com/winlator/container/ContainerManager.java
@@ -337,7 +337,7 @@ public class ContainerManager {
                 dstFile = onExtractFileListener.onExtractFile(dstFile, 0);
                 if (dstFile == null) continue;
             }
-            FileUtils.copy(new File(srcDir, dlname), dstFile);
+            FileUtils.symlink(new File(srcDir, dlname), dstFile);
         }
     }
 
@@ -359,7 +359,7 @@ public class ContainerManager {
                 if (dstFile == null) continue;
             }
             Log.d("Extraction", "copying " + file + " to " + dstFile);
-            FileUtils.copy(file, dstFile);
+            FileUtils.symlink(file, dstFile);
         }
     }
 

--- a/app/src/main/java/com/winlator/container/ContainerManager.java
+++ b/app/src/main/java/com/winlator/container/ContainerManager.java
@@ -6,6 +6,7 @@ import android.util.Log;
 
 // import com.winlator.R;
 import app.gamenative.R;
+import app.gamenative.utils.VcRedistStep;
 import app.gamenative.utils.downloader.ContainerFilesDownloaderKt;
 import app.gamenative.utils.downloader.ProgressCallback;
 import com.winlator.box86_64.Box86_64Preset;
@@ -337,7 +338,14 @@ public class ContainerManager {
                 dstFile = onExtractFileListener.onExtractFile(dstFile, 0);
                 if (dstFile == null) continue;
             }
-            FileUtils.symlink(new File(srcDir, dlname), dstFile);
+            File srcFile = new File(srcDir, dlname);
+            boolean isVcRedistDll = (dstName.equals("system32") && VcRedistStep.INSTANCE.getSystem32Dlls().contains(dlname)) ||
+                                    (dstName.equals("syswow64") && VcRedistStep.INSTANCE.getSyswow64Dlls().contains(dlname));
+            if (isVcRedistDll) {
+                FileUtils.copy(srcFile, dstFile);
+            } else {
+                FileUtils.symlink(srcFile, dstFile);
+            }
         }
     }
 
@@ -359,7 +367,13 @@ public class ContainerManager {
                 if (dstFile == null) continue;
             }
             Log.d("Extraction", "copying " + file + " to " + dstFile);
-            FileUtils.symlink(file, dstFile);
+            boolean isVcRedistDll = (dstName.equals("system32") && VcRedistStep.INSTANCE.getSystem32Dlls().contains(dllName)) ||
+                                    (dstName.equals("syswow64") && VcRedistStep.INSTANCE.getSyswow64Dlls().contains(dllName));
+            if (isVcRedistDll) {
+                FileUtils.copy(file, dstFile);
+            } else {
+                FileUtils.symlink(file, dstFile);
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Previously, dll files from proton are copied top container windows dir, which added unnecessary storage requirement on every game installation.
Change it to symlink can significant reduce each added storage on each container.

## Recording
58.04GB, Storage usage initially:
<img width="1280" height="960" alt="Screenshot_20260719_064826" src="https://github.com/user-attachments/assets/49e5f290-2a96-4621-abff-af48487273cf" />

56.40GB, Storage after one of the game changed to another, which remove existing dlls and symlink current proton dll back:
<img width="1280" height="960" alt="Screenshot_20260719_065047" src="https://github.com/user-attachments/assets/69e43c55-b7de-4e9a-9b48-c6f50be430f2" />

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Symlink Proton/common DLLs during container setup to eliminate duplicate files and reduce disk usage per game. VC++ Redistributable DLLs in `system32`/`syswow64` are detected and still copied for compatibility.

- **Bug Fixes**
  - Use symlinks for Proton/common DLL extraction so containers share files.
  - Add VC++ DLL allowlists in `VcRedistStep` and copy those from `ContainerManager` instead of symlinking.

<sup>Written for commit 59ecedb8bf88247e667a347697779ec8ea4c53ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



