### PR TITLE
Support importing custom Vulkan wrappers

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -401,6 +401,11 @@ fun ContainerConfigDialog(
         val installedWine = installedLists?.wine.orEmpty()
         val installedProton = installedLists?.proton.orEmpty()
         val installedWrapperDrivers = availability?.installedDrivers.orEmpty()
+        val installedWrappers = installedLists?.wrapper.orEmpty()
+
+        val bionicGraphicsDriversMerged = remember(bionicGraphicsDrivers, installedWrappers) {
+            (bionicGraphicsDrivers + installedWrappers.map { "Wrapper-$it" }).distinct()
+        }
 
         val dxvkOptions = remember(dxvkVersionsBase, installedDxvk, manifestDxvk) {
             ManifestComponentHelper.buildVersionOptionList(dxvkVersionsBase, installedDxvk, manifestDxvk)
@@ -660,7 +665,7 @@ fun ContainerConfigDialog(
 
         // Bionic-specific state
         val bionicDriverIndexRef = rememberSaveable {
-            val idx = bionicGraphicsDrivers.indexOfFirst { StringUtils.parseIdentifier(it) == config.graphicsDriver }
+            val idx = bionicGraphicsDriversMerged.indexOfFirst { StringUtils.parseIdentifier(it) == config.graphicsDriver }
             mutableIntStateOf(if (idx >= 0) idx else 0)
         }
         var bionicDriverIndex by bionicDriverIndexRef
@@ -743,6 +748,11 @@ fun ContainerConfigDialog(
             val ver = cfg.get("version", DefaultVersion.WRAPPER)
             val newIdx = wrapperOptions.ids.indexOfFirst { it.equals(ver, true) }.coerceAtLeast(0)
             if (wrapperVersionIndex != newIdx) wrapperVersionIndex = newIdx
+        }
+
+        LaunchedEffect(bionicGraphicsDriversMerged, config.graphicsDriver) {
+            val newIdx = bionicGraphicsDriversMerged.indexOfFirst { StringUtils.parseIdentifier(it) == config.graphicsDriver }
+            if (newIdx >= 0 && bionicDriverIndex != newIdx) bionicDriverIndex = newIdx
         }
 
         val screenSizeIndexRef = rememberSaveable {
@@ -1139,7 +1149,7 @@ fun ContainerConfigDialog(
             bionicWineEntriesBase = bionicWineEntriesBase,
             glibcWineEntriesBase = glibcWineEntriesBase,
             emulatorEntries = emulatorEntries,
-            bionicGraphicsDrivers = bionicGraphicsDrivers,
+            bionicGraphicsDrivers = bionicGraphicsDriversMerged,
             baseWrapperVersions = baseWrapperVersions,
             languages = languages,
             dxvkOptions = dxvkOptions,

--- a/app/src/main/java/app/gamenative/ui/screen/settings/ContentsManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/ContentsManagerDialog.kt
@@ -267,7 +267,8 @@ fun ContentsManagerDialog(open: Boolean, onDismiss: () -> Unit) {
                             ContentProfile.ContentType.CONTENT_TYPE_VKD3D,
                             ContentProfile.ContentType.CONTENT_TYPE_BOX64,
                             ContentProfile.ContentType.CONTENT_TYPE_WOWBOX64,
-                            ContentProfile.ContentType.CONTENT_TYPE_FEXCORE
+                            ContentProfile.ContentType.CONTENT_TYPE_FEXCORE,
+                            ContentProfile.ContentType.CONTENT_TYPE_WRAPPER
                         )
                         ContentProfile.ContentType.values().filter { it in allowed }.forEach { t ->
                             DropdownMenuItem(

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -5532,7 +5532,15 @@ private suspend fun extractGraphicsDriverFiles(
                 val wrapperComponentId = mainWrapperSelection.lowercase(Locale.getDefault())
                 Log.d("GraphicsDriverExtraction", "WRAPPER selection changed or first boot. Extracting: $wrapperComponentId")
                 try {
-                    extractGraphicsDriverComponent(context, wrapperComponentId, rootDir!!)
+                    val wrapperContentsManager = ContentsManager(context)
+                    val wrapperProfile: ContentProfile? =
+                        wrapperContentsManager.getProfileByEntryName(wrapperComponentId)
+                    if (wrapperProfile != null) {
+                        Timber.d("Applying user-defined wrapper content profile: $wrapperComponentId")
+                        wrapperContentsManager.applyContent(wrapperProfile)
+                    } else {
+                        extractGraphicsDriverComponent(context, wrapperComponentId, rootDir!!)
+                    }
                     // After success, save the new version so we don't re-extract next time.
                     container.putExtra("lastInstalledMainWrapper", mainWrapperSelection)
                     container.saveData()

--- a/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
+++ b/app/src/main/java/app/gamenative/utils/ManifestComponentHelper.kt
@@ -38,6 +38,7 @@ object ManifestComponentHelper {
         val fexcore: List<String>,
         val wine: List<String>,
         val proton: List<String>,
+        val wrapper: List<String> = emptyList(),
     )
 
     data class InstalledContentListsAndDrivers(
@@ -109,6 +110,9 @@ object ManifestComponentHelper {
                 ),
                 proton = profilesToDisplay(
                     mgr.getProfiles(ContentProfile.ContentType.CONTENT_TYPE_PROTON),
+                ),
+                wrapper = profilesToDisplay(
+                    mgr.getProfiles(ContentProfile.ContentType.CONTENT_TYPE_WRAPPER),
                 ),
             )
         } catch (_: Exception) {

--- a/app/src/main/java/com/winlator/contents/ContentProfile.java
+++ b/app/src/main/java/com/winlator/contents/ContentProfile.java
@@ -23,6 +23,7 @@ public class ContentProfile {
         CONTENT_TYPE_PROTON("Proton"),
         CONTENT_TYPE_TURNIP("Turnip"),
         CONTENT_TYPE_VORTEK("Vortek"),
+        CONTENT_TYPE_WRAPPER("Wrapper"),
         CONTENT_TYPE_VIRGL("VirGL"),
         CONTENT_TYPE_DXVK("DXVK"),
         CONTENT_TYPE_VKD3D("VKD3D"),

--- a/app/src/main/java/com/winlator/contents/ContentsManager.java
+++ b/app/src/main/java/com/winlator/contents/ContentsManager.java
@@ -31,6 +31,9 @@ public class ContentsManager {
     public static final String[] VORTEK_TRUST_FILES = {"${libdir}/libvulkan_vortek.so", "${libdir}/libvulkan_freedreno.so",
             "${sharedir}/vulkan/icd.d/vortek_icd.aarch64.json"};
     public static final String[] VIRGL_TRUST_FILES = {"${libdir}/libGL.so.1", "${libdir}/libglapi.so.0"};
+    public static final String[] WRAPPER_TRUST_FILES = {"${libdir}/libvulkan_wrapper.so",
+            "${sharedir}/vulkan/icd.d/wrapper_icd.aarch64.json", "${libdir}/libmain_hook.so", "${libdir}/libhook_impl.so",
+            "${libdir}/libadrenotools.so", "${libdir}/libgsl_alloc_hook.so", "${libdir}/libfile_redirect_hook.so"};
     public static final String[] DXVK_TRUST_FILES = {"${system32}/d3d8.dll", "${system32}/d3d9.dll", "${system32}/d3d10.dll", "${system32}/d3d10_1.dll",
             "${system32}/d3d10core.dll", "${system32}/d3d11.dll", "${system32}/dxgi.dll", "${syswow64}/d3d8.dll", "${syswow64}/d3d9.dll", "${syswow64}/d3d10.dll",
             "${syswow64}/d3d10_1.dll", "${syswow64}/d3d10core.dll", "${syswow64}/d3d11.dll", "${syswow64}/dxgi.dll"};
@@ -519,6 +522,7 @@ public class ContentsManager {
                     case CONTENT_TYPE_TURNIP -> TURNIP_TRUST_FILES;
                     case CONTENT_TYPE_VORTEK -> VORTEK_TRUST_FILES;
                     case CONTENT_TYPE_VIRGL -> VIRGL_TRUST_FILES;
+                    case CONTENT_TYPE_WRAPPER -> WRAPPER_TRUST_FILES;
                     case CONTENT_TYPE_DXVK -> DXVK_TRUST_FILES;
                     case CONTENT_TYPE_VKD3D -> VKD3D_TRUST_FILES;
                     case CONTENT_TYPE_BOX64 -> BOX64_TRUST_FILES;


### PR DESCRIPTION
## Description
Lets users import their own Vulkan wrapper (`libvulkan_wrapper.so`) through the existing Contents Manager, instead of being limited to the built-in `Wrapper` / `Wrapper-v2` / `Wrapper-gamenative` options.

Most of the plumbing already existed — `ContentsManager` already imports `.tzst`, validates a `profile.json`, guards path traversal, and its `${libdir}` / `${sharedir}` targets map exactly onto the wrapper archive layout. This wires a `Wrapper` content type into it and connects it to the graphics driver selection.

**Changes:**
- `ContentProfile` — new `CONTENT_TYPE_WRAPPER("Wrapper")`.
- `ContentsManager` — `WRAPPER_TRUST_FILES` covering `libvulkan_wrapper.so`, `wrapper_icd.aarch64.json` and the hook libs, so a normal wrapper package installs without an "untrusted files" warning.
- `ContentsManagerDialog` — Wrapper added to the type list, so imported wrappers can be viewed and removed.
- `ManifestComponentHelper` — installed wrappers surfaced on `InstalledContentLists`.
- `ContainerConfigDialog` — imported wrappers merged into the bionic graphics driver dropdown, plus a `LaunchedEffect` to re-resolve the selected index once content finishes loading (it loads after the initial index is computed).
- `XServerScreen` — the wrapper extraction block now checks for a content profile first and applies it, falling back to the existing bundled/downloaded component otherwise.

**Naming:** an imported wrapper displays as `Wrapper-<verName>-<verCode>`, which is the `ContentsManager` entry name. `parseIdentifier` turns that into `wrapper-<verName>-<verCode>`, which both satisfies the existing `startsWith("wrapper")` guard and matches `getProfileByEntryName`. No changes to the selection plumbing were needed.

**Deletion** follows the same pattern as DXVK/VKD3D/Box64: if the profile is gone, `getProfileByEntryName` returns null and extraction falls back to the built-in path, so a container pointing at a deleted wrapper still launches.

**Packaging format** — a `.tzst`/`.wcp` with a root `profile.json`:
```json
{ "type": "Wrapper", "versionName": "mycustom", "versionCode": 1, "description": "...",
  "files": [
    { "source": "usr/lib/libvulkan_wrapper.so", "target": "${libdir}/libvulkan_wrapper.so" },
    { "source": "usr/share/vulkan/icd.d/wrapper_icd.aarch64.json",
      "target": "${sharedir}/vulkan/icd.d/wrapper_icd.aarch64.json" }
  ] }
```

### Testing
`:app:compileModernDebugJavaWithJavac` passes with no new warnings. The import → select → launch flow has **not** been exercised on device yet; worth a manual pass with a real wrapper package before merge.

## Recording
Not attached — needs an on-device run with a packaged wrapper.

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [ ] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for importing custom Vulkan wrappers via the Contents Manager. Imported wrappers show up in the Bionic graphics driver dropdown and are used at launch, with safe fallback to built‑ins.

- New Features
  - Added `Wrapper` content type and trusted files to `ContentsManager` to avoid warnings (`libvulkan_wrapper.so`, `wrapper_icd.aarch64.json`, hook libs).
  - Imported wrappers are listed in the Contents Manager and can be removed.
  - Installed wrappers are merged into the Bionic graphics drivers as `Wrapper-<versionName>-<versionCode>`, with selection re-synced after content loads.
  - Launch path applies an imported wrapper profile when present; falls back to the bundled component if missing or deleted.
  - Manifest helper now surfaces installed wrappers for display.

<sup>Written for commit ddc6959de65f50111ac7a3e771455348bc88f38c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing graphics wrapper content as a dedicated content type.
  * Custom wrapper content can now be used during graphics driver installation.
  * Wrapper drivers are included in available graphics driver selections and installed content listings.
  * Added trusted file handling for Vulkan wrapper and hook libraries.

* **Bug Fixes**
  * Improved synchronization of the selected graphics driver when available options change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->