### PR TITLE
feat:Add support for installing native Android game builds (Steam Frame)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_LOGS" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/app/src/main/java/app/gamenative/data/DepotInfo.kt
+++ b/app/src/main/java/app/gamenative/data/DepotInfo.kt
@@ -27,8 +27,12 @@ data class DepotInfo(
     val systemDefined: Boolean = false,
     val steamDeck: Boolean = false,
 ) {
-    /** Windows or OS-untagged (neither Linux nor macOS) */
+    /** Windows or OS-untagged (neither Linux, macOS nor Android) */
     val isWindowsCompatible: Boolean
         get() = osList.contains(OS.windows) ||
-            (!osList.contains(OS.linux) && !osList.contains(OS.macos))
+            (!osList.contains(OS.linux) && !osList.contains(OS.macos) && !osList.contains(OS.android))
+
+    /** Explicitly tagged for Android (Steam Frame / Lepton depots) */
+    val isAndroidCompatible: Boolean
+        get() = osList.contains(OS.android)
 }

--- a/app/src/main/java/app/gamenative/enums/OS.kt
+++ b/app/src/main/java/app/gamenative/enums/OS.kt
@@ -8,6 +8,7 @@ enum class OS(val code: Int) {
     windows(0x01),
     macos(0x02),
     linux(0x04),
+    android(0x08),
     ;
 
     companion object {

--- a/app/src/main/java/app/gamenative/service/DownloadService.kt
+++ b/app/src/main/java/app/gamenative/service/DownloadService.kt
@@ -80,7 +80,7 @@ object DownloadService {
     }
 
     fun getSizeFromStoreDisplay (appId: Int, branch: String = "public"): String {
-        val depots = SteamService.getDownloadableDepots(appId)
+        val depots = SteamService.getDownloadableDepots(appId, wantAndroid = SteamService.isAndroidPlatform(appId))
         val installBytes = depots.values.sumOf { (it.manifests[branch] ?: it.manifests["public"])?.size ?: 0L }
         return StorageUtils.formatBinarySize(installBytes)
     }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -948,7 +948,7 @@ class SteamService : Service(), IChallengeUrlChanged {
         ): Map<Int, DepotInfo> {
             val dlcAppIdsWithSingleDepots = getDlcAppIdsWithSingleDepot(depots)
             val effectiveLanguage = SteamUtils.effectiveDepotLanguage(
-                depots, preferredLanguage, ownedDlc, licensedDepotIds, hasSteamUnlockedBranch,
+                depots, preferredLanguage, ownedDlc, licensedDepotIds, hasSteamUnlockedBranch, wantAndroid,
             )
             val eligible = eligibleDepots(depots, effectiveLanguage, ownedDlc, licensedDepotIds, wantAndroid)
             val has64Bit = eligible.any { it.osArch == OSArch.Arch64 }
@@ -1025,7 +1025,7 @@ class SteamService : Service(), IChallengeUrlChanged {
 
             // parent app's arch applies to DLC arch selection
             val mainLanguage = SteamUtils.effectiveDepotLanguage(
-                appInfo.depots, preferredLanguage, ownedDlc, licensedDepots, hasSteamUnlockedBranch,
+                appInfo.depots, preferredLanguage, ownedDlc, licensedDepots, hasSteamUnlockedBranch, wantAndroid,
             )
             val has64Bit = eligibleDepots(appInfo.depots, mainLanguage, ownedDlc, licensedDepots, wantAndroid)
                 .any { it.osArch == OSArch.Arch64 }
@@ -1036,7 +1036,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                 val dlcLicensedDepots = getLicensedDepotIds(dlcApp.id)
                 // Resolve the DLC's own language too, so DLC that omits the container language installs.
                 val dlcLanguage = SteamUtils.effectiveDepotLanguage(
-                    dlcApp.depots, preferredLanguage, null, dlcLicensedDepots, hasSteamUnlockedBranch,
+                    dlcApp.depots, preferredLanguage, null, dlcLicensedDepots, hasSteamUnlockedBranch, wantAndroid,
                 )
                 val dlcEligible = eligibleDepots(dlcApp.depots, dlcLanguage, null, dlcLicensedDepots, wantAndroid)
                 val dlcHasNonDeckWin = dlcEligible.any { !it.steamDeck && (if (wantAndroid) it.isAndroidCompatible else it.isWindowsCompatible) }

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1421,7 +1421,8 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         /** Whether the container for [appId] has the game's Android (Steam Frame / Lepton) depot selected. */
         fun isAndroidPlatform(appId: Int): Boolean {
-            val container = ContainerManager(instance!!.applicationContext).getContainerById("STEAM_${appId}")
+            val context = instance?.applicationContext ?: return false
+            val container = ContainerManager(context).getContainerById("STEAM_${appId}")
             return container?.platform.equals(Container.PLATFORM_ANDROID, ignoreCase = true)
         }
 

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -50,6 +50,7 @@ import app.gamenative.enums.SaveLocation
 import app.gamenative.enums.SyncResult
 import app.gamenative.events.AndroidEvent
 import app.gamenative.events.SteamEvent
+import app.gamenative.utils.AndroidGameLauncher
 import app.gamenative.utils.CaseInsensitiveFileSystem
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.FileUtils
@@ -841,6 +842,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             licensedDepotIds: Set<Int>? = null,
             hasSteamUnlockedBranch: Boolean = false,
             dlcAppIdsWithSingleDepots: Set<Int>? = null,
+            wantAndroid: Boolean = false,
         ): Boolean {
             if (depot.manifests.isEmpty() && depot.encryptedManifests.isNotEmpty() && !hasSteamUnlockedBranch)
                 return false
@@ -850,9 +852,14 @@ class SteamService : Service(), IChallengeUrlChanged {
                 depot.sharedInstall
             if (!hasContent)
                 return false
-            // 2. Supported OS
-            if (!depot.isWindowsCompatible)
+            // 2. Supported OS (Windows/untagged by default, or the Android depot when the
+            // user opted into the Android platform for this container)
+            if (wantAndroid) {
+                if (!depot.isAndroidCompatible)
+                    return false
+            } else if (!depot.isWindowsCompatible) {
                 return false
+            }
             // 3. 64-bit or indeterminate
             // Arch selection: allow 64-bit and Unknown always.
             // Allow 32-bit only when no 64-bit depot exists.
@@ -915,12 +922,14 @@ class SteamService : Service(), IChallengeUrlChanged {
             preferredLanguage: String,
             ownedDlc: Map<Int, DepotInfo>?,
             licensedDepotIds: Set<Int>?,
+            wantAndroid: Boolean = false,
         ): Collection<DepotInfo> {
             val dlcAppIdsWithSingleDepots = getDlcAppIdsWithSingleDepot(depots)
             return depots.values.filter { depot ->
                 filterForDownloadableDepots(depot, prefer64Bit = false, preferNonDeckWindows = false, preferredLanguage,
                     ownedDlc, licensedDepotIds,
-                    dlcAppIdsWithSingleDepots = dlcAppIdsWithSingleDepots
+                    dlcAppIdsWithSingleDepots = dlcAppIdsWithSingleDepots,
+                    wantAndroid = wantAndroid,
                 )
             }
         }
@@ -935,23 +944,25 @@ class SteamService : Service(), IChallengeUrlChanged {
             ownedDlc: Map<Int, DepotInfo>?,
             licensedDepotIds: Set<Int>?,
             hasSteamUnlockedBranch: Boolean = false,
+            wantAndroid: Boolean = false,
         ): Map<Int, DepotInfo> {
             val dlcAppIdsWithSingleDepots = getDlcAppIdsWithSingleDepot(depots)
             val effectiveLanguage = SteamUtils.effectiveDepotLanguage(
                 depots, preferredLanguage, ownedDlc, licensedDepotIds, hasSteamUnlockedBranch,
             )
-            val eligible = eligibleDepots(depots, effectiveLanguage, ownedDlc, licensedDepotIds)
+            val eligible = eligibleDepots(depots, effectiveLanguage, ownedDlc, licensedDepotIds, wantAndroid)
             val has64Bit = eligible.any { it.osArch == OSArch.Arch64 }
-            val hasNonDeckWin = eligible.any { !it.steamDeck && it.isWindowsCompatible }
+            val hasNonDeckWin = eligible.any { !it.steamDeck && (if (wantAndroid) it.isAndroidCompatible else it.isWindowsCompatible) }
             return depots.filter { (_, depot) ->
                 filterForDownloadableDepots(depot, has64Bit, hasNonDeckWin, effectiveLanguage,
                     ownedDlc, licensedDepotIds,
-                    dlcAppIdsWithSingleDepots = dlcAppIdsWithSingleDepots
+                    dlcAppIdsWithSingleDepots = dlcAppIdsWithSingleDepots,
+                    wantAndroid = wantAndroid,
                 )
             }
         }
 
-        fun getMainAppDepots(appId: Int, containerLanguage: String): Map<Int, DepotInfo> {
+        fun getMainAppDepots(appId: Int, containerLanguage: String, wantAndroid: Boolean = false): Map<Int, DepotInfo> {
             val appInfo = getAppInfoOf(appId) ?: return emptyMap()
             val ownedDlc = runBlocking { getOwnedAppDlc(appId) }
             val hasSteamUnlockedBranch = runBlocking { getSteamUnlockedBranches(appId).isNotEmpty() }
@@ -974,7 +985,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                 }
             }
 
-            val baseDepots = resolveDownloadableDepots(appInfo.depots, containerLanguage, ownedDlc, licensedDepots, hasSteamUnlockedBranch)
+            val baseDepots = resolveDownloadableDepots(appInfo.depots, containerLanguage, ownedDlc, licensedDepots, hasSteamUnlockedBranch, wantAndroid)
 
             // Find in the depots of mainApp, that if any of the depotID is actually belongs to another steam_app entry
             // override the dlcAppId to the corresponding app id
@@ -995,28 +1006,28 @@ class SteamService : Service(), IChallengeUrlChanged {
          * Get downloadable depots for a given app (default language), including all DLCs
          * @return Map of app ID to depot ID to depot info
          */
-        fun getDownloadableDepots(appId: Int): Map<Int, DepotInfo> {
+        fun getDownloadableDepots(appId: Int, wantAndroid: Boolean = false): Map<Int, DepotInfo> {
             val preferredLanguage = PrefManager.containerLanguage
-            return getDownloadableDepots(appId, preferredLanguage)
+            return getDownloadableDepots(appId, preferredLanguage, wantAndroid)
         }
 
         /**
          * Get downloadable depots for a given app (container language), including all DLCs
          * @return Map of app ID to depot ID to depot info
          */
-        fun getDownloadableDepots(appId: Int, preferredLanguage: String): Map<Int, DepotInfo> {
+        fun getDownloadableDepots(appId: Int, preferredLanguage: String, wantAndroid: Boolean = false): Map<Int, DepotInfo> {
             val appInfo = getAppInfoOf(appId) ?: return emptyMap()
             val ownedDlc = runBlocking { getOwnedAppDlc(appId) }
             val hasSteamUnlockedBranch = runBlocking { getSteamUnlockedBranches(appId).isNotEmpty() }
             val licensedDepots = getLicensedDepotIds(appId).orEmpty().toMutableSet()
 
-            val map = getMainAppDepots(appId, preferredLanguage).toMutableMap()
+            val map = getMainAppDepots(appId, preferredLanguage, wantAndroid).toMutableMap()
 
             // parent app's arch applies to DLC arch selection
             val mainLanguage = SteamUtils.effectiveDepotLanguage(
                 appInfo.depots, preferredLanguage, ownedDlc, licensedDepots, hasSteamUnlockedBranch,
             )
-            val has64Bit = eligibleDepots(appInfo.depots, mainLanguage, ownedDlc, licensedDepots)
+            val has64Bit = eligibleDepots(appInfo.depots, mainLanguage, ownedDlc, licensedDepots, wantAndroid)
                 .any { it.osArch == OSArch.Arch64 }
 
             val indirectDlcApps = getDownloadableDlcAppsOf(appId).orEmpty()
@@ -1027,13 +1038,14 @@ class SteamService : Service(), IChallengeUrlChanged {
                 val dlcLanguage = SteamUtils.effectiveDepotLanguage(
                     dlcApp.depots, preferredLanguage, null, dlcLicensedDepots, hasSteamUnlockedBranch,
                 )
-                val dlcEligible = eligibleDepots(dlcApp.depots, dlcLanguage, null, dlcLicensedDepots)
-                val dlcHasNonDeckWin = dlcEligible.any { !it.steamDeck && it.isWindowsCompatible }
+                val dlcEligible = eligibleDepots(dlcApp.depots, dlcLanguage, null, dlcLicensedDepots, wantAndroid)
+                val dlcHasNonDeckWin = dlcEligible.any { !it.steamDeck && (if (wantAndroid) it.isAndroidCompatible else it.isWindowsCompatible) }
                 dlcApp.depots
                     .filter { (_, depot) ->
                         filterForDownloadableDepots(depot, has64Bit, dlcHasNonDeckWin, dlcLanguage,
                             null, dlcLicensedDepots, hasSteamUnlockedBranch,
-                            dlcAppIdsWithSingleDepots = dlcAppIdsWithSingleDepots
+                            dlcAppIdsWithSingleDepots = dlcAppIdsWithSingleDepots,
+                            wantAndroid = wantAndroid,
                         )
                     }
                     .forEach { (depotId, depot) ->
@@ -1407,6 +1419,12 @@ class SteamService : Service(), IChallengeUrlChanged {
             }
         }
 
+        /** Whether the container for [appId] has the game's Android (Steam Frame / Lepton) depot selected. */
+        fun isAndroidPlatform(appId: Int): Boolean {
+            val container = ContainerManager(instance!!.applicationContext).getContainerById("STEAM_${appId}")
+            return container?.platform.equals(Container.PLATFORM_ANDROID, ignoreCase = true)
+        }
+
         fun downloadApp(appId: Int, dlcAppIds: List<Int>, branch: String = "public", isUpdateOrVerify: Boolean): DownloadInfo? {
             if (!checkWifiOrNotify()) return null
             return getAppInfoOf(appId)?.let { appInfo ->
@@ -1416,17 +1434,17 @@ class SteamService : Service(), IChallengeUrlChanged {
                 } else {
                     PrefManager.containerLanguage
                 }
+                val wantAndroid = container?.platform.equals(Container.PLATFORM_ANDROID, ignoreCase = true)
 
-                Timber.tag("SteamService").d("downloadApp: downloading app $appId with language $containerLanguage, branch $branch")
-
-                val depots = getDownloadableDepots(appId = appId, preferredLanguage = containerLanguage)
+                val depots = getDownloadableDepots(appId = appId, preferredLanguage = containerLanguage, wantAndroid = wantAndroid)
                 downloadApp(
                     appId = appId,
                     downloadableDepots = depots,
                     userSelectedDlcAppIds = dlcAppIds,
                     branch = branch,
                     containerLanguage = containerLanguage,
-                    isUpdateOrVerify = isUpdateOrVerify)
+                    isUpdateOrVerify = isUpdateOrVerify,
+                    wantAndroid = wantAndroid)
             }
         }
 
@@ -1726,6 +1744,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             branch: String,
             containerLanguage: String,
             isUpdateOrVerify: Boolean,
+            wantAndroid: Boolean = false,
         ): DownloadInfo? {
             val appDirPath = getAppDirPath(appId)
 
@@ -1741,7 +1760,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             }
 
             // Depots from Main game
-            val mainDepots = getMainAppDepots(appId, containerLanguage)
+            val mainDepots = getMainAppDepots(appId, containerLanguage, wantAndroid)
             var mainAppDepots = mainDepots.filter { (_, depot) ->
                 depot.dlcAppId == INVALID_APP_ID
             } + mainDepots.filter { (_, depot) ->
@@ -2219,6 +2238,19 @@ class SteamService : Service(), IChallengeUrlChanged {
                             downloadInfo.setPostInstallSyncing(false)
                             downloadInfo.updateStatusMessage(null)
                             PluviaApp.events.emit(AndroidEvent.PostInstallSyncStatusChanged(appId, false))
+                        }
+                    }
+
+                    // Android platform: the download itself doesn't put the game on the device —
+                    // kick off the system install prompt right away instead of waiting for a
+                    // manual Play click.
+                    if (isAndroidPlatform(appId)) {
+                        when (AndroidGameLauncher.installAndLaunch(svc.applicationContext, appId)) {
+                            AndroidGameLauncher.Result.InstallStarted ->
+                                SnackbarManager.show(svc.getString(R.string.android_game_install_started))
+                            AndroidGameLauncher.Result.Failed ->
+                                SnackbarManager.show(svc.getString(R.string.android_game_launch_failed))
+                            AndroidGameLauncher.Result.Launched -> Unit
                         }
                     }
                 }

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1614,6 +1614,20 @@ fun preLaunchApp(
         // create container if it does not already exist
         // TODO: combine somehow with container creation in HomeLibraryAppScreen
         val containerManager = ContainerManager(context)
+
+        // If a container already exists and is set to the Android platform, short-circuit before
+        // any Wine-specific setup below. getOrCreateContainer() can extract a Wine container
+        // pattern when creating a brand-new container, which a native Android launch neither
+        // needs nor should be able to fail because of.
+        if (containerManager.hasContainer(appId)) {
+            val existing = containerManager.getContainerById(appId)
+            if (existing?.platform.equals(Container.PLATFORM_ANDROID, ignoreCase = true)) {
+                setLoadingDialogVisible(false)
+                onSuccess(context, appId)
+                return@launch
+            }
+        }
+
         val container = if (useTemporaryOverride) {
             ContainerUtils.getOrCreateContainerWithOverride(context, appId)
         } else {

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1620,6 +1620,14 @@ fun preLaunchApp(
             ContainerUtils.getOrCreateContainer(context, appId)
         }
 
+        // Native Android (Steam Frame / Lepton) build: no Wine/Proton container, no manifest
+        // components to resolve — skip straight to launch.
+        if (container.platform.equals(Container.PLATFORM_ANDROID, ignoreCase = true)) {
+            setLoadingDialogVisible(false)
+            onSuccess(context, appId)
+            return@launch
+        }
+
         // Clear session metadata on every launch to ensure fresh values
         container.clearSessionMetadata()
 

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -1290,11 +1290,11 @@ fun ContainerConfigDialog(
                                 if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
                                 when (event.key) {
                                     Key.ButtonR1, Key.ButtonR2 -> {
-                                        selectedTab = (selectedTab + 1) % tabs.size
+                                        if (!isAndroidPlatform) selectedTab = (selectedTab + 1) % tabs.size
                                         true
                                     }
                                     Key.ButtonL1, Key.ButtonL2 -> {
-                                        selectedTab = (selectedTab - 1 + tabs.size) % tabs.size
+                                        if (!isAndroidPlatform) selectedTab = (selectedTab - 1 + tabs.size) % tabs.size
                                         true
                                     }
                                     else -> false

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -1408,6 +1408,7 @@ internal fun ExecutablePathDropdown(
     value: String,
     onValueChange: (String) -> Unit,
     containerData: ContainerData,
+    enabled: Boolean = true,
 ) {
     var expanded by remember { mutableStateOf(false) }
     var executables by remember { mutableStateOf<List<String>>(emptyList()) }
@@ -1424,14 +1425,15 @@ internal fun ExecutablePathDropdown(
     }
 
     ExposedDropdownMenuBox(
-        expanded = expanded,
-        onExpandedChange = { expanded = it },
+        expanded = expanded && enabled,
+        onExpandedChange = { if (enabled) expanded = it },
         modifier = modifier
     ) {
         NoExtractOutlinedTextField(
             value = value,
             onValueChange = onValueChange,
             readOnly = true,
+            enabled = enabled,
             label = { Text(stringResource(R.string.container_config_executable_path)) },
             placeholder = { Text(stringResource(R.string.container_config_executable_path_placeholder)) },
             trailingIcon = {
@@ -1448,7 +1450,7 @@ internal fun ExecutablePathDropdown(
                 // so the anchor never opens via controller. Intercept it here and toggle
                 // the menu. (Up/down focus-escape is handled in NoExtractOutlinedTextField.)
                 .onPreviewKeyEvent { event ->
-                    if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                    if (event.type != KeyEventType.KeyDown || !enabled) return@onPreviewKeyEvent false
                     when (event.key) {
                         Key.DirectionCenter, Key.Enter, Key.NumPadEnter, Key.Spacebar, Key.ButtonA -> {
                             expanded = !expanded

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -1415,6 +1415,12 @@ internal fun ExecutablePathDropdown(
     var isLoading by remember { mutableStateOf(true) }
     val context = LocalContext.current
 
+    // Otherwise a stale `expanded = true` from before this field was disabled would keep the
+    // menu open (and its items selectable) even though it's now greyed out.
+    LaunchedEffect(enabled) {
+        if (!enabled) expanded = false
+    }
+
     // Load executables from A: drive when component is first created
     LaunchedEffect(containerData.drives) {
         isLoading = true
@@ -1464,7 +1470,7 @@ internal fun ExecutablePathDropdown(
 
         if (!isLoading && executables.isNotEmpty()) {
             ExposedDropdownMenu(
-                expanded = expanded,
+                expanded = expanded && enabled,
                 onDismissRequest = { expanded = false }
             ) {
                 executables.forEach { executable ->

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -279,6 +279,7 @@ fun ContainerConfigDialog(
     default: Boolean = false,
     title: String,
     initialConfig: ContainerData = ContainerData(),
+    hasAndroidVersion: Boolean = false,
     onDismissRequest: () -> Unit,
     onSave: (ContainerData) -> Unit,
 ) {
@@ -378,6 +379,7 @@ fun ContainerConfigDialog(
         val installedLists = availability?.installed
 
         val isBionicVariant = config.containerVariant.equals(Container.BIONIC, ignoreCase = true)
+        val isAndroidPlatform = config.platform.equals(Container.PLATFORM_ANDROID, ignoreCase = true)
         val manifestDownloadMessage = if (manifestDownloadLabel.isNotEmpty()) {
             stringResource(R.string.manifest_downloading_item, manifestDownloadLabel)
         } else {
@@ -1175,6 +1177,8 @@ fun ContainerConfigDialog(
             gpuExtensions = gpuExtensions,
             inspectionMode = inspectionMode,
             isBionicVariant = isBionicVariant,
+            isAndroidPlatform = isAndroidPlatform,
+            hasAndroidVersion = hasAndroidVersion,
             nonDeletableDriveLetters = nonDeletableDriveLetters,
             availableDriveLetters = availableDriveLetters,
             launchManifestInstall = { entry, label, isDriver, expectedType, onInstalled ->
@@ -1252,6 +1256,12 @@ fun ContainerConfigDialog(
                     },
                 ) { paddingValues ->
                     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+                    // Android platform doesn't use Wine/Box64 at all: force the user back to
+                    // General (where the platform picker lives) so they can't get stuck on a
+                    // now-disabled tab.
+                    LaunchedEffect(isAndroidPlatform) {
+                        if (isAndroidPlatform) selectedTab = 0
+                    }
                     val tabs = listOf(
                         stringResource(R.string.container_config_tab_general),
                         stringResource(R.string.container_config_tab_graphics),
@@ -1302,6 +1312,7 @@ fun ContainerConfigDialog(
                             tabs.forEachIndexed { index, label ->
                                 Tab(
                                     selected = selectedTab == index,
+                                    enabled = index == 0 || !isAndroidPlatform,
                                     onClick = { selectedTab = index },
                                     text = { Text(text = label) },
                                     modifier = if (index == 0) {

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigState.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigState.kt
@@ -127,6 +127,8 @@ class ContainerConfigState(
     val gpuExtensions: List<String>,
     val inspectionMode: Boolean,
     val isBionicVariant: Boolean,
+    val isAndroidPlatform: Boolean,
+    val hasAndroidVersion: Boolean,
     val nonDeletableDriveLetters: Set<String>,
     val availableDriveLetters: List<String>,
     val launchManifestInstall: (ManifestEntry, String, Boolean, ContentProfile.ContentType?, () -> Unit) -> Unit,

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GameManagerDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GameManagerDialog.kt
@@ -116,7 +116,7 @@ fun GameManagerDialog(
         allDownloadableApps.clear()
 
         // Get Downloadable Depots
-        val allPossibleDownloadableDepots = SteamService.getDownloadableDepots(gameId)
+        val allPossibleDownloadableDepots = SteamService.getDownloadableDepots(gameId, wantAndroid = SteamService.isAndroidPlatform(gameId))
         downloadableDepots.putAll(allPossibleDownloadableDepots)
 
         // Get Optional DLC IDs

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
@@ -137,7 +137,28 @@ fun GeneralTabContent(
         )
     }
 
-    SettingsGroup() {
+    SettingsGroup {
+        if (state.hasAndroidVersion) {
+            val platformItems = listOf(
+                stringResource(R.string.container_platform_normal),
+                stringResource(R.string.container_platform_android),
+            )
+            val platformIndex = if (config.platform.equals(Container.PLATFORM_ANDROID, ignoreCase = true)) 1 else 0
+            SettingsListDropdown(
+                colors = settingsTileColors(),
+                title = { Text(text = stringResource(R.string.container_platform)) },
+                subtitle = { Text(text = stringResource(R.string.container_platform_description)) },
+                value = platformIndex,
+                items = platformItems,
+                enabled = true,
+                onItemSelected = { idx ->
+                    val newPlatform = if (idx == 1) Container.PLATFORM_ANDROID else Container.PLATFORM_WINDOWS
+                    state.config.value = config.copy(platform = newPlatform)
+                },
+            )
+        }
+    }
+    SettingsGroup(enabled = !state.isAndroidPlatform) {
         run {
             val variantIndex = rememberSaveable {
                 mutableIntStateOf(
@@ -282,7 +303,6 @@ fun GeneralTabContent(
             }
         }
         SettingsListDropdown(
-            enabled = true,
             value = state.languageIndex.value,
             items = state.languages.map(displayNameForLanguage),
             fallbackDisplay = displayNameForLanguage("english"),

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GeneralTab.kt
@@ -283,11 +283,13 @@ fun GeneralTabContent(
             value = config.executablePath,
             onValueChange = { state.config.value = config.copy(executablePath = it) },
             containerData = config,
+            enabled = !state.isAndroidPlatform,
         )
         NoExtractOutlinedTextField(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
             value = config.execArgs,
             onValueChange = { state.config.value = config.copy(execArgs = it) },
+            enabled = !state.isAndroidPlatform,
             label = { Text(text = stringResource(R.string.exec_arguments)) },
             placeholder = { Text(text = stringResource(R.string.exec_arguments_example)) },
             singleLine = true,

--- a/app/src/main/java/app/gamenative/ui/data/LibraryState.kt
+++ b/app/src/main/java/app/gamenative/ui/data/LibraryState.kt
@@ -1,5 +1,6 @@
 package app.gamenative.ui.data
 
+import app.gamenative.BuildConfig
 import app.gamenative.PrefManager
 import app.gamenative.data.GameCompatibilityStatus
 import app.gamenative.data.GameSource
@@ -11,8 +12,22 @@ import app.gamenative.ui.enums.LibraryTab
 import app.gamenative.ui.enums.SortOption
 import java.util.EnumSet
 
+/**
+ * Modern/ModernXr can't show or toggle the Android filter (see LibraryOptionsPanel), but a
+ * persisted selection from a Legacy install — or a restored backup — could still carry the flag.
+ * Strip it here so it can never silently restrict/empty the library with no way to turn it off.
+ */
+private fun sanitizedLibraryFilter(): EnumSet<AppFilter> {
+    val stored = PrefManager.libraryFilter
+    return if (BuildConfig.MODERN_ANDROID && stored.contains(AppFilter.ANDROID)) {
+        EnumSet.copyOf(stored).apply { remove(AppFilter.ANDROID) }
+    } else {
+        stored
+    }
+}
+
 data class LibraryState(
-    val appInfoSortType: EnumSet<AppFilter> = PrefManager.libraryFilter,
+    val appInfoSortType: EnumSet<AppFilter> = sanitizedLibraryFilter(),
     val appInfoList: List<LibraryItem> = emptyList(),
     val isRefreshing: Boolean = false,
 

--- a/app/src/main/java/app/gamenative/ui/enums/AppFilter.kt
+++ b/app/src/main/java/app/gamenative/ui/enums/AppFilter.kt
@@ -1,6 +1,7 @@
 package app.gamenative.ui.enums
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Android
 import androidx.compose.material.icons.filled.AvTimer
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Computer
@@ -83,6 +84,11 @@ enum class AppFilter(
         code = 0x400,
         displayTextRes = R.string.filter_proven_gpu,
         icon = Icons.Rounded.SportsEsports,
+    ),
+    ANDROID(
+        code = 0x1000,
+        displayTextRes = R.string.app_filter_android,
+        icon = Icons.Default.Android,
     ),
     // ALPHABETIC(
     //     code = 0x20,

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -626,6 +626,15 @@ class LibraryViewModel @Inject constructor(
                         true
                     }
                 }
+                .filter { item ->
+                    // item.depots is already deserialized in memory on the SteamApp we just
+                    // loaded, so this check is free — no per-item DB lookup.
+                    if (currentState.appInfoSortType.contains(AppFilter.ANDROID)) {
+                        item.depots.values.any { it.isAndroidCompatible }
+                    } else {
+                        true
+                    }
+                }
                 .toList()
 
             // Per-collection counts: computed from the owner/type/search-filtered set (independent of the
@@ -946,12 +955,17 @@ class LibraryViewModel @Inject constructor(
             // sources can't match it — keep them out of the combined list (and their tab counts).
             val steamCollectionSelected = allowedSteamAppIds != null
 
+            // The Android depot feature only exists for Steam apps (it's a Steam Frame / Lepton
+            // concept), so the other sources can never match this filter either.
+            val androidFilterActive = currentState.appInfoSortType.contains(AppFilter.ANDROID)
+            val excludeNonSteam = steamCollectionSelected || androidFilterActive
+
             val combined = buildList {
                 if (includeSteam) addAll(steamEntries)
-                if (includeOpen && !steamCollectionSelected) addAll(customEntries)
-                if (includeGOG && !steamCollectionSelected) addAll(gogEntries)
-                if (includeEpic && !steamCollectionSelected) addAll(epicEntries)
-                if (includeAmazon && !steamCollectionSelected) addAll(amazonEntries)
+                if (includeOpen && !excludeNonSteam) addAll(customEntries)
+                if (includeGOG && !excludeNonSteam) addAll(gogEntries)
+                if (includeEpic && !excludeNonSteam) addAll(epicEntries)
+                if (includeAmazon && !excludeNonSteam) addAll(amazonEntries)
             }.sortedWith(sortComparator).mapIndexed { idx, entry ->
                 entry.item.copy(index = idx, isInstalled = entry.isInstalled)
             }

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -467,14 +467,24 @@ class MainViewModel @Inject constructor(
 
     fun launchApp(context: Context, appId: String) {
         viewModelScope.launch {
-            val container = withContext(Dispatchers.IO) { ContainerUtils.getOrCreateContainer(context, appId) }
+            // Shared by both the Android and Wine paths below.
+            viewModelScope.launch(Dispatchers.IO) {
+                libraryPlayHistoryDao.upsert(
+                    LibraryPlayHistory(
+                        appId = appId,
+                        lastPlayed = System.currentTimeMillis(),
+                    ),
+                )
+            }
+
+            // getOrCreateContainerWithOverride also picks up a temporary per-launch config
+            // (e.g. from an external Intent launch) — falls back to the persisted container
+            // untouched when there's no override, so this is safe unconditionally.
+            val container = withContext(Dispatchers.IO) {
+                ContainerUtils.getOrCreateContainerWithOverride(context, appId)
+            }
             if (container.platform.equals(Container.PLATFORM_ANDROID, ignoreCase = true)) {
                 // Native Android (Steam Frame / Lepton) build: no Wine container involved at all.
-                withContext(Dispatchers.IO) {
-                    libraryPlayHistoryDao.upsert(
-                        LibraryPlayHistory(appId = appId, lastPlayed = System.currentTimeMillis()),
-                    )
-                }
                 val gameId = ContainerUtils.extractGameIdFromContainerId(appId)
                 when (withContext(Dispatchers.IO) { AndroidGameLauncher.installAndLaunch(context, gameId) }) {
                     AndroidGameLauncher.Result.InstallStarted ->
@@ -487,15 +497,6 @@ class MainViewModel @Inject constructor(
             }
 
             // Show booting splash before launching the app
-            viewModelScope.launch(Dispatchers.IO) {
-                libraryPlayHistoryDao.upsert(
-                    LibraryPlayHistory(
-                        appId = appId,
-                        lastPlayed = System.currentTimeMillis(),
-                    ),
-                )
-            }
-
             setShowBootingSplash(true)
             PluviaApp.events.emit(AndroidEvent.SetAllowedOrientation(PrefManager.allowedOrientation))
 

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
+import app.gamenative.R
 import app.gamenative.data.GameProcessInfo
 import app.gamenative.data.GameSource
 import app.gamenative.data.LibraryPlayHistory
@@ -29,11 +30,14 @@ import app.gamenative.utils.CustomGameScanner
 import app.gamenative.ui.data.MainState
 import app.gamenative.ui.enums.ConnectionState
 import app.gamenative.ui.screen.PluviaScreen
+import app.gamenative.ui.util.SnackbarManager
+import app.gamenative.utils.AndroidGameLauncher
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.IntentLaunchManager
 import app.gamenative.utils.SteamUtils
 import app.gamenative.utils.UpdateInfo
 import com.materialkolor.PaletteStyle
+import com.winlator.container.Container
 import com.winlator.xserver.Window
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.dragonbra.javasteam.steam.handlers.steamapps.AppProcessInfo
@@ -462,8 +466,27 @@ class MainViewModel @Inject constructor(
     }
 
     fun launchApp(context: Context, appId: String) {
-        // Show booting splash before launching the app
         viewModelScope.launch {
+            val container = withContext(Dispatchers.IO) { ContainerUtils.getOrCreateContainer(context, appId) }
+            if (container.platform.equals(Container.PLATFORM_ANDROID, ignoreCase = true)) {
+                // Native Android (Steam Frame / Lepton) build: no Wine container involved at all.
+                withContext(Dispatchers.IO) {
+                    libraryPlayHistoryDao.upsert(
+                        LibraryPlayHistory(appId = appId, lastPlayed = System.currentTimeMillis()),
+                    )
+                }
+                val gameId = ContainerUtils.extractGameIdFromContainerId(appId)
+                when (withContext(Dispatchers.IO) { AndroidGameLauncher.installAndLaunch(context, gameId) }) {
+                    AndroidGameLauncher.Result.InstallStarted ->
+                        SnackbarManager.show(context.getString(R.string.android_game_install_started))
+                    AndroidGameLauncher.Result.Failed ->
+                        SnackbarManager.show(context.getString(R.string.android_game_launch_failed))
+                    AndroidGameLauncher.Result.Launched -> Unit
+                }
+                return@launch
+            }
+
+            // Show booting splash before launching the app
             viewModelScope.launch(Dispatchers.IO) {
                 libraryPlayHistoryDao.upsert(
                     LibraryPlayHistory(

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -606,6 +606,12 @@ abstract class BaseAppScreen {
 
     protected open fun supportsSaveTransfer(libraryItem: LibraryItem): Boolean = false
 
+    /** Whether this game also has a native Android (Steam Frame / Lepton) depot available. */
+    open fun hasAndroidVersion(libraryItem: LibraryItem): Boolean = false
+
+    /** Package name of the Android app installed/installing for this game, or null if not applicable. */
+    open fun getAndroidPackageName(context: Context, libraryItem: LibraryItem): String? = null
+
     protected open suspend fun exportSaves(
         context: Context,
         libraryItem: LibraryItem,
@@ -1070,6 +1076,39 @@ abstract class BaseAppScreen {
             performStateRefresh(true)
         }
 
+        // Android platform games: the actual install happens in the system's own installer UI,
+        // outside our control, so listen for its completion broadcast instead of requiring the
+        // user to leave and come back to this screen for the Play button to appear.
+        DisposableEffect(libraryItem.appId) {
+            val androidPackageName = getAndroidPackageName(context, libraryItem)
+            if (androidPackageName == null) {
+                onDispose { }
+            } else {
+                val receiver = object : android.content.BroadcastReceiver() {
+                    override fun onReceive(ctx: Context, intent: Intent) {
+                        if (intent.data?.schemeSpecificPart == androidPackageName) {
+                            requestStateRefresh(true)
+                        }
+                    }
+                }
+                val filter = android.content.IntentFilter().apply {
+                    addAction(Intent.ACTION_PACKAGE_ADDED)
+                    addAction(Intent.ACTION_PACKAGE_REPLACED)
+                    addAction(Intent.ACTION_PACKAGE_REMOVED)
+                    addDataScheme("package")
+                }
+                androidx.core.content.ContextCompat.registerReceiver(
+                    context,
+                    receiver,
+                    filter,
+                    androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED,
+                )
+                onDispose {
+                    context.unregisterReceiver(receiver)
+                }
+            }
+        }
+
         var showConfigDialog by androidx.compose.runtime.remember {
             androidx.compose.runtime.mutableStateOf(false)
         }
@@ -1380,6 +1419,7 @@ abstract class BaseAppScreen {
             ContainerConfigDialog(
                 title = "${displayInfo.name} Config",
                 initialConfig = containerData,
+                hasAndroidVersion = remember(libraryItem.appId) { hasAndroidVersion(libraryItem) },
                 onDismissRequest = { showConfigDialog = false },
                 onSave = {
                     saveContainerConfig(context, libraryItem, it)

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -1053,6 +1054,11 @@ abstract class BaseAppScreen {
 
         val uiScope = rememberCoroutineScope()
 
+        // Increments on every refresh, unlike isDownloadingState/isInstalledState which can flip
+        // true->false within the same recomposition on a very fast download and never be observed
+        // by an effect keyed on them — this always counts as a distinct key.
+        var stateRefreshGeneration by remember(libraryItem.appId) { mutableIntStateOf(0) }
+
         suspend fun performStateRefresh(includeUpdatePending: Boolean) {
             isInstalledState = isInstalled(context, libraryItem)
             isValidToDownloadState = isValidToDownload(context, libraryItem)
@@ -1064,6 +1070,7 @@ abstract class BaseAppScreen {
             if (includeUpdatePending) {
                 isUpdatePendingState = isUpdatePendingSuspend(context, libraryItem)
             }
+            stateRefreshGeneration++
         }
 
         fun requestStateRefresh(includeUpdatePending: Boolean) {
@@ -1079,10 +1086,10 @@ abstract class BaseAppScreen {
         // Android platform games: the actual install happens in the system's own installer UI,
         // outside our control, so listen for its completion broadcast instead of requiring the
         // user to leave and come back to this screen for the Play button to appear.
-        // Keyed on download/install state too: getAndroidPackageName() reads the APK off disk,
-        // which is null until the download finishes, so the effect needs to re-run once that
-        // changes rather than being stuck with the null result from the initial composition.
-        DisposableEffect(libraryItem.appId, isDownloadingState, isInstalledState) {
+        // Keyed on stateRefreshGeneration: getAndroidPackageName() reads the APK off disk, which
+        // is null until the download finishes, so the effect needs to re-run once that changes
+        // rather than being stuck with the null result from the initial composition.
+        DisposableEffect(libraryItem.appId, stateRefreshGeneration) {
             val androidPackageName = getAndroidPackageName(context, libraryItem)
             if (androidPackageName == null) {
                 onDispose { }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -1052,6 +1052,14 @@ abstract class BaseAppScreen {
             mutableStateOf(hasLeftoverInstall(context, libraryItem))
         }
 
+        // hasAndroidVersion() can hit the database (SteamService.getAppInfoOf does a blocking
+        // Room query) — compute it off the main thread once per screen visit, instead of
+        // re-running it synchronously on the main thread every time Edit Container is opened.
+        var hasAndroidVersionState by remember(libraryItem.appId) { mutableStateOf(false) }
+        LaunchedEffect(libraryItem.appId) {
+            hasAndroidVersionState = withContext(Dispatchers.IO) { hasAndroidVersion(libraryItem) }
+        }
+
         val uiScope = rememberCoroutineScope()
 
         // Increments on every refresh, unlike isDownloadingState/isInstalledState which can flip
@@ -1127,8 +1135,14 @@ abstract class BaseAppScreen {
         }
 
         val onEditContainer: () -> Unit = {
-            containerData = loadContainerData(context, libraryItem)
-            showConfigDialog = true
+            // loadContainerData() reads/parses the container's JSON off disk (and may create it
+            // on first access) — do that off the main thread so opening this dialog doesn't
+            // freeze the screen while it loads.
+            uiScope.launch {
+                val data = withContext(Dispatchers.IO) { loadContainerData(context, libraryItem) }
+                containerData = data
+                showConfigDialog = true
+            }
         }
 
         // Export for Frontend launcher
@@ -1429,7 +1443,7 @@ abstract class BaseAppScreen {
             ContainerConfigDialog(
                 title = "${displayInfo.name} Config",
                 initialConfig = containerData,
-                hasAndroidVersion = remember(libraryItem.appId) { hasAndroidVersion(libraryItem) },
+                hasAndroidVersion = hasAndroidVersionState,
                 onDismissRequest = { showConfigDialog = false },
                 onSave = {
                     saveContainerConfig(context, libraryItem, it)

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -1079,7 +1079,10 @@ abstract class BaseAppScreen {
         // Android platform games: the actual install happens in the system's own installer UI,
         // outside our control, so listen for its completion broadcast instead of requiring the
         // user to leave and come back to this screen for the Play button to appear.
-        DisposableEffect(libraryItem.appId) {
+        // Keyed on download/install state too: getAndroidPackageName() reads the APK off disk,
+        // which is null until the download finishes, so the effect needs to re-run once that
+        // changes rather than being stuck with the null result from the initial composition.
+        DisposableEffect(libraryItem.appId, isDownloadingState, isInstalledState) {
             val androidPackageName = getAndroidPackageName(context, libraryItem)
             if (androidPackageName == null) {
                 onDispose { }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -227,8 +227,20 @@ class SteamAppScreen : BaseAppScreen() {
             return pendingUpdateVerifyOperations[gameId]
         }
 
-        // Shared state for deletion progress dialog
-        var showDeletingDialog by mutableStateOf(false)
+        // Shared state for deletion progress dialog - map of gameId to visibility
+        private val deletingDialogVisible = mutableStateMapOf<Int, Boolean>()
+
+        fun showDeletingDialog(gameId: Int) {
+            deletingDialogVisible[gameId] = true
+        }
+
+        fun hideDeletingDialog(gameId: Int) {
+            deletingDialogVisible.remove(gameId)
+        }
+
+        fun isDeletingDialogVisible(gameId: Int): Boolean {
+            return deletingDialogVisible[gameId] == true
+        }
     }
 
     @Composable
@@ -252,11 +264,16 @@ class SteamAppScreen : BaseAppScreen() {
         var isInstalled by remember(libraryItem.appId) {
             mutableStateOf(SteamService.isAppInstalled(gameId))
         }
+        // Bumped on every LibraryInstallStatusChanged, even when isInstalled itself doesn't
+        // change (e.g. platform switched on a not-yet-installed game) — sizeFromStore below
+        // depends on the container's platform, not just on install state.
+        var refreshTrigger by remember(libraryItem.appId) { mutableIntStateOf(0) }
 
         DisposableEffect(gameId) {
             val listener: (AndroidEvent.LibraryInstallStatusChanged) -> Unit = { event ->
                 if (event.appId == gameId) {
                     isInstalled = SteamService.isAppInstalled(gameId)
+                    refreshTrigger++
                 }
             }
             PluviaApp.events.on<AndroidEvent.LibraryInstallStatusChanged, Unit>(listener)
@@ -290,7 +307,7 @@ class SteamAppScreen : BaseAppScreen() {
 
         // Get size on disk (async, will update via state)
         var sizeOnDisk by remember { mutableStateOf<String?>(null) }
-        LaunchedEffect(isInstalled, gameId) {
+        LaunchedEffect(isInstalled, gameId, refreshTrigger) {
             if (isInstalled) {
                 DownloadService.getSizeOnDiskDisplay(gameId) {
                     sizeOnDisk = it
@@ -302,7 +319,7 @@ class SteamAppScreen : BaseAppScreen() {
 
         // Get size from store (async, will update via state)
         var sizeFromStore by remember { mutableStateOf<String?>(null) }
-        LaunchedEffect(isInstalled, gameId) {
+        LaunchedEffect(isInstalled, gameId, refreshTrigger) {
             if (!isInstalled) {
                 // Load size from store on IO, assign on Main to respect Compose threading
                 val size = withContext(Dispatchers.IO) {
@@ -884,13 +901,18 @@ class SteamAppScreen : BaseAppScreen() {
             platformChanged && SteamService.isAppInstalled(gameId) -> {
                 CoroutineScope(Dispatchers.IO).launch {
                     SnackbarManager.show(context.getString(R.string.container_platform_switch_reinstalling))
-                    // Resolve and prompt removal of the installed Android app BEFORE its .apk
-                    // is deleted below — that's the only place the package name can still be
-                    // read from, and once the platform is switched away there's no other path
-                    // back to it.
+                    // Resolve and prompt removal of the installed Android app BEFORE its .apk is
+                    // deleted below — that's the only place the package name can still be read
+                    // from, and once the platform is switched away there's no other path back to
+                    // it. Wait for confirmation: if the user cancels, leave the files/app alone
+                    // rather than orphaning a still-installed app.
                     if (wasAndroid) {
-                        withContext(Dispatchers.Main) {
+                        val canDeleteFiles = withContext(Dispatchers.Main) {
                             AndroidGameLauncher.requestUninstall(context, gameId)
+                        }
+                        if (!canDeleteFiles) {
+                            SnackbarManager.show(context.getString(R.string.android_game_uninstall_cancelled))
+                            return@launch
                         }
                     }
                     SteamService.deleteApp(gameId)
@@ -903,12 +925,22 @@ class SteamAppScreen : BaseAppScreen() {
                     SteamService.downloadApp(gameId)
                 }
             }
+            platformChanged -> {
+                // Not installed yet, nothing to redownload — but the store-size display on the
+                // game page reads the container's platform and needs a nudge to recompute now
+                // that it changed.
+                PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.STEAM))
+            }
         }
     }
 
     override fun supportsContainerConfig(): Boolean = true
 
     override fun hasAndroidVersion(libraryItem: LibraryItem): Boolean {
+        // Modern/ModernXr strip the install/uninstall-package permissions (Horizon Store
+        // compliance), so they can't actually install a native Android build — keep the
+        // selector Legacy-only rather than offering a choice that can't work there.
+        if (BuildConfig.MODERN_ANDROID) return false
         return SteamService.getAppInfoOf(libraryItem.gameId)?.depots?.values?.any { it.isAndroidCompatible } == true
     }
 
@@ -1173,7 +1205,7 @@ class SteamAppScreen : BaseAppScreen() {
                         downloadInfo?.cancel()
                         SteamService.workshopPausedApps.remove(gameId)
                         hideInstallDialog(gameId)
-                        showDeletingDialog = true
+                        showDeletingDialog(gameId)
                         CoroutineScope(Dispatchers.IO).launch {
                             try {
                                 SteamService.deleteApp(gameId)
@@ -1181,7 +1213,7 @@ class SteamAppScreen : BaseAppScreen() {
                                 PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(gameId, GameSource.STEAM))
                             } finally {
                                 withContext(NonCancellable + Dispatchers.Main) {
-                                    showDeletingDialog = false
+                                    hideDeletingDialog(gameId)
                                 }
                             }
                         }
@@ -1300,7 +1332,7 @@ class SteamAppScreen : BaseAppScreen() {
                     TextButton(
                         onClick = {
                             hideUninstallDialog(libraryItem.appId)
-                            showDeletingDialog = true
+                            showDeletingDialog(gameId)
 
                             CoroutineScope(Dispatchers.IO).launch {
                                 try {
@@ -1309,12 +1341,18 @@ class SteamAppScreen : BaseAppScreen() {
 
                                     // The installed Android app (Steam Frame / Lepton games) is a
                                     // separate system entity from GameNative's own downloaded copy —
-                                    // prompt its uninstall before we delete the .apk we need to
-                                    // resolve the package name from. Checked by looking for an actual
-                                    // .apk on disk rather than the container's current platform
-                                    // setting, which may have since been switched back.
-                                    withContext(Dispatchers.Main) {
+                                    // prompt its uninstall and wait for confirmation before we delete
+                                    // the .apk we need to resolve the package name from. Checked by
+                                    // looking for an actual .apk on disk rather than the container's
+                                    // current platform setting, which may have since been switched back.
+                                    val canDeleteFiles = withContext(Dispatchers.Main) {
                                         AndroidGameLauncher.requestUninstall(context, gameId)
+                                    }
+                                    if (!canDeleteFiles) {
+                                        withContext(Dispatchers.Main) {
+                                            SnackbarManager.show(context.getString(R.string.android_game_uninstall_cancelled))
+                                        }
+                                        return@launch
                                     }
 
                                     val success = SteamService.deleteApp(gameId)
@@ -1351,7 +1389,7 @@ class SteamAppScreen : BaseAppScreen() {
                                     }
                                 } finally {
                                     withContext(NonCancellable + Dispatchers.Main) {
-                                        showDeletingDialog = false
+                                        hideDeletingDialog(gameId)
                                     }
                                 }
                             }
@@ -1380,7 +1418,7 @@ class SteamAppScreen : BaseAppScreen() {
         }
 
         // Deletion progress dialog
-        if (showDeletingDialog) {
+        if (isDeletingDialogVisible(gameId)) {
             LoadingDialog(
                 visible = true,
                 progress = -1f,

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -872,6 +872,7 @@ class SteamAppScreen : BaseAppScreen() {
     override fun saveContainerConfig(context: Context, libraryItem: LibraryItem, config: ContainerData) {
         val container = getContainer(context, libraryItem.appId)
         val platformChanged = !container.platform.equals(config.platform, ignoreCase = true)
+        val wasAndroid = container.platform.equals(Container.PLATFORM_ANDROID, ignoreCase = true)
         val languageChanged = container.language != config.language
         ContainerUtils.applyToContainer(context, libraryItem.appId, config)
 
@@ -883,6 +884,15 @@ class SteamAppScreen : BaseAppScreen() {
             platformChanged && SteamService.isAppInstalled(gameId) -> {
                 CoroutineScope(Dispatchers.IO).launch {
                     SnackbarManager.show(context.getString(R.string.container_platform_switch_reinstalling))
+                    // Resolve and prompt removal of the installed Android app BEFORE its .apk
+                    // is deleted below — that's the only place the package name can still be
+                    // read from, and once the platform is switched away there's no other path
+                    // back to it.
+                    if (wasAndroid) {
+                        withContext(Dispatchers.Main) {
+                            AndroidGameLauncher.requestUninstall(context, gameId)
+                        }
+                    }
                     SteamService.deleteApp(gameId)
                     DownloadService.invalidateCache()
                     SteamService.downloadApp(gameId)

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -57,6 +57,7 @@ import app.gamenative.ui.data.AppMenuOption
 import app.gamenative.ui.data.GameDisplayInfo
 import app.gamenative.ui.enums.AppOptionMenuType
 import app.gamenative.ui.enums.DialogType
+import app.gamenative.utils.AndroidGameLauncher
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.MarkerUtils
 import app.gamenative.utils.SteamUtils
@@ -367,7 +368,14 @@ class SteamAppScreen : BaseAppScreen() {
     }
 
     override fun isInstalled(context: Context, libraryItem: LibraryItem): Boolean {
-        return SteamService.isAppInstalled(libraryItem.gameId)
+        val gameId = libraryItem.gameId
+        if (!SteamService.isAppInstalled(gameId)) return false
+        // Android platform: the depot being downloaded isn't the same as the app actually
+        // being installed on the system — only show Play once it really is.
+        if (SteamService.isAndroidPlatform(gameId)) {
+            return AndroidGameLauncher.isGameInstalled(context, gameId)
+        }
+        return true
     }
 
     override fun isValidToDownload(context: Context, libraryItem: LibraryItem): Boolean {
@@ -863,16 +871,42 @@ class SteamAppScreen : BaseAppScreen() {
 
     override fun saveContainerConfig(context: Context, libraryItem: LibraryItem, config: ContainerData) {
         val container = getContainer(context, libraryItem.appId)
+        val platformChanged = !container.platform.equals(config.platform, ignoreCase = true)
+        val languageChanged = container.language != config.language
         ContainerUtils.applyToContainer(context, libraryItem.appId, config)
 
-        if (container.language != config.language) {
-            CoroutineScope(Dispatchers.IO).launch {
-                SteamService.downloadApp(libraryItem.gameId)
+        val gameId = libraryItem.gameId
+        when {
+            // Switching platform on an already-installed game: drop the old platform's files
+            // and fetch the newly selected one. Not installed yet -> just remember the choice,
+            // the Install/Play button will pick it up when the user actually installs.
+            platformChanged && SteamService.isAppInstalled(gameId) -> {
+                CoroutineScope(Dispatchers.IO).launch {
+                    SnackbarManager.show(context.getString(R.string.container_platform_switch_reinstalling))
+                    SteamService.deleteApp(gameId)
+                    DownloadService.invalidateCache()
+                    SteamService.downloadApp(gameId)
+                }
+            }
+            languageChanged -> {
+                CoroutineScope(Dispatchers.IO).launch {
+                    SteamService.downloadApp(gameId)
+                }
             }
         }
     }
 
     override fun supportsContainerConfig(): Boolean = true
+
+    override fun hasAndroidVersion(libraryItem: LibraryItem): Boolean {
+        return SteamService.getAppInfoOf(libraryItem.gameId)?.depots?.values?.any { it.isAndroidCompatible } == true
+    }
+
+    override fun getAndroidPackageName(context: Context, libraryItem: LibraryItem): String? {
+        val gameId = libraryItem.gameId
+        if (!SteamService.isAndroidPlatform(gameId)) return null
+        return AndroidGameLauncher.resolvePackageName(context, gameId)
+    }
 
     override fun getExportFileExtension(): String = ".steam"
 
@@ -1008,7 +1042,7 @@ class SteamAppScreen : BaseAppScreen() {
             }
         }
 
-        LaunchedEffect(gameId, hasStoragePermission) {
+        LaunchedEffect(gameId, hasStoragePermission, installDialogState.visible) {
             if (!hasStoragePermission) {
                 installSizeInfo = null
                 return@LaunchedEffect
@@ -1017,7 +1051,8 @@ class SteamAppScreen : BaseAppScreen() {
                 val info = withContext(Dispatchers.IO) {
                     val container = ContainerManager(context).getContainerById("STEAM_$gameId")
                     val language = container?.language ?: PrefManager.containerLanguage
-                    val depots = SteamService.getDownloadableDepots(gameId, language)
+                    val wantAndroid = container?.platform.equals(Container.PLATFORM_ANDROID, ignoreCase = true)
+                    val depots = SteamService.getDownloadableDepots(gameId, language, wantAndroid)
                     Timber.i("There are ${depots.size} depots belonging to ${libraryItem.appId}")
                     val branch = SteamService.getInstalledApp(gameId)?.branch ?: "public"
                     val availableBytes = StorageUtils.getAvailableSpaceForUncreatedPath(SteamService.getAppDirPath(gameId))
@@ -1261,6 +1296,16 @@ class SteamAppScreen : BaseAppScreen() {
                                 try {
                                     val installedAppInfo = getInstalledApp(libraryItem.gameId)
                                     val gameRootDir = getInstallPath(context, libraryItem)?.let(::File)
+
+                                    // The installed Android app (Steam Frame / Lepton games) is a
+                                    // separate system entity from GameNative's own downloaded copy —
+                                    // prompt its uninstall before we delete the .apk we need to
+                                    // resolve the package name from. Checked by looking for an actual
+                                    // .apk on disk rather than the container's current platform
+                                    // setting, which may have since been switched back.
+                                    withContext(Dispatchers.Main) {
+                                        AndroidGameLauncher.requestUninstall(context, gameId)
+                                    }
 
                                     val success = SteamService.deleteApp(gameId)
                                     DownloadService.invalidateCache()

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/SteamAppScreen.kt
@@ -914,6 +914,7 @@ class SteamAppScreen : BaseAppScreen() {
                             SnackbarManager.show(context.getString(R.string.android_game_uninstall_cancelled))
                             return@launch
                         }
+                        AndroidGameLauncher.cleanupStagedApk(context, gameId)
                     }
                     SteamService.deleteApp(gameId)
                     DownloadService.invalidateCache()
@@ -1354,6 +1355,7 @@ class SteamAppScreen : BaseAppScreen() {
                                         }
                                         return@launch
                                     }
+                                    AndroidGameLauncher.cleanupStagedApk(context, gameId)
 
                                     val success = SteamService.deleteApp(gameId)
                                     DownloadService.invalidateCache()

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryOptionsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryOptionsPanel.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import app.gamenative.BuildConfig
 import app.gamenative.PrefManager
 import app.gamenative.R
 import app.gamenative.data.SteamCollection
@@ -259,18 +260,24 @@ fun LibraryOptionsPanel(
                                 .padding(horizontal = 8.dp),
                             verticalArrangement = Arrangement.spacedBy(2.dp)
                         ) {
+                            // Modern/ModernXr builds can't install a native Android build (Horizon
+                            // Store compliance strips the install-package permissions), so this
+                            // filter would just hide games with nothing wrong with them there.
+                            val statusFilters = remember {
+                                buildList {
+                                    add(AppFilter.INSTALLED)
+                                    add(AppFilter.SHARED)
+                                    add(AppFilter.COMPATIBLE)
+                                    add(AppFilter.EXPIRED)
+                                    add(AppFilter.PLAYABLE)
+                                    add(AppFilter.FIVE_STAR)
+                                    add(AppFilter.FIVE_STAR_GPU)
+                                    add(AppFilter.PROVEN_GPU)
+                                    if (!BuildConfig.MODERN_ANDROID) add(AppFilter.ANDROID)
+                                }
+                            }
                             AppFilter.entries.forEach { appFilter ->
-                                if (appFilter in listOf(
-                                        AppFilter.INSTALLED,
-                                        AppFilter.SHARED,
-                                        AppFilter.COMPATIBLE,
-                                        AppFilter.EXPIRED,
-                                        AppFilter.PLAYABLE,
-                                        AppFilter.FIVE_STAR,
-                                        AppFilter.FIVE_STAR_GPU,
-                                        AppFilter.PROVEN_GPU,
-                                    )
-                                ) {
+                                if (appFilter in statusFilters) {
                                     OptionListItem(
                                         text = stringResource(appFilter.displayTextRes),
                                         selected = selectedFilters.contains(appFilter),

--- a/app/src/main/java/app/gamenative/utils/AndroidGameLauncher.kt
+++ b/app/src/main/java/app/gamenative/utils/AndroidGameLauncher.kt
@@ -76,6 +76,8 @@ object AndroidGameLauncher {
         }
     }
 
+    private const val STAGING_DIR_NAME = "android_game_installs"
+
     /**
      * Copies the downloaded .apk into the app's own cache dir so FileProvider only ever needs to
      * grant access to a narrow, app-controlled location (already covered by the existing
@@ -83,13 +85,26 @@ object AndroidGameLauncher {
      */
     private fun stageApkForInstall(context: Context, gameId: Int, apk: File): File? {
         return try {
-            val stagingDir = File(context.cacheDir, "android_game_installs").apply { mkdirs() }
+            val stagingDir = File(context.cacheDir, STAGING_DIR_NAME).apply { mkdirs() }
             val staged = File(stagingDir, "$gameId.apk")
             apk.copyTo(staged, overwrite = true)
             staged
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Could not stage APK for install from ${apk.absolutePath}")
             null
+        }
+    }
+
+    /**
+     * Removes this game's staged install copy, if any. Each staged .apk is only overwritten by a
+     * later install of the *same* game, so without this, every distinct Android game ever
+     * installed leaves a permanent copy behind in the cache dir. Safe to call any time, including
+     * when nothing was ever staged.
+     */
+    fun cleanupStagedApk(context: Context, gameId: Int) {
+        val staged = File(File(context.cacheDir, STAGING_DIR_NAME), "$gameId.apk")
+        if (staged.exists() && !staged.delete()) {
+            Timber.tag(TAG).w("Could not delete staged APK ${staged.absolutePath}")
         }
     }
 

--- a/app/src/main/java/app/gamenative/utils/AndroidGameLauncher.kt
+++ b/app/src/main/java/app/gamenative/utils/AndroidGameLauncher.kt
@@ -1,0 +1,141 @@
+package app.gamenative.utils
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Environment
+import app.gamenative.service.SteamService
+import timber.log.Timber
+import java.io.File
+
+/**
+ * Installs/launches the native Android build of a game (Steam Frame / Lepton depot),
+ * bypassing the Wine/Winlator container entirely.
+ */
+object AndroidGameLauncher {
+
+    private const val TAG = "AndroidGameLauncher"
+
+    private fun findApkFile(gameId: Int): File? {
+        val dir = File(SteamService.getAppDirPath(gameId))
+        if (!dir.exists()) return null
+        return dir.walkTopDown().firstOrNull { it.isFile && it.extension.equals("apk", ignoreCase = true) }
+    }
+
+    private fun findObbFiles(gameId: Int): List<File> {
+        val dir = File(SteamService.getAppDirPath(gameId))
+        if (!dir.exists()) return emptyList()
+        return dir.walkTopDown().filter { it.isFile && it.extension.equals("obb", ignoreCase = true) }.toList()
+    }
+
+    private fun getApkPackageName(context: Context, apk: File): String? {
+        return try {
+            context.packageManager.getPackageArchiveInfo(apk.absolutePath, 0)?.packageName
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Could not read package info from ${apk.absolutePath}")
+            null
+        }
+    }
+
+    private fun isPackageInstalled(context: Context, packageName: String): Boolean {
+        return try {
+            context.packageManager.getPackageInfo(packageName, 0)
+            true
+        } catch (e: PackageManager.NameNotFoundException) {
+            false
+        }
+    }
+
+    /**
+     * Best-effort OBB placement under /Android/obb/<package>/. On Android 11+ this requires
+     * broad ("All files access") storage permission GameNative doesn't currently request, so
+     * this silently no-ops there — games that need their OBB will fail to start until that's added.
+     */
+    private fun copyObbFiles(gameId: Int, packageName: String) {
+        val obbFiles = findObbFiles(gameId)
+        if (obbFiles.isEmpty()) return
+        try {
+            val obbRoot = File(Environment.getExternalStorageDirectory(), "Android/obb/$packageName")
+            obbRoot.mkdirs()
+            obbFiles.forEach { src -> src.copyTo(File(obbRoot, src.name), overwrite = true) }
+            Timber.tag(TAG).i("Copied ${obbFiles.size} OBB file(s) to ${obbRoot.absolutePath}")
+        } catch (e: Exception) {
+            Timber.tag(TAG).w(e, "Could not place OBB files for $packageName (needs broader storage access on Android 11+)")
+        }
+    }
+
+    /** Package name of this game's downloaded .apk, or null if none is on disk / unreadable. */
+    fun resolvePackageName(context: Context, gameId: Int): String? {
+        val apk = findApkFile(gameId) ?: return null
+        return getApkPackageName(context, apk)
+    }
+
+    /** Whether the Android app for this game is actually installed on the system (not just downloaded). */
+    fun isGameInstalled(context: Context, gameId: Int): Boolean {
+        val packageName = resolvePackageName(context, gameId) ?: return false
+        return isPackageInstalled(context, packageName)
+    }
+
+    sealed class Result {
+        data object Launched : Result()
+        data object InstallStarted : Result()
+        data object Failed : Result()
+    }
+
+    /**
+     * If the downloaded APK is already installed, launches it directly. Otherwise kicks off
+     * the system install flow (user confirmation required) — the caller must ask the user to
+     * press Play again once that finishes; there is no reliable synchronous "wait for install".
+     */
+    fun installAndLaunch(context: Context, gameId: Int): Result {
+        val apk = findApkFile(gameId)
+        if (apk == null) {
+            Timber.tag(TAG).e("No APK found on disk for game $gameId")
+            return Result.Failed
+        }
+        val packageName = getApkPackageName(context, apk)
+        if (packageName == null) {
+            Timber.tag(TAG).e("Could not resolve package name from ${apk.absolutePath}")
+            return Result.Failed
+        }
+        if (!isPackageInstalled(context, packageName)) {
+            copyObbFiles(gameId, packageName)
+            UpdateInstaller.installApk(context, apk)
+            return Result.InstallStarted
+        }
+        val intent = context.packageManager.getLaunchIntentForPackage(packageName)
+            ?: return Result.Failed
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+        return Result.Launched
+    }
+
+    /**
+     * Prompts the system uninstall dialog for the Android package matching this game, if one
+     * is actually installed. Must be called before the downloaded .apk is deleted from disk
+     * (needed to resolve the package name). This is a separate step from GameNative forgetting
+     * the game — the installed app is a distinct entity on the system that Android requires
+     * explicit user confirmation to remove.
+     */
+    fun requestUninstall(context: Context, gameId: Int) {
+        val apk = findApkFile(gameId)
+        if (apk == null) {
+            Timber.tag(TAG).w("requestUninstall: no APK found on disk for game $gameId, skipping system uninstall")
+            return
+        }
+        val packageName = getApkPackageName(context, apk)
+        if (packageName == null) {
+            Timber.tag(TAG).w("requestUninstall: could not resolve package name from ${apk.absolutePath}")
+            return
+        }
+        if (!isPackageInstalled(context, packageName)) {
+            Timber.tag(TAG).w("requestUninstall: package $packageName is not currently installed, skipping")
+            return
+        }
+        Timber.tag(TAG).i("requestUninstall: prompting system uninstall for $packageName")
+        val intent = Intent(Intent.ACTION_DELETE, Uri.parse("package:$packageName"))
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/AndroidGameLauncher.kt
+++ b/app/src/main/java/app/gamenative/utils/AndroidGameLauncher.kt
@@ -2,6 +2,7 @@ package app.gamenative.utils
 
 import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -47,6 +48,13 @@ object AndroidGameLauncher {
             Timber.tag(TAG).e(e, "Could not read package info from ${apk.absolutePath}")
             null
         }
+    }
+
+    /** Unwraps a possibly-wrapped Context (e.g. a ContextWrapper) to find the backing Activity. */
+    private tailrec fun Context.findActivity(): ComponentActivity? = when (this) {
+        is ComponentActivity -> this
+        is ContextWrapper -> baseContext.findActivity()
+        else -> null
     }
 
     private fun isPackageInstalled(context: Context, packageName: String): Boolean {
@@ -186,7 +194,7 @@ object AndroidGameLauncher {
             Timber.tag(TAG).i("requestUninstall: package $packageName is not currently installed, nothing to do")
             return true
         }
-        val activity = context as? ComponentActivity
+        val activity = context.findActivity()
         if (activity == null) {
             Timber.tag(TAG).e("requestUninstall: context is not a ComponentActivity, cannot prompt for a result")
             return false

--- a/app/src/main/java/app/gamenative/utils/AndroidGameLauncher.kt
+++ b/app/src/main/java/app/gamenative/utils/AndroidGameLauncher.kt
@@ -1,13 +1,18 @@
 package app.gamenative.utils
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Environment
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
 import app.gamenative.service.SteamService
+import kotlinx.coroutines.suspendCancellableCoroutine
 import timber.log.Timber
 import java.io.File
+import kotlin.coroutines.resume
 
 /**
  * Installs/launches the native Android build of a game (Steam Frame / Lepton depot),
@@ -17,16 +22,22 @@ object AndroidGameLauncher {
 
     private const val TAG = "AndroidGameLauncher"
 
+    // Depot content for an Android build is expected to be shallow (apk + an obb/ folder at
+    // most); bound the walk so a huge, deeply-nested Workshop/DLC tree can't make this slow.
+    private const val MAX_SEARCH_DEPTH = 6
+
     private fun findApkFile(gameId: Int): File? {
         val dir = File(SteamService.getAppDirPath(gameId))
         if (!dir.exists()) return null
-        return dir.walkTopDown().firstOrNull { it.isFile && it.extension.equals("apk", ignoreCase = true) }
+        return dir.walkTopDown().maxDepth(MAX_SEARCH_DEPTH)
+            .firstOrNull { it.isFile && it.extension.equals("apk", ignoreCase = true) }
     }
 
     private fun findObbFiles(gameId: Int): List<File> {
         val dir = File(SteamService.getAppDirPath(gameId))
         if (!dir.exists()) return emptyList()
-        return dir.walkTopDown().filter { it.isFile && it.extension.equals("obb", ignoreCase = true) }.toList()
+        return dir.walkTopDown().maxDepth(MAX_SEARCH_DEPTH)
+            .filter { it.isFile && it.extension.equals("obb", ignoreCase = true) }.toList()
     }
 
     private fun getApkPackageName(context: Context, apk: File): String? {
@@ -62,6 +73,23 @@ object AndroidGameLauncher {
             Timber.tag(TAG).i("Copied ${obbFiles.size} OBB file(s) to ${obbRoot.absolutePath}")
         } catch (e: Exception) {
             Timber.tag(TAG).w(e, "Could not place OBB files for $packageName (needs broader storage access on Android 11+)")
+        }
+    }
+
+    /**
+     * Copies the downloaded .apk into the app's own cache dir so FileProvider only ever needs to
+     * grant access to a narrow, app-controlled location (already covered by the existing
+     * cache-path entry) instead of the whole install-directory tree.
+     */
+    private fun stageApkForInstall(context: Context, gameId: Int, apk: File): File? {
+        return try {
+            val stagingDir = File(context.cacheDir, "android_game_installs").apply { mkdirs() }
+            val staged = File(stagingDir, "$gameId.apk")
+            apk.copyTo(staged, overwrite = true)
+            staged
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Could not stage APK for install from ${apk.absolutePath}")
+            null
         }
     }
 
@@ -101,8 +129,8 @@ object AndroidGameLauncher {
         }
         if (!isPackageInstalled(context, packageName)) {
             copyObbFiles(gameId, packageName)
-            UpdateInstaller.installApk(context, apk)
-            return Result.InstallStarted
+            val staged = stageApkForInstall(context, gameId, apk) ?: return Result.Failed
+            return if (UpdateInstaller.installApk(context, staged)) Result.InstallStarted else Result.Failed
         }
         val intent = context.packageManager.getLaunchIntentForPackage(packageName)
             ?: return Result.Failed
@@ -112,30 +140,64 @@ object AndroidGameLauncher {
     }
 
     /**
-     * Prompts the system uninstall dialog for the Android package matching this game, if one
-     * is actually installed. Must be called before the downloaded .apk is deleted from disk
-     * (needed to resolve the package name). This is a separate step from GameNative forgetting
-     * the game — the installed app is a distinct entity on the system that Android requires
-     * explicit user confirmation to remove.
+     * Prompts the system uninstall dialog for the Android package matching this game (if one is
+     * actually installed) and suspends until the dialog is dismissed. Uses
+     * ACTION_UNINSTALL_PACKAGE + EXTRA_RETURN_RESULT so the result (confirmed vs. cancelled) comes
+     * back immediately as an activity result, instead of waiting on an ACTION_PACKAGE_REMOVED
+     * broadcast that a cancelled dialog never sends — that previously left the caller's "deleting"
+     * UI stuck for a long fixed timeout on every cancel.
+     *
+     * Returns true when it's safe for the caller to delete the downloaded .apk / GameNative's own
+     * install record: either nothing was installed to begin with, or the system confirmed removal.
+     * Returns false if the user cancelled (or context isn't an Activity capable of launching for a
+     * result), so the caller must NOT delete anything in that case — otherwise the app would be
+     * left installed with no way left to resolve its package name.
+     *
+     * Must be called before the downloaded .apk is deleted from disk (needed to resolve the
+     * package name in the first place).
      */
-    fun requestUninstall(context: Context, gameId: Int) {
+    suspend fun requestUninstall(context: Context, gameId: Int): Boolean {
         val apk = findApkFile(gameId)
         if (apk == null) {
             Timber.tag(TAG).w("requestUninstall: no APK found on disk for game $gameId, skipping system uninstall")
-            return
+            return true
         }
         val packageName = getApkPackageName(context, apk)
         if (packageName == null) {
             Timber.tag(TAG).w("requestUninstall: could not resolve package name from ${apk.absolutePath}")
-            return
+            return true
         }
         if (!isPackageInstalled(context, packageName)) {
-            Timber.tag(TAG).w("requestUninstall: package $packageName is not currently installed, skipping")
-            return
+            Timber.tag(TAG).i("requestUninstall: package $packageName is not currently installed, nothing to do")
+            return true
         }
+        val activity = context as? ComponentActivity
+        if (activity == null) {
+            Timber.tag(TAG).e("requestUninstall: context is not a ComponentActivity, cannot prompt for a result")
+            return false
+        }
+
         Timber.tag(TAG).i("requestUninstall: prompting system uninstall for $packageName")
-        val intent = Intent(Intent.ACTION_DELETE, Uri.parse("package:$packageName"))
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
+        return suspendCancellableCoroutine { cont ->
+            lateinit var launcher: androidx.activity.result.ActivityResultLauncher<Intent>
+            launcher = activity.activityResultRegistry.register(
+                "android_game_uninstall_$gameId",
+                ActivityResultContracts.StartActivityForResult(),
+            ) { result ->
+                launcher.unregister()
+                if (cont.isActive) cont.resume(result.resultCode == Activity.RESULT_OK)
+            }
+            cont.invokeOnCancellation { runCatching { launcher.unregister() } }
+
+            val intent = Intent(Intent.ACTION_UNINSTALL_PACKAGE, Uri.parse("package:$packageName"))
+                .putExtra(Intent.EXTRA_RETURN_RESULT, true)
+            try {
+                launcher.launch(intent)
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Could not launch system uninstall for $packageName")
+                launcher.unregister()
+                if (cont.isActive) cont.resume(false)
+            }
+        }
     }
 }

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -1084,8 +1084,12 @@ object ContainerUtils {
         return if (containerManager.hasContainer(appId)) {
             val container = containerManager.getContainerById(appId)
 
-            // Apply temporary override if present (without saving to disk)
-            if (IntentLaunchManager.hasTemporaryOverride(appId)) {
+            // Temporary overrides only carry Wine/Winlator settings (graphics driver, dxwrapper,
+            // etc.) and applyToContainer() unconditionally writes to .wine/user.reg — a native
+            // Android container never has a .wine folder, so skip overrides entirely there rather
+            // than risk that write failing before AndroidGameLauncher ever runs.
+            val isAndroidContainer = container.platform.equals(Container.PLATFORM_ANDROID, ignoreCase = true)
+            if (!isAndroidContainer && IntentLaunchManager.hasTemporaryOverride(appId)) {
                 val overrideConfig = IntentLaunchManager.getTemporaryOverride(appId)
                 if (overrideConfig != null) {
                     // Backup original config before applying override (if not already backed up)

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -328,6 +328,7 @@ object ContainerUtils {
             box64Preset = container.box64Preset,
             desktopTheme = container.desktopTheme,
             containerVariant = container.containerVariant,
+            platform = container.platform,
             wineVersion = container.wineVersion,
             emulator = container.emulator,
             fexcoreVersion = container.fexCoreVersion,
@@ -521,6 +522,7 @@ object ContainerUtils {
         container.desktopTheme = containerData.desktopTheme
         container.graphicsDriverVersion = containerData.graphicsDriverVersion
         container.containerVariant = containerData.containerVariant
+        container.platform = containerData.platform
         container.wineVersion = containerData.wineVersion
         container.emulator = containerData.emulator
         container.fexCoreVersion = containerData.fexcoreVersion

--- a/app/src/main/java/app/gamenative/utils/SteamUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/SteamUtils.kt
@@ -114,6 +114,7 @@ object SteamUtils {
         ownedDlc: Map<Int, DepotInfo>?,
         licensedDepotIds: Set<Int>?,
         hasSteamUnlockedBranch: Boolean = false,
+        wantAndroid: Boolean = false,
     ): String {
         // A depot installs once its language is chosen if it passes every check except language
         // and arch. Arch is left out because it is a per-language preference, not a gate.
@@ -126,7 +127,8 @@ object SteamUtils {
                 licensedDepotIds == null || depotId in licensedDepotIds
             // Mirror the SteamChina realm gate in filterForDownloadableDepots, or we could pick a
             // language only the final pass drops and lose the real fallback.
-            return isWindowsCompatible && realm != SteamRealm.SteamChina &&
+            val osCompatible = if (wantAndroid) isAndroidCompatible else isWindowsCompatible
+            return osCompatible && realm != SteamRealm.SteamChina &&
                 hasContent && ownedIfDlc && licensedIfBaseGame
         }
 

--- a/app/src/main/java/app/gamenative/utils/UpdateInstaller.kt
+++ b/app/src/main/java/app/gamenative/utils/UpdateInstaller.kt
@@ -53,11 +53,11 @@ object UpdateInstaller {
             Timber.i("Download complete: ${destFile.absolutePath}, size: $fileSize bytes")
 
             // Install the APK
-            withContext(Dispatchers.Main) {
+            val installStarted = withContext(Dispatchers.Main) {
                 installApk(context, destFile)
             }
 
-            return@withContext true
+            return@withContext installStarted
         } catch (e: Exception) {
             Timber.e(e, "Error downloading/installing update")
             return@withContext false

--- a/app/src/main/java/app/gamenative/utils/UpdateInstaller.kt
+++ b/app/src/main/java/app/gamenative/utils/UpdateInstaller.kt
@@ -64,7 +64,7 @@ object UpdateInstaller {
         }
     }
 
-    private fun installApk(context: Context, apkFile: File) {
+    fun installApk(context: Context, apkFile: File) {
         try {
             // Verify file exists before attempting installation
             if (!apkFile.exists()) {

--- a/app/src/main/java/app/gamenative/utils/UpdateInstaller.kt
+++ b/app/src/main/java/app/gamenative/utils/UpdateInstaller.kt
@@ -64,12 +64,13 @@ object UpdateInstaller {
         }
     }
 
-    fun installApk(context: Context, apkFile: File) {
+    /** Returns true only if the system install intent was actually launched. */
+    fun installApk(context: Context, apkFile: File): Boolean {
         try {
             // Verify file exists before attempting installation
             if (!apkFile.exists()) {
                 Timber.e("APK file does not exist: ${apkFile.absolutePath}")
-                return
+                return false
             }
 
             Timber.i("Installing APK from: ${apkFile.absolutePath}, size: ${apkFile.length()} bytes")
@@ -84,7 +85,7 @@ object UpdateInstaller {
                     )
                 } catch (e: Exception) {
                     Timber.e(e, "Error getting FileProvider URI")
-                    return
+                    return false
                 }
             } else {
                 // Use file:// URI for older versions
@@ -114,8 +115,10 @@ object UpdateInstaller {
 
             context.startActivity(intent)
             Timber.i("Install intent launched successfully")
+            return true
         } catch (e: Exception) {
             Timber.e(e, "Error launching install intent")
+            return false
         }
     }
 }

--- a/app/src/main/java/com/winlator/container/Container.java
+++ b/app/src/main/java/com/winlator/container/Container.java
@@ -72,6 +72,10 @@ public class Container {
     public static final String STEAM_TYPE_ULTRALIGHT = "ultralight";
     public static final String GLIBC = "glibc";
     public static final String BIONIC = "bionic";
+
+    // Which Steam depot platform to download/install for this game.
+    public static final String PLATFORM_WINDOWS = "windows";
+    public static final String PLATFORM_ANDROID = "android";
     public static final byte MAX_DRIVE_LETTERS = 8;
     public final String id;
     private String name;
@@ -167,6 +171,8 @@ public class Container {
     private boolean portraitMode = false;
 
     private String containerVariant = DEFAULT_VARIANT;
+
+    private String platform = PLATFORM_WINDOWS;
 
     public String getGraphicsDriverVersion() {
         return graphicsDriverVersion;
@@ -512,6 +518,14 @@ public class Container {
         return this.containerVariant;
     }
 
+    public void setPlatform(String platform) {
+        this.platform = platform != null && !platform.isEmpty() ? platform : PLATFORM_WINDOWS;
+    }
+
+    public String getPlatform() {
+        return this.platform;
+    }
+
     public String getExtra(String name) {
         return getExtra(name, "");
     }
@@ -739,6 +753,7 @@ public class Container {
             data.put("steamType", steamType);
             data.put("language", language);
             data.put("containerVariant", containerVariant);
+            data.put("platform", platform);
             data.put("emulator", emulator);
             data.put("fexcoreVersion", fexcoreVersion);
 
@@ -845,6 +860,9 @@ public class Container {
                     break;
                 case "containerVariant" :
                     setContainerVariant(data.getString(key));
+                    break;
+                case "platform" :
+                    setPlatform(data.getString(key));
                     break;
                 case "inputType" :
                     setInputType(data.getInt(key));

--- a/app/src/main/java/com/winlator/container/ContainerData.kt
+++ b/app/src/main/java/com/winlator/container/ContainerData.kt
@@ -44,6 +44,8 @@ data class ContainerData(
     val desktopTheme: String = WineThemeManager.DEFAULT_DESKTOP_THEME,
     // container runtime variant (glibc or bionic)
     val containerVariant: String = Container.DEFAULT_VARIANT,
+    // which Steam depot platform to download/install (windows or android)
+    val platform: String = Container.PLATFORM_WINDOWS,
     // wine version identifier (used for bionic variant), defaults to main wine
     val wineVersion: String = WineInfo.MAIN_WINE_VERSION.identifier(),
     // selected 32-bit emulator for WoW64 processes (FEXCore/Box64)
@@ -144,6 +146,7 @@ data class ContainerData(
                     "box64Preset" to state.box64Preset,
                     "desktopTheme" to state.desktopTheme,
                     "containerVariant" to state.containerVariant,
+                    "platform" to state.platform,
                     "wineVersion" to state.wineVersion,
                     "emulator" to state.emulator,
                     "fexcoreVersion" to state.fexcoreVersion,
@@ -214,6 +217,7 @@ data class ContainerData(
                     box64Preset = savedMap["box64Preset"] as String,
                     desktopTheme = savedMap["desktopTheme"] as String,
                     containerVariant = (savedMap["containerVariant"] as? String) ?: Container.DEFAULT_VARIANT,
+                    platform = (savedMap["platform"] as? String) ?: Container.PLATFORM_WINDOWS,
                     wineVersion = (savedMap["wineVersion"] as? String) ?: WineInfo.MAIN_WINE_VERSION.identifier(),
                     emulator = (savedMap["emulator"] as? String) ?: Container.DEFAULT_EMULATOR,
                     fexcoreVersion = (savedMap["fexcoreVersion"] as? String) ?: DefaultVersion.FEXCORE,

--- a/app/src/main/java/com/winlator/container/ContainerManager.java
+++ b/app/src/main/java/com/winlator/container/ContainerManager.java
@@ -225,6 +225,7 @@ public class ContainerManager {
         dstContainer.setDesktopTheme(srcContainer.getDesktopTheme());
         dstContainer.setRcfileId(srcContainer.getRCFileId());
         dstContainer.setWineVersion(srcContainer.getWineVersion());
+        dstContainer.setPlatform(srcContainer.getPlatform());
         dstContainer.saveData();
 
         containers.add(dstContainer);

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -646,6 +646,13 @@
     <string name="value">Valeur</string>
     <string name="no_more_known_variables">Plus de variables connues</string>
     <string name="container_variant">Variante du conteneur</string>
+    <string name="container_platform">Version</string>
+    <string name="container_platform_description">Choisissez entre télécharger la version Windows (via Wine) ou la version Android native, lorsque le jeu la propose.</string>
+    <string name="container_platform_normal">Normal (Windows)</string>
+    <string name="container_platform_android">Android</string>
+    <string name="container_platform_switch_reinstalling">Changement de version — suppression de l\'installation actuelle et récupération de la nouvelle…</string>
+    <string name="android_game_install_started">Installation de la version Android — appuyez de nouveau sur Jouer une fois l\'installation terminée.</string>
+    <string name="android_game_launch_failed">Impossible d\'installer ou de lancer la version Android de ce jeu.</string>
     <string name="wine_version">Version Wine</string>
     <string name="exec_arguments">Arguments d\'exécution</string>
     <string name="exec_arguments_example">Exemple : -dx11</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -647,12 +647,13 @@
     <string name="no_more_known_variables">Plus de variables connues</string>
     <string name="container_variant">Variante du conteneur</string>
     <string name="container_platform">Version</string>
-    <string name="container_platform_description">Choisissez entre télécharger la version Windows (via Wine) ou la version Android native, lorsque le jeu la propose.</string>
-    <string name="container_platform_normal">Normal (Windows)</string>
+    <string name="container_platform_description">Choisissez de télécharger la version Windows (via Wine/Proton) ou la version Android native, lorsque le jeu la propose.</string>
+    <string name="container_platform_normal">Normale (Windows)</string>
     <string name="container_platform_android">Android</string>
     <string name="container_platform_switch_reinstalling">Changement de version — suppression de l\'installation actuelle et récupération de la nouvelle…</string>
     <string name="android_game_install_started">Installation de la version Android — appuyez de nouveau sur Jouer une fois l\'installation terminée.</string>
     <string name="android_game_launch_failed">Impossible d\'installer ou de lancer la version Android de ce jeu.</string>
+    <string name="android_game_uninstall_cancelled">Désinstallation annulée — l\'application est toujours installée, rien n\'a été supprimé.</string>
     <string name="wine_version">Version Wine</string>
     <string name="exec_arguments">Arguments d\'exécution</string>
     <string name="exec_arguments_example">Exemple : -dx11</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1629,6 +1629,7 @@
     <string name="filter_five_star_device">Avis 5 étoiles sur l\'appareil</string>
     <string name="filter_five_star_gpu">Avis 5 étoiles sur le GPU</string>
     <string name="filter_proven_gpu">Éprouvé sur votre GPU</string>
+    <string name="app_filter_android">Version Android disponible</string>
     <string name="option_manage_mods">Gérer les mods Nexus</string>
     <string name="nexus_search_clear">Effacer la recherche</string>
     <string name="nexus_filter_all">Tout</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -767,6 +767,13 @@
     <string name="value">Value</string>
     <string name="no_more_known_variables">No more known variables</string>
     <string name="container_variant">Container Variant</string>
+    <string name="container_platform">Version</string>
+    <string name="container_platform_description">Choose whether to download the Windows version (runs via Wine) or the native Android version, when the game offers one.</string>
+    <string name="container_platform_normal">Normal (Windows)</string>
+    <string name="container_platform_android">Android</string>
+    <string name="container_platform_switch_reinstalling">Switching version — removing the current install and fetching the new one…</string>
+    <string name="android_game_install_started">Installing the Android version — press Play again once it\'s installed.</string>
+    <string name="android_game_launch_failed">Couldn\'t install or launch the Android version of this game.</string>
     <string name="wine_version">Wine Version</string>
     <string name="exec_arguments">Exec Arguments</string>
     <string name="exec_arguments_example">Example: -dx11</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -726,6 +726,7 @@
     <string name="filter_five_star_device">5-star reviews on device</string>
     <string name="filter_five_star_gpu">5-star reviews on GPU</string>
     <string name="filter_proven_gpu">Proven on your GPU</string>
+    <string name="app_filter_android">Android version available</string>
 
     <!-- Login & Connection -->
     <string name="connecting_to_steam">Connecting to Steam…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -768,12 +768,13 @@
     <string name="no_more_known_variables">No more known variables</string>
     <string name="container_variant">Container Variant</string>
     <string name="container_platform">Version</string>
-    <string name="container_platform_description">Choose whether to download the Windows version (runs via Wine) or the native Android version, when the game offers one.</string>
+    <string name="container_platform_description">Choose whether to download the Windows version (runs via Wine/Proton) or the native Android version, when the game offers one.</string>
     <string name="container_platform_normal">Normal (Windows)</string>
     <string name="container_platform_android">Android</string>
     <string name="container_platform_switch_reinstalling">Switching version — removing the current install and fetching the new one…</string>
     <string name="android_game_install_started">Installing the Android version — press Play again once it\'s installed.</string>
     <string name="android_game_launch_failed">Couldn\'t install or launch the Android version of this game.</string>
+    <string name="android_game_uninstall_cancelled">Uninstall was cancelled — the app is still installed, nothing was deleted.</string>
     <string name="wine_version">Wine Version</string>
     <string name="exec_arguments">Exec Arguments</string>
     <string name="exec_arguments_example">Example: -dx11</string>

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -3,5 +3,9 @@
     <cache-path name="cache" path="." />
     <external-cache-path name="external_cache" path="." />
     <files-path name="diagnostics" path="imagefs/usr/tmp/" />
+    <!-- Installed game files can live under the app's internal data dir, external app dir,
+         or an external SD volume (see SteamService.allInstallPaths) — cover all of them for
+         installing downloaded Android game APKs via FileProvider. -->
+    <root-path name="game_files" path="." />
 </paths>
 

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -3,15 +3,8 @@
     <cache-path name="cache" path="." />
     <external-cache-path name="external_cache" path="." />
     <files-path name="diagnostics" path="imagefs/usr/tmp/" />
-    <!-- Games installed to the external app-scoped dir (SteamService.externalAppInstallPath)
-         map cleanly to this narrower, dedicated path. -->
-    <external-files-path name="external_game_files" path="Steam/steamapps/common/" />
-    <!-- Fallback for the other two install roots SteamService.allInstallPaths supports, neither
-         of which has a narrower FileProvider path type: the internal install root lives directly
-         under the app's private data dir (context.dataDir), not under files/ or cache/, and SD
-         card volumes are discovered per-device at runtime so their paths can't be declared here
-         statically. A hardcoded root-path sub-path (e.g. "data/user/0/<pkg>/...") would be more
-         fragile, not less — it would break on secondary user profiles, which the Quest supports. -->
-    <root-path name="game_files" path="." />
+    <!-- Android game APKs are staged into the app's own cache dir before install
+         (AndroidGameLauncher.stageApkForInstall), so the existing cache-path entry above already
+         covers them — no broader access to the install-directory tree is needed. -->
 </paths>
 

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -3,9 +3,15 @@
     <cache-path name="cache" path="." />
     <external-cache-path name="external_cache" path="." />
     <files-path name="diagnostics" path="imagefs/usr/tmp/" />
-    <!-- Installed game files can live under the app's internal data dir, external app dir,
-         or an external SD volume (see SteamService.allInstallPaths) — cover all of them for
-         installing downloaded Android game APKs via FileProvider. -->
+    <!-- Games installed to the external app-scoped dir (SteamService.externalAppInstallPath)
+         map cleanly to this narrower, dedicated path. -->
+    <external-files-path name="external_game_files" path="Steam/steamapps/common/" />
+    <!-- Fallback for the other two install roots SteamService.allInstallPaths supports, neither
+         of which has a narrower FileProvider path type: the internal install root lives directly
+         under the app's private data dir (context.dataDir), not under files/ or cache/, and SD
+         card volumes are discovered per-device at runtime so their paths can't be declared here
+         statically. A hardcoded root-path sub-path (e.g. "data/user/0/<pkg>/...") would be more
+         fragile, not less — it would break on secondary user profiles, which the Quest supports. -->
     <root-path name="game_files" path="." />
 </paths>
 

--- a/app/src/modern/AndroidManifest.xml
+++ b/app/src/modern/AndroidManifest.xml
@@ -3,5 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove" />
+    <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" tools:node="remove" />
 
 </manifest>

--- a/app/src/modernXr/AndroidManifest.xml
+++ b/app/src/modernXr/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove" />
+    <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" tools:node="remove" />
     <uses-permission android:name="android.permission.READ_LOGS" tools:node="remove" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove" />

--- a/app/src/test/java/app/gamenative/enums/OSTest.kt
+++ b/app/src/test/java/app/gamenative/enums/OSTest.kt
@@ -1,0 +1,58 @@
+package app.gamenative.enums
+
+import java.util.EnumSet
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OSTest {
+
+    @Test
+    fun `from string parses android`() {
+        assertEquals(EnumSet.of(OS.android), OS.from("android"))
+    }
+
+    @Test
+    fun `from string parses a comma separated list including android`() {
+        assertEquals(EnumSet.of(OS.windows, OS.android), OS.from("windows,android"))
+    }
+
+    @Test
+    fun `from string falls back to none for an unknown value`() {
+        assertEquals(EnumSet.of(OS.none), OS.from("some_unknown_os"))
+    }
+
+    @Test
+    fun `from string returns none for a null or empty value`() {
+        assertEquals(EnumSet.of(OS.none), OS.from(null))
+        assertEquals(EnumSet.of(OS.none), OS.from(""))
+    }
+
+    // OS.from(Int) always contains `none` too, since none.code == 0 and any bitmask ANDed with 0
+    // is 0 — a pre-existing quirk unrelated to the `android` bit — so these check membership
+    // rather than exact set equality.
+    @Test
+    fun `code and from int round trip for android alone`() {
+        val roundTripped = OS.from(OS.code(EnumSet.of(OS.android)))
+        assertTrue(roundTripped.contains(OS.android))
+        assertFalse(roundTripped.contains(OS.windows))
+        assertFalse(roundTripped.contains(OS.macos))
+        assertFalse(roundTripped.contains(OS.linux))
+    }
+
+    @Test
+    fun `code and from int round trip for a combination including android`() {
+        val osses = EnumSet.of(OS.windows, OS.linux, OS.android)
+        val roundTripped = OS.from(OS.code(osses))
+        assertTrue(roundTripped.containsAll(osses))
+        assertFalse(roundTripped.contains(OS.macos))
+    }
+
+    @Test
+    fun `android has a distinct bit from the other OS values`() {
+        assertEquals(0x08, OS.android.code)
+        val others = listOf(OS.none, OS.windows, OS.macos, OS.linux)
+        others.forEach { assertEquals(0, it.code and OS.android.code) }
+    }
+}

--- a/app/src/test/java/app/gamenative/utils/SteamUtilsDepotLanguageTest.kt
+++ b/app/src/test/java/app/gamenative/utils/SteamUtilsDepotLanguageTest.kt
@@ -48,7 +48,8 @@ class SteamUtilsDepotLanguageTest {
         ownedDlc: Map<Int, DepotInfo>? = null,
         licensedDepotIds: Set<Int>? = null,
         hasSteamUnlockedBranch: Boolean = false,
-    ) = SteamUtils.effectiveDepotLanguage(depots, preferred, ownedDlc, licensedDepotIds, hasSteamUnlockedBranch)
+        wantAndroid: Boolean = false,
+    ) = SteamUtils.effectiveDepotLanguage(depots, preferred, ownedDlc, licensedDepotIds, hasSteamUnlockedBranch, wantAndroid)
 
     // -- Priority 1: requested language wins when available --
 
@@ -194,5 +195,55 @@ class SteamUtilsDepotLanguageTest {
     @Test
     fun `returns preferred language when there are no depots`() {
         assertEquals("french", resolve(emptyMap(), "french"))
+    }
+
+    // -- Android depot selection (wantAndroid) --
+
+    @Test
+    fun `returns requested language when the android depot ships it`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "english", osList = EnumSet.of(OS.android)),
+            depot(depotId = 2, language = "french", osList = EnumSet.of(OS.android)),
+        )
+        assertEquals("french", resolve(depots, "french", wantAndroid = true))
+    }
+
+    @Test
+    fun `falls back to english for android depots when requested language is absent`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "english", osList = EnumSet.of(OS.android)),
+            depot(depotId = 2, language = "german", osList = EnumSet.of(OS.android)),
+        )
+        assertEquals("english", resolve(depots, "french", wantAndroid = true))
+    }
+
+    @Test
+    fun `an untagged depot is not a neutral fallback for android — windows-only neutrality does not carry over`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "german", osList = EnumSet.of(OS.android)),
+            // Untagged (OS.none): counts as installable for Windows (isWindowsCompatible), but
+            // isAndroidCompatible requires an explicit android tag, so this must NOT satisfy the
+            // Android pass and must NOT be treated as a neutral depot there.
+            depot(depotId = 2, language = "", osList = EnumSet.of(OS.none)),
+        )
+        assertEquals("german", resolve(depots, "french", wantAndroid = true))
+    }
+
+    @Test
+    fun `a windows-only depot is ignored when android is requested`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "german", osList = EnumSet.of(OS.windows)),
+        )
+        // No android-compatible depot at all -> nothing to steer the language away from preferred.
+        assertEquals("french", resolve(depots, "french", wantAndroid = true))
+    }
+
+    @Test
+    fun `a depot explicitly tagged both android and neutral-language keeps the preferred language`() {
+        val depots = depotsOf(
+            depot(depotId = 1, language = "", osList = EnumSet.of(OS.android)),
+            depot(depotId = 2, language = "german", osList = EnumSet.of(OS.android)),
+        )
+        assertEquals("french", resolve(depots, "french", wantAndroid = true))
     }
 }


### PR DESCRIPTION
Steam now lets some games be installed as a native Android app instead of the usual Windows build run through Wine (ahead of Valve's Steam Frame headset). This adds a per-game Version choice in Edit Container: picking Android downloads, installs, and launches the game as a real Android app, bypassing Wine entirely for that game.

Build : https://www.transfernow.net/dl/20260723bHOQ5wLl

## Description

Some games on Steam now ship a native Android build alongside their usual Windows build — this is in preparation for Valve's upcoming Steam Frame VR headset, but it also just works as a regular Android app on any device.

This PR adds the ability to pick that Android version instead of the Windows one, per game:

New "Version" dropdown in Edit Container (only shows up for games that actually have an Android build available).
Picking "Android" downloads the right files, installs the app through Android's normal system installer, and launches it directly — no Wine, no Proton, no Box64 involved at all for that game.
Uninstalling now also removes the installed Android app itself, not just the downloaded files.
Everything defaults to the current Windows/Wine behavior — nothing changes for existing games unless you explicitly pick Android for one.
One thing worth knowing about the build variants: this only works on the Legacy builds (legacy / legacyXr) for now. The Modern builds (modern / modernXr) intentionally have the "install/uninstall other apps" permissions stripped out, because the Meta Horizon Store rejected a previous submission over exactly those permissions. Since modernXr is the variant meant for store distribution, adding this feature there would risk the same rejection again — so for now, Android games are a Legacy-only feature. Worth a deliberate call later if we want this on Modern too.

New android filter

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-game support for installing and launching native Android (Steam Frame/Lepton) builds. You can choose Android per game; it skips Wine, auto-prompts system install after download, and the UI updates live.

- **New Features**
  - Version picker in Edit Container for games with an Android depot; Android mode disables non-General tabs and Wine fields; dialog opens without blocking the UI.
  - Platform-aware depot filtering, language selection, and size; Android flow auto-starts the system installer after download and launches the installed app; Play only appears once the system app is installed.
  - Library: new “Android version available” filter; hidden on `modern`/`modernXr` and stripped if persisted; non‑Steam sources are excluded when the Android filter is active.

- **Bug Fixes**
  - Android containers fully bypass Wine, including pre-launch and temporary overrides; launch path short-circuits to native.
  - Uninstall prompts to remove the Android app first and honors cancel; staged APKs are cleaned up; no more freeze on cancel; immediate install prompt uses a safe cache path.
  - UI refreshes on package add/remove and on platform changes; store/install size recompute with the selected platform; permissions: `REQUEST_DELETE_PACKAGES` kept in legacy, removed in `modern`/`modernXr`.

<sup>Written for commit 654e7d90beecf8654465e5dcee7c6f32abceb011. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Android game support with per-container platform selection (Windows/Android).
  * Added Android APK install/launch and uninstall with install/launch failure and uninstall-cancel feedback.

* **Improvements**
  * Depot availability, language, and download sizing are now platform-aware (Android vs Windows).
  * Library filtering and install-size refresh are improved; Android platforms restrict advanced configuration tabs/fields.

* **Permissions/Packaging**
  * Updated Android manifests to adjust delete-package permission handling.

* **UI/Localization**
  * Added Android platform UI strings (including French).

* **Tests**
  * Added unit tests for Android OS parsing and bitmask behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->