### PR TITLE
fix: skip directinput and directinput8 components extraction

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -5256,7 +5256,8 @@ private suspend fun extractWinComponentFiles(
 
             if (!container.wineVersion.contains("arm64ec") && identifier.contains("opengl") && useNative) continue
 
-            if (useNative) {
+            // Note: GameNative do not bundle directinput and directinput8 dlls, need to skip them and use wine/proton dll instead
+            if (useNative && (identifier != "directinput8" && identifier != "directinput")) {
                 // Download or use cached/bundled wincomponent
                 val componentFile = WinComponentDownloader.ensureWinComponentAvailable(
                     context, identifier


### PR DESCRIPTION
## Description
In PR #1495, directinput and directinput8 entries are added, but gamenative does not bundle the directinput dlls, which would cause the following error:

<img width="1325" height="115" alt="image" src="https://github.com/user-attachments/assets/d53af744-a288-4662-ab18-5b2aa54dd97c" />

The fix is to skip using bundled asset and use wine / proton dll instead.

## Recording
N/A

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip extraction of `directinput` and `directinput8` when `useNative` is enabled, using Wine/Proton DLLs instead to avoid missing-DLL errors. Fixes the error introduced after adding these entries in #1495.

<sup>Written for commit 4028651dc4c5c5f1a8c0e52fbb27597f62f2448e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DirectInput and DirectInput8 component handling when native components are enabled.
  * These components now use the appropriate existing override behavior instead of being installed through the native component path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->