### PR TITLE
Fix Workshop Mods for YOMI:HUSTLE when using bionic steam

### DIFF
--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -76,6 +76,7 @@ object WorkshopManager {
     private const val RAIN_WORLD_MODS_PATH = "RainWorld_Data/StreamingAssets/mods"
     private const val RAIN_WORLD_ENABLED_MODS_PATH = "RainWorld_Data/StreamingAssets/enabledMods.txt"
     private const val ONI_APP_ID = 457140
+    private const val YOMI_HUSTLE_APP_ID = 2212330
     private const val MAX_PAGES = 50
     private const val PAGE_SIZE = 100
     private var workshopTypesPatched = false
@@ -90,7 +91,10 @@ object WorkshopManager {
         1942280, // Brotato
         SlayTheSpireModTheSpireCompatibility.APP_ID,  // Slay the Spire - Workshop items include Java/JAR payloads
         564310,  // Serious Sam Fusion 2017 - .gro files are ZIP payloads read by the game
+        YOMI_HUSTLE_APP_ID, // YOMI HUSTLE loads Workshop mod ZIPs without extracting them
     )
+
+    private val YOMI_HUSTLE_FLAT_FILE_EXTENSIONS = setOf("zip")
 
     private val ZIP_PAYLOAD_EXTENSIONS_BY_APP_ID = mapOf(
         SlayTheSpireModTheSpireCompatibility.APP_ID to setOf("jar"),
@@ -319,6 +323,23 @@ object WorkshopManager {
             val itemDir = File(workshopContentDir, item.publishedFileId.toString())
             val partialDir = File(workshopContentDir, "${item.publishedFileId}.partial")
             val completeMarker = File(itemDir, COMPLETE_MARKER)
+
+            // Older builds extracted YOMI's Workshop ZIPs and deleted the archives.
+            // Re-download those items once so the original archive (and therefore
+            // its multiplayer hash) is restored instead of rebuilding a different ZIP.
+            if (
+                item.appId == YOMI_HUSTLE_APP_ID &&
+                File(itemDir, ".zip_extracted").isFile &&
+                itemDir.listFiles()?.none {
+                    it.isFile && it.extension.equals("zip", ignoreCase = true)
+                } != false
+            ) {
+                Timber.tag(TAG).i(
+                    "Item ${item.publishedFileId} '${item.title}' needs sync: " +
+                        "restoring YOMI Workshop ZIP removed by an older build"
+                )
+                return@filter true
+            }
 
             // DepotDownloader leaves .partial sibling dirs after completing.
             // If the complete marker exists, the download finished — clean up
@@ -2560,6 +2581,7 @@ object WorkshopManager {
     ) {
         val appId = workshopContentDir.name.toIntOrNull() ?: -1
         val isSlayTheSpire = appId == SlayTheSpireModTheSpireCompatibility.APP_ID
+        val isYomiHustle = appId == YOMI_HUSTLE_APP_ID
 
         if (isSlayTheSpire) {
             SlayTheSpireModTheSpireCompatibility.cleanupManagedWorkshopFiles(gameRootDir)
@@ -2785,6 +2807,21 @@ object WorkshopManager {
                             .sortedBy { id -> orderByRainWorldId[id] ?: Int.MAX_VALUE },
                         previousRainWorldWorkshopIds,
                     )
+                } else if (isYomiHustle) {
+                    val activeItemDirs = modDirs.associate { itemDir ->
+                        (itemDir.name.toLongOrNull() ?: 0L) to itemDir
+                    }
+                    val result = WorkshopSymlinker().sync(
+                        WorkshopModPathStrategy.SymlinkIntoDir(listOf(targetDir)),
+                        activeItemDirs,
+                        workshopContentDir,
+                        flatFileExtensions = YOMI_HUSTLE_FLAT_FILE_EXTENSIONS,
+                    )
+                    if (result.hasErrors) {
+                        result.errors.forEach { (key, value) ->
+                            Timber.tag(TAG).w("YOMI manual-path symlinker error [$key]: $value")
+                        }
+                    }
                 } else {
                     modDirs.forEach { itemDir ->
                         val linkPath = targetDir.toPath().resolve(itemDir.name)
@@ -3707,7 +3744,15 @@ object WorkshopManager {
                         val itemsForSync = if (mirrorItemIds.isEmpty()) activeItemDirs else regularItems
                         val symlinker = WorkshopSymlinker()
                         val result = symlinker.sync(
-                            effectiveStrategy, itemsForSync, workshopContentDir, titlesByItemId,
+                            effectiveStrategy,
+                            itemsForSync,
+                            workshopContentDir,
+                            titlesByItemId,
+                            flatFileExtensions = if (isYomiHustle) {
+                                YOMI_HUSTLE_FLAT_FILE_EXTENSIONS
+                            } else {
+                                emptySet()
+                            },
                         )
                         if (result.hasErrors) {
                             result.errors.forEach { (k, v) ->

--- a/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopManager.kt
@@ -294,6 +294,14 @@ object WorkshopManager {
     private const val MIN_SIZE_VALIDATION_BYTES = 8L * 1024L * 1024L
     private const val SUSPICIOUS_SIZE_RATIO_DIVISOR = 20L
 
+    private fun needsYomiWorkshopZipRestore(item: WorkshopItem, itemDir: File): Boolean {
+        return item.appId == YOMI_HUSTLE_APP_ID &&
+            File(itemDir, ".zip_extracted").isFile &&
+            itemDir.listFiles()?.none {
+                it.isFile && it.extension.equals("zip", ignoreCase = true)
+            } != false
+    }
+
     /**
      * Filters items that need downloading. An item needs sync if:
      * - It has downloadable content (fileUrl or manifestId)
@@ -327,13 +335,7 @@ object WorkshopManager {
             // Older builds extracted YOMI's Workshop ZIPs and deleted the archives.
             // Re-download those items once so the original archive (and therefore
             // its multiplayer hash) is restored instead of rebuilding a different ZIP.
-            if (
-                item.appId == YOMI_HUSTLE_APP_ID &&
-                File(itemDir, ".zip_extracted").isFile &&
-                itemDir.listFiles()?.none {
-                    it.isFile && it.extension.equals("zip", ignoreCase = true)
-                } != false
-            ) {
+            if (needsYomiWorkshopZipRestore(item, itemDir)) {
                 Timber.tag(TAG).i(
                     "Item ${item.publishedFileId} '${item.title}' needs sync: " +
                         "restoring YOMI Workshop ZIP removed by an older build"
@@ -4446,10 +4448,12 @@ object WorkshopManager {
             val marker = File(itemDir, COMPLETE_MARKER)
             val markerExists = marker.exists()
             val hasContent = itemDir.listFiles()?.any { !it.name.startsWith(".") } == true
-            val isMissing = !markerExists || !hasContent
+            val needsYomiZipRestore = needsYomiWorkshopZipRestore(item, itemDir)
+            val isMissing = !markerExists || !hasContent || needsYomiZipRestore
             Timber.tag(TAG).d(
                 "[UpdateCheck] Item ${item.publishedFileId} '${item.title}': " +
                     "marker=$markerExists, hasContent=$hasContent, " +
+                    "needsYomiZipRestore=$needsYomiZipRestore, " +
                     "dirExists=${itemDir.exists()}, isMissing=$isMissing"
             )
             isMissing

--- a/app/src/main/java/app/gamenative/workshop/WorkshopSymlinker.kt
+++ b/app/src/main/java/app/gamenative/workshop/WorkshopSymlinker.kt
@@ -41,14 +41,25 @@ class WorkshopSymlinker {
         activeItemDirs: Map<Long, File>,
         workshopContentBase: File,
         itemTitles: Map<Long, String> = emptyMap(),
+        flatFileExtensions: Set<String> = emptySet(),
     ): SyncResult {
+        val normalizedFlatFileExtensions = flatFileExtensions.mapTo(mutableSetOf()) {
+            it.lowercase().removePrefix(".")
+        }
         return when (strategy) {
             is WorkshopModPathStrategy.Standard -> {
                 Timber.tag(TAG).d("Strategy is Standard — no filesystem manipulation needed")
                 SyncResult(0, activeItemDirs.size, 0, emptyMap())
             }
             is WorkshopModPathStrategy.SymlinkIntoDir ->
-                syncIntoAllDirs(strategy.effectiveDirs, activeItemDirs, workshopContentBase, true, itemTitles)
+                syncIntoAllDirs(
+                    strategy.effectiveDirs,
+                    activeItemDirs,
+                    workshopContentBase,
+                    true,
+                    itemTitles,
+                    normalizedFlatFileExtensions,
+                )
             is WorkshopModPathStrategy.CopyIntoDir ->
                 syncIntoAllDirs(strategy.effectiveDirs, activeItemDirs, workshopContentBase, false, itemTitles)
         }
@@ -63,12 +74,20 @@ class WorkshopSymlinker {
         workshopContentBase: File,
         useSymlinks: Boolean,
         itemTitles: Map<Long, String> = emptyMap(),
+        flatFileExtensions: Set<String> = emptySet(),
     ): SyncResult {
         var totalCreated = 0; var totalSkipped = 0; var totalRemoved = 0
         val allErrors = mutableMapOf<String, String>()
 
         for (dir in targetDirs) {
-            val r = syncIntoOneDir(dir, activeItemDirs, workshopContentBase, useSymlinks, itemTitles)
+            val r = syncIntoOneDir(
+                dir,
+                activeItemDirs,
+                workshopContentBase,
+                useSymlinks,
+                itemTitles,
+                flatFileExtensions,
+            )
             totalCreated += r.created; totalSkipped += r.skipped; totalRemoved += r.removed
             r.errors.forEach { (k, v) -> allErrors["${dir.name}/$k"] = v }
         }
@@ -86,6 +105,7 @@ class WorkshopSymlinker {
         workshopContentBase: File,
         useSymlinks: Boolean,
         itemTitles: Map<Long, String> = emptyMap(),
+        flatFileExtensions: Set<String> = emptySet(),
     ): SyncResult {
         Timber.tag(TAG).i(
             "syncIntoOneDir: ${targetDir.absolutePath} " +
@@ -114,15 +134,19 @@ class WorkshopSymlinker {
         // mods/<modTitle>/file.mod.zip, not mods/file.mod.zip.
         if (useSymlinks) {
             val isModContainerDir = targetDir.name.lowercase() in MOD_CONTAINER_NAMES
+            val forceFlatFiles = flatFileExtensions.isNotEmpty()
             val allSingleFile = !isModContainerDir && activeItemDirs.values.all { srcDir ->
                 val children = srcDir.listFiles()
                     ?.filter { !it.name.startsWith(".") }
                     ?: emptyList()
                 children.size == 1 && children.single().isFile
             }
-            if (allSingleFile) {
+            if (forceFlatFiles || allSingleFile) {
                 return syncFlatFilesIntoDir(
-                    targetDir, activeItemDirs, workshopContentBase,
+                    targetDir,
+                    activeItemDirs,
+                    workshopContentBase,
+                    flatFileExtensions,
                 )
             }
         }
@@ -214,6 +238,7 @@ class WorkshopSymlinker {
         targetDir: File,
         activeItemDirs: Map<Long, File>,
         workshopContentBase: File,
+        allowedExtensions: Set<String> = emptySet(),
     ): SyncResult {
         Timber.tag(TAG).i(
             "syncFlatFilesIntoDir: ${targetDir.absolutePath} (${activeItemDirs.size} items)"
@@ -226,7 +251,11 @@ class WorkshopSymlinker {
         val expectedFiles = linkedMapOf<String, File>() // filename → source file
         for ((id, sourceDir) in activeItemDirs.entries.sortedBy { it.key }) {
             sourceDir.listFiles()
-                ?.filter { it.isFile && !it.name.startsWith(".") }
+                ?.filter {
+                    it.isFile &&
+                        !it.name.startsWith(".") &&
+                        (allowedExtensions.isEmpty() || it.extension.lowercase() in allowedExtensions)
+                }
                 ?.forEach { f ->
                     if (f.name in expectedFiles) {
                         Timber.tag(TAG).w(
@@ -237,6 +266,11 @@ class WorkshopSymlinker {
                         expectedFiles[f.name] = f
                     }
                 }
+        }
+        if (allowedExtensions.isNotEmpty() && expectedFiles.isEmpty()) {
+            Timber.tag(TAG).w(
+                "No flat-file payloads with extensions $allowedExtensions found for ${activeItemDirs.size} items"
+            )
         }
 
         // Remove stale file symlinks that we created (point into workshopContentBase)


### PR DESCRIPTION
## Description
Fix Workshop Mods for YOMI:HUSTLE when using bionic steam


## Recording
https://drive.google.com/file/d/1E_O43I_LkIXG4x8QPA-Fu3l6uVTVPzZ6/view?usp=drivesdk


## Type of Change
- [X] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes YOMI:HUSTLE Workshop mods on Bionic Steam by symlinking original mod ZIPs (no extraction) and restoring missing archives so multiplayer hashes match. Tightens update checks to auto-restore legacy installs that deleted ZIPs.

- **Bug Fixes**
  - Added `YOMI_HUSTLE_APP_ID` and force `.zip` as flat-file payloads for this game.
  - Detect legacy YOMI installs during sync and update checks; re-download once to restore the original ZIP.
  - Extended `WorkshopSymlinker` with `flatFileExtensions` and applied to YOMI in auto and manual-path syncing, with clear warnings when no ZIP payloads are found.

<sup>Written for commit 9ef3d4f15bc433068ce4e33580605149e7bb6bc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Workshop mod syncing specifically for Yomi Hustle.
  * ZIP-based mods are now handled more reliably, reducing unintended extraction during setup.
  * Added recovery to restore missing original ZIP archives when older installations left extracted files behind.
  * Enhanced detection and placement of ZIP-based workshop content for both manual and automatic mod configuration.
  * Added warnings when filtered ZIP payloads can’t be found, making sync issues easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->