### PR TITLE
fix: controller focus on common screens (library screen and library app screen)

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryAppScreen.kt
@@ -570,6 +570,7 @@ internal fun AppScreenContent(
     onUpdateClick: () -> Unit,
     onBack: () -> Unit = {},
     optionsMenu: List<AppMenuOption>,
+    dialogOpen: Boolean = false,
 ) {
     val context = LocalContext.current
     // reactive — recomposes when network state changes
@@ -596,6 +597,18 @@ internal fun AppScreenContent(
 
     LaunchedEffect(Unit) {
         playButtonFocusRequester.requestFocus()
+    }
+
+    // Restore focus when options menu, dialogs
+    LaunchedEffect(optionsMenuVisible, dialogOpen) {
+        if (!optionsMenuVisible && !dialogOpen) {
+            kotlinx.coroutines.delay(100) // Brief delay for menu/dialog animation
+            try {
+                playButtonFocusRequester.requestFocus()
+            } catch (_: IllegalStateException) {
+                // FocusRequester not attached
+            }
+        }
     }
 
     // Button state calculations (needed by key event handler)

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -388,8 +388,11 @@ private fun LibraryScreenContent(
         }
     }
 
+    // Moved all state.appInfoList.isNotEmpty() checking to this function
+    fun isListFocusable(): Boolean = state.appInfoList.isNotEmpty() || state.currentTab == LibraryTab.RECOMMENDED
+
     fun requestGridFocusOrDefer() {
-        if (state.appInfoList.isEmpty()) return
+        if (!isListFocusable()) return
         ensureKeyboardInputMode()
         try {
             gridFirstItemFocusRequester.requestFocus()
@@ -401,7 +404,7 @@ private fun LibraryScreenContent(
     }
 
     fun requestCarouselFocusOrDefer(targetListIndex: Int = currentCarouselFocusTargetIndex()) {
-        if (state.appInfoList.isEmpty()) return
+        if (!isListFocusable()) return
         ensureKeyboardInputMode()
         carouselFocusTargetListIndex = targetListIndex.coerceIn(0, state.appInfoList.lastIndex)
         try {
@@ -414,7 +417,7 @@ private fun LibraryScreenContent(
     }
 
     fun requestContentFocusOrDefer(targetListIndex: Int = preferredContentFocusIndex()) {
-        if (state.appInfoList.isEmpty()) return
+        if (!isListFocusable()) return
         if (currentPaneType == PaneType.CAROUSEL) {
             requestCarouselFocusOrDefer(targetListIndex)
         } else {
@@ -494,7 +497,7 @@ private fun LibraryScreenContent(
             // Brief delay to let the UI settle after transition
             kotlinx.coroutines.delay(100)
             // Restore focus to content area
-            if (state.appInfoList.isNotEmpty()) {
+            if (isListFocusable()) {
                 requestContentFocusOrDefer()
             } else {
                 requestRootFocusSafe()
@@ -534,7 +537,7 @@ private fun LibraryScreenContent(
         // The user may have moved focus up into the tab bar during the delay; don't yank it back.
         if (tabBarHasFocus) return@LaunchedEffect
 
-        if (state.appInfoList.isEmpty()) {
+        if (isListFocusable()) {
             // Empty tab - focus root so bumpers still work
             requestRootFocusSafe()
         } else {
@@ -552,7 +555,7 @@ private fun LibraryScreenContent(
         state.isOptionsPanelOpen,
         state.isSearching,
     ) {
-        if (pendingGridFocusRequest && state.appInfoList.isNotEmpty()) {
+        if (pendingGridFocusRequest && isListFocusable()) {
             if (selectedAppId == null && !isSystemMenuOpen && !state.isOptionsPanelOpen && !state.isSearching) {
                 var retries = 0
                 while (pendingGridFocusRequest && retries < 8) {
@@ -578,7 +581,7 @@ private fun LibraryScreenContent(
         state.isOptionsPanelOpen,
         state.isSearching,
     ) {
-        if (pendingCarouselFocusRequest && state.appInfoList.isNotEmpty()) {
+        if (pendingCarouselFocusRequest && isListFocusable()) {
             if (selectedAppId == null && !isSystemMenuOpen && !state.isOptionsPanelOpen && !state.isSearching) {
                 val targetIndex = currentCarouselFocusTargetIndex()
                 if (carouselListState.layoutInfo.visibleItemsInfo.none { it.index == targetIndex }) {
@@ -630,7 +633,7 @@ private fun LibraryScreenContent(
             // Give a brief moment for the overlay to animate out
             kotlinx.coroutines.delay(50)
             // Restore focus to the active content layout
-            if (state.appInfoList.isNotEmpty()) {
+            if (isListFocusable()) {
                 requestContentFocusOrDefer()
             } else {
                 // Empty list - focus root so bumpers still work
@@ -652,7 +655,7 @@ private fun LibraryScreenContent(
             !isSystemMenuOpen &&
             !state.isOptionsPanelOpen &&
             !state.isSearching &&
-            state.appInfoList.isNotEmpty() &&
+            isListFocusable() &&
             controllerBootstrapNeeded &&
             !rootHasFocus &&
             !tabBarHasFocus &&
@@ -775,7 +778,7 @@ private fun LibraryScreenContent(
                         !state.isOptionsPanelOpen &&
                         !isSystemMenuOpen &&
                         !state.isSearching &&
-                        state.appInfoList.isNotEmpty() &&
+                        isListFocusable() &&
                         controllerBootstrapNeeded &&
                         // Don't pull focus to the grid while the user is on the tab bar (D-pad
                         // up/left/right and analog nudges aren't consumed by the bar otherwise).
@@ -910,6 +913,10 @@ private fun LibraryScreenContent(
                                 selectedLibraryItem = item
                             },
                             modifier = Modifier.fillMaxSize(),
+                            firstCarouselItemFocusRequester = carouselFocusRequester,
+                            firstGridItemFocusRequester = gridFirstItemFocusRequester,
+                            focusTargetListIndex = if (currentPaneType == PaneType.CAROUSEL) currentCarouselFocusTargetIndex() else gridFocusTargetListIndex,
+                            onFocusedIndexChanged = { carouselFocusTargetListIndex = it },
                         )
                     } else {
                         Box(modifier = Modifier.fillMaxSize())
@@ -1042,7 +1049,7 @@ private fun LibraryScreenContent(
                         onAddGameClick = onAddCustomGameClick,
                         onMenuClick = { isSystemMenuOpen = true },
                         onNavigateDownToGrid = {
-                            if (state.appInfoList.isNotEmpty()) {
+                            if (isListFocusable()) {
                                 requestContentFocusOrDefer()
                             }
                         },

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -332,6 +332,8 @@ private fun LibraryScreenContent(
     var pendingGridFocusRequest by remember { mutableStateOf(false) }
     var pendingCarouselFocusRequest by remember { mutableStateOf(false) }
 
+    var recommendationItemCount by remember { mutableIntStateOf(0) }
+
     var isSystemMenuOpen by remember { mutableStateOf(false) }
     // Track previous overlay states to detect when they close
     var wasSystemMenuOpen by remember { mutableStateOf(false) }
@@ -360,8 +362,16 @@ private fun LibraryScreenContent(
     var tabBarHasFocus by remember { mutableStateOf(false) }
     var lastBootstrapAtMs by remember { mutableLongStateOf(0L) }
 
+    fun getContentLastIndex(): Int {
+        return if (state.currentTab == LibraryTab.RECOMMENDED) {
+            (recommendationItemCount - 1).coerceAtLeast(0)
+        } else {
+            state.appInfoList.lastIndex.coerceAtLeast(0)
+        }
+    }
+
     fun firstVisibleContentIndex(): Int {
-        val lastIndex = state.appInfoList.lastIndex
+        val lastIndex = getContentLastIndex()
         if (lastIndex < 0) return 0
 
         return if (currentPaneType == PaneType.CAROUSEL) {
@@ -372,7 +382,7 @@ private fun LibraryScreenContent(
     }
 
     fun currentCarouselFocusTargetIndex(): Int {
-        val lastIndex = state.appInfoList.lastIndex
+        val lastIndex = getContentLastIndex()
         if (lastIndex < 0) return 0
 
         return carouselFocusTargetListIndex.coerceIn(0, lastIndex)
@@ -406,7 +416,7 @@ private fun LibraryScreenContent(
     fun requestCarouselFocusOrDefer(targetListIndex: Int = currentCarouselFocusTargetIndex()) {
         if (!isListFocusable()) return
         ensureKeyboardInputMode()
-        carouselFocusTargetListIndex = targetListIndex.coerceIn(0, state.appInfoList.lastIndex)
+        carouselFocusTargetListIndex = targetListIndex.coerceIn(0, getContentLastIndex())
         try {
             carouselFocusRequester.requestFocus()
             pendingCarouselFocusRequest = false
@@ -917,6 +927,7 @@ private fun LibraryScreenContent(
                             firstGridItemFocusRequester = gridFirstItemFocusRequester,
                             focusTargetListIndex = if (currentPaneType == PaneType.CAROUSEL) currentCarouselFocusTargetIndex() else gridFocusTargetListIndex,
                             onFocusedIndexChanged = { carouselFocusTargetListIndex = it },
+                            onItemCountChanged = { recommendationItemCount = it },
                         )
                     } else {
                         Box(modifier = Modifier.fillMaxSize())

--- a/app/src/main/java/app/gamenative/ui/screen/library/RecommendedTabPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/RecommendedTabPane.kt
@@ -41,6 +41,10 @@ fun RecommendedTabPane(
     onNavigate: (LibraryItem) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: GogRecommendationsViewModel = hiltViewModel(),
+    firstCarouselItemFocusRequester: androidx.compose.ui.focus.FocusRequester? = null,
+    firstGridItemFocusRequester: androidx.compose.ui.focus.FocusRequester? = null,
+    focusTargetListIndex: Int = 0,
+    onFocusedIndexChanged: (Int) -> Unit = {},
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
@@ -124,6 +128,9 @@ fun RecommendedTabPane(
                     onNavigate = { appId -> items.find { it.appId == appId }?.let(onNavigate) },
                     onRefresh = { viewModel.refresh() },
                     modifier = Modifier.fillMaxSize(),
+                    firstCarouselItemFocusRequester = firstCarouselItemFocusRequester,
+                    focusTargetListIndex = focusTargetListIndex,
+                    onFocusedIndexChanged = onFocusedIndexChanged,
                 )
             }
 
@@ -136,6 +143,8 @@ fun RecommendedTabPane(
                     onNavigate = { appId -> items.find { it.appId == appId }?.let(onNavigate) },
                     onRefresh = { viewModel.refresh() },
                     modifier = Modifier.fillMaxSize(),
+                    firstGridItemFocusRequester = firstGridItemFocusRequester,
+                    focusTargetListIndex = focusTargetListIndex,
                 )
             }
         }

--- a/app/src/main/java/app/gamenative/ui/screen/library/RecommendedTabPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/RecommendedTabPane.kt
@@ -45,6 +45,7 @@ fun RecommendedTabPane(
     firstGridItemFocusRequester: androidx.compose.ui.focus.FocusRequester? = null,
     focusTargetListIndex: Int = 0,
     onFocusedIndexChanged: (Int) -> Unit = {},
+    onItemCountChanged: (Int) -> Unit = {},
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
@@ -60,6 +61,10 @@ fun RecommendedTabPane(
 
     val items = remember(state.cards) {
         state.cards.mapIndexed { index, card -> card.toLibraryItem(index) }
+    }
+
+    LaunchedEffect(items.size) {
+        onItemCountChanged(items.size)
     }
 
     // Batched impression tracking: accumulate which cards actually scrolled into view and

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/BaseAppScreen.kt
@@ -1359,6 +1359,7 @@ abstract class BaseAppScreen {
             },
             onBack = onBack,
             optionsMenu = optionsMenu,
+            dialogOpen = showConfigDialog || manageModsRequested,
         )
 
         if (showReadiness && launchActivity != null) {

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
@@ -329,6 +329,22 @@ internal fun LibraryCarouselPane(
         }
     }
 
+    // Auto-focus first item when list becomes non-empty
+    LaunchedEffect(state.appInfoList.size, firstCarouselItemFocusRequester) {
+        if (state.appInfoList.isNotEmpty() && firstCarouselItemFocusRequester != null) {
+            delay(150) // Brief delay to ensure layout is ready
+
+            // Check if focusTargetListIndex still null or 0 after delay
+            if (focusTargetListIndex == null || focusTargetListIndex == 0) {
+                try {
+                    firstCarouselItemFocusRequester.requestFocus()
+                } catch (_: IllegalStateException) {
+                    // FocusRequester not attached yet
+                }
+            }
+        }
+    }
+
     LaunchedEffect(listState, state.appInfoList.size, state.totalAppsInFilter) {
         snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
             .filterNotNull()

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -169,6 +169,22 @@ internal fun LibraryListPane(
     val horizontalPadding = AdaptivePadding.horizontal()
     val gridSpacing = AdaptivePadding.gridSpacing()
 
+    // Auto-focus first item when list becomes non-empty
+    LaunchedEffect(state.appInfoList.size, firstGridItemFocusRequester) {
+        if (state.appInfoList.isNotEmpty() && firstGridItemFocusRequester != null) {
+            delay(150) // Brief delay to ensure layout is ready
+
+            // Check if focusTargetListIndex still null or 0 after delay
+            if (focusTargetListIndex == null || focusTargetListIndex == 0) {
+                try {
+                    firstGridItemFocusRequester.requestFocus()
+                } catch (_: IllegalStateException) {
+                    // FocusRequester not attached yet
+                }
+            }
+        }
+    }
+
     LaunchedEffect(listState, state.appInfoList.size) {
         snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
             .filterNotNull()


### PR DESCRIPTION
## Description
fix: controller focus on common screens (library screen and library app screen)

## Recording
N/A

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes controller focus on the Library and Library App screens. Focus now reliably returns after menus/dialogs close, and the first item auto-focuses when content appears across Library and Recommended tabs.

- **Bug Fixes**
  - Library App Screen: restore focus to the Play button after closing the options menu or dialogs; added a `dialogOpen` prop and safe delayed refocus.
  - Library Screen: added `getContentLastIndex` to keep focus indices in range for both Recommended and store tabs; unified checks via `isListFocusable`; restored content focus after overlays close; avoided pulling focus when the tab bar is active.
  - Recommended and List/Carousel panes: pass `FocusRequester`s and focus target index; auto-focus the first item when data appears; propagate item count and focused index changes; ignore unattached requester errors.

<sup>Written for commit 5e6bd87204c26733932e5282b532519c24909dab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller/gamepad focus behavior across library tabs, grids, and carousels.
  * Restores focus more reliably after navigating back, switching tabs, or closing overlays/menus.
  * Automatically focuses the first loaded library/recommendation item (with safe timing) as content appears.
  * Prevents focus from returning to the library play button while dialogs are open.
* **Refactor**
  * Updated internal focus targeting logic to account for recommendation sizing and list boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->