### PR TITLE
composit carousel view offscreen to stop it from slowing down the ent…

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -3815,7 +3815,7 @@ class SteamService : Service(), IChallengeUrlChanged {
 
             else -> {
                 if (shouldClearUserDataForLoggedOnFailure(callback.result)) {
-                    clearUserData()
+                    PrefManager.clearSteamSessionPreferences()
                 }
 
                 _loginResult = LoginResult.Failed

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -46,6 +47,8 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.pointer.PointerEventType
@@ -273,6 +276,8 @@ internal fun LibraryCarouselPane(
     val cardHeight = minOf(baseCardHeight, maxCardHeight * CAROUSEL_CARD_SIZE_MULTIPLIER)
     val cardWidth = cardHeight * CAROUSEL_CARD_ASPECT_RATIO
     val itemContainerHeight = cardHeight + cardTopOverflow + cardBottomOverflow
+    val tiltPivotY = (cardTopOverflow.value + (cardHeight.value + badgeReservedHeight.value) / 2f) /
+        itemContainerHeight.value
     val cardWidthPx = with(density) { cardWidth.toPx() }
     // Keep lazy items composed slightly beyond the viewport because rotation/translation can leave
     // transformed pixels visible after the raw item slot has technically moved offscreen.
@@ -479,9 +484,9 @@ internal fun LibraryCarouselPane(
                                 Box(
                                     modifier = Modifier
                                         .align(Alignment.TopCenter)
-                                        .padding(top = cardTopOverflow)
-                                        .width(cardWidth)
-                                        .height(cardHeight + badgeReservedHeight)
+                                        .wrapContentHeight(align = Alignment.Top, unbounded = true)
+                                        .width(carouselItemSlotWidth)
+                                        .height(itemContainerHeight)
                                         .graphicsLayer {
                                             val tiltInput = tiltInputState.value
                                             val distanceFromCenter = tiltInput.distanceFromCenterPx
@@ -531,12 +536,15 @@ internal fun LibraryCarouselPane(
                                             this.rotationY = computedRotationY
                                             this.translationX = computedTranslationX
                                             cameraDistance = cameraDistancePx
+                                            transformOrigin = TransformOrigin(0.5f, tiltPivotY)
                                             clip = false
+                                            compositingStrategy = CompositingStrategy.Offscreen
                                         },
                                 ) {
                                     Box(
                                         modifier = Modifier
                                             .align(Alignment.TopCenter)
+                                            .padding(top = cardTopOverflow)
                                             .width(cardWidth)
                                             .height(cardHeight),
                                         contentAlignment = Alignment.Center,

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDynamicBackdrop.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDynamicBackdrop.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -12,9 +13,11 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -23,12 +26,13 @@ import androidx.compose.ui.unit.dp
 import app.gamenative.R
 import app.gamenative.data.LibraryItem
 import app.gamenative.ui.enums.PaneType
+import app.gamenative.ui.theme.PluviaTheme
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.coil.CoilImage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-private val DYNAMIC_BACKDROP_BLUR_RADIUS = 12.dp
+private val DYNAMIC_BACKDROP_BLUR_RADIUS = 7.dp
 
 @Composable
 internal fun LibraryDynamicBackdrop(
@@ -37,11 +41,23 @@ internal fun LibraryDynamicBackdrop(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val scrimColor = MaterialTheme.colorScheme.scrim
+    val desaturate = remember {
+        ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0.25f) })
+    }
 
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(Color.Black),
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(
+                        MaterialTheme.colorScheme.background,
+                        PluviaTheme.colors.surfacePanel,
+                        MaterialTheme.colorScheme.background,
+                    ),
+                ),
+            ),
     ) {
         Crossfade(
             targetState = appInfo,
@@ -76,11 +92,13 @@ internal fun LibraryDynamicBackdrop(
                                 scaleX = 1.06f
                                 scaleY = 1.06f
                             }
+                            .alpha(0.38f)
                             .blur(DYNAMIC_BACKDROP_BLUR_RADIUS),
                         imageModel = { currentImageUrl },
                         imageOptions = ImageOptions(
                             contentScale = ContentScale.Crop,
                             contentDescription = null,
+                            colorFilter = desaturate,
                         ),
                         loading = {},
                         failure = {
@@ -97,36 +115,12 @@ internal fun LibraryDynamicBackdrop(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color.Black.copy(alpha = 0.18f)),
-        )
-
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
                 .background(
                     brush = Brush.verticalGradient(
                         colorStops = arrayOf(
-                            0.0f to Color.Black.copy(alpha = 0.74f),
-                            0.16f to Color.Black.copy(alpha = 0.52f),
-                            0.38f to Color.Black.copy(alpha = 0.24f),
-                            0.62f to Color.Black.copy(alpha = 0.34f),
-                            1.0f to Color.Black.copy(alpha = 0.72f),
-                        ),
-                    ),
-                ),
-        )
-
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(
-                    brush = Brush.horizontalGradient(
-                        colorStops = arrayOf(
-                            0.0f to Color.Black.copy(alpha = 0.34f),
-                            0.14f to Color.Black.copy(alpha = 0.16f),
-                            0.5f to Color.Transparent,
-                            0.86f to Color.Black.copy(alpha = 0.16f),
-                            1.0f to Color.Black.copy(alpha = 0.34f),
+                            0.0f to scrimColor.copy(alpha = 0.48f),
+                            0.4f to scrimColor.copy(alpha = 0.48f),
+                            1.0f to scrimColor.copy(alpha = 0.62f),
                         ),
                     ),
                 ),


### PR DESCRIPTION
…ire app, stop crashes "deleting" steam games

## Description
Carousel view was horribly broken, this builds the cards and caches them so that they don't re-render every frame.

## Recording


## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves library carousel performance by rendering each card offscreen and reducing overdraw. Also prevents Steam login failures from wiping the game library.

- **Performance**
  - Carousel: enabled offscreen compositing, set a stable transform pivot, and sized the item container to avoid remeasure/recompose churn for smoother scrolling.
  - Backdrop: reduced blur (12dp → 7dp), applied light desaturation and theme scrims, and removed extra overlays to cut overdraw.

- **Bug Fixes**
  - On Steam auth failure, only clear Steam session preferences via `PrefManager.clearSteamSessionPreferences()` instead of clearing all user data. This stops the “deleted games” issue.

<sup>Written for commit 8695379d24893ea3335322e0cd5bfaa6e9351a97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Steam login recovery while preserving broader account data when session cleanup is required.
  * Fixed library carousel card sizing, alignment, and 3D tilt rendering.
* **Style**
  * Refined the library backdrop with theme-aware colors, softer blur, improved desaturation, and updated scrim gradients for a more cohesive appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->