### PR TITLE
fix: fine tune carousel size calculation to fit different screen size

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
@@ -9,14 +9,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -42,26 +40,20 @@ import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.blur
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
-import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import app.gamenative.PrefManager
 import app.gamenative.R
 import app.gamenative.data.LibraryItem
 import app.gamenative.ui.data.LibraryState
@@ -69,17 +61,13 @@ import app.gamenative.ui.data.statsFor
 import app.gamenative.ui.enums.PaneType
 import app.gamenative.ui.util.AdaptivePadding
 import app.gamenative.ui.util.shouldShowGamepadUI
-import com.skydoves.landscapist.ImageOptions
-import com.skydoves.landscapist.coil.CoilImage
 import kotlin.math.abs
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val CAROUSEL_TILT_ANGLE = 30.061367f
 private const val CAROUSEL_SPACING_RATIO = -0.11f
@@ -88,9 +76,6 @@ private const val CAROUSEL_SIDE_OFFSET_RATIO = 0.028464798f
 private const val CAROUSEL_STEP_OFFSET_RATIO = 0.08f
 private const val CAROUSEL_ITEM_OVERSCAN_RATIO = 0.4f
 private const val CAROUSEL_CARD_ASPECT_RATIO = 2f / 3f
-private const val CAROUSEL_CARD_SIZE_MULTIPLIER = 1.22f
-private const val CAROUSEL_CARD_VERTICAL_OVERFLOW = 32f
-private const val CAROUSEL_BADGE_RESERVED_HEIGHT = 0f
 private const val CAROUSEL_MOUSE_WHEEL_SCROLL_MULTIPLIER = 72f
 private const val CAROUSEL_MOUSE_DRAG_SLOP_PX = 8f
 
@@ -255,29 +240,24 @@ internal fun LibraryCarouselPane(
     val configuration = LocalConfiguration.current
     val horizontalPadding = AdaptivePadding.horizontal()
     val showGamepadHints = shouldShowGamepadUI()
-    val topOverlayClearance = if (state.isSearching) 116.dp else 104.dp
-    val bottomOverlayClearance = if (showGamepadHints) 156.dp else 32.dp
-    val baseCardWidth = when (configuration.screenWidthDp) {
-        in 0..700 -> 200.dp
-        in 701..1100 -> 240.dp
-        else -> 270.dp
-    }
-    val baseCardHeight = baseCardWidth / CAROUSEL_CARD_ASPECT_RATIO
-    val cardVerticalOverflow = CAROUSEL_CARD_VERTICAL_OVERFLOW.dp
-    val badgeReservedHeight = CAROUSEL_BADGE_RESERVED_HEIGHT.dp
-    val cardTopOverflow = cardVerticalOverflow
-    val cardBottomOverflow = cardVerticalOverflow + badgeReservedHeight
-    val availableCarouselHeight =
-        (configuration.screenHeightDp.dp - topOverlayClearance - bottomOverlayClearance)
-            .coerceAtLeast(220.dp)
-    val maxCardHeight =
-        (availableCarouselHeight - cardTopOverflow - cardBottomOverflow)
-            .coerceAtLeast(180.dp)
-    val cardHeight = minOf(baseCardHeight, maxCardHeight * CAROUSEL_CARD_SIZE_MULTIPLIER)
+    val hideStatusBar = PrefManager.hideStatusBarWhenNotInGame
+
+    // Fine-Tuned Values by JT, working on both landscape and portrait screens
+    val hintBarHeight = if (showGamepadHints) 56.dp else 0.dp
+    val extraTopPadding = if (showGamepadHints) 0.dp else 8.dp
+    val extraBottomPadding = if (hideStatusBar) 0.dp else 24.dp
+    val carouselTopMargin = (if (state.isSearching) 64.dp else 56.dp) + extraTopPadding
+    val carouselBottomMargin = 8.dp + hintBarHeight + extraBottomPadding
+    val cardTopPadding = 16.dp
+    val cardBottomPadding = 16.dp
+
+    // Correct calculation, no more messy calculations
+    val landscapeScale = if (configuration.screenWidthDp > configuration.screenHeightDp) 1.0f else 0.5f
+    val availableCarouselHeight = (configuration.screenHeightDp.dp - carouselTopMargin - carouselBottomMargin) * landscapeScale
+    val cardHeight = (availableCarouselHeight - cardTopPadding - cardBottomPadding)
     val cardWidth = cardHeight * CAROUSEL_CARD_ASPECT_RATIO
-    val itemContainerHeight = cardHeight + cardTopOverflow + cardBottomOverflow
-    val tiltPivotY = (cardTopOverflow.value + (cardHeight.value + badgeReservedHeight.value) / 2f) /
-        itemContainerHeight.value
+    val itemContainerHeight = cardHeight + cardTopPadding + cardBottomPadding
+
     val cardWidthPx = with(density) { cardWidth.toPx() }
     // Keep lazy items composed slightly beyond the viewport because rotation/translation can leave
     // transformed pixels visible after the raw item slot has technically moved offscreen.
@@ -367,16 +347,20 @@ internal fun LibraryCarouselPane(
     val currentAppInfoList by rememberUpdatedState(state.appInfoList)
     LaunchedEffect(listState) {
         var pendingUpdate: Job? = null
+        var lastSettledIndex = -1
         snapshotFlow { listState.isScrollInProgress to centeredIndex }
-            .collect { (isScrolling, _) ->
+            .collect { (isScrolling, currentCentered) ->
                 pendingUpdate?.cancel()
                 if (!isScrolling) {
                     pendingUpdate = launch {
                         delay(200)
                         val list = currentAppInfoList
-                        val idx = centeredIndex.takeIf { it in list.indices }
+                        val idx = currentCentered.takeIf { it in list.indices }
                             ?: listState.firstVisibleItemIndex.coerceIn(0, list.lastIndex.coerceAtLeast(0))
-                        settledBackdropItem = list.getOrNull(idx)
+                        if (idx != lastSettledIndex) {
+                            lastSettledIndex = idx
+                            settledBackdropItem = list.getOrNull(idx)
+                        }
                     }
                 }
             }
@@ -434,8 +418,8 @@ internal fun LibraryCarouselPane(
                         contentPadding = PaddingValues(
                             start = centeredSlotHorizontalPadding,
                             end = centeredSlotHorizontalPadding,
-                            top = topOverlayClearance,
-                            bottom = bottomOverlayClearance,
+                            top = carouselTopMargin,
+                            bottom = carouselBottomMargin,
                         ),
                     ) {
                         items(
@@ -536,7 +520,6 @@ internal fun LibraryCarouselPane(
                                             this.rotationY = computedRotationY
                                             this.translationX = computedTranslationX
                                             cameraDistance = cameraDistancePx
-                                            transformOrigin = TransformOrigin(0.5f, tiltPivotY)
                                             clip = false
                                             compositingStrategy = CompositingStrategy.Offscreen
                                         },
@@ -544,7 +527,7 @@ internal fun LibraryCarouselPane(
                                     Box(
                                         modifier = Modifier
                                             .align(Alignment.TopCenter)
-                                            .padding(top = cardTopOverflow)
+                                            .padding(top = cardTopPadding)
                                             .width(cardWidth)
                                             .height(cardHeight),
                                         contentAlignment = Alignment.Center,
@@ -594,8 +577,8 @@ internal fun LibraryCarouselPane(
                         contentPadding = PaddingValues(
                             start = centeredHorizontalPadding,
                             end = centeredHorizontalPadding,
-                            top = topOverlayClearance,
-                            bottom = bottomOverlayClearance,
+                            top = carouselTopMargin,
+                            bottom = carouselBottomMargin,
                         ),
                     ) {
                         items(6) {


### PR DESCRIPTION
## Description
fix: fine tune carousel size calculation to fit different screen size

## Recording
N/A

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fine-tunes carousel sizing so cards scale and center correctly across screen sizes and orientations. Fixes clipping and spacing under search and gamepad hint overlays.

- **Bug Fixes**
  - Recalculate available height from new margins (search bar, hint bar, and `PrefManager.hideStatusBarWhenNotInGame`) with simple card paddings; derive `cardHeight`/`cardWidth` from aspect ratio and a landscape/portrait scale.
  - Remove old overflow and size multipliers; drop tilt pivot math; update `LazyRow` content padding to match new margins.
  - Prevent redundant backdrop updates by tracking the last settled index for smoother, less jittery scrolling.

<sup>Written for commit 7b603754bade8c0d98df1e84474808aeadc15b6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved carousel sizing and spacing across searching, landscape, gamepad hint, and status bar configurations.
  * Refined card positioning and alignment for a more consistent visual layout.
  * Improved backdrop updates while scrolling to reduce unnecessary changes and keep the displayed artwork synchronized with the centered game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->