### PR TITLE
Force software rendering for Forza Horizon 4's CEF overlay

### DIFF
--- a/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
@@ -39,6 +39,7 @@ object GameFixesRegistry {
         STEAM_Fix_413150,
         STEAM_Fix_413420,
         STEAM_Fix_752580,
+        STEAM_Fix_1293830,
         STEAM_Fix_1637320,
         STEAM_Fix_1962700,
         STEAM_Fix_2868840,

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_1293830.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_1293830.kt
@@ -1,0 +1,57 @@
+package app.gamenative.gamefixes
+
+import android.content.Context
+import app.gamenative.data.GameSource
+import com.winlator.container.Container
+import com.winlator.core.WineRegistryEditor
+import java.io.File
+import timber.log.Timber
+
+private const val FORZA_WEB_HELPER_DLL_OVERRIDES_KEY =
+    "Software\\Wine\\AppDefaults\\ForzaWebHelper.exe\\DllOverrides"
+private const val FORZA_WEB_HELPER_DIRECT3D_KEY =
+    "Software\\Wine\\AppDefaults\\ForzaWebHelper.exe\\Direct3D"
+private val FORZA_WEB_HELPER_BUILTIN_DLLS = listOf("dxgi", "d3d11", "d3d9")
+
+/**
+ * Forza Horizon 4 (Steam)
+ *
+ * The CEF overlay (ForzaWebHelper.exe) does not render with GPU acceleration.
+ * libcef.dll statically imports d3d9/d3d11, so they cannot be disabled outright;
+ * instead route them to wine's builtin wined3d with renderer=no3d for that exe
+ * only. D3D device creation then fails at runtime, ANGLE gives up, and CEF
+ * falls back to software rendering while the game keeps DXVK.
+ */
+val STEAM_Fix_1293830: KeyedGameFix = object : KeyedGameFix {
+    override val gameSource = GameSource.STEAM
+    override val gameId = "1293830"
+
+    override fun apply(
+        context: Context,
+        gameId: String,
+        installPath: String,
+        installPathWindows: String,
+        container: Container,
+    ): Boolean = try {
+        val userRegFile = File(container.rootDir, ".wine/user.reg")
+        if (!userRegFile.isFile) {
+            userRegFile.parentFile?.mkdirs()
+            userRegFile.writeText("WINE REGISTRY Version 2\n\n")
+        }
+        WineRegistryEditor(userRegFile).use { editor ->
+            editor.setCreateKeyIfNotExist(true)
+            for (dll in FORZA_WEB_HELPER_BUILTIN_DLLS) {
+                if (editor.getStringValue(FORZA_WEB_HELPER_DLL_OVERRIDES_KEY, dll, null) != "builtin") {
+                    editor.setStringValue(FORZA_WEB_HELPER_DLL_OVERRIDES_KEY, dll, "builtin")
+                }
+            }
+            if (editor.getStringValue(FORZA_WEB_HELPER_DIRECT3D_KEY, "renderer", null) != "no3d") {
+                editor.setStringValue(FORZA_WEB_HELPER_DIRECT3D_KEY, "renderer", "no3d")
+            }
+        }
+        true
+    } catch (e: Exception) {
+        Timber.tag("GameFixes").e(e, "Failed to apply Forza Horizon 4 web helper DLL overrides")
+        false
+    }
+}


### PR DESCRIPTION
Forza Horizon 4's sign-in/web overlays (ForzaWebHelper.exe, CEF) don't render with GPU acceleration on our stack - the popup either crashes or sits on a blank page, so you can never log in to Xbox Live.

Chromium's usual escape hatches don't work here: FH4's libcef build predates ANGLE_DEFAULT_PLATFORM, and disabling d3d9/d3d11 outright via per-exe DllOverrides makes libcef.dll fail to load entirely (it imports both statically), which crash-loops every helper process.

This adds a gamefix that scopes overrides to ForzaWebHelper.exe only: dxgi/d3d11/d3d9 are routed to wine's builtin wined3d and the exe gets Direct3D renderer=no3d. Device creation then fails at runtime instead of load time, ANGLE gives up cleanly, and CEF falls back to software rendering. The game itself keeps DXVK untouched.

Tested on device: the sign-in overlay now renders and login completes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force software rendering for Forza Horizon 4’s CEF web overlay so the Xbox Live sign-in popup renders instead of crashing or showing a blank page. Scoped to `ForzaWebHelper.exe`; the game keeps DXVK.

- **Bug Fixes**
  - Added `STEAM_Fix_1293830` to set Wine registry for `ForzaWebHelper.exe`: `DllOverrides` for `dxgi`/`d3d11`/`d3d9` → `builtin`, and `Direct3D` `renderer=no3d`, forcing ANGLE/CEF to use software rendering.
  - Tested: overlay renders and login completes.

<sup>Written for commit 0e5418ee14f66be783cecba35fe45220f09b941b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a compatibility fix for *Forza Horizon 4* on Steam.
  * Improved the in-game overlay’s rendering compatibility by applying software-rendering settings when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->