### PR TITLE
fix: library screen focus bug

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -394,7 +394,9 @@ private fun LibraryScreenContent(
     val inputModeManager = LocalInputModeManager.current
     fun ensureKeyboardInputMode() {
         if (isGameControllerConnected()) {
-            inputModeManager.requestInputMode(InputMode.Keyboard)
+            if (inputModeManager.inputMode != InputMode.Keyboard) {
+                inputModeManager.requestInputMode(InputMode.Keyboard)
+            }
         }
     }
 
@@ -403,7 +405,6 @@ private fun LibraryScreenContent(
 
     fun requestGridFocusOrDefer() {
         if (!isListFocusable()) return
-        ensureKeyboardInputMode()
         try {
             gridFirstItemFocusRequester.requestFocus()
             pendingGridFocusRequest = false
@@ -415,7 +416,6 @@ private fun LibraryScreenContent(
 
     fun requestCarouselFocusOrDefer(targetListIndex: Int = currentCarouselFocusTargetIndex()) {
         if (!isListFocusable()) return
-        ensureKeyboardInputMode()
         carouselFocusTargetListIndex = targetListIndex.coerceIn(0, getContentLastIndex())
         try {
             carouselFocusRequester.requestFocus()
@@ -437,7 +437,6 @@ private fun LibraryScreenContent(
     }
 
     fun requestRootFocusSafe() {
-        ensureKeyboardInputMode()
         try {
             rootFocusRequester.requestFocus()
         } catch (_: IllegalStateException) {}
@@ -681,6 +680,7 @@ private fun LibraryScreenContent(
 
     DisposableEffect(Unit) {
         val onGlobalKeyEvent: (AndroidEvent.KeyEvent) -> Boolean = { androidEvent ->
+            ensureKeyboardInputMode()
             val event = androidEvent.event
             if (event.action != KeyEvent.ACTION_DOWN) {
                 false
@@ -730,6 +730,7 @@ private fun LibraryScreenContent(
         }
 
         val onGlobalMotionEvent: (AndroidEvent.MotionEvent) -> Boolean = { androidEvent ->
+            ensureKeyboardInputMode()
             val event = androidEvent.event
             if (event == null || !canBootstrapContentFocus()) {
                 false
@@ -778,7 +779,6 @@ private fun LibraryScreenContent(
                     controllerBootstrapNeeded = true
                 }
             }
-            .focusGroup()
             .onPreviewKeyEvent { keyEvent ->
                 // TODO: consider abstracting this
                 // Handle gamepad buttons

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -405,6 +405,7 @@ private fun LibraryScreenContent(
 
     fun requestGridFocusOrDefer() {
         if (!isListFocusable()) return
+        ensureKeyboardInputMode()
         try {
             gridFirstItemFocusRequester.requestFocus()
             pendingGridFocusRequest = false
@@ -416,6 +417,7 @@ private fun LibraryScreenContent(
 
     fun requestCarouselFocusOrDefer(targetListIndex: Int = currentCarouselFocusTargetIndex()) {
         if (!isListFocusable()) return
+        ensureKeyboardInputMode()
         carouselFocusTargetListIndex = targetListIndex.coerceIn(0, getContentLastIndex())
         try {
             carouselFocusRequester.requestFocus()
@@ -437,6 +439,7 @@ private fun LibraryScreenContent(
     }
 
     fun requestRootFocusSafe() {
+        ensureKeyboardInputMode()
         try {
             rootFocusRequester.requestFocus()
         } catch (_: IllegalStateException) {}
@@ -680,7 +683,6 @@ private fun LibraryScreenContent(
 
     DisposableEffect(Unit) {
         val onGlobalKeyEvent: (AndroidEvent.KeyEvent) -> Boolean = { androidEvent ->
-            ensureKeyboardInputMode()
             val event = androidEvent.event
             if (event.action != KeyEvent.ACTION_DOWN) {
                 false
@@ -730,7 +732,6 @@ private fun LibraryScreenContent(
         }
 
         val onGlobalMotionEvent: (AndroidEvent.MotionEvent) -> Boolean = { androidEvent ->
-            ensureKeyboardInputMode()
             val event = androidEvent.event
             if (event == null || !canBootstrapContentFocus()) {
                 false

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
@@ -314,22 +314,6 @@ internal fun LibraryCarouselPane(
         }
     }
 
-    // Auto-focus first item when list becomes non-empty
-    LaunchedEffect(state.appInfoList.size, firstCarouselItemFocusRequester) {
-        if (state.appInfoList.isNotEmpty() && firstCarouselItemFocusRequester != null) {
-            delay(150) // Brief delay to ensure layout is ready
-
-            // Check if focusTargetListIndex still null or 0 after delay
-            if (focusTargetListIndex == null || focusTargetListIndex == 0) {
-                try {
-                    firstCarouselItemFocusRequester.requestFocus()
-                } catch (_: IllegalStateException) {
-                    // FocusRequester not attached yet
-                }
-            }
-        }
-    }
-
     LaunchedEffect(listState, state.appInfoList.size, state.totalAppsInFilter) {
         snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
             .filterNotNull()

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -169,22 +169,6 @@ internal fun LibraryListPane(
     val horizontalPadding = AdaptivePadding.horizontal()
     val gridSpacing = AdaptivePadding.gridSpacing()
 
-    // Auto-focus first item when list becomes non-empty
-    LaunchedEffect(state.appInfoList.size, firstGridItemFocusRequester) {
-        if (state.appInfoList.isNotEmpty() && firstGridItemFocusRequester != null) {
-            delay(150) // Brief delay to ensure layout is ready
-
-            // Check if focusTargetListIndex still null or 0 after delay
-            if (focusTargetListIndex == null || focusTargetListIndex == 0) {
-                try {
-                    firstGridItemFocusRequester.requestFocus()
-                } catch (_: IllegalStateException) {
-                    // FocusRequester not attached yet
-                }
-            }
-        }
-    }
-
     LaunchedEffect(listState, state.appInfoList.size) {
         snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
             .filterNotNull()


### PR DESCRIPTION
## Description
fix: library screen focus bug

## Recording
N/A

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes focus instability in the Library screen so focus no longer jumps when content loads, and keyboard/controller navigation stays consistent.

- **Bug Fixes**
  - Only request `InputMode.Keyboard` if not already active.
  - Reverted `ensureKeyboardInputMode()` call site: enforce on global key/motion events, not during focus requests.
  - Remove auto-focus of the first item in `LibraryCarouselPane` and `LibraryListPane`.
  - Remove `focusGroup()` from the root container to prevent unintended focus capture.

<sup>Written for commit 59fc077d565a8ac82b331e59fa3d57e8c3862501. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller and keyboard input handling on the Library screen.
  * Prevented unnecessary switching when keyboard mode is already active after connecting a controller.
  * Enhanced focus stability for Library navigation, including carousel interactions.
  * Removed auto-focusing of the first library item when content loads to reduce unexpected selection changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->