### PR TITLE
controller claim on input

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -928,7 +928,7 @@ fun XServerScreen(
             isMouse && !device.isVirtual && isExternal
         }
         val controllerManager = ControllerManager.getInstance()
-        controllerManager.autoAssignConnectedDevices()
+        controllerManager.scanForDevices()
         hasPhysicalController = controllerManager.getDetectedDevices().isNotEmpty()
         controllerSlotStatusVersion++
         xServerView?.getxServer()?.winHandler?.refreshControllerMappingsForHotplug()
@@ -1285,10 +1285,14 @@ fun XServerScreen(
             QuickMenuAction.EXIT_GAME -> {
                 PostHog.capture(
                     event = "game_closed",
-                    properties = mapOf(
-                        "game_name" to ContainerUtils.resolveGameName(appId),
-                        "game_store" to ContainerUtils.extractGameSourceFromContainerId(appId).name,
-                    ),
+                    properties = buildMap {
+                        put("game_name", ContainerUtils.resolveGameName(appId))
+                        put("game_store", ContainerUtils.extractGameSourceFromContainerId(appId).name)
+                        if (PrefManager.usageAnalyticsEnabled) {
+                            put("max_controllers", ControllerManager.getInstance().sessionPeakClaimedSlots)
+                            put("external_controller_used", ControllerManager.getInstance().sessionUsedExternalController)
+                        }
+                    },
                 )
                 imeInputReceiver?.hideKeyboard()
                 // Resume processes before exiting so they can receive SIGTERM cleanly.
@@ -1371,6 +1375,7 @@ fun XServerScreen(
         }
 
         inputManager.registerInputDeviceListener(deviceListener, null)
+        ControllerManager.getInstance().resetClaims()
         scanForExternalDevices()
 
         onDispose {
@@ -1431,6 +1436,12 @@ fun XServerScreen(
                 else -> false
             }
         } else if ((showElementEditor || keepPausedForEditor || showQuickMenu || isEditMode) && (isGamepad || isKeyboard)) {
+            if (isGamepad) {
+                ControllerManager.getInstance().claimSlotForInput(
+                    it.event.device.id,
+                    it.event.action == KeyEvent.ACTION_DOWN && it.event.repeatCount == 0,
+                )
+            }
             val escPressed = !keepPausedForEditor &&
                 isKeyboard &&
                 it.event.keyCode == KeyEvent.KEYCODE_ESCAPE
@@ -1452,7 +1463,10 @@ fun XServerScreen(
             var handled = false
             if (isGamepad) {
                 val winHandler = xServerView!!.getxServer().winHandler
-                val assignedSlot = ControllerManager.getInstance().getSlotForDevice(it.event.device.id)
+                val assignedSlot = ControllerManager.getInstance().claimSlotForInput(
+                    it.event.device.id,
+                    it.event.action == KeyEvent.ACTION_DOWN && it.event.repeatCount == 0,
+                )
                 if (assignedSlot > 0) {
                     handled = winHandler.onKeyEvent(it.event)
                 } else {
@@ -1498,13 +1512,22 @@ fun XServerScreen(
         val isGamepad = ExternalController.isGameController(it.event?.device)
 
         if ((showElementEditor || keepPausedForEditor || showQuickMenu || isEditMode) && isGamepad) {
+            if (it.event != null) {
+                ControllerManager.getInstance().claimSlotForInput(
+                    it.event.device.id,
+                    ControllerManager.isClaimMotion(it.event),
+                )
+            }
             // Let Compose consume any gamepad motion while menu is visible.
             false
         } else {
             var handled = false
             if (isGamepad && it.event != null) {
                 val winHandler = xServerView!!.getxServer().winHandler
-                val assignedSlot = ControllerManager.getInstance().getSlotForDevice(it.event.device.id)
+                val assignedSlot = ControllerManager.getInstance().claimSlotForInput(
+                    it.event.device.id,
+                    ControllerManager.isClaimMotion(it.event),
+                )
                 if (assignedSlot > 0) {
                     handled = winHandler.onGenericMotionEvent(it.event)
                 } else {
@@ -3013,6 +3036,7 @@ private fun showInputControls(profile: ControlsProfile, winHandler: WinHandler, 
 
 
         // Clear any physical device from P1 to prevent conflicts.
+        controllerManager.setSlot0ReservedForVirtual(true)
         controllerManager.unassignSlot(0)
 
 
@@ -3025,6 +3049,7 @@ private fun hideInputControls() {
     PluviaApp.inputControlsView?.setShowTouchscreenControls(false)
     PluviaApp.inputControlsView?.setVisibility(View.GONE)
     PluviaApp.inputControlsView?.setProfile(null)
+    ControllerManager.getInstance().setSlot0ReservedForVirtual(false)
     PluviaApp.xServerView?.getxServer()?.winHandler?.refreshControllerMappingsForHotplug()
 
     PluviaApp.touchpadView?.setSensitivity(1.0f)
@@ -3244,7 +3269,7 @@ private fun buildControllerStatusSnapshot(
     container: Container,
     areControlsVisible: Boolean,
 ): ControllerStatusSnapshot {
-    controllerManager.autoAssignConnectedDevices()
+    controllerManager.scanForDevices()
     val guestApi = describePreferredInputApi(container)
     val slots = (0 until WinHandler.MAX_PLAYERS).map { slot ->
         val assignedDevice = controllerManager.getAssignedDeviceForSlot(slot)

--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -4,24 +4,17 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.hardware.input.InputManager;
-import android.os.Handler;
-import android.os.Looper;
-import android.os.SystemClock;
 import android.util.Log;
 import android.preference.PreferenceManager;
 import android.util.SparseArray;
 import android.view.InputDevice;
 import android.view.KeyEvent;
+import android.view.MotionEvent;
 
-import app.gamenative.PrefManager;
-
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class ControllerManager {
@@ -60,12 +53,9 @@ public class ControllerManager {
     // This tracks which of the 4 player slots are enabled by the user.
     private final boolean[] enabledSlots = new boolean[MAX_SLOTS];
     private final List<OnSlotsChangedListener> slotListeners = new CopyOnWriteArrayList<>();
-    private final ArrayDeque<Integer> recentlyFreedSlots = new ArrayDeque<>();
-
-    private static final long ASSIGN_SETTLE_MS = 300L;
-    private final Map<String, Long> firstSeenByIdentifier = new HashMap<>();
-    private final Handler settleHandler = new Handler(Looper.getMainLooper());
-    private final Runnable settleAssignRunnable = this::autoAssignConnectedDevices;
+    private boolean slot0ReservedForVirtual;
+    private int sessionPeakClaimedSlots;
+    private boolean sessionUsedExternalController;
 
     public interface OnSlotsChangedListener {
         void onSlotsChanged();
@@ -84,13 +74,9 @@ public class ControllerManager {
         this.preferences = PreferenceManager.getDefaultSharedPreferences(this.context);
         this.inputManager = (InputManager) this.context.getSystemService(Context.INPUT_SERVICE);
 
-        // On startup, we load saved settings and scan for connected devices.
         loadAssignments();
-        autoAssignConnectedDevices();
+        scanForDevices();
     }
-
-
-
 
     /**
      * Scans for all physically connected game controllers and updates the internal list.
@@ -98,55 +84,25 @@ public class ControllerManager {
     public void scanForDevices() {
         detectedDevices.clear();
         int[] deviceIds = inputManager.getInputDeviceIds();
-        Set<String> present = new HashSet<>();
         for (int deviceId : deviceIds) {
             InputDevice device = inputManager.getInputDevice(deviceId);
-            // Some handhelds expose built-in controls as virtual devices, so
-            // accept any device that reports a real gamepad/joystick shape.
             if (device != null && isGameController(device)) {
                 detectedDevices.add(device);
                 String ident = getDeviceIdentifier(device);
-                knownDeviceIdentifiers.put(deviceId, ident);
-                if (ident != null) present.add(ident);
+                if (ident != null) knownDeviceIdentifiers.put(deviceId, ident);
             }
         }
-        long now = SystemClock.elapsedRealtime();
-        for (String ident : present) {
-            if (!firstSeenByIdentifier.containsKey(ident)) {
-                firstSeenByIdentifier.put(ident, now);
-            }
-        }
-        firstSeenByIdentifier.keySet().retainAll(present);
     }
 
-    private boolean isSettled(String identifier) {
-        Long t = firstSeenByIdentifier.get(identifier);
-        return t != null && (SystemClock.elapsedRealtime() - t) >= ASSIGN_SETTLE_MS;
-    }
-
-    private void scheduleSettleAssign() {
-        settleHandler.removeCallbacks(settleAssignRunnable);
-        settleHandler.postDelayed(settleAssignRunnable, ASSIGN_SETTLE_MS + 20L);
-    }
-
-    /**
-     * Loads the saved player slot assignments and enabled states from SharedPreferences.
-     */
     private void loadAssignments() {
         slotAssignments.clear();
         lastKnownSlotByIdentifier.clear();
         for (int i = 0; i < MAX_SLOTS; i++) {
-            // Load which device is assigned to this slot
-            String prefKey = PREF_PLAYER_SLOT_PREFIX + i;
-            String deviceIdentifier = preferences.getString(prefKey, null);
+            String deviceIdentifier = preferences.getString(PREF_PLAYER_SLOT_PREFIX + i, null);
             if (deviceIdentifier != null) {
-                slotAssignments.put(i, deviceIdentifier);
                 lastKnownSlotByIdentifier.put(deviceIdentifier, i);
             }
-
-            // Load whether this slot is enabled. Default P1=true, P2-4=false.
-            String enabledKey = PREF_ENABLED_SLOTS_PREFIX + i;
-            enabledSlots[i] = preferences.getBoolean(enabledKey, i == 0);
+            enabledSlots[i] = preferences.getBoolean(PREF_ENABLED_SLOTS_PREFIX + i, i == 0);
         }
     }
 
@@ -186,8 +142,8 @@ public class ControllerManager {
         boolean isJoystick = device.supportsSource(InputDevice.SOURCE_JOYSTICK);
 
         boolean hasAxes =
-                device.getMotionRange(android.view.MotionEvent.AXIS_X) != null ||
-                        device.getMotionRange(android.view.MotionEvent.AXIS_Y) != null;
+                device.getMotionRange(MotionEvent.AXIS_X) != null ||
+                        device.getMotionRange(MotionEvent.AXIS_Y) != null;
 
         boolean[] hasGamepadKeysArray = device.hasKeys(
                 KeyEvent.KEYCODE_BUTTON_A,
@@ -288,7 +244,6 @@ public class ControllerManager {
         // Assign the new device to the target slot.
         slotAssignments.put(slotIndex, newDeviceIdentifier);
         lastKnownSlotByIdentifier.put(newDeviceIdentifier, slotIndex);
-        recentlyFreedSlots.remove(slotIndex);
     }
 
     /**
@@ -302,7 +257,6 @@ public class ControllerManager {
             lastKnownSlotByIdentifier.put(deviceIdentifier, slotIndex);
         }
         slotAssignments.remove(slotIndex);
-        markSlotRecentlyFreed(slotIndex);
         saveAssignments();
         notifySlotsChanged();
     }
@@ -386,73 +340,11 @@ public class ControllerManager {
         if (device == null || !isGameController(device)) {
             return;
         }
-
         String deviceIdentifier = getDeviceIdentifier(device);
-        if (deviceIdentifier == null) {
-            return;
+        if (deviceIdentifier != null) {
+            knownDeviceIdentifiers.put(deviceId, deviceIdentifier);
         }
-
-        knownDeviceIdentifiers.put(deviceId, deviceIdentifier);
         scanForDevices();
-        int existing = getSlotForDevice(deviceId);
-        if (existing >= 0) {
-            return;
-        }
-
-        if (!isSettled(deviceIdentifier)) {
-            scheduleSettleAssign();
-            return;
-        }
-
-        int slot = getPreferredFreeSlot(deviceIdentifier);
-        if (slot >= 0) {
-            enabledSlots[slot] = true;
-            assignDeviceIdentifierToSlot(slot, deviceIdentifier);
-            saveAssignments();
-            notifySlotsChanged();
-            Log.i(TAG, "Auto-assigned deviceId=" + deviceId + " to Player " + (slot + 1));
-            return;
-        }
-        Log.i(TAG, "No free controller slot for deviceId=" + deviceId);
-    }
-
-    /**
-     * Assigns any currently connected controller that is not already bound to a player slot.
-     * Built-in controllers can be present before Android dispatches any hot-plug callback,
-     * so callers should run this after a device scan during startup/session refresh.
-     */
-    public void autoAssignConnectedDevices() {
-        scanForDevices();
-        boolean changed = false;
-        for (InputDevice device : detectedDevices) {
-            String deviceIdentifier = getDeviceIdentifier(device);
-            if (deviceIdentifier == null || getSlotForDevice(device.getId()) >= 0) {
-                continue;
-            }
-
-            if (!isSettled(deviceIdentifier)) {
-                scheduleSettleAssign();
-                continue;
-            }
-
-            int slot = getPreferredFreeSlot(deviceIdentifier);
-            if (slot < 0) {
-                Log.i(TAG, "No free controller slot for connected deviceId=" + device.getId());
-                break;
-            }
-
-            enabledSlots[slot] = true;
-            assignDeviceIdentifierToSlot(slot, deviceIdentifier);
-            knownDeviceIdentifiers.put(device.getId(), deviceIdentifier);
-            changed = true;
-            Log.i(TAG, "Auto-assigned connected deviceId=" + device.getId()
-                    + " to Player " + (slot + 1));
-        }
-
-        if (changed) {
-            saveAssignments();
-            notifySlotsChanged();
-        }
     }
 
     public void onDeviceDisconnected(int deviceId) {
@@ -465,29 +357,103 @@ public class ControllerManager {
             if (deviceIdentifier != null) {
                 lastKnownSlotByIdentifier.put(deviceIdentifier, slot);
             }
-            markSlotRecentlyFreed(slot);
             saveAssignments();
             notifySlotsChanged();
             Log.i(TAG, "Unassigned disconnected deviceId=" + deviceId + " from Player " + (slot + 1));
         }
     }
 
-    private void markSlotRecentlyFreed(int slot) {
-        if (slot < 0 || slot >= MAX_SLOTS) {
-            return;
+    public int claimSlotForInput(int deviceId, boolean claimInput) {
+        int slot = getSlotForDevice(deviceId);
+        if (slot == 0 || !claimInput) return slot;
+
+        if (slot > 0) {
+            if (slotAssignments.get(0) != null || slot0ReservedForVirtual) return slot;
+            scanForDevices();
+            if (detectedDevices.size() != 1) return slot;
+            InputDevice device = inputManager.getInputDevice(deviceId);
+            String deviceIdentifier = getDeviceIdentifier(device);
+            if (deviceIdentifier == null) return slot;
+            enabledSlots[0] = true;
+            assignDeviceIdentifierToSlot(0, deviceIdentifier);
+            saveAssignments();
+            notifySlotsChanged();
+            Log.i(TAG, "Promoted deviceId=" + deviceId + " from Player " + (slot + 1) + " to Player 1");
+            return 0;
         }
-        recentlyFreedSlots.remove(slot);
-        recentlyFreedSlots.addLast(slot);
+
+        InputDevice device = inputManager.getInputDevice(deviceId);
+        if (device == null || !isGameController(device)) return -1;
+        String deviceIdentifier = getDeviceIdentifier(device);
+        if (deviceIdentifier == null) return -1;
+        scanForDevices();
+        int freeSlot = getPreferredFreeSlot(deviceIdentifier);
+        if (freeSlot < 0) return -1;
+        enabledSlots[freeSlot] = true;
+        assignDeviceIdentifierToSlot(freeSlot, deviceIdentifier);
+        knownDeviceIdentifiers.put(deviceId, deviceIdentifier);
+        sessionPeakClaimedSlots = Math.max(sessionPeakClaimedSlots, slotAssignments.size());
+        if (isExternalDevice(device)) {
+            sessionUsedExternalController = true;
+        }
+        saveAssignments();
+        notifySlotsChanged();
+        Log.i(TAG, "Claimed Player " + (freeSlot + 1) + " for deviceId=" + deviceId);
+        return freeSlot;
+    }
+
+    public void resetClaims() {
+        slotAssignments.clear();
+        for (int i = 0; i < MAX_SLOTS; i++) {
+            enabledSlots[i] = (i == 0);
+        }
+        sessionPeakClaimedSlots = 0;
+        sessionUsedExternalController = false;
+        notifySlotsChanged();
+    }
+
+    public int getSessionPeakClaimedSlots() {
+        return sessionPeakClaimedSlots;
+    }
+
+    public boolean getSessionUsedExternalController() {
+        return sessionUsedExternalController;
+    }
+
+    private static boolean isExternalDevice(InputDevice device) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            return device.isExternal();
+        }
+        return true;
+    }
+
+    public void setSlot0ReservedForVirtual(boolean reserved) {
+        slot0ReservedForVirtual = reserved;
+    }
+
+    public static boolean isClaimMotion(MotionEvent event) {
+        int[] axes = {
+                MotionEvent.AXIS_X, MotionEvent.AXIS_Y, MotionEvent.AXIS_Z, MotionEvent.AXIS_RZ,
+                MotionEvent.AXIS_HAT_X, MotionEvent.AXIS_HAT_Y, MotionEvent.AXIS_LTRIGGER,
+                MotionEvent.AXIS_RTRIGGER, MotionEvent.AXIS_BRAKE, MotionEvent.AXIS_GAS,
+        };
+        for (int axis : axes) {
+            if (Math.abs(event.getAxisValue(axis)) > 0.25f) return true;
+        }
+        return false;
     }
 
     private boolean isSlotAvailable(int slot) {
-        return slot >= 0 && slot < MAX_SLOTS && getAssignedDeviceForSlot(slot) == null;
+        if (slot < 0 || slot >= MAX_SLOTS) return false;
+        if (slot == 0 && slot0ReservedForVirtual) return false;
+        return getAssignedDeviceForSlot(slot) == null;
     }
 
     private int getPreferredFreeSlot(String deviceIdentifier) {
+        if (isSlotAvailable(0)) return 0;
+
         Integer previousSlot = lastKnownSlotByIdentifier.get(deviceIdentifier);
         if (previousSlot != null && isSlotAvailable(previousSlot)) {
-            recentlyFreedSlots.remove(previousSlot);
             return previousSlot;
         }
 

--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -431,6 +431,10 @@ public class ControllerManager {
         slot0ReservedForVirtual = reserved;
     }
 
+    public boolean isSlot0ReservedForVirtual() {
+        return slot0ReservedForVirtual;
+    }
+
     public static boolean isClaimMotion(MotionEvent event) {
         int[] axes = {
                 MotionEvent.AXIS_X, MotionEvent.AXIS_Y, MotionEvent.AXIS_Z, MotionEvent.AXIS_RZ,

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -182,6 +182,10 @@ public class WinHandler implements ControllerManager.OnSlotsChangedListener {
         }
         controllerManager.scanForDevices();
         InputDevice p1Device = controllerManager.getAssignedDeviceForSlot(0);
+        if (p1Device == null && !controllerManager.isSlot0ReservedForVirtual()
+                && !controllerManager.getDetectedDevices().isEmpty()) {
+            p1Device = controllerManager.getDetectedDevices().get(0);
+        }
         if (p1Device != null) {
             currentController = ExternalController.getController(p1Device.getId());
             if (currentController != null) {

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -50,7 +50,12 @@ import java.util.concurrent.Executors;
 
 import timber.log.Timber;
 
-public class WinHandler {
+public class WinHandler implements ControllerManager.OnSlotsChangedListener {
+
+    @Override
+    public void onSlotsChanged() {
+        refreshControllerMappingsForHotplug();
+    }
 
     private static final String TAG = "WinHandler";
     private final ControllerManager controllerManager;
@@ -493,6 +498,7 @@ public class WinHandler {
 
     public void stop() {
         this.running = false;
+        controllerManager.removeOnSlotsChangedListener(this);
         for (int slot = 0; slot < MAX_PLAYERS; slot++) {
             rumbleTeardown(slot);
         }
@@ -701,6 +707,7 @@ public class WinHandler {
 
     public void start() {
         try {
+            controllerManager.addOnSlotsChangedListener(this);
             this.localhost = InetAddress.getLocalHost();
             Context context = activity.getApplicationContext();
             File gamepadShmDir = new File(


### PR DESCRIPTION
## Description
Let the controller claim the slot until a button is pressed, some games require this (dave the diver needed a button press before the sticks would be detected)

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Controllers now claim the lowest free slot on first real input, and we expose a provisional P1 before any input so games that only scan at startup can see a controller. This prevents slot 0 from being stolen by enumeration order and respects the virtual gamepad reservation.

- **Bug Fixes**
  - Claim slots on first button press or stick movement.
  - Provisional P1 maps to the first detected device unless slot 0 is reserved for the virtual gamepad.
  - Fixes games that only scan at launch missing controllers (e.g., Dave the Diver).

<sup>Written for commit 22c2027cc5e9dd371ca6f7f96ebdf95efdadd98a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller mapping so Player 1 is automatically assigned to the first detected device when no controller is assigned.
  * Preserved virtual gamepad reservations during automatic assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->