### PR TITLE
Final multicontroller fix

### DIFF
--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -369,8 +369,7 @@ public class ControllerManager {
 
         if (slot > 0) {
             if (slotAssignments.get(0) != null || slot0ReservedForVirtual) return slot;
-            scanForDevices();
-            if (detectedDevices.size() != 1) return slot;
+            if (slotAssignments.size() != 1) return slot;
             InputDevice device = inputManager.getInputDevice(deviceId);
             String deviceIdentifier = getDeviceIdentifier(device);
             if (deviceIdentifier == null) return slot;

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -197,10 +197,30 @@ public class WinHandler implements ControllerManager.OnSlotsChangedListener {
         }
         setGamepadSlotConnected(0, currentController != null || isVirtualGamepadActive());
         // Initialize Extra Players (2, 3, 4)
+        java.util.HashSet<Integer> usedDeviceIds = new java.util.HashSet<>();
+        if (p1Device != null) {
+            usedDeviceIds.add(p1Device.getId());
+        }
+        InputDevice[] assignedExtras = new InputDevice[extraControllers.length];
+        for (int i = 0; i < extraControllers.length; i++) {
+            assignedExtras[i] = controllerManager.getAssignedDeviceForSlot(i + 1);
+            if (assignedExtras[i] != null) {
+                usedDeviceIds.add(assignedExtras[i].getId());
+            }
+        }
         for (int i = 0; i < extraControllers.length; i++) {
             // Player 2 is slot 1, which corresponds to extraControllers[0]
-            InputDevice extraDevice = controllerManager.getAssignedDeviceForSlot(i + 1);
+            InputDevice extraDevice = assignedExtras[i];
+            if (extraDevice == null) {
+                for (InputDevice candidate : controllerManager.getDetectedDevices()) {
+                    if (!usedDeviceIds.contains(candidate.getId())) {
+                        extraDevice = candidate;
+                        break;
+                    }
+                }
+            }
             if (extraDevice != null) {
+                usedDeviceIds.add(extraDevice.getId());
                 extraControllers[i] = ExternalController.getController(extraDevice.getId());
                 if (extraControllers[i] != null) {
                     extraControllers[i].setContext(activity);


### PR DESCRIPTION
## Description
Some games were enumerating all attached pads at launch - we need to enumerate but not had the pads a slot at launch so that the first one with a button press grabs the slot. This makes games continue to work with an external keyboard and mouse attached.

Secondly, also needed to promote any remaining attached controllers when one is detached.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix multi-controller enumeration and slot promotion. Games now see all pads at launch but slots are only claimed on first input; when a controller disconnects, the remaining claimant is promoted to P1.

- **Bug Fixes**
  - Provisionally fill extra slots (P2–P4) with unclaimed detected controllers so enumerate-once co‑op games can find them; input claims still control routing.
  - Base P1 promotion on remaining claims instead of detected device count to avoid missed promotion when idle/built-in devices are present.

<sup>Written for commit c03e069218f86d2125dd960ade8aea0dd2210f6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller slot assignment to prevent duplicate devices from being assigned to multiple player slots.
  * Improved controller mapping refresh to correctly detect and assign available controllers to additional player slots.
  * Preserved existing controller assignments while filling unassigned slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->