### PR TITLE
Revert claim-on-input controller model; displace idle P1 on first input instead

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -928,7 +928,7 @@ fun XServerScreen(
             isMouse && !device.isVirtual && isExternal
         }
         val controllerManager = ControllerManager.getInstance()
-        controllerManager.scanForDevices()
+        controllerManager.autoAssignConnectedDevices()
         hasPhysicalController = controllerManager.getDetectedDevices().isNotEmpty()
         controllerSlotStatusVersion++
         xServerView?.getxServer()?.winHandler?.refreshControllerMappingsForHotplug()
@@ -1285,14 +1285,10 @@ fun XServerScreen(
             QuickMenuAction.EXIT_GAME -> {
                 PostHog.capture(
                     event = "game_closed",
-                    properties = buildMap {
-                        put("game_name", ContainerUtils.resolveGameName(appId))
-                        put("game_store", ContainerUtils.extractGameSourceFromContainerId(appId).name)
-                        if (PrefManager.usageAnalyticsEnabled) {
-                            put("max_controllers", ControllerManager.getInstance().sessionPeakClaimedSlots)
-                            put("external_controller_used", ControllerManager.getInstance().sessionUsedExternalController)
-                        }
-                    },
+                    properties = mapOf(
+                        "game_name" to ContainerUtils.resolveGameName(appId),
+                        "game_store" to ContainerUtils.extractGameSourceFromContainerId(appId).name,
+                    ),
                 )
                 imeInputReceiver?.hideKeyboard()
                 // Resume processes before exiting so they can receive SIGTERM cleanly.
@@ -1375,7 +1371,6 @@ fun XServerScreen(
         }
 
         inputManager.registerInputDeviceListener(deviceListener, null)
-        ControllerManager.getInstance().resetClaims()
         scanForExternalDevices()
 
         onDispose {
@@ -1436,12 +1431,6 @@ fun XServerScreen(
                 else -> false
             }
         } else if ((showElementEditor || keepPausedForEditor || showQuickMenu || isEditMode) && (isGamepad || isKeyboard)) {
-            if (isGamepad) {
-                ControllerManager.getInstance().claimSlotForInput(
-                    it.event.device.id,
-                    it.event.action == KeyEvent.ACTION_DOWN && it.event.repeatCount == 0,
-                )
-            }
             val escPressed = !keepPausedForEditor &&
                 isKeyboard &&
                 it.event.keyCode == KeyEvent.KEYCODE_ESCAPE
@@ -1463,10 +1452,7 @@ fun XServerScreen(
             var handled = false
             if (isGamepad) {
                 val winHandler = xServerView!!.getxServer().winHandler
-                val assignedSlot = ControllerManager.getInstance().claimSlotForInput(
-                    it.event.device.id,
-                    it.event.action == KeyEvent.ACTION_DOWN && it.event.repeatCount == 0,
-                )
+                val assignedSlot = ControllerManager.getInstance().getSlotForDevice(it.event.device.id)
                 if (assignedSlot > 0) {
                     handled = winHandler.onKeyEvent(it.event)
                 } else {
@@ -1512,22 +1498,13 @@ fun XServerScreen(
         val isGamepad = ExternalController.isGameController(it.event?.device)
 
         if ((showElementEditor || keepPausedForEditor || showQuickMenu || isEditMode) && isGamepad) {
-            if (it.event != null) {
-                ControllerManager.getInstance().claimSlotForInput(
-                    it.event.device.id,
-                    ControllerManager.isClaimMotion(it.event),
-                )
-            }
             // Let Compose consume any gamepad motion while menu is visible.
             false
         } else {
             var handled = false
             if (isGamepad && it.event != null) {
                 val winHandler = xServerView!!.getxServer().winHandler
-                val assignedSlot = ControllerManager.getInstance().claimSlotForInput(
-                    it.event.device.id,
-                    ControllerManager.isClaimMotion(it.event),
-                )
+                val assignedSlot = ControllerManager.getInstance().getSlotForDevice(it.event.device.id)
                 if (assignedSlot > 0) {
                     handled = winHandler.onGenericMotionEvent(it.event)
                 } else {
@@ -3036,7 +3013,6 @@ private fun showInputControls(profile: ControlsProfile, winHandler: WinHandler, 
 
 
         // Clear any physical device from P1 to prevent conflicts.
-        controllerManager.setSlot0ReservedForVirtual(true)
         controllerManager.unassignSlot(0)
 
 
@@ -3049,7 +3025,6 @@ private fun hideInputControls() {
     PluviaApp.inputControlsView?.setShowTouchscreenControls(false)
     PluviaApp.inputControlsView?.setVisibility(View.GONE)
     PluviaApp.inputControlsView?.setProfile(null)
-    ControllerManager.getInstance().setSlot0ReservedForVirtual(false)
     PluviaApp.xServerView?.getxServer()?.winHandler?.refreshControllerMappingsForHotplug()
 
     PluviaApp.touchpadView?.setSensitivity(1.0f)
@@ -3269,7 +3244,7 @@ private fun buildControllerStatusSnapshot(
     container: Container,
     areControlsVisible: Boolean,
 ): ControllerStatusSnapshot {
-    controllerManager.scanForDevices()
+    controllerManager.autoAssignConnectedDevices()
     val guestApi = describePreferredInputApi(container)
     val slots = (0 until WinHandler.MAX_PLAYERS).map { slot ->
         val assignedDevice = controllerManager.getAssignedDeviceForSlot(slot)

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -1285,10 +1285,14 @@ fun XServerScreen(
             QuickMenuAction.EXIT_GAME -> {
                 PostHog.capture(
                     event = "game_closed",
-                    properties = mapOf(
-                        "game_name" to ContainerUtils.resolveGameName(appId),
-                        "game_store" to ContainerUtils.extractGameSourceFromContainerId(appId).name,
-                    ),
+                    properties = buildMap {
+                        put("game_name", ContainerUtils.resolveGameName(appId))
+                        put("game_store", ContainerUtils.extractGameSourceFromContainerId(appId).name)
+                        if (PrefManager.usageAnalyticsEnabled) {
+                            put("max_controllers", ControllerManager.getInstance().sessionUsedControllerCount)
+                            put("external_controller_used", ControllerManager.getInstance().sessionUsedExternalController)
+                        }
+                    },
                 )
                 imeInputReceiver?.hideKeyboard()
                 // Resume processes before exiting so they can receive SIGTERM cleanly.
@@ -1371,6 +1375,7 @@ fun XServerScreen(
         }
 
         inputManager.registerInputDeviceListener(deviceListener, null)
+        ControllerManager.getInstance().resetSessionActivity()
         scanForExternalDevices()
 
         onDispose {
@@ -1452,6 +1457,11 @@ fun XServerScreen(
             var handled = false
             if (isGamepad) {
                 val winHandler = xServerView!!.getxServer().winHandler
+                if (it.event.action == KeyEvent.ACTION_DOWN && it.event.repeatCount == 0 &&
+                    ControllerManager.getInstance().noteGamepadButton(it.event.device.id)
+                ) {
+                    winHandler.refreshControllerMappingsForHotplug()
+                }
                 val assignedSlot = ControllerManager.getInstance().getSlotForDevice(it.event.device.id)
                 if (assignedSlot > 0) {
                     handled = winHandler.onKeyEvent(it.event)
@@ -1504,6 +1514,7 @@ fun XServerScreen(
             var handled = false
             if (isGamepad && it.event != null) {
                 val winHandler = xServerView!!.getxServer().winHandler
+                ControllerManager.getInstance().noteGamepadActivity(it.event)
                 val assignedSlot = ControllerManager.getInstance().getSlotForDevice(it.event.device.id)
                 if (assignedSlot > 0) {
                     handled = winHandler.onGenericMotionEvent(it.event)

--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -369,7 +369,8 @@ public class ControllerManager {
 
         if (slot > 0) {
             if (slotAssignments.get(0) != null || slot0ReservedForVirtual) return slot;
-            if (slotAssignments.size() != 1) return slot;
+            scanForDevices();
+            if (detectedDevices.size() != 1) return slot;
             InputDevice device = inputManager.getInputDevice(deviceId);
             String deviceIdentifier = getDeviceIdentifier(device);
             if (deviceIdentifier == null) return slot;

--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -12,6 +12,7 @@ import android.preference.PreferenceManager;
 import android.util.SparseArray;
 import android.view.InputDevice;
 import android.view.KeyEvent;
+import android.view.MotionEvent;
 
 import app.gamenative.PrefManager;
 
@@ -66,6 +67,8 @@ public class ControllerManager {
     private final Map<String, Long> firstSeenByIdentifier = new HashMap<>();
     private final Handler settleHandler = new Handler(Looper.getMainLooper());
     private final Runnable settleAssignRunnable = this::autoAssignConnectedDevices;
+    private final Set<Integer> sessionActiveDeviceIds = new HashSet<>();
+    private boolean sessionUsedExternalController;
 
     public interface OnSlotsChangedListener {
         void onSlotsChanged();
@@ -478,6 +481,62 @@ public class ControllerManager {
         }
         recentlyFreedSlots.remove(slot);
         recentlyFreedSlots.addLast(slot);
+    }
+
+    public void resetSessionActivity() {
+        sessionActiveDeviceIds.clear();
+        sessionUsedExternalController = false;
+    }
+
+    public int getSessionUsedControllerCount() {
+        return sessionActiveDeviceIds.size();
+    }
+
+    public boolean getSessionUsedExternalController() {
+        return sessionUsedExternalController;
+    }
+
+    public void noteGamepadActivity(MotionEvent event) {
+        if (isRealGamepadMotion(event)) markActive(event.getDeviceId());
+    }
+
+    public boolean noteGamepadButton(int deviceId) {
+        markActive(deviceId);
+        int slot = getSlotForDevice(deviceId);
+        if (slot == 0) return false;
+        InputDevice occupant = getAssignedDeviceForSlot(0);
+        if (occupant != null && sessionActiveDeviceIds.contains(occupant.getId())) return false;
+        String deviceIdentifier = getDeviceIdentifierForDeviceId(deviceId);
+        if (deviceIdentifier == null) return false;
+        String occupantIdentifier = occupant != null ? getDeviceIdentifier(occupant) : null;
+        assignDeviceIdentifierToSlot(0, deviceIdentifier);
+        if (occupantIdentifier != null && slot > 0) {
+            assignDeviceIdentifierToSlot(slot, occupantIdentifier);
+        }
+        saveAssignments();
+        notifySlotsChanged();
+        Log.i(TAG, "deviceId=" + deviceId + " displaced idle Player 1");
+        return true;
+    }
+
+    private void markActive(int deviceId) {
+        if (!sessionActiveDeviceIds.add(deviceId)) return;
+        InputDevice device = inputManager.getInputDevice(deviceId);
+        if (device != null &&
+                (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.Q || device.isExternal())) {
+            sessionUsedExternalController = true;
+        }
+    }
+
+    private static boolean isRealGamepadMotion(MotionEvent event) {
+        return Math.abs(event.getAxisValue(MotionEvent.AXIS_X)) > 0.25f
+                || Math.abs(event.getAxisValue(MotionEvent.AXIS_Y)) > 0.25f
+                || Math.abs(event.getAxisValue(MotionEvent.AXIS_Z)) > 0.25f
+                || Math.abs(event.getAxisValue(MotionEvent.AXIS_RZ)) > 0.25f
+                || Math.abs(event.getAxisValue(MotionEvent.AXIS_LTRIGGER)) > 0.25f
+                || Math.abs(event.getAxisValue(MotionEvent.AXIS_RTRIGGER)) > 0.25f
+                || Math.abs(event.getAxisValue(MotionEvent.AXIS_HAT_X)) > 0.25f
+                || Math.abs(event.getAxisValue(MotionEvent.AXIS_HAT_Y)) > 0.25f;
     }
 
     private boolean isSlotAvailable(int slot) {

--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -431,10 +431,6 @@ public class ControllerManager {
         slot0ReservedForVirtual = reserved;
     }
 
-    public boolean isSlot0ReservedForVirtual() {
-        return slot0ReservedForVirtual;
-    }
-
     public static boolean isClaimMotion(MotionEvent event) {
         int[] axes = {
                 MotionEvent.AXIS_X, MotionEvent.AXIS_Y, MotionEvent.AXIS_Z, MotionEvent.AXIS_RZ,

--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -67,7 +67,7 @@ public class ControllerManager {
     private final Map<String, Long> firstSeenByIdentifier = new HashMap<>();
     private final Handler settleHandler = new Handler(Looper.getMainLooper());
     private final Runnable settleAssignRunnable = this::autoAssignConnectedDevices;
-    private final Set<Integer> sessionActiveDeviceIds = new HashSet<>();
+    private final Set<String> sessionActiveIdentifiers = new HashSet<>();
     private boolean sessionUsedExternalController;
 
     public interface OnSlotsChangedListener {
@@ -484,12 +484,12 @@ public class ControllerManager {
     }
 
     public void resetSessionActivity() {
-        sessionActiveDeviceIds.clear();
+        sessionActiveIdentifiers.clear();
         sessionUsedExternalController = false;
     }
 
     public int getSessionUsedControllerCount() {
-        return sessionActiveDeviceIds.size();
+        return sessionActiveIdentifiers.size();
     }
 
     public boolean getSessionUsedExternalController() {
@@ -505,12 +505,13 @@ public class ControllerManager {
         int slot = getSlotForDevice(deviceId);
         if (slot == 0) return false;
         InputDevice occupant = getAssignedDeviceForSlot(0);
-        if (occupant != null && sessionActiveDeviceIds.contains(occupant.getId())) return false;
+        if (occupant == null) return false;
+        String occupantIdentifier = getDeviceIdentifier(occupant);
+        if (occupantIdentifier == null || sessionActiveIdentifiers.contains(occupantIdentifier)) return false;
         String deviceIdentifier = getDeviceIdentifierForDeviceId(deviceId);
         if (deviceIdentifier == null) return false;
-        String occupantIdentifier = occupant != null ? getDeviceIdentifier(occupant) : null;
         assignDeviceIdentifierToSlot(0, deviceIdentifier);
-        if (occupantIdentifier != null && slot > 0) {
+        if (slot > 0) {
             assignDeviceIdentifierToSlot(slot, occupantIdentifier);
         }
         saveAssignments();
@@ -520,7 +521,8 @@ public class ControllerManager {
     }
 
     private void markActive(int deviceId) {
-        if (!sessionActiveDeviceIds.add(deviceId)) return;
+        String identifier = getDeviceIdentifierForDeviceId(deviceId);
+        if (identifier == null || !sessionActiveIdentifiers.add(identifier)) return;
         InputDevice device = inputManager.getInputDevice(deviceId);
         if (device != null &&
                 (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.Q || device.isExternal())) {

--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -4,17 +4,24 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.hardware.input.InputManager;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
 import android.util.Log;
 import android.preference.PreferenceManager;
 import android.util.SparseArray;
 import android.view.InputDevice;
 import android.view.KeyEvent;
-import android.view.MotionEvent;
 
+import app.gamenative.PrefManager;
+
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class ControllerManager {
@@ -53,9 +60,12 @@ public class ControllerManager {
     // This tracks which of the 4 player slots are enabled by the user.
     private final boolean[] enabledSlots = new boolean[MAX_SLOTS];
     private final List<OnSlotsChangedListener> slotListeners = new CopyOnWriteArrayList<>();
-    private boolean slot0ReservedForVirtual;
-    private int sessionPeakClaimedSlots;
-    private boolean sessionUsedExternalController;
+    private final ArrayDeque<Integer> recentlyFreedSlots = new ArrayDeque<>();
+
+    private static final long ASSIGN_SETTLE_MS = 300L;
+    private final Map<String, Long> firstSeenByIdentifier = new HashMap<>();
+    private final Handler settleHandler = new Handler(Looper.getMainLooper());
+    private final Runnable settleAssignRunnable = this::autoAssignConnectedDevices;
 
     public interface OnSlotsChangedListener {
         void onSlotsChanged();
@@ -74,9 +84,13 @@ public class ControllerManager {
         this.preferences = PreferenceManager.getDefaultSharedPreferences(this.context);
         this.inputManager = (InputManager) this.context.getSystemService(Context.INPUT_SERVICE);
 
+        // On startup, we load saved settings and scan for connected devices.
         loadAssignments();
-        scanForDevices();
+        autoAssignConnectedDevices();
     }
+
+
+
 
     /**
      * Scans for all physically connected game controllers and updates the internal list.
@@ -84,25 +98,55 @@ public class ControllerManager {
     public void scanForDevices() {
         detectedDevices.clear();
         int[] deviceIds = inputManager.getInputDeviceIds();
+        Set<String> present = new HashSet<>();
         for (int deviceId : deviceIds) {
             InputDevice device = inputManager.getInputDevice(deviceId);
+            // Some handhelds expose built-in controls as virtual devices, so
+            // accept any device that reports a real gamepad/joystick shape.
             if (device != null && isGameController(device)) {
                 detectedDevices.add(device);
                 String ident = getDeviceIdentifier(device);
-                if (ident != null) knownDeviceIdentifiers.put(deviceId, ident);
+                knownDeviceIdentifiers.put(deviceId, ident);
+                if (ident != null) present.add(ident);
             }
         }
+        long now = SystemClock.elapsedRealtime();
+        for (String ident : present) {
+            if (!firstSeenByIdentifier.containsKey(ident)) {
+                firstSeenByIdentifier.put(ident, now);
+            }
+        }
+        firstSeenByIdentifier.keySet().retainAll(present);
     }
 
+    private boolean isSettled(String identifier) {
+        Long t = firstSeenByIdentifier.get(identifier);
+        return t != null && (SystemClock.elapsedRealtime() - t) >= ASSIGN_SETTLE_MS;
+    }
+
+    private void scheduleSettleAssign() {
+        settleHandler.removeCallbacks(settleAssignRunnable);
+        settleHandler.postDelayed(settleAssignRunnable, ASSIGN_SETTLE_MS + 20L);
+    }
+
+    /**
+     * Loads the saved player slot assignments and enabled states from SharedPreferences.
+     */
     private void loadAssignments() {
         slotAssignments.clear();
         lastKnownSlotByIdentifier.clear();
         for (int i = 0; i < MAX_SLOTS; i++) {
-            String deviceIdentifier = preferences.getString(PREF_PLAYER_SLOT_PREFIX + i, null);
+            // Load which device is assigned to this slot
+            String prefKey = PREF_PLAYER_SLOT_PREFIX + i;
+            String deviceIdentifier = preferences.getString(prefKey, null);
             if (deviceIdentifier != null) {
+                slotAssignments.put(i, deviceIdentifier);
                 lastKnownSlotByIdentifier.put(deviceIdentifier, i);
             }
-            enabledSlots[i] = preferences.getBoolean(PREF_ENABLED_SLOTS_PREFIX + i, i == 0);
+
+            // Load whether this slot is enabled. Default P1=true, P2-4=false.
+            String enabledKey = PREF_ENABLED_SLOTS_PREFIX + i;
+            enabledSlots[i] = preferences.getBoolean(enabledKey, i == 0);
         }
     }
 
@@ -142,8 +186,8 @@ public class ControllerManager {
         boolean isJoystick = device.supportsSource(InputDevice.SOURCE_JOYSTICK);
 
         boolean hasAxes =
-                device.getMotionRange(MotionEvent.AXIS_X) != null ||
-                        device.getMotionRange(MotionEvent.AXIS_Y) != null;
+                device.getMotionRange(android.view.MotionEvent.AXIS_X) != null ||
+                        device.getMotionRange(android.view.MotionEvent.AXIS_Y) != null;
 
         boolean[] hasGamepadKeysArray = device.hasKeys(
                 KeyEvent.KEYCODE_BUTTON_A,
@@ -244,6 +288,7 @@ public class ControllerManager {
         // Assign the new device to the target slot.
         slotAssignments.put(slotIndex, newDeviceIdentifier);
         lastKnownSlotByIdentifier.put(newDeviceIdentifier, slotIndex);
+        recentlyFreedSlots.remove(slotIndex);
     }
 
     /**
@@ -257,6 +302,7 @@ public class ControllerManager {
             lastKnownSlotByIdentifier.put(deviceIdentifier, slotIndex);
         }
         slotAssignments.remove(slotIndex);
+        markSlotRecentlyFreed(slotIndex);
         saveAssignments();
         notifySlotsChanged();
     }
@@ -340,11 +386,73 @@ public class ControllerManager {
         if (device == null || !isGameController(device)) {
             return;
         }
+
         String deviceIdentifier = getDeviceIdentifier(device);
-        if (deviceIdentifier != null) {
-            knownDeviceIdentifiers.put(deviceId, deviceIdentifier);
+        if (deviceIdentifier == null) {
+            return;
         }
+
+        knownDeviceIdentifiers.put(deviceId, deviceIdentifier);
         scanForDevices();
+        int existing = getSlotForDevice(deviceId);
+        if (existing >= 0) {
+            return;
+        }
+
+        if (!isSettled(deviceIdentifier)) {
+            scheduleSettleAssign();
+            return;
+        }
+
+        int slot = getPreferredFreeSlot(deviceIdentifier);
+        if (slot >= 0) {
+            enabledSlots[slot] = true;
+            assignDeviceIdentifierToSlot(slot, deviceIdentifier);
+            saveAssignments();
+            notifySlotsChanged();
+            Log.i(TAG, "Auto-assigned deviceId=" + deviceId + " to Player " + (slot + 1));
+            return;
+        }
+        Log.i(TAG, "No free controller slot for deviceId=" + deviceId);
+    }
+
+    /**
+     * Assigns any currently connected controller that is not already bound to a player slot.
+     * Built-in controllers can be present before Android dispatches any hot-plug callback,
+     * so callers should run this after a device scan during startup/session refresh.
+     */
+    public void autoAssignConnectedDevices() {
+        scanForDevices();
+        boolean changed = false;
+        for (InputDevice device : detectedDevices) {
+            String deviceIdentifier = getDeviceIdentifier(device);
+            if (deviceIdentifier == null || getSlotForDevice(device.getId()) >= 0) {
+                continue;
+            }
+
+            if (!isSettled(deviceIdentifier)) {
+                scheduleSettleAssign();
+                continue;
+            }
+
+            int slot = getPreferredFreeSlot(deviceIdentifier);
+            if (slot < 0) {
+                Log.i(TAG, "No free controller slot for connected deviceId=" + device.getId());
+                break;
+            }
+
+            enabledSlots[slot] = true;
+            assignDeviceIdentifierToSlot(slot, deviceIdentifier);
+            knownDeviceIdentifiers.put(device.getId(), deviceIdentifier);
+            changed = true;
+            Log.i(TAG, "Auto-assigned connected deviceId=" + device.getId()
+                    + " to Player " + (slot + 1));
+        }
+
+        if (changed) {
+            saveAssignments();
+            notifySlotsChanged();
+        }
     }
 
     public void onDeviceDisconnected(int deviceId) {
@@ -357,103 +465,29 @@ public class ControllerManager {
             if (deviceIdentifier != null) {
                 lastKnownSlotByIdentifier.put(deviceIdentifier, slot);
             }
+            markSlotRecentlyFreed(slot);
             saveAssignments();
             notifySlotsChanged();
             Log.i(TAG, "Unassigned disconnected deviceId=" + deviceId + " from Player " + (slot + 1));
         }
     }
 
-    public int claimSlotForInput(int deviceId, boolean claimInput) {
-        int slot = getSlotForDevice(deviceId);
-        if (slot == 0 || !claimInput) return slot;
-
-        if (slot > 0) {
-            if (slotAssignments.get(0) != null || slot0ReservedForVirtual) return slot;
-            scanForDevices();
-            if (detectedDevices.size() != 1) return slot;
-            InputDevice device = inputManager.getInputDevice(deviceId);
-            String deviceIdentifier = getDeviceIdentifier(device);
-            if (deviceIdentifier == null) return slot;
-            enabledSlots[0] = true;
-            assignDeviceIdentifierToSlot(0, deviceIdentifier);
-            saveAssignments();
-            notifySlotsChanged();
-            Log.i(TAG, "Promoted deviceId=" + deviceId + " from Player " + (slot + 1) + " to Player 1");
-            return 0;
+    private void markSlotRecentlyFreed(int slot) {
+        if (slot < 0 || slot >= MAX_SLOTS) {
+            return;
         }
-
-        InputDevice device = inputManager.getInputDevice(deviceId);
-        if (device == null || !isGameController(device)) return -1;
-        String deviceIdentifier = getDeviceIdentifier(device);
-        if (deviceIdentifier == null) return -1;
-        scanForDevices();
-        int freeSlot = getPreferredFreeSlot(deviceIdentifier);
-        if (freeSlot < 0) return -1;
-        enabledSlots[freeSlot] = true;
-        assignDeviceIdentifierToSlot(freeSlot, deviceIdentifier);
-        knownDeviceIdentifiers.put(deviceId, deviceIdentifier);
-        sessionPeakClaimedSlots = Math.max(sessionPeakClaimedSlots, slotAssignments.size());
-        if (isExternalDevice(device)) {
-            sessionUsedExternalController = true;
-        }
-        saveAssignments();
-        notifySlotsChanged();
-        Log.i(TAG, "Claimed Player " + (freeSlot + 1) + " for deviceId=" + deviceId);
-        return freeSlot;
-    }
-
-    public void resetClaims() {
-        slotAssignments.clear();
-        for (int i = 0; i < MAX_SLOTS; i++) {
-            enabledSlots[i] = (i == 0);
-        }
-        sessionPeakClaimedSlots = 0;
-        sessionUsedExternalController = false;
-        notifySlotsChanged();
-    }
-
-    public int getSessionPeakClaimedSlots() {
-        return sessionPeakClaimedSlots;
-    }
-
-    public boolean getSessionUsedExternalController() {
-        return sessionUsedExternalController;
-    }
-
-    private static boolean isExternalDevice(InputDevice device) {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-            return device.isExternal();
-        }
-        return true;
-    }
-
-    public void setSlot0ReservedForVirtual(boolean reserved) {
-        slot0ReservedForVirtual = reserved;
-    }
-
-    public static boolean isClaimMotion(MotionEvent event) {
-        int[] axes = {
-                MotionEvent.AXIS_X, MotionEvent.AXIS_Y, MotionEvent.AXIS_Z, MotionEvent.AXIS_RZ,
-                MotionEvent.AXIS_HAT_X, MotionEvent.AXIS_HAT_Y, MotionEvent.AXIS_LTRIGGER,
-                MotionEvent.AXIS_RTRIGGER, MotionEvent.AXIS_BRAKE, MotionEvent.AXIS_GAS,
-        };
-        for (int axis : axes) {
-            if (Math.abs(event.getAxisValue(axis)) > 0.25f) return true;
-        }
-        return false;
+        recentlyFreedSlots.remove(slot);
+        recentlyFreedSlots.addLast(slot);
     }
 
     private boolean isSlotAvailable(int slot) {
-        if (slot < 0 || slot >= MAX_SLOTS) return false;
-        if (slot == 0 && slot0ReservedForVirtual) return false;
-        return getAssignedDeviceForSlot(slot) == null;
+        return slot >= 0 && slot < MAX_SLOTS && getAssignedDeviceForSlot(slot) == null;
     }
 
     private int getPreferredFreeSlot(String deviceIdentifier) {
-        if (isSlotAvailable(0)) return 0;
-
         Integer previousSlot = lastKnownSlotByIdentifier.get(deviceIdentifier);
         if (previousSlot != null && isSlotAvailable(previousSlot)) {
+            recentlyFreedSlots.remove(previousSlot);
             return previousSlot;
         }
 

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -182,10 +182,6 @@ public class WinHandler implements ControllerManager.OnSlotsChangedListener {
         }
         controllerManager.scanForDevices();
         InputDevice p1Device = controllerManager.getAssignedDeviceForSlot(0);
-        if (p1Device == null && !controllerManager.isSlot0ReservedForVirtual()
-                && !controllerManager.getDetectedDevices().isEmpty()) {
-            p1Device = controllerManager.getDetectedDevices().get(0);
-        }
         if (p1Device != null) {
             currentController = ExternalController.getController(p1Device.getId());
             if (currentController != null) {

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -50,12 +50,7 @@ import java.util.concurrent.Executors;
 
 import timber.log.Timber;
 
-public class WinHandler implements ControllerManager.OnSlotsChangedListener {
-
-    @Override
-    public void onSlotsChanged() {
-        refreshControllerMappingsForHotplug();
-    }
+public class WinHandler {
 
     private static final String TAG = "WinHandler";
     private final ControllerManager controllerManager;
@@ -498,7 +493,6 @@ public class WinHandler implements ControllerManager.OnSlotsChangedListener {
 
     public void stop() {
         this.running = false;
-        controllerManager.removeOnSlotsChangedListener(this);
         for (int slot = 0; slot < MAX_PLAYERS; slot++) {
             rumbleTeardown(slot);
         }
@@ -707,7 +701,6 @@ public class WinHandler implements ControllerManager.OnSlotsChangedListener {
 
     public void start() {
         try {
-            controllerManager.addOnSlotsChangedListener(this);
             this.localhost = InetAddress.getLocalHost();
             Context context = activity.getApplicationContext();
             File gamepadShmDir = new File(

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -197,30 +197,10 @@ public class WinHandler implements ControllerManager.OnSlotsChangedListener {
         }
         setGamepadSlotConnected(0, currentController != null || isVirtualGamepadActive());
         // Initialize Extra Players (2, 3, 4)
-        java.util.HashSet<Integer> usedDeviceIds = new java.util.HashSet<>();
-        if (p1Device != null) {
-            usedDeviceIds.add(p1Device.getId());
-        }
-        InputDevice[] assignedExtras = new InputDevice[extraControllers.length];
-        for (int i = 0; i < extraControllers.length; i++) {
-            assignedExtras[i] = controllerManager.getAssignedDeviceForSlot(i + 1);
-            if (assignedExtras[i] != null) {
-                usedDeviceIds.add(assignedExtras[i].getId());
-            }
-        }
         for (int i = 0; i < extraControllers.length; i++) {
             // Player 2 is slot 1, which corresponds to extraControllers[0]
-            InputDevice extraDevice = assignedExtras[i];
-            if (extraDevice == null) {
-                for (InputDevice candidate : controllerManager.getDetectedDevices()) {
-                    if (!usedDeviceIds.contains(candidate.getId())) {
-                        extraDevice = candidate;
-                        break;
-                    }
-                }
-            }
+            InputDevice extraDevice = controllerManager.getAssignedDeviceForSlot(i + 1);
             if (extraDevice != null) {
-                usedDeviceIds.add(extraDevice.getId());
                 extraControllers[i] = ExternalController.getController(extraDevice.getId());
                 if (extraControllers[i] != null) {
                     extraControllers[i].setContext(activity);


### PR DESCRIPTION
## Description
Reverts the claim-on-input controller assignment model (#1754, #1761, #1766) and replaces it with a minimal rule on top of the stock #1716 behavior.

The claim model left controller slots empty until first input, but many games (Dave the Diver, Mewgenics, Blazing Chrome, Skul) enumerate gamepads only once at process startup, so pads that claimed a slot after boot were never seen. The provisional-visibility follow-ups papered over that per-slot and introduced their own regressions (co-op enumeration, Avatar Legends under bionic Steam, promotion failing on handhelds because built-ins count as detected hardware).

After the reverts, `ControllerManager` and `WinHandler` are byte-identical to the #1716 merge; `XServerScreen` keeps the unrelated changes that landed in between. On top of that, one additive change (+74/−4 across two files):

- **Displacement rule**: when a gamepad button press arrives from a device that isn't Player 1 and the current P1 occupant has produced no gamepad input this session, the sender takes slot 0 and the idle occupant moves to the sender's old slot. Stick/trigger motion past the deadzone marks a device active, so a sticks-only P1 (racing games) is never treated as idle. Active players are never displaced, so co-op cannot reshuffle mid-game. Assignments persist, so the corrected order sticks for future launches.
- **Analytics**: `game_closed` gains `max_controllers` (distinct controllers that produced input during the session) and `external_controller_used`, only attached when usage analytics is enabled.

This fixes the original reports (kb/m dongle or idle first-enumerated pad holding P1 while the pad in the player's hands sits on P2, and takeover after the driving pad disconnects) while keeping boot-time behavior identical to the stable build everywhere else.

Known pre-existing issues deliberately not addressed here (also present on stable): identical same-model controllers sharing an input descriptor, and partially-bound controller profiles fighting the raw input path.

## Recording
N/A — behavior change is slot assignment; validated via the test matrix below.

Tested: kb/m + pad (pad's first press takes P1), single pad, built-in + external, two-pad co-op (no reshuffle), driver disconnect mid-game (survivor takes over on next press), boot-time enumeration games.

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores boot-time controller auto-assign and removes the claim-on-input model. Adds a displacement rule where a non‑P1 device’s first real button press can take P1 only if the current P1 is idle; activity is tracked by device identifier across reconnects so co-op stays stable and P1 never auto-fills or reshuffles.

- **Bug Fixes**
  - Startup-only enumeration games see all pads; assignments use bound devices only (no fallback), keeping order consistent.
  - Activity protection survives reconnects by tracking device identifiers; active players never reshuffle.
  - Displacement requires an occupied P1; disconnects no longer open takeover windows, so P1 waits for its owner.

- **New Features**
  - Displacement rule: first button from a non-P1 takes P1 and moves the idle occupant to the sender’s slot; stick/trigger motion marks a device active.
  - Auto-assign connected controllers to the next free or last-known slot after a short settle; tracks recently freed slots.
  - Analytics: `game_closed` includes `max_controllers` and `external_controller_used`, sourced from session activity and gated by `PrefManager.usageAnalyticsEnabled`.

<sup>Written for commit 2eabdd1caf2be32489bb8948c1e336be2bd28ab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic controller assignment with delayed “settling” for newly connected devices.
  * More accurate per-session tracking of used controllers and external controller usage.
* **Bug Fixes**
  * Refined gamepad button/motion routing to use the correct controller slot for each device.
  * Prevented slot changes from using the old claim/reservation flow; virtual on-screen controls now enable/unassign slot 0 correctly.
  * Controller status/quick-menu analytics now reflects the session’s actual used controller count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->