### PR TITLE
Support Look-through buttons outside shooter mode

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/dialog/ControlAppearanceEditor.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ControlAppearanceEditor.kt
@@ -37,7 +37,8 @@ internal data class ControlAppearance(
     val activeColorCustom: Boolean,
     val opacity: Float,
     val strokeScale: Float,
-    val shooterLookThrough: Boolean
+    val lookThrough: Boolean?,
+    val legacyShooterLookThrough: Boolean,
 ) {
     fun applyTo(element: ControlElement) {
         element.setScale(scale)
@@ -45,7 +46,8 @@ internal data class ControlAppearance(
         element.setButtonActiveColor(activeColor, activeColorCustom)
         element.setButtonOpacity(opacity)
         element.setButtonStrokeScale(strokeScale)
-        element.setShooterLookThrough(shooterLookThrough)
+        element.setShooterLookThrough(legacyShooterLookThrough)
+        element.lookThroughSetting = lookThrough
     }
 
     companion object {
@@ -56,7 +58,8 @@ internal data class ControlAppearance(
             activeColorCustom = element.hasCustomButtonActiveColor(),
             opacity = element.buttonOpacity,
             strokeScale = element.buttonStrokeScale,
-            shooterLookThrough = element.isShooterLookThrough
+            lookThrough = element.lookThroughSetting,
+            legacyShooterLookThrough = element.shooterLookThroughSetting,
         )
     }
 }

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ElementEditorDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ElementEditorDialog.kt
@@ -996,7 +996,7 @@ fun ElementEditorDialog(
                                 currentScale = 1.0f
                                 element.setScale(1.0f)
                                 currentButtonStrokeScale = ControlElement.DEFAULT_BUTTON_STROKE_SCALE
-                                currentLookThrough = null
+                                currentLookThrough = ControlElement.DEFAULT_LOOK_THROUGH
                                 currentLegacyShooterLookThrough = true
                                 view.invalidate()
                                 hasUnsavedChanges = true

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ElementEditorDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ElementEditorDialog.kt
@@ -996,7 +996,8 @@ fun ElementEditorDialog(
                                 currentScale = 1.0f
                                 element.setScale(1.0f)
                                 currentButtonStrokeScale = ControlElement.DEFAULT_BUTTON_STROKE_SCALE
-                                currentLookThrough = false
+                                currentLookThrough = null
+                                currentLegacyShooterLookThrough = true
                                 view.invalidate()
                                 hasUnsavedChanges = true
                             },

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ElementEditorDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ElementEditorDialog.kt
@@ -195,7 +195,10 @@ fun ElementEditorDialog(
         mutableFloatStateOf(if (element.buttonOpacity >= 0f) element.buttonOpacity else view.overlayOpacity)
     }
     var currentButtonStrokeScale by remember { mutableFloatStateOf(element.buttonStrokeScale) }
-    var currentShooterLookThrough by remember { mutableStateOf(element.isShooterLookThrough) }
+    var currentLookThrough by remember { mutableStateOf(element.lookThroughSetting) }
+    var currentLegacyShooterLookThrough by remember {
+        mutableStateOf(element.shooterLookThroughSetting)
+    }
     val originalControlAppearances by remember {
         mutableStateOf(
             view.profile?.elements
@@ -214,7 +217,8 @@ fun ElementEditorDialog(
             if (currentButtonOpacityInherited) ControlElement.INHERIT_BUTTON_OPACITY else currentButtonOpacity
         )
         element.setButtonStrokeScale(currentButtonStrokeScale)
-        element.setShooterLookThrough(currentShooterLookThrough)
+        element.setShooterLookThrough(currentLegacyShooterLookThrough)
+        element.lookThroughSetting = currentLookThrough
     }
 
     fun currentAppearance() = ControlAppearance(
@@ -224,7 +228,8 @@ fun ElementEditorDialog(
         activeColorCustom = currentButtonActiveColorCustom,
         opacity = if (currentButtonOpacityInherited) ControlElement.INHERIT_BUTTON_OPACITY else currentButtonOpacity,
         strokeScale = currentButtonStrokeScale,
-        shooterLookThrough = currentShooterLookThrough
+        lookThrough = currentLookThrough,
+        legacyShooterLookThrough = currentLegacyShooterLookThrough,
     )
 
     fun textForSave(): String? {
@@ -285,7 +290,8 @@ fun ElementEditorDialog(
         currentButtonOpacity,
         currentButtonOpacityInherited,
         currentButtonStrokeScale,
-        currentShooterLookThrough,
+        currentLookThrough,
+        currentLegacyShooterLookThrough,
         currentTypeIndex
     ) {
         applyCurrentControlAppearance()
@@ -924,11 +930,11 @@ fun ElementEditorDialog(
 
                         SettingsSwitch(
                             colors = settingsTileColorsAlt(),
-                            title = { Text(stringResource(R.string.button_shooter_look_through)) },
-                            subtitle = { Text(stringResource(R.string.button_shooter_look_through_subtitle)) },
-                            state = currentShooterLookThrough,
+                            title = { Text(stringResource(R.string.button_look_through)) },
+                            subtitle = { Text(stringResource(R.string.button_look_through_subtitle)) },
+                            state = currentLookThrough == true,
                             onCheckedChange = {
-                                currentShooterLookThrough = it
+                                currentLookThrough = it
                                 hasUnsavedChanges = true
                             },
                         )
@@ -952,7 +958,8 @@ fun ElementEditorDialog(
                                     currentButtonOpacityInherited = appearance.opacity < 0f
                                     currentButtonOpacity = if (appearance.opacity >= 0f) appearance.opacity else view.overlayOpacity
                                     currentButtonStrokeScale = appearance.strokeScale
-                                    currentShooterLookThrough = appearance.shooterLookThrough
+                                    currentLookThrough = appearance.lookThrough
+                                    currentLegacyShooterLookThrough = appearance.legacyShooterLookThrough
                                     hasUnsavedChanges = true
                                 }
                             },
@@ -989,7 +996,7 @@ fun ElementEditorDialog(
                                 currentScale = 1.0f
                                 element.setScale(1.0f)
                                 currentButtonStrokeScale = ControlElement.DEFAULT_BUTTON_STROKE_SCALE
-                                currentShooterLookThrough = true
+                                currentLookThrough = false
                                 view.invalidate()
                                 hasUnsavedChanges = true
                             },

--- a/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
@@ -35,6 +35,7 @@ public class ControlElement {
     public static final int DEFAULT_BUTTON_ACTIVE_COLOR = 0x00ffffff;
     public static final float INHERIT_BUTTON_OPACITY = -1.0f;
     public static final float DEFAULT_BUTTON_STROKE_SCALE = 1.0f;
+    public static final boolean DEFAULT_LOOK_THROUGH = false;
     public enum Type {
         BUTTON, D_PAD, RANGE_BUTTON, STICK, TRACKPAD, SHOOTER_MODE;
 
@@ -102,11 +103,9 @@ public class ControlElement {
     private boolean buttonActiveColorCustom = false;
     private float buttonOpacity = INHERIT_BUTTON_OPACITY;
     private float buttonStrokeScale = DEFAULT_BUTTON_STROKE_SCALE;
-    // General touch-area look-through is separate from the legacy shooter-only
-    // setting so loading an existing profile does not change its behavior.
-    // Null means this profile predates general look-through and should keep the
-    // legacy shooter-only setting. Once edited, true/false controls both modes.
-    private Boolean lookThrough = null;
+    // Null is reserved for buttons loaded from profiles that predate general
+    // look-through. Those buttons retain their legacy shooter-only setting.
+    private Boolean lookThrough = DEFAULT_LOOK_THROUGH;
     private boolean shooterLookThrough = true;
 
     public ControlElement(InputControlsView inputControlsView) {
@@ -116,6 +115,7 @@ public class ControlElement {
     private void reset() {
         setBinding(Binding.NONE);
         scroller = null;
+        lookThrough = DEFAULT_LOOK_THROUGH;
 
         if (type == Type.STICK) {
             bindings[0] = Binding.GAMEPAD_LEFT_THUMB_UP;

--- a/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
@@ -81,6 +81,7 @@ public class ControlElement {
     private boolean toggleSwitch = false;
     private boolean scrollLocked = false;
     private int currentPointerId = -1;
+    private boolean currentPointerActivatedButtonBindings = false;
     private final Rect boundingBox = new Rect();
     private boolean[] states = new boolean[4];
     private boolean boundingBoxNeedsUpdate = true;
@@ -1089,10 +1090,12 @@ public class ControlElement {
     public boolean handleTouchDown(int pointerId, float x, float y) {
         if (currentPointerId == -1 && containsPoint(x, y)) {
             currentPointerId = pointerId;
+            currentPointerActivatedButtonBindings = false;
             inputControlsView.invalidate();
             if (type == Type.BUTTON) {
                 if (isKeepButtonPressedAfterMinTime()) touchTime = System.currentTimeMillis();
                 if (!toggleSwitch || !selected) {
+                    currentPointerActivatedButtonBindings = !selected;
                     inputControlsView.handleInputEvent(getBindingAt(0), true);
                     inputControlsView.handleInputEvent(getBindingAt(1), true);
                 }
@@ -1256,6 +1259,7 @@ public class ControlElement {
                 else {
                     inputControlsView.invalidate();
                 }
+                currentPointerActivatedButtonBindings = false;
             }
             else if (type == Type.RANGE_BUTTON || type == Type.D_PAD || type == Type.STICK || type == Type.TRACKPAD) {
                 for (byte i = 0; i < states.length; i++) {
@@ -1282,5 +1286,30 @@ public class ControlElement {
             return true;
         }
         return false;
+    }
+
+    public boolean cancelTouch() {
+        if (currentPointerId == -1) return false;
+
+        if (type == Type.BUTTON) {
+            if (currentPointerActivatedButtonBindings) {
+                inputControlsView.handleInputEvent(getBindingAt(0), false);
+                inputControlsView.handleInputEvent(getBindingAt(1), false);
+            }
+            currentPointerActivatedButtonBindings = false;
+            touchTime = null;
+        }
+        else if (type == Type.RANGE_BUTTON || type == Type.D_PAD || type == Type.STICK || type == Type.TRACKPAD) {
+            for (byte i = 0; i < states.length; i++) {
+                if (states[i]) inputControlsView.handleInputEvent(getBindingAt(i), false);
+                states[i] = false;
+            }
+            if (type == Type.RANGE_BUTTON) scroller.handleTouchUp();
+            currentPosition = null;
+        }
+
+        currentPointerId = -1;
+        inputControlsView.invalidate();
+        return true;
     }
 }

--- a/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
@@ -101,6 +101,11 @@ public class ControlElement {
     private boolean buttonActiveColorCustom = false;
     private float buttonOpacity = INHERIT_BUTTON_OPACITY;
     private float buttonStrokeScale = DEFAULT_BUTTON_STROKE_SCALE;
+    // General touch-area look-through is separate from the legacy shooter-only
+    // setting so loading an existing profile does not change its behavior.
+    // Null means this profile predates general look-through and should keep the
+    // legacy shooter-only setting. Once edited, true/false controls both modes.
+    private Boolean lookThrough = null;
     private boolean shooterLookThrough = true;
 
     public ControlElement(InputControlsView inputControlsView) {
@@ -314,12 +319,28 @@ public class ControlElement {
         this.buttonStrokeScale = Mathf.clamp(buttonStrokeScale, 0.5f, 2.0f);
     }
 
+    public boolean isLookThrough() {
+        return Boolean.TRUE.equals(lookThrough);
+    }
+
+    public Boolean getLookThroughSetting() {
+        return lookThrough;
+    }
+
+    public void setLookThroughSetting(Boolean lookThrough) {
+        this.lookThrough = lookThrough;
+    }
+
     public boolean isShooterLookThrough() {
-        return shooterLookThrough;
+        return lookThrough != null ? lookThrough : shooterLookThrough;
     }
 
     public void setShooterLookThrough(boolean shooterLookThrough) {
         this.shooterLookThrough = shooterLookThrough;
+    }
+
+    public boolean getShooterLookThroughSetting() {
+        return shooterLookThrough;
     }
 
     public void copyButtonAppearanceFrom(ControlElement element) {
@@ -328,6 +349,7 @@ public class ControlElement {
         buttonActiveColorCustom = element.buttonActiveColorCustom;
         buttonOpacity = element.buttonOpacity;
         buttonStrokeScale = element.buttonStrokeScale;
+        lookThrough = element.lookThrough;
         shooterLookThrough = element.shooterLookThrough;
     }
 
@@ -1045,6 +1067,7 @@ public class ControlElement {
             if (buttonActiveColorCustom || buttonActiveColor != DEFAULT_BUTTON_ACTIVE_COLOR) elementJSONObject.put("buttonActiveColor", formatRgbColor(buttonActiveColor));
             if (buttonOpacity >= 0) elementJSONObject.put("buttonOpacity", (double)buttonOpacity);
             if (buttonStrokeScale != DEFAULT_BUTTON_STROKE_SCALE) elementJSONObject.put("buttonStrokeScale", (double)buttonStrokeScale);
+            if (type == Type.BUTTON && lookThrough != null) elementJSONObject.put("lookThrough", lookThrough);
             if (type == Type.BUTTON && !shooterLookThrough) elementJSONObject.put("shooterLookThrough", false);
 
             return elementJSONObject;

--- a/app/src/main/java/com/winlator/inputcontrols/ControlsProfile.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControlsProfile.java
@@ -263,6 +263,12 @@ public class ControlsProfile implements Comparable<ControlsProfile> {
                     Log.w("ControlsProfile", "Skipping element with unknown type: " + elementJSONObject.getString("type"));
                     continue;
                 }
+                if (elementJSONObject.has("lookThrough")) {
+                    element.setLookThroughSetting(elementJSONObject.getBoolean("lookThrough"));
+                }
+                else {
+                    element.setLookThroughSetting(null);
+                }
                 element.setShape(ControlElement.Shape.valueOf(elementJSONObject.getString("shape")));
                 element.setToggleSwitch(elementJSONObject.getBoolean("toggleSwitch"));
                 element.setX((int)(elementJSONObject.getDouble("x") * inputControlsView.getMaxWidth()));
@@ -286,7 +292,6 @@ public class ControlsProfile implements Comparable<ControlsProfile> {
                 }
                 if (elementJSONObject.has("buttonOpacity")) element.setButtonOpacity((float)elementJSONObject.getDouble("buttonOpacity"));
                 if (elementJSONObject.has("buttonStrokeScale")) element.setButtonStrokeScale((float)elementJSONObject.getDouble("buttonStrokeScale"));
-                if (elementJSONObject.has("lookThrough")) element.setLookThroughSetting(elementJSONObject.getBoolean("lookThrough"));
                 if (elementJSONObject.has("shooterLookThrough")) element.setShooterLookThrough(elementJSONObject.getBoolean("shooterLookThrough"));
 
                 boolean hasGamepadBinding = true;

--- a/app/src/main/java/com/winlator/inputcontrols/ControlsProfile.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControlsProfile.java
@@ -286,6 +286,7 @@ public class ControlsProfile implements Comparable<ControlsProfile> {
                 }
                 if (elementJSONObject.has("buttonOpacity")) element.setButtonOpacity((float)elementJSONObject.getDouble("buttonOpacity"));
                 if (elementJSONObject.has("buttonStrokeScale")) element.setButtonStrokeScale((float)elementJSONObject.getDouble("buttonStrokeScale"));
+                if (elementJSONObject.has("lookThrough")) element.setLookThroughSetting(elementJSONObject.getBoolean("lookThrough"));
                 if (elementJSONObject.has("shooterLookThrough")) element.setShooterLookThrough(elementJSONObject.getBoolean("shooterLookThrough"));
 
                 boolean hasGamepadBinding = true;

--- a/app/src/main/java/com/winlator/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/widget/InputControlsView.java
@@ -152,6 +152,11 @@ public class InputControlsView extends View {
     }
 
     private void cancelTouchRouting() {
+        if (profile != null) {
+            for (ControlElement element : profile.getElements()) element.cancelTouch();
+        }
+        releaseAllShooterInputs();
+        commitGamepadState();
         if (touchpadView != null) touchpadView.cancelTouchInput();
         touchpadPointers.clear();
         lookThroughPointerState.clear();
@@ -1013,7 +1018,7 @@ public class InputControlsView extends View {
         return true;
     }
 
-    private boolean handleShooterTouchDown(int pointerId, float x, float y) {
+    private boolean handleShooterTouchDown(int pointerId, float x, float y, boolean allowButtonLookThrough) {
         boolean handled = false;
 
         // Check container shooter mode toggle button first
@@ -1043,7 +1048,9 @@ public class InputControlsView extends View {
             if (element.handleTouchDown(pointerId, x, y)) {
                 performHapticFeedback(android.view.HapticFeedbackConstants.VIRTUAL_KEY);
                 handled = true;
-                if (element.getType() == ControlElement.Type.BUTTON && element.isShooterLookThrough()) {
+                if (allowButtonLookThrough
+                        && element.getType() == ControlElement.Type.BUTTON
+                        && element.isShooterLookThrough()) {
                     startPendingButtonLookPointer(pointerId, x, y, element);
                 }
                 break;
@@ -1209,7 +1216,7 @@ public class InputControlsView extends View {
             boolean handled = false;
             boolean touchscreenMode = touchpadView.isTouchscreenMode();
             if (touchscreenMode && lookThroughPointerState.isActive()) {
-                lookThroughPointerState.clear();
+                cancelTouchRouting();
             }
 
             switch (actionMasked) {
@@ -1219,7 +1226,8 @@ public class InputControlsView extends View {
                     float y = event.getY(actionIndex);
 
                     // Shooter mode intercept (use containerShooterMode so toggle button is always reachable)
-                    if ((shooterModeActive || containerShooterMode) && handleShooterTouchDown(pointerId, x, y)) {
+                    if ((shooterModeActive || containerShooterMode)
+                            && handleShooterTouchDown(pointerId, x, y, !touchscreenMode)) {
                         break;
                     }
 
@@ -1302,43 +1310,34 @@ public class InputControlsView extends View {
                 case MotionEvent.ACTION_UP:
                 case MotionEvent.ACTION_POINTER_UP:
                 case MotionEvent.ACTION_CANCEL:
+                    if (actionMasked == MotionEvent.ACTION_CANCEL) {
+                        cancelTouchRouting();
+                        handled = true;
+                        break;
+                    }
                     // Shooter mode intercept
                     if (shooterModeActive || containerShooterModeRuntime) {
-                        if (actionMasked == MotionEvent.ACTION_CANCEL) {
-                            releaseAllShooterInputs();
-                            commitGamepadState();
+                        if (pendingButtonLooks.get(pointerId) != null) {
+                            releasePendingButtonLook(pointerId);
                             handled = true;
                         }
-                        else {
-                            if (pendingButtonLooks.get(pointerId) != null) {
-                                releasePendingButtonLook(pointerId);
-                                handled = true;
-                            }
-                            if (pointerId == joystickPointerId) {
-                                releaseShooterJoystick();
-                                handled = true;
-                            }
-                            if (pointerId == rightJoystickPointerId) {
-                                releaseRightJoystick();
-                                handled = true;
-                            }
-                            if (pointerId == lookPointerId) {
-                                releaseShooterLook();
-                                handled = true;
-                            }
+                        if (pointerId == joystickPointerId) {
+                            releaseShooterJoystick();
+                            handled = true;
+                        }
+                        if (pointerId == rightJoystickPointerId) {
+                            releaseRightJoystick();
+                            handled = true;
+                        }
+                        if (pointerId == lookPointerId) {
+                            releaseShooterLook();
+                            handled = true;
                         }
                     }
                     for (ControlElement element : profile.getElements()) if (element.handleTouchUp(pointerId)) handled = true;
-                    if (actionMasked == MotionEvent.ACTION_CANCEL) {
-                        if (touchpadPointers.size() > 0) touchpadView.onTouchEvent(event);
-                        lookThroughPointerState.clear();
-                        touchpadPointers.clear();
-                    }
-                    else {
-                        if (touchpadPointers.get(pointerId)) touchpadView.onTouchEvent(event);
-                        lookThroughPointerState.release(pointerId);
-                        touchpadPointers.delete(pointerId);
-                    }
+                    if (touchpadPointers.get(pointerId)) touchpadView.onTouchEvent(event);
+                    lookThroughPointerState.release(pointerId);
+                    touchpadPointers.delete(pointerId);
                     break;
             }
 

--- a/app/src/main/java/com/winlator/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/widget/InputControlsView.java
@@ -146,9 +146,15 @@ public class InputControlsView extends View {
     }
 
     public void setEditMode(boolean editMode) {
-        if (editMode) lookThroughPointerState.clear();
+        if (this.editMode != editMode) cancelTouchRouting();
         this.editMode = editMode;
         invalidate(); // Trigger redraw to show/hide grid background immediately
+    }
+
+    private void cancelTouchRouting() {
+        if (touchpadView != null) touchpadView.cancelTouchInput();
+        touchpadPointers.clear();
+        lookThroughPointerState.clear();
     }
 
     public void setOverlayOpacity(float overlayOpacity) {
@@ -310,7 +316,7 @@ public class InputControlsView extends View {
     }
 
     public synchronized void setProfile(ControlsProfile profile) {
-        lookThroughPointerState.clear();
+        cancelTouchRouting();
         if (profile != null) {
             this.profile = profile;
             deselectAllElements();
@@ -378,8 +384,7 @@ public class InputControlsView extends View {
 
     @Override
     protected void onDetachedFromWindow() {
-        lookThroughPointerState.clear();
-        touchpadPointers.clear();
+        cancelTouchRouting();
         if (mouseMoveTimer != null)
             mouseMoveTimer.cancel();
         super.onDetachedFromWindow();
@@ -428,7 +433,7 @@ public class InputControlsView extends View {
     }
 
     public void setShooterModeActive(boolean active) {
-        if (active) lookThroughPointerState.clear();
+        if (shooterModeActive != active) cancelTouchRouting();
         if (!active) {
             releaseAllShooterInputs();
         }
@@ -438,7 +443,9 @@ public class InputControlsView extends View {
     }
 
     public void setContainerShooterMode(boolean enabled) {
-        if (enabled) lookThroughPointerState.clear();
+        if (containerShooterMode != enabled || containerShooterModeRuntime != enabled) {
+            cancelTouchRouting();
+        }
         this.containerShooterMode = enabled;
         this.containerShooterModeRuntime = enabled;
         if (!enabled && !shooterModeActive) {
@@ -1013,6 +1020,7 @@ public class InputControlsView extends View {
         if (containerShooterMode && isRuntimeToggleVisible()) {
             android.graphics.RectF toggleRect = getToggleButtonRect();
             if (toggleRect.contains(x, y)) {
+                cancelTouchRouting();
                 containerShooterModeRuntime = !containerShooterModeRuntime;
                 if (!containerShooterModeRuntime) {
                     releaseAllShooterInputs();

--- a/app/src/main/java/com/winlator/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/widget/InputControlsView.java
@@ -19,8 +19,10 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewConfiguration;
 import android.widget.FrameLayout;
 import android.util.SparseArray;
+import android.util.SparseBooleanArray;
 
 import androidx.compose.ui.input.pointer.PointerIcon;
 import androidx.core.graphics.ColorUtils;
@@ -84,6 +86,11 @@ public class InputControlsView extends View {
     private ControlElement lookFireElement = null;
     // Delays button-originated look/move until the touch becomes an intentional drag.
     private final SparseArray<PendingButtonLook> pendingButtonLooks = new SparseArray<>();
+    // General look-through owns one movement-only pointer and quarantines background pointers.
+    private final LookThroughPointerState lookThroughPointerState = new LookThroughPointerState();
+    // Pointers whose DOWN event was delivered to TouchpadView's normal gesture system.
+    private final SparseBooleanArray touchpadPointers = new SparseBooleanArray();
+    private final int lookThroughTouchSlop;
     // Right dynamic joystick (for gamepad_right_stick look type)
     private int rightJoystickPointerId = -1;
     private float rightJoystickCenterX, rightJoystickCenterY;
@@ -125,6 +132,7 @@ public class InputControlsView extends View {
     @SuppressLint("ResourceType")
     public InputControlsView(Context context) {
         super(context);
+        lookThroughTouchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
         setClickable(true);
         setFocusable(true);
         setFocusableInTouchMode(true);
@@ -138,6 +146,7 @@ public class InputControlsView extends View {
     }
 
     public void setEditMode(boolean editMode) {
+        if (editMode) lookThroughPointerState.clear();
         this.editMode = editMode;
         invalidate(); // Trigger redraw to show/hide grid background immediately
     }
@@ -301,6 +310,7 @@ public class InputControlsView extends View {
     }
 
     public synchronized void setProfile(ControlsProfile profile) {
+        lookThroughPointerState.clear();
         if (profile != null) {
             this.profile = profile;
             deselectAllElements();
@@ -368,6 +378,8 @@ public class InputControlsView extends View {
 
     @Override
     protected void onDetachedFromWindow() {
+        lookThroughPointerState.clear();
+        touchpadPointers.clear();
         if (mouseMoveTimer != null)
             mouseMoveTimer.cancel();
         super.onDetachedFromWindow();
@@ -416,6 +428,7 @@ public class InputControlsView extends View {
     }
 
     public void setShooterModeActive(boolean active) {
+        if (active) lookThroughPointerState.clear();
         if (!active) {
             releaseAllShooterInputs();
         }
@@ -425,6 +438,7 @@ public class InputControlsView extends View {
     }
 
     public void setContainerShooterMode(boolean enabled) {
+        if (enabled) lookThroughPointerState.clear();
         this.containerShooterMode = enabled;
         this.containerShooterModeRuntime = enabled;
         if (!enabled && !shooterModeActive) {
@@ -1185,6 +1199,10 @@ public class InputControlsView extends View {
             int pointerId = event.getPointerId(actionIndex);
             int actionMasked = event.getActionMasked();
             boolean handled = false;
+            boolean touchscreenMode = touchpadView.isTouchscreenMode();
+            if (touchscreenMode && lookThroughPointerState.isActive()) {
+                lookThroughPointerState.clear();
+            }
 
             switch (actionMasked) {
                 case MotionEvent.ACTION_DOWN:
@@ -1199,10 +1217,17 @@ public class InputControlsView extends View {
 
                     touchpadView.setPointerButtonLeftEnabled(true);
                     touchpadView.setPointerButtonRightEnabled(true);
+                    boolean lookThroughCandidate = false;
                     for (ControlElement element : profile.getElements()) {
                         if (element.handleTouchDown(pointerId, x, y)) {
                             performHapticFeedback(android.view.HapticFeedbackConstants.VIRTUAL_KEY);
                             handled = true;
+                            if (event.getToolType(actionIndex) == MotionEvent.TOOL_TYPE_FINGER
+                                    && element.getType() == ControlElement.Type.BUTTON
+                                    && !touchscreenMode
+                                    && element.isLookThrough()) {
+                                lookThroughCandidate = true;
+                            }
                         }
                         if (element.getBindingAt(0) == Binding.MOUSE_LEFT_BUTTON) {
                             touchpadView.setPointerButtonLeftEnabled(false);
@@ -1211,7 +1236,20 @@ public class InputControlsView extends View {
                             touchpadView.setPointerButtonRightEnabled(false);
                         }
                     }
-                    if (!handled) touchpadView.onTouchEvent(event);
+                    if (lookThroughCandidate) {
+                        lookThroughPointerState.tryStart(
+                                pointerId,
+                                x,
+                                y,
+                                touchpadPointers.size() > 0
+                        );
+                    }
+                    if (!handled) {
+                        if (!lookThroughPointerState.isActive()) {
+                            touchpadPointers.put(pointerId, true);
+                            touchpadView.onTouchEvent(event);
+                        }
+                    }
                     break;
                 }
                 case MotionEvent.ACTION_MOVE: {
@@ -1236,7 +1274,20 @@ public class InputControlsView extends View {
                         for (ControlElement element : profile.getElements()) {
                             if (element.handleTouchMove(pid, x, y)) handled = true;
                         }
-                        if (!handled) touchpadView.onTouchEvent(event);
+                        if (lookThroughPointerState.owns(pid)) {
+                            LookThroughPointerState.Delta delta = lookThroughPointerState.move(
+                                    pid,
+                                    x,
+                                    y,
+                                    lookThroughTouchSlop
+                            );
+                            if (delta != null) {
+                                touchpadView.movePointerFromLookThrough(delta.x, delta.y);
+                            }
+                        }
+                    }
+                    if (!(shooterModeActive || containerShooterModeRuntime) && touchpadPointers.size() > 0) {
+                        touchpadView.onTouchEvent(event);
                     }
                     break;
                 }
@@ -1270,7 +1321,16 @@ public class InputControlsView extends View {
                         }
                     }
                     for (ControlElement element : profile.getElements()) if (element.handleTouchUp(pointerId)) handled = true;
-                    if (!handled) touchpadView.onTouchEvent(event);
+                    if (actionMasked == MotionEvent.ACTION_CANCEL) {
+                        if (touchpadPointers.size() > 0) touchpadView.onTouchEvent(event);
+                        lookThroughPointerState.clear();
+                        touchpadPointers.clear();
+                    }
+                    else {
+                        if (touchpadPointers.get(pointerId)) touchpadView.onTouchEvent(event);
+                        lookThroughPointerState.release(pointerId);
+                        touchpadPointers.delete(pointerId);
+                    }
                     break;
             }
 

--- a/app/src/main/java/com/winlator/widget/LookThroughPointerState.java
+++ b/app/src/main/java/com/winlator/widget/LookThroughPointerState.java
@@ -1,0 +1,65 @@
+package com.winlator.widget;
+
+/** Tracks the pointer exclusively owned by general button look-through. */
+final class LookThroughPointerState {
+    static final int INVALID_POINTER_ID = -1;
+
+    static final class Delta {
+        float x;
+        float y;
+    }
+
+    private int pointerId = INVALID_POINTER_ID;
+    private float startX;
+    private float startY;
+    private float lastX;
+    private float lastY;
+    private boolean dragging;
+    private final Delta moveDelta = new Delta();
+
+    boolean tryStart(int pointerId, float x, float y, boolean normalTouchActive) {
+        if (this.pointerId != INVALID_POINTER_ID || normalTouchActive) return false;
+        this.pointerId = pointerId;
+        startX = lastX = x;
+        startY = lastY = y;
+        dragging = false;
+        return true;
+    }
+
+    boolean owns(int pointerId) {
+        return this.pointerId == pointerId;
+    }
+
+    boolean isActive() {
+        return pointerId != INVALID_POINTER_ID;
+    }
+
+    Delta move(int pointerId, float x, float y, float touchSlop) {
+        if (!owns(pointerId)) return null;
+
+        if (!dragging) {
+            float dx = x - startX;
+            float dy = y - startY;
+            if (dx * dx + dy * dy < touchSlop * touchSlop) return null;
+            dragging = true;
+        }
+
+        moveDelta.x = x - lastX;
+        moveDelta.y = y - lastY;
+        lastX = x;
+        lastY = y;
+        return moveDelta;
+    }
+
+    void release(int pointerId) {
+        if (owns(pointerId)) {
+            this.pointerId = INVALID_POINTER_ID;
+            dragging = false;
+        }
+    }
+
+    void clear() {
+        pointerId = INVALID_POINTER_ID;
+        dragging = false;
+    }
+}

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -209,7 +209,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         // any held drag/long-press/2F/3F-hold injections, and resets gesture
         // state. Avoids leaking pressed buttons/keys when the view is removed
         // mid-gesture (e.g., game exit while a hold is active).
-        handleTsCancel();
+        cancelTouchInput();
         super.onDetachedFromWindow();
     }
 

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -510,12 +510,28 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
                 }
                 break;
             case MotionEvent.ACTION_CANCEL:
-                for (byte i = 0; i < MAX_FINGERS; i++) fingers[i] = null;
-                numFingers = 0;
+                cancelTouchInput();
                 break;
         }
 
         return true;
+    }
+
+    void cancelTouchInput() {
+        continueClick = false;
+        for (byte i = 0; i < MAX_FINGERS; i++) {
+            Finger finger = fingers[i];
+            if (finger != null) {
+                releasePointerButtonLeft(finger);
+                releasePointerButtonRight(finger);
+                fingers[i] = null;
+            }
+        }
+        numFingers = 0;
+        scrollAccumY = 0;
+        scrolling = false;
+        suppressNextLeftTap = false;
+        handleTsCancel();
     }
 
     private boolean handleTouchscreenEvent(MotionEvent event) {

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -496,6 +496,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
                                 handleFingerUp(fingers[i]);
                                 fingers[i] = null;
                                 numFingers--;
+                                if (numFingers == 0) cancelSimulatedTouchPress();
                             }
                         }
                     }
@@ -508,6 +509,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
                     handleFingerUp(fingers[pointerId]);
                     fingers[pointerId] = null;
                     numFingers--;
+                    if (numFingers == 0) cancelSimulatedTouchPress();
                 }
                 break;
         }
@@ -516,6 +518,20 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     }
 
     void cancelTouchInput() {
+        cancelSimulatedTouchPress();
+        cancelPointerButtonLeft(fingerPointerButtonLeft);
+        cancelPointerButtonRight(fingerPointerButtonRight);
+        for (byte i = 0; i < MAX_FINGERS; i++) {
+            fingers[i] = null;
+        }
+        numFingers = 0;
+        scrollAccumY = 0;
+        scrolling = false;
+        suppressNextLeftTap = false;
+        handleTsCancel();
+    }
+
+    private void cancelSimulatedTouchPress() {
         continueClick = false;
         if (simulatedTouchPressRunnable != null) {
             removeCallbacks(simulatedTouchPressRunnable);
@@ -527,16 +543,6 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
             }
             simulatedTouchButtonDown = false;
         }
-        cancelPointerButtonLeft(fingerPointerButtonLeft);
-        cancelPointerButtonRight(fingerPointerButtonRight);
-        for (byte i = 0; i < MAX_FINGERS; i++) {
-            fingers[i] = null;
-        }
-        numFingers = 0;
-        scrollAccumY = 0;
-        scrolling = false;
-        suppressNextLeftTap = false;
-        handleTsCancel();
     }
 
     private void scheduleSimulatedTouchPress() {

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -49,6 +49,8 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     private final float[] xform;
     private boolean simTouchScreen = false;
     private boolean continueClick = true;
+    private Runnable simulatedTouchPressRunnable;
+    private boolean simulatedTouchButtonDown;
     private int lastTouchedPosX;
     private int lastTouchedPosY;
     private static final Byte CLICK_DELAYED_TIME = 50;
@@ -454,19 +456,13 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
                 fingers[pointerId] = new Finger(event.getX(actionIndex), event.getY(actionIndex));
                 numFingers++;
                 if (simTouchScreen) {
-                    final Runnable clickDelay = () -> {
-                        if (continueClick) {
-                            xServer.injectPointerMove(lastTouchedPosX, lastTouchedPosY);
-                            xServer.injectPointerButtonPress(Pointer.Button.BUTTON_LEFT);
-                        }
-                    };
                     if (pointerId == 0) {
                         continueClick = true;
                         if (Math.hypot(fingers[0].x - lastTouchedPosX, fingers[0].y - lastTouchedPosY) * resolutionScale > EFFECTIVE_TOUCH_DISTANCE) {
                             lastTouchedPosX = fingers[0].x;
                             lastTouchedPosY = fingers[0].y;
                         }
-                        postDelayed(clickDelay, CLICK_DELAYED_TIME);
+                        scheduleSimulatedTouchPress();
                     } else if (pointerId == 1) {
                         // When put a finger on InputControl, such as a button.
                         // The pointerId that TouchPadView got won't increase from 1, so map 1 as 0 here.
@@ -476,7 +472,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
                                 lastTouchedPosX = fingers[1].x;
                                 lastTouchedPosY = fingers[1].y;
                             }
-                            postDelayed(clickDelay, CLICK_DELAYED_TIME);
+                            scheduleSimulatedTouchPress();
                         } else
                             continueClick = System.currentTimeMillis() - fingers[0].touchTime > CLICK_DELAYED_TIME;
                     }
@@ -521,6 +517,16 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
     void cancelTouchInput() {
         continueClick = false;
+        if (simulatedTouchPressRunnable != null) {
+            removeCallbacks(simulatedTouchPressRunnable);
+            simulatedTouchPressRunnable = null;
+        }
+        if (simulatedTouchButtonDown) {
+            if (xServer.pointer.isButtonPressed(Pointer.Button.BUTTON_LEFT)) {
+                xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_LEFT);
+            }
+            simulatedTouchButtonDown = false;
+        }
         cancelPointerButtonLeft(fingerPointerButtonLeft);
         cancelPointerButtonRight(fingerPointerButtonRight);
         for (byte i = 0; i < MAX_FINGERS; i++) {
@@ -531,6 +537,25 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         scrolling = false;
         suppressNextLeftTap = false;
         handleTsCancel();
+    }
+
+    private void scheduleSimulatedTouchPress() {
+        if (simulatedTouchPressRunnable != null) {
+            removeCallbacks(simulatedTouchPressRunnable);
+        }
+        simulatedTouchPressRunnable = new Runnable() {
+            @Override
+            public void run() {
+                if (simulatedTouchPressRunnable != this) return;
+                simulatedTouchPressRunnable = null;
+                if (continueClick) {
+                    xServer.injectPointerMove(lastTouchedPosX, lastTouchedPosY);
+                    xServer.injectPointerButtonPress(Pointer.Button.BUTTON_LEFT);
+                    simulatedTouchButtonDown = true;
+                }
+            }
+        };
+        postDelayed(simulatedTouchPressRunnable, CLICK_DELAYED_TIME);
     }
 
     private void cancelPointerButtonLeft(Finger finger) {
@@ -1953,6 +1978,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
             Pointer.Button button = Pointer.Button.BUTTON_LEFT;
             if (pointer.isButtonPressed(button)) {
                 this.xServer.injectPointerButtonRelease(button);
+                simulatedTouchButtonDown = false;
             }
             this.xServer.injectPointerButtonPress(button);
             this.fingerPointerButtonLeft = finger;

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -2002,6 +2002,28 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         this.moveCursorToTouchpoint = moveCursorToTouchpoint;
     }
 
+    /**
+     * Moves the pointer for a drag owned by an on-screen look-through button.
+     * This deliberately bypasses tap, hold, scroll, pinch, and multi-finger recognition.
+     */
+    public void movePointerFromLookThrough(float deltaX, float deltaY) {
+        if (touchscreenMouseDisabled) return;
+
+        float[] delta = computeDeltaPoint(0, 0, deltaX, deltaY);
+        float moveX = delta[0] * sensitivity;
+        float moveY = delta[1] * sensitivity;
+        if (Math.abs(moveX) > CURSOR_ACCELERATION_THRESHOLD) moveX *= CURSOR_ACCELERATION;
+        if (Math.abs(moveY) > CURSOR_ACCELERATION_THRESHOLD) moveY *= CURSOR_ACCELERATION;
+
+        int dx = Mathf.roundPoint(moveX);
+        int dy = Mathf.roundPoint(moveY);
+        if (xServer.isRelativeMouseMovement()) {
+            xServer.getWinHandler().mouseEvent(MouseEventFlags.MOVE, dx, dy, 0);
+        } else {
+            xServer.injectPointerMoveDelta(dx, dy);
+        }
+    }
+
     public boolean onExternalMouseEvent(MotionEvent event) {
         boolean handled = false;
         if (event.isFromSource(InputDevice.SOURCE_MOUSE)) {

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -434,9 +434,14 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     }
 
     private boolean handleTouchpadEvent(MotionEvent event) {
+        int actionMasked = event.getActionMasked();
+        if (actionMasked == MotionEvent.ACTION_CANCEL) {
+            cancelTouchInput();
+            return true;
+        }
+
         int actionIndex = event.getActionIndex();
         int pointerId = event.getPointerId(actionIndex);
-        int actionMasked = event.getActionMasked();
         if (pointerId >= MAX_FINGERS) return true;
 
         switch (actionMasked) {
@@ -509,9 +514,6 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
                     numFingers--;
                 }
                 break;
-            case MotionEvent.ACTION_CANCEL:
-                cancelTouchInput();
-                break;
         }
 
         return true;
@@ -519,19 +521,38 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
     void cancelTouchInput() {
         continueClick = false;
+        cancelPointerButtonLeft(fingerPointerButtonLeft);
+        cancelPointerButtonRight(fingerPointerButtonRight);
         for (byte i = 0; i < MAX_FINGERS; i++) {
-            Finger finger = fingers[i];
-            if (finger != null) {
-                releasePointerButtonLeft(finger);
-                releasePointerButtonRight(finger);
-                fingers[i] = null;
-            }
+            fingers[i] = null;
         }
         numFingers = 0;
         scrollAccumY = 0;
         scrolling = false;
         suppressNextLeftTap = false;
         handleTsCancel();
+    }
+
+    private void cancelPointerButtonLeft(Finger finger) {
+        if (finger == null || finger != fingerPointerButtonLeft) return;
+        fingerPointerButtonLeft = null;
+        if (xServer.isRelativeMouseMovement()) {
+            xServer.getWinHandler().mouseEvent(MouseEventFlags.LEFTUP, 0, 0, 0);
+        }
+        else if (xServer.pointer.isButtonPressed(Pointer.Button.BUTTON_LEFT)) {
+            xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_LEFT);
+        }
+    }
+
+    private void cancelPointerButtonRight(Finger finger) {
+        if (finger == null || finger != fingerPointerButtonRight) return;
+        fingerPointerButtonRight = null;
+        if (xServer.isRelativeMouseMovement()) {
+            xServer.getWinHandler().mouseEvent(MouseEventFlags.RIGHTUP, 0, 0, 0);
+        }
+        else if (xServer.pointer.isButtonPressed(Pointer.Button.BUTTON_RIGHT)) {
+            xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_RIGHT);
+        }
     }
 
     private boolean handleTouchscreenEvent(MotionEvent event) {

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1922,8 +1922,8 @@
     <string name="control_stroke_width_default">Standard</string>
     <string name="control_stroke_width_thick">Tyk</string>
     <string name="control_stroke_width_extra_thick">Ekstra tyk</string>
-    <string name="button_shooter_look_through">Shooter-gennemkig</string>
-    <string name="button_shooter_look_through_subtitle">Tillad at denne knapberøring også styrer dynamisk shooter-bevægelse og blik</string>
+    <string name="button_look_through">Gennemkig</string>
+    <string name="button_look_through_subtitle">Tryk på og træk fra denne knap for også at styre bevægelse eller kameravisningen. Ikke tilgængelig i touchscreen-tilstand.</string>
     <string name="preview">Forhåndsvisning</string>
     <string name="active">Aktiv</string>
     <string name="apply_all">Anvend alle</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1992,8 +1992,8 @@
     <string name="control_stroke_width_default">Standard</string>
     <string name="control_stroke_width_thick">Dick</string>
     <string name="control_stroke_width_extra_thick">Extra dick</string>
-    <string name="button_shooter_look_through">Shooter-Durchgriff</string>
-    <string name="button_shooter_look_through_subtitle">Diese Tastenberührung auch zur Steuerung dynamischer Shooter-Bewegung und des Blicks verwenden</string>
+    <string name="button_look_through">Durchgriff</string>
+    <string name="button_look_through_subtitle">Diese Taste drücken und von ihr aus ziehen, um zusätzlich Bewegung oder Kamerablick zu steuern. Im Touchscreen-Modus nicht verfügbar.</string>
     <string name="preview">Vorschau</string>
     <string name="active">Aktiv</string>
     <string name="apply_all">Auf alle anwenden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2050,8 +2050,8 @@
     <string name="control_stroke_width_default">Predeterminado</string>
     <string name="control_stroke_width_thick">Grueso</string>
     <string name="control_stroke_width_extra_thick">Extra grueso</string>
-    <string name="button_shooter_look_through">Paso de mirada shooter</string>
-    <string name="button_shooter_look_through_subtitle">Permitir que este toque de botón también controle el movimiento y la mirada shooter dinámicos</string>
+    <string name="button_look_through">Control al arrastrar</string>
+    <string name="button_look_through_subtitle">Pulsa y arrastra desde este botón para controlar también el movimiento o la cámara. No disponible en el modo de pantalla táctil.</string>
     <string name="preview">Vista previa</string>
     <string name="active">Activo</string>
     <string name="apply_all">Aplicar a todos</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2052,8 +2052,8 @@
     <string name="control_stroke_width_default">Par défaut</string>
     <string name="control_stroke_width_thick">Épais</string>
     <string name="control_stroke_width_extra_thick">Très épais</string>
-    <string name="button_shooter_look_through">Passage du regard shooter</string>
-    <string name="button_shooter_look_through_subtitle">Permettre à ce toucher de bouton de contrôler aussi le mouvement et le regard shooter dynamiques</string>
+    <string name="button_look_through">Contrôle par glissement</string>
+    <string name="button_look_through_subtitle">Appuyez sur ce bouton et faites glisser pour contrôler aussi le déplacement ou la caméra. Indisponible en mode écran tactile.</string>
     <string name="preview">Aperçu</string>
     <string name="active">Actif</string>
     <string name="apply_all">Appliquer à tous</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -2043,8 +2043,8 @@
     <string name="control_stroke_width_default">Predefinito</string>
     <string name="control_stroke_width_thick">Spesso</string>
     <string name="control_stroke_width_extra_thick">Molto spesso</string>
-    <string name="button_shooter_look_through">Movimento e mira in modalità sparatutto</string>
-    <string name="button_shooter_look_through_subtitle">Consenti a questo tocco del pulsante di controllare anche movimento e mira shooter dinamici</string>
+    <string name="button_look_through">Controllo tramite trascinamento</string>
+    <string name="button_look_through_subtitle">Premi e trascina da questo pulsante per controllare anche il movimento o la visuale. Non disponibile in modalità touchscreen.</string>
     <string name="preview">Anteprima</string>
     <string name="active">Attivo</string>
     <string name="apply_all">Applica a tutti</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2009,7 +2009,7 @@
     <string name="control_stroke_width_default">既定</string>
     <string name="control_stroke_width_thick">太い</string>
     <string name="control_stroke_width_extra_thick">極太</string>
-    <string name="button_look_through">ドラッグ操作を透過</string>
+    <string name="button_look_through">ドラッグ中の移動・視点操作</string>
     <string name="button_look_through_subtitle">このボタンを押したままドラッグして、移動やカメラ操作も行います。タッチスクリーンモードでは使用できません。</string>
     <string name="preview">プレビュー</string>
     <string name="active">アクティブ</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2009,8 +2009,8 @@
     <string name="control_stroke_width_default">既定</string>
     <string name="control_stroke_width_thick">太い</string>
     <string name="control_stroke_width_extra_thick">極太</string>
-    <string name="button_shooter_look_through">シューター透過操作</string>
-    <string name="button_shooter_look_through_subtitle">このボタンのタッチでも動的シューター移動や視点操作を行う</string>
+    <string name="button_look_through">ドラッグ操作を透過</string>
+    <string name="button_look_through_subtitle">このボタンを押したままドラッグして、移動やカメラ操作も行います。タッチスクリーンモードでは使用できません。</string>
     <string name="preview">プレビュー</string>
     <string name="active">アクティブ</string>
     <string name="apply_all">すべてに適用</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2050,8 +2050,8 @@
     <string name="control_stroke_width_default">기본</string>
     <string name="control_stroke_width_thick">두껍게</string>
     <string name="control_stroke_width_extra_thick">매우 두껍게</string>
-    <string name="button_shooter_look_through">슈터 통과 입력</string>
-    <string name="button_shooter_look_through_subtitle">이 버튼 터치가 동적 슈터 이동 및 시점도 제어하도록 허용</string>
+    <string name="button_look_through">드래그 입력 통과</string>
+    <string name="button_look_through_subtitle">이 버튼을 누른 채 드래그하여 이동이나 카메라 시점도 조작합니다. 터치스크린 모드에서는 사용할 수 없습니다.</string>
     <string name="preview">미리보기</string>
     <string name="active">활성</string>
     <string name="apply_all">모두 적용</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -2050,8 +2050,8 @@
     <string name="control_stroke_width_default">Domyślna</string>
     <string name="control_stroke_width_thick">Gruba</string>
     <string name="control_stroke_width_extra_thick">Bardzo gruba</string>
-    <string name="button_shooter_look_through">Przepuszczanie widoku shooter</string>
-    <string name="button_shooter_look_through_subtitle">Pozwól temu dotknięciu przycisku także sterować dynamicznym ruchem i widokiem shooter</string>
+    <string name="button_look_through">Sterowanie przez przeciąganie</string>
+    <string name="button_look_through_subtitle">Naciśnij i przeciągnij od tego przycisku, aby sterować także ruchem lub widokiem kamery. Niedostępne w trybie ekranu dotykowego.</string>
     <string name="preview">Podgląd</string>
     <string name="active">Aktywny</string>
     <string name="apply_all">Zastosuj do wszystkich</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1922,8 +1922,8 @@
     <string name="control_stroke_width_default">Padrão</string>
     <string name="control_stroke_width_thick">Grossa</string>
     <string name="control_stroke_width_extra_thick">Extra grossa</string>
-    <string name="button_shooter_look_through">Passagem de mira shooter</string>
-    <string name="button_shooter_look_through_subtitle">Permitir que este toque de botão também controle movimento e mira shooter dinâmicos</string>
+    <string name="button_look_through">Controle por arrasto</string>
+    <string name="button_look_through_subtitle">Pressione e arraste a partir deste botão para também controlar o movimento ou a câmera. Indisponível no modo de tela sensível ao toque.</string>
     <string name="preview">Prévia</string>
     <string name="active">Ativo</string>
     <string name="apply_all">Aplicar a todos</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -2053,8 +2053,8 @@
     <string name="control_stroke_width_default">Implicit</string>
     <string name="control_stroke_width_thick">Gros</string>
     <string name="control_stroke_width_extra_thick">Foarte gros</string>
-    <string name="button_shooter_look_through">Trecere privire shooter</string>
-    <string name="button_shooter_look_through_subtitle">Permite ca această atingere a butonului să controleze și mișcarea și privirea shooter dinamice</string>
+    <string name="button_look_through">Control prin glisare</string>
+    <string name="button_look_through_subtitle">Apasă și glisează de la acest buton pentru a controla și mișcarea sau camera. Indisponibil în modul ecran tactil.</string>
     <string name="preview">Previzualizare</string>
     <string name="active">Activ</string>
     <string name="apply_all">Aplică tuturor</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1978,8 +1978,8 @@ https://gamenative.app
     <string name="control_stroke_width_default">По умолчанию</string>
     <string name="control_stroke_width_thick">Толстая</string>
     <string name="control_stroke_width_extra_thick">Очень толстая</string>
-    <string name="button_shooter_look_through">Сквозной ввод shooter</string>
-    <string name="button_shooter_look_through_subtitle">Разрешить этому касанию кнопки также управлять динамическим движением и обзором shooter</string>
+    <string name="button_look_through">Сквозное управление</string>
+    <string name="button_look_through_subtitle">Нажмите эту кнопку и проведите от неё, чтобы также управлять движением или камерой. Недоступно в режиме сенсорного экрана.</string>
     <string name="preview">Предпросмотр</string>
     <string name="active">Активно</string>
     <string name="apply_all">Применить ко всем</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -2046,8 +2046,8 @@
     <string name="control_stroke_width_default">За замовчуванням</string>
     <string name="control_stroke_width_thick">Товста</string>
     <string name="control_stroke_width_extra_thick">Дуже товста</string>
-    <string name="button_shooter_look_through">Наскрізне введення shooter</string>
-    <string name="button_shooter_look_through_subtitle">Дозволити цьому дотику кнопки також керувати динамічним рухом і оглядом shooter</string>
+    <string name="button_look_through">Наскрізне керування</string>
+    <string name="button_look_through_subtitle">Натисніть цю кнопку й проведіть від неї, щоб також керувати рухом або камерою. Недоступно в режимі сенсорного екрана.</string>
     <string name="preview">Попередній перегляд</string>
     <string name="active">Активно</string>
     <string name="apply_all">Застосувати до всіх</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2070,8 +2070,8 @@
     <string name="control_stroke_width_default">默认</string>
     <string name="control_stroke_width_thick">粗</string>
     <string name="control_stroke_width_extra_thick">特粗</string>
-    <string name="button_shooter_look_through">射击模式穿透</string>
-    <string name="button_shooter_look_through_subtitle">允许此按钮触摸同时控制动态射击移动和视角</string>
+    <string name="button_look_through">拖动穿透</string>
+    <string name="button_look_through_subtitle">按住此按钮并拖动，也可控制移动或镜头视角。触摸屏模式下不可用。</string>
     <string name="preview">预览</string>
     <string name="active">激活</string>
     <string name="apply_all">全部应用</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2061,8 +2061,8 @@
     <string name="control_stroke_width_default">預設</string>
     <string name="control_stroke_width_thick">粗</string>
     <string name="control_stroke_width_extra_thick">特粗</string>
-    <string name="button_shooter_look_through">射擊模式穿透</string>
-    <string name="button_shooter_look_through_subtitle">允許此按鈕觸控同時控制動態射擊移動和視角</string>
+    <string name="button_look_through">拖曳穿透</string>
+    <string name="button_look_through_subtitle">按住此按鈕並拖曳，也可控制移動或鏡頭視角。觸控螢幕模式下無法使用。</string>
     <string name="preview">預覽</string>
     <string name="active">啟用</string>
     <string name="apply_all">全部套用</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -416,8 +416,8 @@
     <string name="control_stroke_width_default">Default</string>
     <string name="control_stroke_width_thick">Thick</string>
     <string name="control_stroke_width_extra_thick">Extra thick</string>
-    <string name="button_shooter_look_through">Shooter Look-through</string>
-    <string name="button_shooter_look_through_subtitle">Allow this button touch to also control dynamic shooter movement/look</string>
+    <string name="button_look_through">Look-through</string>
+    <string name="button_look_through_subtitle">Press and drag from this button to also control movement or camera look. Not available in touchscreen mode.</string>
     <string name="preview">Preview</string>
     <string name="active">Active</string>
     <string name="apply_all">Apply All</string>

--- a/app/src/test/java/app/gamenative/ui/component/dialog/ControlAppearanceLookThroughTest.kt
+++ b/app/src/test/java/app/gamenative/ui/component/dialog/ControlAppearanceLookThroughTest.kt
@@ -1,0 +1,25 @@
+package app.gamenative.ui.component.dialog
+
+import com.winlator.inputcontrols.ControlElement
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ControlAppearanceLookThroughTest {
+    @Test
+    fun `copying a legacy appearance preserves its shooter fallback`() {
+        val source = ControlElement(null).apply {
+            setShooterLookThrough(false)
+        }
+        val target = ControlElement(null).apply {
+            lookThroughSetting = true
+            setShooterLookThrough(true)
+        }
+
+        ControlAppearance.capture(source).applyTo(target)
+
+        assertNull(target.lookThroughSetting)
+        assertFalse(target.shooterLookThroughSetting)
+        assertFalse(target.isShooterLookThrough)
+    }
+}

--- a/app/src/test/java/app/gamenative/ui/component/dialog/ControlAppearanceLookThroughTest.kt
+++ b/app/src/test/java/app/gamenative/ui/component/dialog/ControlAppearanceLookThroughTest.kt
@@ -9,6 +9,7 @@ class ControlAppearanceLookThroughTest {
     @Test
     fun `copying a legacy appearance preserves its shooter fallback`() {
         val source = ControlElement(null).apply {
+            lookThroughSetting = null
             setShooterLookThrough(false)
         }
         val target = ControlElement(null).apply {

--- a/app/src/test/java/com/winlator/inputcontrols/ControlElementCancellationTest.kt
+++ b/app/src/test/java/com/winlator/inputcontrols/ControlElementCancellationTest.kt
@@ -1,0 +1,52 @@
+package com.winlator.inputcontrols
+
+import com.winlator.widget.InputControlsView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ControlElementCancellationTest {
+    @Test
+    fun `cancelling a held button releases its binding without handling a normal up`() {
+        val view = mockk<InputControlsView>(relaxed = true)
+        every { view.snappingSize } returns 10
+        val element = ControlElement(view).apply {
+            setX(50)
+            setY(50)
+            setBindingAt(0, Binding.KEY_A)
+        }
+
+        assertTrue(element.handleTouchDown(7, 50f, 50f))
+        assertTrue(element.cancelTouch())
+        assertFalse(element.cancelTouch())
+
+        verify(exactly = 1) { view.handleInputEvent(Binding.KEY_A, true) }
+        verify(exactly = 1) { view.handleInputEvent(Binding.KEY_A, false) }
+    }
+
+    @Test
+    fun `cancelling a selected toggle keeps its latched binding active`() {
+        val view = mockk<InputControlsView>(relaxed = true)
+        every { view.snappingSize } returns 10
+        val element = ControlElement(view).apply {
+            setX(50)
+            setY(50)
+            setBindingAt(0, Binding.KEY_A)
+            setToggleSwitch(true)
+            setSelected(true)
+        }
+
+        assertTrue(element.handleTouchDown(8, 50f, 50f))
+        assertTrue(element.cancelTouch())
+
+        assertTrue(element.isSelected)
+        verify(exactly = 0) { view.handleInputEvent(Binding.KEY_A, true) }
+        verify(exactly = 0) { view.handleInputEvent(Binding.KEY_A, false) }
+    }
+}

--- a/app/src/test/java/com/winlator/inputcontrols/ControlElementLookThroughTest.kt
+++ b/app/src/test/java/com/winlator/inputcontrols/ControlElementLookThroughTest.kt
@@ -1,5 +1,6 @@
 package com.winlator.inputcontrols
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -7,8 +8,30 @@ import org.junit.Test
 
 class ControlElementLookThroughTest {
     @Test
+    fun `new buttons explicitly disable look-through by default`() {
+        val element = ControlElement(null)
+
+        assertEquals(false, element.lookThroughSetting)
+        assertFalse(element.isLookThrough)
+        assertFalse(element.isShooterLookThrough)
+    }
+
+    @Test
+    fun `reset restores the explicit look-through default`() {
+        val element = ControlElement(null)
+        element.lookThroughSetting = true
+
+        element.setType(ControlElement.Type.BUTTON)
+
+        assertEquals(false, element.lookThroughSetting)
+        assertFalse(element.isLookThrough)
+        assertFalse(element.isShooterLookThrough)
+    }
+
+    @Test
     fun `legacy profiles remain shooter-only by default`() {
         val element = ControlElement(null)
+        element.lookThroughSetting = null
 
         assertNull(element.lookThroughSetting)
         assertFalse(element.isLookThrough)

--- a/app/src/test/java/com/winlator/inputcontrols/ControlElementLookThroughTest.kt
+++ b/app/src/test/java/com/winlator/inputcontrols/ControlElementLookThroughTest.kt
@@ -1,0 +1,45 @@
+package com.winlator.inputcontrols
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ControlElementLookThroughTest {
+    @Test
+    fun `legacy profiles remain shooter-only by default`() {
+        val element = ControlElement(null)
+
+        assertNull(element.lookThroughSetting)
+        assertFalse(element.isLookThrough)
+        assertTrue(element.isShooterLookThrough)
+    }
+
+    @Test
+    fun `explicitly disabling general look-through disables both modes`() {
+        val element = ControlElement(null)
+        element.lookThroughSetting = false
+
+        assertFalse(element.isLookThrough)
+        assertFalse(element.isShooterLookThrough)
+    }
+
+    @Test
+    fun `general look-through also applies in shooter mode`() {
+        val element = ControlElement(null)
+        element.setShooterLookThrough(false)
+        element.lookThroughSetting = true
+
+        assertTrue(element.isLookThrough)
+        assertTrue(element.isShooterLookThrough)
+    }
+
+    @Test
+    fun `legacy shooter opt-out remains disabled`() {
+        val element = ControlElement(null)
+        element.setShooterLookThrough(false)
+
+        assertFalse(element.isLookThrough)
+        assertFalse(element.isShooterLookThrough)
+    }
+}

--- a/app/src/test/java/com/winlator/widget/LookThroughPointerStateTest.kt
+++ b/app/src/test/java/com/winlator/widget/LookThroughPointerStateTest.kt
@@ -1,0 +1,56 @@
+package com.winlator.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LookThroughPointerStateTest {
+    @Test
+    fun `drag starts only after touch slop and reports incremental movement`() {
+        val state = LookThroughPointerState()
+
+        assertTrue(state.tryStart(3, 10f, 10f, false))
+        assertNull(state.move(3, 15f, 10f, 8f))
+
+        val first = state.move(3, 19f, 10f, 8f)!!
+        assertEquals(9f, first.x, 0f)
+        assertEquals(0f, first.y, 0f)
+
+        val second = state.move(3, 22f, 14f, 8f)!!
+        assertEquals(3f, second.x, 0f)
+        assertEquals(4f, second.y, 0f)
+    }
+
+    @Test
+    fun `normal touch ownership prevents look-through from interrupting a gesture`() {
+        val state = LookThroughPointerState()
+
+        assertFalse(state.tryStart(4, 0f, 0f, true))
+        assertFalse(state.isActive)
+    }
+
+    @Test
+    fun `active pointer keeps ownership until release`() {
+        val state = LookThroughPointerState()
+
+        assertTrue(state.tryStart(1, 0f, 0f, false))
+        assertFalse(state.tryStart(2, 10f, 10f, false))
+        state.release(1)
+        assertFalse(state.isActive)
+        assertTrue(state.tryStart(2, 10f, 10f, false))
+        assertTrue(state.owns(2))
+    }
+
+    @Test
+    fun `cancel clears the owned pointer`() {
+        val state = LookThroughPointerState()
+        state.tryStart(5, 0f, 0f, false)
+
+        state.clear()
+
+        assertFalse(state.isActive)
+        assertFalse(state.owns(5))
+    }
+}


### PR DESCRIPTION
## Description
This was a request here: https://discord.com/channels/1378308569287622737/1412756778159964201/1531208146654068806

Renames the shooter look-through control appearance option to “Look-through”. Allows a Look-through button to remain held while controlling pointer or camera movement in both standard touchpad mode and shooter mode.

Purposefully keeping look-through disabled in touchscreen mode because its direct-touch and multi-touch behavior conflicts with button-originated pointer forwarding.


## Recording

https://github.com/user-attachments/assets/c3f1a85f-839f-4ae6-9ba7-61396d3e328b

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [X] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add general Look-through for on-screen buttons so a press-and-drag can control movement or camera in both standard touchpad and shooter modes. It stays disabled in touchscreen mode to avoid gesture conflicts.

- **Bug Fixes**
  - Defaults and legacy: changing or resetting a button restores `lookThrough=false`; legacy buttons loaded without `lookThrough` keep the shooter-only fallback.
  - Cancellation and routing: added `TouchpadView.cancelTouchInput`; cancel on `ACTION_CANCEL`, edit/profile/mode changes, and when the touchpad detaches; schedule and cancel simulated touch presses (release if pressed); route look-through drags via `movePointerFromLookThrough` after touch slop; quarantine normal touchpad gestures; on release, only bindings activated by that pointer are cleared and toggle latches remain latched.

- **Migration**
  - Existing profiles keep shooter-only behavior until edited. New buttons default to `lookThrough=false`; legacy profiles use `lookThrough=null` and fall back to `shooterLookThrough`. Saving/loading preserves both.

<sup>Written for commit 1d992e8eb580bce91e51ea60c6f2d33d7eafc8e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buttons now support press-and-drag controls for movement or camera view.
  * Look-through settings work consistently across general and shooter-specific controls.
  * Drag input coordinates with touchpad controls to prevent conflicting pointer actions.
  * The feature is unavailable in touchscreen mode.
  * Improved touch cancellation and cleanup when switching modes or releasing controls.

* **Documentation**
  * Updated translated labels and descriptions to explain generalized button-drag behavior.

* **Tests**
  * Added coverage for settings compatibility, pointer handling, activation thresholds, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->