### PR TITLE
Fix touch D-pad remapping for shared-axis inputs

### DIFF
--- a/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
@@ -1189,12 +1189,20 @@ public class ControlElement {
             else {
                 final boolean[] states = {deltaY <= -DPAD_DEAD_ZONE, deltaX >= DPAD_DEAD_ZONE, deltaY >= DPAD_DEAD_ZONE, deltaX <= -DPAD_DEAD_ZONE};
 
+                // Release transitions first because opposing stick and mouse-move
+                // bindings share an axis. An inactive direction must not clear an
+                // active direction later in the same update.
                 for (byte i = 0; i < 4; i++) {
                     float value = i == 1 || i == 3 ? deltaX : deltaY;
-                    Binding binding = getBindingAt(i);
-                    boolean state = binding.isMouseMove() ? (states[i] || states[(i+2)%4]) : states[i];
-                    inputControlsView.handleInputEvent(binding, state, value);
-                    this.states[i] = state;
+                    if (this.states[i] && !states[i]) {
+                        inputControlsView.handleInputEvent(getBindingAt(i), false, value);
+                    }
+                }
+
+                for (byte i = 0; i < 4; i++) {
+                    float value = i == 1 || i == 3 ? deltaX : deltaY;
+                    if (states[i]) inputControlsView.handleInputEvent(getBindingAt(i), true, value);
+                    this.states[i] = states[i];
                 }
 
                 inputControlsView.invalidate();

--- a/app/src/test/java/com/winlator/inputcontrols/ControlElementDPadRemapTest.kt
+++ b/app/src/test/java/com/winlator/inputcontrols/ControlElementDPadRemapTest.kt
@@ -99,7 +99,7 @@ class ControlElementDPadRemapTest {
     }
 
     @Test
-    fun `mouse movement activates only the touched direction`() {
+    fun `mouse movement activates only the touched direction and reverses release first`() {
         val events = mutableListOf<Pair<Binding, Boolean>>()
         val view = mock<InputControlsView>()
         whenever(view.snappingSize).thenReturn(10)
@@ -119,5 +119,12 @@ class ControlElementDPadRemapTest {
         assertTrue(element.handleTouchDown(1, 100f, 160f))
         assertTrue(events.contains(Binding.MOUSE_MOVE_DOWN to true))
         assertTrue(events.none { it == Binding.MOUSE_MOVE_UP to true })
+
+        events.clear()
+        assertTrue(element.handleTouchMove(1, 100f, 40f))
+        assertEquals(
+            listOf(Binding.MOUSE_MOVE_DOWN to false, Binding.MOUSE_MOVE_UP to true),
+            events,
+        )
     }
 }

--- a/app/src/test/java/com/winlator/inputcontrols/ControlElementDPadRemapTest.kt
+++ b/app/src/test/java/com/winlator/inputcontrols/ControlElementDPadRemapTest.kt
@@ -1,0 +1,123 @@
+package com.winlator.inputcontrols
+
+import com.winlator.widget.InputControlsView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ControlElementDPadRemapTest {
+    private data class Fixture(val element: ControlElement, val state: GamepadState)
+
+    private fun fixture(): Fixture {
+        val state = GamepadState()
+        val view = mock<InputControlsView>()
+        whenever(view.snappingSize).thenReturn(10)
+
+        fun applyEvent(binding: Binding, pressed: Boolean, offset: Float) {
+            when (binding) {
+                Binding.GAMEPAD_LEFT_THUMB_UP,
+                Binding.GAMEPAD_LEFT_THUMB_DOWN,
+                -> state.thumbLY = if (pressed) offset else 0f
+                Binding.GAMEPAD_LEFT_THUMB_LEFT,
+                Binding.GAMEPAD_LEFT_THUMB_RIGHT,
+                -> state.thumbLX = if (pressed) offset else 0f
+                else -> Unit
+            }
+        }
+        doAnswer { invocation ->
+            applyEvent(invocation.getArgument(0), invocation.getArgument(1), invocation.getArgument(2))
+            null
+        }.whenever(view).handleInputEvent(any<Binding>(), any(), any())
+        doAnswer { invocation ->
+            applyEvent(invocation.getArgument(0), invocation.getArgument(1), 0f)
+            null
+        }.whenever(view).handleInputEvent(any<Binding>(), any())
+
+        return Fixture(
+            ControlElement(view).apply {
+                setType(ControlElement.Type.D_PAD)
+                setX(100)
+                setY(100)
+                setBindingAt(0, Binding.GAMEPAD_LEFT_THUMB_UP)
+                setBindingAt(1, Binding.GAMEPAD_LEFT_THUMB_RIGHT)
+                setBindingAt(2, Binding.GAMEPAD_LEFT_THUMB_DOWN)
+                setBindingAt(3, Binding.GAMEPAD_LEFT_THUMB_LEFT)
+            },
+            state,
+        )
+    }
+
+    @Test
+    fun `all cardinal directions survive opposing idle bindings`() {
+        val directions = listOf(
+            Triple(100f to 40f, 0f, -1f),
+            Triple(160f to 100f, 1f, 0f),
+            Triple(100f to 160f, 0f, 1f),
+            Triple(40f to 100f, -1f, 0f),
+        )
+
+        directions.forEach { (point, expectedXSign, expectedYSign) ->
+            val (element, state) = fixture()
+            assertTrue(element.handleTouchDown(1, point.first, point.second))
+            assertEquals(expectedXSign, Math.signum(state.thumbLX), 0f)
+            assertEquals(expectedYSign, Math.signum(state.thumbLY), 0f)
+        }
+    }
+
+    @Test
+    fun `direct reversals release old direction before applying new direction`() {
+        val (element, state) = fixture()
+
+        assertTrue(element.handleTouchDown(1, 100f, 160f))
+        assertTrue(state.thumbLY > 0f)
+        assertTrue(element.handleTouchMove(1, 100f, 40f))
+        assertTrue(state.thumbLY < 0f)
+        assertTrue(element.handleTouchMove(1, 160f, 100f))
+        assertTrue(state.thumbLX > 0f)
+        assertEquals(0f, state.thumbLY, 0f)
+        assertTrue(element.handleTouchMove(1, 40f, 100f))
+        assertTrue(state.thumbLX < 0f)
+    }
+
+    @Test
+    fun `lifting finger returns remapped stick to neutral`() {
+        val (element, state) = fixture()
+
+        assertTrue(element.handleTouchDown(1, 40f, 40f))
+        assertTrue(state.thumbLX < 0f)
+        assertTrue(state.thumbLY < 0f)
+        assertTrue(element.handleTouchUp(1))
+        assertEquals(0f, state.thumbLX, 0f)
+        assertEquals(0f, state.thumbLY, 0f)
+    }
+
+    @Test
+    fun `mouse movement activates only the touched direction`() {
+        val events = mutableListOf<Pair<Binding, Boolean>>()
+        val view = mock<InputControlsView>()
+        whenever(view.snappingSize).thenReturn(10)
+        doAnswer { invocation ->
+            events += invocation.getArgument<Binding>(0) to invocation.getArgument<Boolean>(1)
+            null
+        }.whenever(view).handleInputEvent(any<Binding>(), any(), any())
+
+        val element = ControlElement(view).apply {
+            setType(ControlElement.Type.D_PAD)
+            setX(100)
+            setY(100)
+            setBindingAt(0, Binding.MOUSE_MOVE_UP)
+            setBindingAt(2, Binding.MOUSE_MOVE_DOWN)
+        }
+
+        assertTrue(element.handleTouchDown(1, 100f, 160f))
+        assertTrue(events.contains(Binding.MOUSE_MOVE_DOWN to true))
+        assertTrue(events.none { it == Binding.MOUSE_MOVE_UP to true })
+    }
+}


### PR DESCRIPTION
## Description
This is a bug mentioned here: https://discord.com/channels/1378308569287622737/1530006463031021628/1530451022059671634

Fix touch D-pad remapping so every direction works correctly, including analog-stick and mouse-movement bindings. Inactive directions no longer override the direction currently being pressed.

## Recording

https://drive.google.com/file/d/1u9SpX5Tr3hWjdjnkLST08lCgVYqlQiAX/view?usp=drivesdk

## Type of Change
- [X] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix touch D-pad remapping for shared-axis inputs so analog stick and mouse-move bindings behave correctly. Opposing idle directions no longer override the pressed direction.

- **Bug Fixes**
  - Process release transitions before presses to avoid shared-axis conflicts on sticks and mouse movement.
  - Handle direct reversals cleanly and reset to neutral when the finger lifts.
  - Add unit tests for cardinal directions, reversals, neutral reset, mouse-move activation, and mouse-move reversal release order.

<sup>Written for commit 7deba93eacd2fe99c19ee186ccbd8ac5f12153b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved D-pad touch handling when changing or releasing directions.
  * Corrected opposing-direction behavior to prevent conflicting movement inputs.
  * Ensured direct direction reversals and neutral touch releases work as expected.

* **Tests**
  * Added coverage for remapped D-pad controls, cardinal directions, reversals, releases, and mouse-direction activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->