### PR TITLE
Respect Nexus Mods Adult Content Preferences

### DIFF
--- a/app/src/main/java/app/gamenative/mods/NexusApiClient.kt
+++ b/app/src/main/java/app/gamenative/mods/NexusApiClient.kt
@@ -80,6 +80,7 @@ data class NexusCollectionInfo(
 enum class NexusApiErrorReason {
     AUTHENTICATION,
     FORBIDDEN,
+    ADULT_CONTENT_BLOCKED,
     DOWNLOAD_AUTHORIZATION_REQUIRED,
     DOWNLOAD_AUTHORIZATION_INVALID,
     DOWNLOAD_AUTHORIZATION_EXPIRED,
@@ -108,6 +109,7 @@ class NexusApiClient(
     private val accessTokenProvider: () -> String? = { null },
 ) {
     private companion object {
+        private const val ADULT_CONTENT_BLOCKED_CODE = "ADULT_CONTENT_BLOCKED"
         private const val MAX_COLLECTION_PAYLOAD_BYTES = 256L * 1024L * 1024L
         private const val MAX_COLLECTION_JSON_BYTES = 64L * 1024L * 1024L
     }
@@ -263,6 +265,18 @@ class NexusApiClient(
             try {
                 val response = postObject(url, payload)
                 val errors = response.optJSONArray("errors")
+                errors?.let { graphErrors ->
+                    for (i in 0 until graphErrors.length()) {
+                        val error = graphErrors.optJSONObject(i) ?: continue
+                        if (error.optJSONObject("extensions")?.optString("code") == ADULT_CONTENT_BLOCKED_CODE) {
+                            throw NexusApiException(
+                                message = error.optString("message").ifBlank { "Adult content blocked" },
+                                statusCode = 403,
+                                reason = NexusApiErrorReason.ADULT_CONTENT_BLOCKED,
+                            )
+                        }
+                    }
+                }
                 val data = response.optJSONObject("data")
                 val revision = data?.optJSONObject("collectionRevision")
                 if (revision == null) {
@@ -305,7 +319,7 @@ class NexusApiClient(
         val variables = JSONObject()
             .put("domainName", reference.gameDomain)
             .put("slug", reference.slug)
-            .put("viewAdultContent", true)
+            .put("viewAdultContent", false)
         reference.revision?.let { variables.put("revision", it) }
         return JSONObject()
             .put("operationName", "CollectionRevisionMods")

--- a/app/src/main/java/app/gamenative/mods/NexusImportState.kt
+++ b/app/src/main/java/app/gamenative/mods/NexusImportState.kt
@@ -175,6 +175,7 @@ internal object NexusImportState {
         fallback: String = "Failed to import Nexus mod",
         expiredAuthorizationMessage: String? = null,
         authenticationMessage: String? = null,
+        adultContentBlockedMessage: String? = null,
     ): String {
         val raw = error.message.orEmpty()
         val normalized = raw.lowercase()
@@ -185,7 +186,13 @@ internal object NexusImportState {
             return raw.ifBlank { "Import canceled." }
         }
         apiException(error)?.let {
-            return apiMessage(it, fallback, expiredAuthorizationMessage, authenticationMessage)
+            return apiMessage(
+                error = it,
+                fallback = fallback,
+                expiredAuthorizationMessage = expiredAuthorizationMessage,
+                authenticationMessage = authenticationMessage,
+                adultContentBlockedMessage = adultContentBlockedMessage,
+            )
         }
         return when (error) {
             is UnknownHostException -> "Network connection failed. Check your connection and try again."
@@ -229,6 +236,7 @@ internal object NexusImportState {
         fallback: String,
         expiredAuthorizationMessage: String?,
         authenticationMessage: String?,
+        adultContentBlockedMessage: String?,
     ): String {
         val quota = if (error.reason == NexusApiErrorReason.RATE_LIMITED || error.statusCode == 429) {
             buildString {
@@ -241,6 +249,7 @@ internal object NexusImportState {
         val base = when (error.reason) {
             NexusApiErrorReason.AUTHENTICATION -> authenticationMessage ?: error.message ?: fallback
             NexusApiErrorReason.FORBIDDEN -> "Nexus denied access to this resource for the current account."
+            NexusApiErrorReason.ADULT_CONTENT_BLOCKED -> adultContentBlockedMessage ?: error.message ?: fallback
             NexusApiErrorReason.DOWNLOAD_AUTHORIZATION_REQUIRED ->
                 "Free Nexus accounts must authorize this file on the Nexus Mods website before GameNative can download it."
             NexusApiErrorReason.DOWNLOAD_AUTHORIZATION_INVALID ->

--- a/app/src/main/java/app/gamenative/ui/component/dialog/NexusModsDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/NexusModsDialog.kt
@@ -695,6 +695,7 @@ fun NexusModsDialog(
     var diagnosticsPaused by remember { mutableStateOf(false) }
     val nexusAuthenticationUnavailableMessage =
         context.getString(R.string.nexus_integration_temporarily_unavailable)
+    val nexusAdultContentBlockedMessage = context.getString(R.string.nexus_adult_content_blocked)
 
     fun nexusUserMessage(
         error: Throwable,
@@ -707,6 +708,7 @@ fun NexusModsDialog(
                 error = error,
                 expiredAuthorizationMessage = expiredAuthorizationMessage,
                 authenticationMessage = authenticationMessage,
+                adultContentBlockedMessage = nexusAdultContentBlockedMessage,
             )
         } else {
             NexusImportState.userMessage(
@@ -714,6 +716,7 @@ fun NexusModsDialog(
                 fallback = fallback,
                 expiredAuthorizationMessage = expiredAuthorizationMessage,
                 authenticationMessage = authenticationMessage,
+                adultContentBlockedMessage = nexusAdultContentBlockedMessage,
             )
         }
     }

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1796,6 +1796,7 @@
     <string name="nexus_resolving_collection_item">Løsning af opkrævning %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">Samling klar: %1$d mods</string>
     <string name="nexus_resolve_collection_failed">Kunne ikke løse Nexus-indsamlingen</string>
+    <string name="nexus_adult_content_blocked">Denne samling er skjult på grund af dine indstillinger for voksenindhold på Nexus Mods.</string>
     <string name="nexus_no_selected_collection_mods_ready">Ingen udvalgte samlingsmods er klar til at downloade</string>
     <string name="nexus_collection_different_file_reused">Samling anmodede om en anden fil; eksisterende installeret fil genbrugt</string>
     <string name="nexus_collection_existing_placement_kept">Eksisterende anbringelse bevares</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1866,6 +1866,7 @@
     <string name="nexus_resolving_collection_item">Sammlung auflösen %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">Sammlung bereit: %1$d Mods</string>
     <string name="nexus_resolve_collection_failed">Nexus-Sammlung konnte nicht aufgelöst werden</string>
+    <string name="nexus_adult_content_blocked">Diese Sammlung ist aufgrund deiner Einstellungen für nicht jugendfreie Inhalte bei Nexus Mods ausgeblendet.</string>
     <string name="nexus_no_selected_collection_mods_ready">Es stehen keine ausgewählten Sammlungs-Mods zum Download bereit</string>
     <string name="nexus_collection_different_file_reused">Sammlung hat eine andere Datei angefordert; bestehende installierte Datei wiederverwendet</string>
     <string name="nexus_collection_existing_placement_kept">Bestehende Platzierung beibehalten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1924,6 +1924,7 @@
     <string name="nexus_resolving_collection_item">Resolver cobro %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">Colección lista: %1$d mods</string>
     <string name="nexus_resolve_collection_failed">No se pudo resolver la recopilación Nexus</string>
+    <string name="nexus_adult_content_blocked">Esta colección está oculta debido a tu configuración de contenido para adultos en Nexus Mods.</string>
     <string name="nexus_no_selected_collection_mods_ready">No hay mods de colección seleccionados listos para descargar</string>
     <string name="nexus_collection_different_file_reused">Cobro solicitó un expediente diferente; archivo instalado existente reutilizado</string>
     <string name="nexus_collection_existing_placement_kept">Se mantiene la colocación existente</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1926,6 +1926,7 @@
     <string name="nexus_resolving_collection_item">Résolution du recouvrement %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">Collection prête : %1$d mods</string>
     <string name="nexus_resolve_collection_failed">Échec de la résolution de la collection Nexus</string>
+    <string name="nexus_adult_content_blocked">Cette collection est masquée en raison de vos paramètres de contenu pour adultes sur Nexus Mods.</string>
     <string name="nexus_no_selected_collection_mods_ready">Aucun mod de collection sélectionné n\'est prêt à être téléchargé</string>
     <string name="nexus_collection_different_file_reused">La collection a demandé un fichier différent ; fichier installé existant réutilisé</string>
     <string name="nexus_collection_existing_placement_kept">Emplacement existant conservé</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1917,6 +1917,7 @@
     <string name="nexus_resolving_collection_item">Risoluzione incasso %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">Collezione pronta: %1$d mod</string>
     <string name="nexus_resolve_collection_failed">Impossibile risolvere la raccolta Nexus</string>
+    <string name="nexus_adult_content_blocked">Questa raccolta è nascosta a causa delle tue impostazioni per i contenuti per adulti su Nexus Mods.</string>
     <string name="nexus_no_selected_collection_mods_ready">Nessuna mod della raccolta selezionata è pronta per il download</string>
     <string name="nexus_collection_different_file_reused">La raccolta ha richiesto un file diverso; file installato esistente riutilizzato</string>
     <string name="nexus_collection_existing_placement_kept">Posizionamento esistente mantenuto</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1883,6 +1883,7 @@
     <string name="nexus_resolving_collection_item">コレクションの解決 %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">コレクションの準備完了: %1$d 個のMOD</string>
     <string name="nexus_resolve_collection_failed">Nexus コレクションを解決できませんでした</string>
+    <string name="nexus_adult_content_blocked">Nexus Mods の成人向けコンテンツ設定により、このコレクションは非表示になっています。</string>
     <string name="nexus_no_selected_collection_mods_ready">選択されたコレクション MOD はダウンロードする準備ができていません</string>
     <string name="nexus_collection_different_file_reused">コレクションは別のファイルを要求しました。既存のインストールされたファイルが再利用される</string>
     <string name="nexus_collection_existing_placement_kept">既存の配置が維持される</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1924,6 +1924,7 @@
     <string name="nexus_resolving_collection_item">컬렉션 확인 중 %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">컬렉션 준비됨: %1$d 모드</string>
     <string name="nexus_resolve_collection_failed">Nexus 컬렉션을 확인하지 못했습니다.</string>
+    <string name="nexus_adult_content_blocked">이 컬렉션은 사용자의 Nexus Mods 성인 콘텐츠 설정에 따라 숨겨져 있습니다.</string>
     <string name="nexus_no_selected_collection_mods_ready">선택한 컬렉션 모드를 다운로드할 준비가 되지 않았습니다.</string>
     <string name="nexus_collection_different_file_reused">컬렉션에서 다른 파일을 요청했습니다. 기존에 설치된 파일 재사용</string>
     <string name="nexus_collection_existing_placement_kept">기존 배치가 유지됨</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1924,6 +1924,7 @@
     <string name="nexus_resolving_collection_item">Rozpatrzenie windykacji %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">Kolekcja gotowa: %1$d modów</string>
     <string name="nexus_resolve_collection_failed">Nie udało się rozwiązać kolekcji Nexus</string>
+    <string name="nexus_adult_content_blocked">Ta kolekcja jest ukryta ze względu na Twoje ustawienia treści dla dorosłych w Nexus Mods.</string>
     <string name="nexus_no_selected_collection_mods_ready">Żadne wybrane mody kolekcji nie są gotowe do pobrania</string>
     <string name="nexus_collection_different_file_reused">Kolekcja zażądała innego pliku; ponownie wykorzystano istniejący zainstalowany plik</string>
     <string name="nexus_collection_existing_placement_kept">Istniejące umiejscowienie zostało zachowane</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1796,6 +1796,7 @@
     <string name="nexus_resolving_collection_item">Resolvendo cobrança %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">Coleção pronta: %1$d mods</string>
     <string name="nexus_resolve_collection_failed">Falha ao resolver a coleta Nexus</string>
+    <string name="nexus_adult_content_blocked">Esta coleção está oculta devido às suas configurações de conteúdo adulto no Nexus Mods.</string>
     <string name="nexus_no_selected_collection_mods_ready">Nenhum mod de coleção selecionado está pronto para download</string>
     <string name="nexus_collection_different_file_reused">A coleção solicitou um arquivo diferente; arquivo instalado existente reutilizado</string>
     <string name="nexus_collection_existing_placement_kept">Colocação existente mantida</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1927,6 +1927,7 @@
     <string name="nexus_resolving_collection_item">Rezolvarea colectării %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">Colecție gata: %1$d moduri</string>
     <string name="nexus_resolve_collection_failed">Nu s-a putut rezolva colecția Nexus</string>
+    <string name="nexus_adult_content_blocked">Această colecție este ascunsă din cauza setărilor tale privind conținutul pentru adulți de pe Nexus Mods.</string>
     <string name="nexus_no_selected_collection_mods_ready">Niciun mod de colecție selectat nu este gata de descărcat</string>
     <string name="nexus_collection_different_file_reused">Colecția a solicitat un alt fișier; fișierul instalat existent a fost reutilizat</string>
     <string name="nexus_collection_existing_placement_kept">Plasament existent păstrat</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1852,6 +1852,7 @@ https://gamenative.app
     <string name="nexus_resolving_collection_item">Разрешение коллекции %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">Коллекция готова: %1$d модов</string>
     <string name="nexus_resolve_collection_failed">Не удалось разрешить коллекцию Nexus.</string>
+    <string name="nexus_adult_content_blocked">Эта коллекция скрыта из-за ваших настроек контента для взрослых на Nexus Mods.</string>
     <string name="nexus_no_selected_collection_mods_ready">Ни один из выбранных модов коллекции не готов к загрузке.</string>
     <string name="nexus_collection_different_file_reused">Коллекция запросила другой файл; существующий установленный файл используется повторно</string>
     <string name="nexus_collection_existing_placement_kept">Существующее размещение сохраняется.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1920,6 +1920,7 @@
     <string name="nexus_resolving_collection_item">Розв\'язка колекції %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">Колекція готова: %1$d модів</string>
     <string name="nexus_resolve_collection_failed">Не вдалося вирішити колекцію Nexus</string>
+    <string name="nexus_adult_content_blocked">Цю колекцію приховано через ваші налаштування вмісту для дорослих у Nexus Mods.</string>
     <string name="nexus_no_selected_collection_mods_ready">Жодна вибрана колекція модів не готова для завантаження</string>
     <string name="nexus_collection_different_file_reused">Колекція запитала інший файл; існуючий встановлений файл повторно використаний</string>
     <string name="nexus_collection_existing_placement_kept">Існуюче розміщення збережено</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1944,6 +1944,7 @@
     <string name="nexus_resolving_collection_item">解决集合%1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">收藏就绪：%1$d模组</string>
     <string name="nexus_resolve_collection_failed">未能解决Nexus 集合</string>
+    <string name="nexus_adult_content_blocked">此合集因你的 Nexus Mods 成人内容设置而被隐藏。</string>
     <string name="nexus_no_selected_collection_mods_ready">没有可供下载的选定合集模组</string>
     <string name="nexus_collection_different_file_reused">集合请求不同的文件；重复使用现有的已安装文件</string>
     <string name="nexus_collection_existing_placement_kept">保留现有安置</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1935,6 +1935,7 @@
     <string name="nexus_resolving_collection_item">正在解析收藏 %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">收藏就緒：%1$d 個模組</string>
     <string name="nexus_resolve_collection_failed">無法解析 Nexus 收藏</string>
+    <string name="nexus_adult_content_blocked">此收藏因你的 Nexus Mods 成人內容設定而被隱藏。</string>
     <string name="nexus_no_selected_collection_mods_ready">沒有可供下載的選定收藏模組</string>
     <string name="nexus_collection_different_file_reused">收藏要求不同的檔案；重複使用現有已安裝檔案</string>
     <string name="nexus_collection_existing_placement_kept">保留現有安置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1936,6 +1936,7 @@
     <string name="nexus_resolving_collection_item">Resolving collection %1$d/%2$d</string>
     <string name="nexus_collection_resolve_ready">Collection ready: %1$d mod(s)</string>
     <string name="nexus_resolve_collection_failed">Failed to resolve Nexus collection</string>
+    <string name="nexus_adult_content_blocked">This collection is hidden by your Nexus Mods adult-content settings.</string>
     <string name="nexus_no_selected_collection_mods_ready">No selected collection mods are ready to download</string>
     <string name="nexus_collection_different_file_reused">Collection requested a different file; existing installed file reused</string>
     <string name="nexus_collection_existing_placement_kept">Existing placement kept</string>

--- a/app/src/test/java/app/gamenative/mods/NexusApiClientTest.kt
+++ b/app/src/test/java/app/gamenative/mods/NexusApiClientTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -230,7 +231,56 @@ class NexusApiClientTest {
         assertTrue(collection.files.single().required)
         val request = server.takeRequest()
         assertEquals("/graphql", request.path)
-        assertTrue(request.body.readUtf8().contains("collectionRevision"))
+        val requestBody = JSONObject(request.body.readUtf8())
+        assertTrue(requestBody.getString("query").contains("collectionRevision"))
+        assertFalse(requestBody.getJSONObject("variables").getBoolean("viewAdultContent"))
+    }
+
+    @Test
+    fun getCollectionRevision_adultContentBlockInPartialResponseDoesNotFallBack() = runBlocking {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """
+                    {
+                      "errors": [
+                        {
+                          "message": "Unrelated warning",
+                          "extensions": { "code": "OTHER" }
+                        },
+                        {
+                          "message": "Adult content blocked",
+                          "path": ["collectionRevision"],
+                          "extensions": { "code": "ADULT_CONTENT_BLOCKED" }
+                        }
+                      ],
+                      "data": {
+                        "collection": { "name": "Hidden Collection" },
+                        "collectionRevision": {
+                          "revisionNumber": 1,
+                          "modFiles": []
+                        }
+                      }
+                    }
+                    """.trimIndent(),
+                ),
+        )
+        server.enqueue(MockResponse().setResponseCode(403).setBody("{}"))
+
+        val error = runCatching {
+            client.getCollectionRevision(
+                NexusCollectionReference("fallout4", "adult-collection", 1),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(error is NexusApiException)
+        val nexusError = error as NexusApiException
+        assertEquals(403, nexusError.statusCode)
+        assertEquals(NexusApiErrorReason.ADULT_CONTENT_BLOCKED, nexusError.reason)
+        assertEquals("Adult content blocked", nexusError.message)
+        assertEquals(1, server.requestCount)
+        assertEquals("/graphql", server.takeRequest().path)
     }
 
     @Test

--- a/app/src/test/java/app/gamenative/mods/NexusImportStateTest.kt
+++ b/app/src/test/java/app/gamenative/mods/NexusImportStateTest.kt
@@ -284,6 +284,23 @@ class NexusImportStateTest {
         )
     }
 
+    @Test
+    fun userMessage_adultContentBlockPrefersLocalizedOverride() {
+        val error = NexusApiException(
+            message = "Adult content blocked",
+            statusCode = 403,
+            reason = NexusApiErrorReason.ADULT_CONTENT_BLOCKED,
+        )
+
+        assertEquals(
+            "Localized adult-content message",
+            NexusImportState.userMessage(
+                error = error,
+                adultContentBlockedMessage = "Localized adult-content message",
+            ),
+        )
+    }
+
     private fun install(
         status: ModInstallStatus,
         fileId: Long,


### PR DESCRIPTION
## Description
Updates Nexus Mods collection requests to respect each user’s adult-content preferences instead of forcing adult content to be visible.

## Recording
N/A

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [X] Compatibility improvements
- [X] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect Nexus Mods adult-content settings when resolving collections. Stops forcing adult content visibility and shows a clear, localized message when a collection is hidden.

- **Bug Fixes**
  - Do not override `viewAdultContent` in collection queries; set to false.
  - Detect GraphQL `ADULT_CONTENT_BLOCKED` and surface a 403 with a specific `NexusApiErrorReason`.
  - Add localized “adult-content blocked” message and wire into `NexusImportState` and `NexusModsDialog`.
  - Tests verify request variables, error handling, and no fallback on partial responses.

<sup>Written for commit ea8f385a7dba457223e33bfae49c0b1be79ba1a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nexus collections now respect adult-content settings and clearly indicate when content is hidden.
  * Adult-content restrictions are reported with localized messages across supported languages.

* **Bug Fixes**
  * Prevented restricted collection responses from incorrectly falling back to another request method.

* **Tests**
  * Added coverage for adult-content errors, localized messaging, and request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->