### PR TITLE
stretched spinner fix

### DIFF
--- a/app/src/main/java/app/gamenative/ui/util/Images.kt
+++ b/app/src/main/java/app/gamenative/ui/util/Images.kt
@@ -3,6 +3,7 @@ package app.gamenative.ui.util
 import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -45,7 +46,7 @@ internal fun ListItemImage(
             contentDescription = contentDescription,
         ),
         loading = {
-            CircularProgressIndicator()
+            CircularProgressIndicator(modifier = Modifier.wrapContentSize())
         },
         failure = {
             onFailure()


### PR DESCRIPTION
## Description
Landscapist propagates min constraints, which would stretch the indicator to the whole slot; wrapContentSize keeps it at its natural size, centered.

# Preview
before:
<img width="712" height="400" alt="before" src="https://github.com/user-attachments/assets/a2293734-4937-42f3-95a8-211f356b2cb4" />

after:
<img width="534" height="300" alt="after" src="https://github.com/user-attachments/assets/a86e20cf-0be5-45ce-a631-1a3fe683650a" />



## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed stretched loading spinner in image placeholders by applying wrapContentSize to keep it at its natural size and centered. Prevents `Landscapist` min constraints from expanding the spinner to fill the slot.

<sup>Written for commit 40f753d5a1e0d5ad39d3bd089e86745ff3322cd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image loading indicators so they fit neatly within the available image area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->