### PR TITLE
Support custom games on the modern build without all-files access

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -327,6 +327,7 @@ dependencies {
 
     // Chrome Custom Tabs for GOG OAuth
     implementation("androidx.browser:browser:1.8.0")
+    implementation("androidx.documentfile:documentfile:1.0.1")
 
     // JavaSteam
     val localBuild = false // Change to 'true' needed when building JavaSteam manually

--- a/app/src/main/java/app/gamenative/ui/enums/LibraryTab.kt
+++ b/app/src/main/java/app/gamenative/ui/enums/LibraryTab.kt
@@ -4,7 +4,6 @@ import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Explore
 import androidx.compose.ui.graphics.vector.ImageVector
-import app.gamenative.BuildConfig
 import app.gamenative.PrefManager
 import app.gamenative.R
 
@@ -85,12 +84,12 @@ enum class LibraryTab(
 
     companion object {
         /**
-         * Tabs shown in the UI. Custom (LOCAL) games rely on all-files access, which only the
-         * legacy storage flavors have, so the tab is hidden on modern (scoped-storage) builds.
+         * Tabs shown in the UI. Custom (LOCAL) games work on all flavors: legacy maps folders
+         * in place via all-files access, modern imports them into app-owned storage.
          */
         val visibleEntries: List<LibraryTab>
             get() {
-                var result = if (BuildConfig.MODERN_ANDROID) entries.filter { it != LOCAL } else entries.toList()
+                var result = entries.toList()
                 if (!PrefManager.showRecommendations) result = result.filter { it != RECOMMENDED }
                 return result
             }

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -1,6 +1,7 @@
 package app.gamenative.ui.model
 
 import android.content.Context
+import android.net.Uri
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -45,6 +46,7 @@ import app.gamenative.ui.enums.LibraryTab.Companion.next
 import app.gamenative.ui.enums.LibraryTab.Companion.previous
 import app.gamenative.ui.enums.SortOption
 import app.gamenative.ui.util.SnackbarManager
+import app.gamenative.utils.CustomGameImporter
 import app.gamenative.utils.CustomGameScanner
 import app.gamenative.data.RecommendationRepository
 import app.gamenative.data.RecommendedGame
@@ -503,6 +505,37 @@ class LibraryViewModel @Inject constructor(
                 if (usesStats(_state.value)) {
                     onFilterApps(paginationCurrentPage)
                 }
+            }
+        }
+    }
+
+    data class CustomGameImportState(
+        val isImporting: Boolean = false,
+        val progress: CustomGameImporter.Progress? = null,
+    )
+
+    private val _importState = MutableStateFlow(CustomGameImportState())
+    val importState: StateFlow<CustomGameImportState> = _importState.asStateFlow()
+
+    // Runs in viewModelScope so the copy survives configuration changes; a scope tied to the
+    // composition would abort a "remove original" import partway through the move
+    fun importCustomGame(uri: Uri, removeOriginal: Boolean) {
+        if (_importState.value.isImporting) return
+        _importState.value = CustomGameImportState(isImporting = true)
+        viewModelScope.launch(Dispatchers.IO) {
+            var lastShown = 0L
+            val result = CustomGameImporter.importFromTreeUri(context, uri, removeOriginal) { progress ->
+                if (progress.copiedBytes - lastShown > 8_000_000L) {
+                    lastShown = progress.copiedBytes
+                    _importState.value = CustomGameImportState(isImporting = true, progress = progress)
+                }
+            }
+            _importState.value = CustomGameImportState()
+            result.onSuccess { path ->
+                addCustomGameFolder(path)
+                SnackbarManager.show(context.getString(R.string.custom_game_import_success))
+            }.onFailure {
+                SnackbarManager.show(context.getString(R.string.custom_game_import_failed))
             }
         }
     }

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -10,8 +10,10 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -33,6 +35,7 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SheetState
@@ -49,6 +52,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -109,6 +113,7 @@ import app.gamenative.ui.util.PlatformLogoutCallbacks
 import app.gamenative.service.amazon.AmazonService
 import app.gamenative.service.epic.EpicService
 import app.gamenative.service.gog.GOGService
+import app.gamenative.utils.CustomGameImporter
 import app.gamenative.utils.CustomGameScanner
 import app.gamenative.utils.PlatformOAuthHandlers
 import app.gamenative.utils.SteamUtils
@@ -473,9 +478,44 @@ private fun LibraryScreenContent(
         },
     )
 
+    // Modern add path: import the picked folder into app-owned storage via the SAF grant,
+    // since the map-in-place flow needs MANAGE_EXTERNAL_STORAGE
+    val importScope = rememberCoroutineScope()
+    var importProgress by remember { mutableStateOf<CustomGameImporter.Progress?>(null) }
+    var isImporting by remember { mutableStateOf(false) }
+    var showModernImportDialog by remember { mutableStateOf(false) }
+    var importRemoveOriginal by remember { mutableStateOf(false) }
+    val importLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree(),
+    ) { uri ->
+        if (uri != null) {
+            isImporting = true
+            importProgress = null
+            importScope.launch {
+                var lastShown = 0L
+                val result = CustomGameImporter.importFromTreeUri(context, uri, importRemoveOriginal) { progress ->
+                    if (progress.copiedBytes - lastShown > 8_000_000L) {
+                        lastShown = progress.copiedBytes
+                        importProgress = progress
+                    }
+                }
+                isImporting = false
+                importProgress = null
+                result.onSuccess { path ->
+                    onAddCustomGameFolder(path)
+                    SnackbarManager.show(context.getString(R.string.custom_game_import_success))
+                }.onFailure {
+                    SnackbarManager.show(context.getString(R.string.custom_game_import_failed))
+                }
+            }
+        }
+    }
+
     // Handle opening folder picker (with dialog check)
     val onAddCustomGameClick = {
-        if (PrefManager.showAddCustomGameDialog) {
+        if (BuildConfig.MODERN_ANDROID) {
+            showModernImportDialog = true
+        } else if (PrefManager.showAddCustomGameDialog) {
             showAddCustomGameDialog = true
         } else {
             folderPicker.launchPicker()
@@ -874,7 +914,7 @@ private fun LibraryScreenContent(
 
                         // X button - add custom game
                         KeyEvent.KEYCODE_BUTTON_X -> {
-                            if (!BuildConfig.MODERN_ANDROID && selectedAppId == null && !state.isSearching && !state.isOptionsPanelOpen && !isSystemMenuOpen) {
+                            if (selectedAppId == null && !state.isSearching && !state.isOptionsPanelOpen && !isSystemMenuOpen) {
                                 onAddCustomGameClick()
                                 true
                             } else {
@@ -1144,17 +1184,13 @@ private fun LibraryScreenContent(
                         labelResId = R.string.search,
                         onClick = { onIsSearching(true) },
                     ),
-                ) + if (!BuildConfig.MODERN_ANDROID) {
-                    listOf(
-                        GamepadAction(
-                            button = GamepadButton.X,
-                            labelResId = R.string.action_add_game,
-                            onClick = onAddCustomGameClick,
-                        ),
-                    )
-                } else {
-                    emptyList()
-                }
+                ) + listOf(
+                    GamepadAction(
+                        button = GamepadButton.X,
+                        labelResId = R.string.action_add_game,
+                        onClick = onAddCustomGameClick,
+                    ),
+                )
             }
 
             GamepadActionBar(
@@ -1235,6 +1271,67 @@ private fun LibraryScreenContent(
                         callbacks = PlatformLogoutCallbacks(),
                     )
                 },
+            )
+        }
+
+        // Pre-import dialog (modern add path)
+        if (showModernImportDialog) {
+            AlertDialog(
+                onDismissRequest = { showModernImportDialog = false },
+                title = { Text(stringResource(R.string.add_custom_game_dialog_title)) },
+                text = {
+                    Column {
+                        Text(stringResource(R.string.custom_game_import_dialog_message))
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.clickable { importRemoveOriginal = !importRemoveOriginal },
+                        ) {
+                            Checkbox(
+                                checked = importRemoveOriginal,
+                                onCheckedChange = { importRemoveOriginal = it },
+                            )
+                            Text(stringResource(R.string.custom_game_import_remove_original))
+                        }
+                    }
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            showModernImportDialog = false
+                            importLauncher.launch(null)
+                        },
+                    ) {
+                        Text(stringResource(R.string.continue_action))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showModernImportDialog = false }) {
+                        Text(stringResource(R.string.cancel))
+                    }
+                },
+            )
+        }
+
+        // Import progress dialog (modern add path)
+        if (isImporting) {
+            AlertDialog(
+                onDismissRequest = { },
+                title = { Text(stringResource(R.string.custom_game_importing)) },
+                text = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        CircularProgressIndicator()
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Column {
+                            val mb = (importProgress?.copiedBytes ?: 0L) / 1_000_000L
+                            Text("$mb MB")
+                            importProgress?.currentFile?.let {
+                                Text(text = it, maxLines = 1)
+                            }
+                        }
+                    }
+                },
+                confirmButton = { },
             )
         }
 

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -2,6 +2,7 @@ package app.gamenative.ui.screen.library
 
 import android.content.Intent
 import android.content.res.Configuration
+import android.net.Uri
 import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -52,7 +53,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -113,7 +114,6 @@ import app.gamenative.ui.util.PlatformLogoutCallbacks
 import app.gamenative.service.amazon.AmazonService
 import app.gamenative.service.epic.EpicService
 import app.gamenative.service.gog.GOGService
-import app.gamenative.utils.CustomGameImporter
 import app.gamenative.utils.CustomGameScanner
 import app.gamenative.utils.PlatformOAuthHandlers
 import app.gamenative.utils.SteamUtils
@@ -135,10 +135,13 @@ fun HomeLibraryScreen(
     isSteamConnected: Boolean = false,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val importState by viewModel.importState.collectAsStateWithLifecycle()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     LibraryScreenContent(
         state = state,
+        importState = importState,
+        onImportCustomGame = viewModel::importCustomGame,
         listState = viewModel.listState,
         sheetState = sheetState,
         onFilterChanged = viewModel::onFilterChanged,
@@ -182,6 +185,8 @@ private fun LibraryScreenContent(
     state: LibraryState,
     listState: LazyGridState,
     sheetState: SheetState,
+    importState: LibraryViewModel.CustomGameImportState = LibraryViewModel.CustomGameImportState(),
+    onImportCustomGame: (Uri, Boolean) -> Unit = { _, _ -> },
     onFilterChanged: (AppFilter) -> Unit,
     onPageChange: (Int) -> Unit,
     onModalBottomSheet: (Boolean) -> Unit,
@@ -480,34 +485,13 @@ private fun LibraryScreenContent(
 
     // Modern add path: import the picked folder into app-owned storage via the SAF grant,
     // since the map-in-place flow needs MANAGE_EXTERNAL_STORAGE
-    val importScope = rememberCoroutineScope()
-    var importProgress by remember { mutableStateOf<CustomGameImporter.Progress?>(null) }
-    var isImporting by remember { mutableStateOf(false) }
     var showModernImportDialog by remember { mutableStateOf(false) }
-    var importRemoveOriginal by remember { mutableStateOf(false) }
+    var importRemoveOriginal by rememberSaveable { mutableStateOf(false) }
     val importLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocumentTree(),
     ) { uri ->
         if (uri != null) {
-            isImporting = true
-            importProgress = null
-            importScope.launch {
-                var lastShown = 0L
-                val result = CustomGameImporter.importFromTreeUri(context, uri, importRemoveOriginal) { progress ->
-                    if (progress.copiedBytes - lastShown > 8_000_000L) {
-                        lastShown = progress.copiedBytes
-                        importProgress = progress
-                    }
-                }
-                isImporting = false
-                importProgress = null
-                result.onSuccess { path ->
-                    onAddCustomGameFolder(path)
-                    SnackbarManager.show(context.getString(R.string.custom_game_import_success))
-                }.onFailure {
-                    SnackbarManager.show(context.getString(R.string.custom_game_import_failed))
-                }
-            }
+            onImportCustomGame(uri, importRemoveOriginal)
         }
     }
 
@@ -1314,7 +1298,7 @@ private fun LibraryScreenContent(
         }
 
         // Import progress dialog (modern add path)
-        if (isImporting) {
+        if (importState.isImporting) {
             AlertDialog(
                 onDismissRequest = { },
                 title = { Text(stringResource(R.string.custom_game_importing)) },
@@ -1323,9 +1307,9 @@ private fun LibraryScreenContent(
                         CircularProgressIndicator()
                         Spacer(modifier = Modifier.width(16.dp))
                         Column {
-                            val mb = (importProgress?.copiedBytes ?: 0L) / 1_000_000L
+                            val mb = (importState.progress?.copiedBytes ?: 0L) / 1_000_000L
                             Text("$mb MB")
-                            importProgress?.currentFile?.let {
+                            importState.progress?.currentFile?.let {
                                 Text(text = it, maxLines = 1)
                             }
                         }

--- a/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/appscreen/CustomGameAppScreen.kt
@@ -440,6 +440,7 @@ class CustomGameAppScreen : BaseAppScreen() {
         libraryItem: LibraryItem,
     ): List<AppMenuOption> {
         return listOfNotNull(
+            getUseKnownConfigOption(context, libraryItem),
             getExportConfigOption(context, libraryItem),
             getImportConfigOption(context, libraryItem),
         )
@@ -516,6 +517,9 @@ class CustomGameAppScreen : BaseAppScreen() {
                                         val folderPath = CustomGameScanner.getFolderPathFromAppId(libraryItem.appId)
                                         cleanupNexusModsForApp(context, libraryItem, folderPath?.let(::File))
                                         if (folderPath != null) {
+                                            if (CustomGameScanner.isManagedFolder(folderPath)) {
+                                                File(folderPath).deleteRecursively()
+                                            }
                                             val manualFolders = PrefManager.customGameManualFolders.toMutableSet()
                                             manualFolders.remove(folderPath)
                                             PrefManager.customGameManualFolders = manualFolders

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryTabBar.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryTabBar.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import app.gamenative.BuildConfig
 import app.gamenative.R
 import app.gamenative.ui.component.focusRing
 import app.gamenative.ui.enums.LibraryTab
@@ -270,13 +269,11 @@ private fun CompactLibraryTabBar(
                 contentDescription = stringResource(R.string.search),
                 onClick = onSearchClick,
             )
-            if (!BuildConfig.MODERN_ANDROID) {
-                CompactIconButton(
-                    icon = Icons.Default.Add,
-                    contentDescription = stringResource(R.string.action_add_game),
-                    onClick = onAddGameClick,
-                )
-            }
+            CompactIconButton(
+                icon = Icons.Default.Add,
+                contentDescription = stringResource(R.string.action_add_game),
+                onClick = onAddGameClick,
+            )
             CompactIconButton(
                 icon = Icons.Default.Menu,
                 contentDescription = stringResource(R.string.menu),
@@ -491,13 +488,11 @@ private fun ExpandedLibraryTabBar(
                 onClick = onSearchClick,
             )
 
-            if (!BuildConfig.MODERN_ANDROID) {
-                IconActionButton(
-                    icon = Icons.Default.Add,
-                    contentDescription = stringResource(R.string.action_add_game),
-                    onClick = onAddGameClick,
-                )
-            }
+            IconActionButton(
+                icon = Icons.Default.Add,
+                contentDescription = stringResource(R.string.action_add_game),
+                onClick = onAddGameClick,
+            )
 
             IconActionButton(
                 icon = Icons.Default.Menu,

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -1230,10 +1230,8 @@ object ContainerUtils {
         GameSource.GOG,
         GameSource.EPIC,
         GameSource.AMAZON,
-        -> true
-
         GameSource.CUSTOM_GAME,
-        -> false
+        -> true
     }
 
     /**

--- a/app/src/main/java/app/gamenative/utils/CustomGameImporter.kt
+++ b/app/src/main/java/app/gamenative/utils/CustomGameImporter.kt
@@ -1,0 +1,123 @@
+package app.gamenative.utils
+
+import android.content.Context
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.File
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Imports a user-picked folder (a SAF tree URI from OpenDocumentTree) into
+ * [CustomGameScanner.importRootPath], needing only the picker grant. The bytes must pass
+ * through this app for wine to be able to read them under scoped storage, so a "move" is
+ * per-file copy + verify + delete-source rather than a rename.
+ */
+object CustomGameImporter {
+
+    data class Progress(val copiedBytes: Long, val currentFile: String)
+
+    /**
+     * @param deleteSource delete each source file once its copy verifies (move semantics)
+     * @return the absolute path of the imported folder on success.
+     */
+    suspend fun importFromTreeUri(
+        context: Context,
+        treeUri: Uri,
+        deleteSource: Boolean,
+        onProgress: (Progress) -> Unit = {},
+    ): Result<String> = withContext(Dispatchers.IO) {
+        try {
+            val src = DocumentFile.fromTreeUri(context, treeUri)
+            if (src == null || !src.isDirectory) {
+                return@withContext Result.failure(IllegalArgumentException("Selected item is not a folder"))
+            }
+
+            val importRoot = CustomGameScanner.importRootPath
+            val name = sanitizeName(src.name)
+            var dest = File(importRoot, name)
+            var suffix = 1
+            while (dest.exists()) {
+                dest = File(importRoot, "$name ($suffix)")
+                suffix++
+            }
+            dest.mkdirs()
+
+            var copied = 0L
+            moveTree(context, src, dest, deleteSource) { bytes, fileName ->
+                copied += bytes
+                onProgress(Progress(copied, fileName))
+            }
+            if (deleteSource) {
+                if (!src.delete()) {
+                    Timber.tag("CustomGameImporter").w("Could not remove source root ${src.uri}")
+                }
+            }
+
+            Timber.tag("CustomGameImporter").d("Imported ${src.name} to ${dest.path} ($copied bytes, move=$deleteSource)")
+            Result.success(dest.absolutePath)
+        } catch (e: Exception) {
+            // Keep the destination: with deleteSource, already-moved files exist only there
+            Timber.tag("CustomGameImporter").e(e, "Import failed")
+            Result.failure(e)
+        }
+    }
+
+    private suspend fun moveTree(
+        context: Context,
+        src: DocumentFile,
+        dest: File,
+        deleteSource: Boolean,
+        onBytes: (Long, String) -> Unit,
+    ) {
+        for (child in src.listFiles()) {
+            coroutineContext.ensureActive()
+            val childName = sanitizeName(child.name)
+            if (child.isDirectory) {
+                val subDir = File(dest, childName)
+                subDir.mkdirs()
+                moveTree(context, child, subDir, deleteSource, onBytes)
+                if (deleteSource && !child.delete()) {
+                    Timber.tag("CustomGameImporter").w("Could not remove source folder ${child.uri}")
+                }
+            } else {
+                val expected = child.length()
+                val outFile = File(dest, childName)
+                var written = 0L
+                val input = context.contentResolver.openInputStream(child.uri)
+                if (input == null) {
+                    throw java.io.IOException("Could not open ${child.uri}")
+                }
+                input.use { ins ->
+                    outFile.outputStream().use { output ->
+                        val buf = ByteArray(1 shl 16)
+                        while (true) {
+                            coroutineContext.ensureActive()
+                            val n = ins.read(buf)
+                            if (n < 0) break
+                            output.write(buf, 0, n)
+                            written += n
+                            onBytes(n.toLong(), childName)
+                        }
+                    }
+                }
+                if (expected > 0 && written != expected) {
+                    outFile.delete()
+                    throw java.io.IOException("Size mismatch for $childName: $written of $expected bytes")
+                }
+                if (deleteSource && !child.delete()) {
+                    Timber.tag("CustomGameImporter").w("Could not delete source file ${child.uri}")
+                }
+            }
+        }
+    }
+
+    /** Strips path separators and blank names so a document name can't escape the sandbox. */
+    private fun sanitizeName(raw: String?): String {
+        val cleaned = raw?.replace('/', '_')?.replace('\\', '_')?.trim()
+        return if (cleaned.isNullOrEmpty() || cleaned == "." || cleaned == "..") "ImportedGame" else cleaned
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
+++ b/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
@@ -71,6 +71,51 @@ object CustomGameScanner {
         }
 
     /**
+     * Destination for imported custom games: CustomGames under the public install root of the
+     * configured install volume, falling back to the app sandbox.
+     */
+    val importRootPath: String
+        get() {
+            val external = PrefManager.externalStoragePath
+            if (PrefManager.useExternalStorage && external.isNotBlank() && File(external).isDirectory) {
+                val dir = File(external, "CustomGames")
+                if (StorageUtils.ensureInstallRoot(dir)) return dir.absolutePath
+            }
+            val appDir = DownloadService.baseExternalAppDirPath
+            if (appDir.isNotEmpty()) {
+                val publicRoot = StorageUtils.publicInstallRoot(File(appDir))
+                if (publicRoot != null) {
+                    val dir = File(publicRoot, "CustomGames")
+                    if (StorageUtils.ensureInstallRoot(dir)) return dir.absolutePath
+                }
+            }
+            return defaultRootPath
+        }
+
+    /**
+     * Roots whose immediate subfolders are treated as custom games: the public GameNative
+     * roots on every volume plus the app's own sandbox folders.
+     */
+    val scanRootPaths: List<String>
+        get() {
+            val roots = LinkedHashSet<String>()
+            val appDir = DownloadService.baseExternalAppDirPath
+            if (appDir.isNotEmpty()) {
+                StorageUtils.publicInstallRoot(File(appDir))?.let { roots.add(File(it, "CustomGames").absolutePath) }
+                roots.add(File(appDir, "CustomGames").absolutePath)
+            }
+            val external = PrefManager.externalStoragePath
+            if (external.isNotBlank()) {
+                roots.add(File(external, "CustomGames").absolutePath)
+            }
+            DownloadService.externalVolumePaths
+                .filterNot { it.contains("/Android/data/") }
+                .forEach { roots.add(File(it, "CustomGames").absolutePath) }
+            roots.add(File(DownloadService.baseDataDirPath, "CustomGames").absolutePath)
+            return roots.toList()
+        }
+
+    /**
      * Ensures the default CustomGames folder exists by creating it if it doesn't.
      * This should be called when the library screen loads to guarantee the folder exists
      * even if there are no custom games yet.
@@ -513,25 +558,39 @@ object CustomGameScanner {
         val items = mutableListOf<LibraryItem>()
         var indexCounter = indexOffsetStart
         val q = query.trim()
+        val existingAppIds = mutableSetOf<String>()
 
-        val manualFolders = PrefManager.customGameManualFolders
-        if (manualFolders.isNotEmpty()) {
-            val existingAppIds = mutableSetOf<String>()
-            for (manualPath in manualFolders) {
-                // Filter by query if provided
-                if (q.isNotEmpty()) {
-                    val folderName = File(manualPath).name
-                    if (!folderName.contains(q, ignoreCase = true)) continue
-                }
+        for (folderPath in candidateFolders()) {
+            // Filter by query if provided
+            if (q.isNotEmpty()) {
+                val folderName = File(folderPath).name
+                if (!folderName.contains(q, ignoreCase = true)) continue
+            }
 
-                val manualItem = createLibraryItemFromFolder(manualPath)
-                if (manualItem != null && existingAppIds.add(manualItem.appId)) {
-                    items.add(manualItem.copy(index = indexCounter++))
-                }
+            val item = createLibraryItemFromFolder(folderPath)
+            if (item != null && existingAppIds.add(item.appId)) {
+                items.add(item.copy(index = indexCounter++))
             }
         }
 
         return items
+    }
+
+    /**
+     * Whether [folderPath] is inside an app-managed CustomGames root and therefore ours to
+     * delete when the game is removed, unlike folders mapped in place.
+     */
+    fun isManagedFolder(folderPath: String): Boolean =
+        scanRootPaths.any { folderPath.startsWith("$it/") }
+
+    /** Manually added folders plus every immediate subfolder of the scan roots. */
+    private fun candidateFolders(): Set<String> {
+        val folders = LinkedHashSet<String>()
+        folders.addAll(PrefManager.customGameManualFolders)
+        for (root in scanRootPaths) {
+            File(root).listFiles { f -> f.isDirectory }?.forEach { folders.add(it.absolutePath) }
+        }
+        return folders
     }
 
     private fun handleCustomGameDetection(folder: File, appId: String, idPart: Int) {
@@ -671,7 +730,7 @@ object CustomGameScanner {
      */
     private fun getOrRebuildCache(): Map<Int, String> {
         return CustomGameCache.getOrRebuildCache(
-            getManualFolders = { PrefManager.customGameManualFolders },
+            getManualFolders = { candidateFolders() },
             readGameIdFromFile = { folder -> readGameIdFromFile(folder) },
         )
     }

--- a/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
+++ b/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
@@ -759,17 +759,25 @@ object CustomGameScanner {
      * If generated, stores it in the file for future use.
      */
     private fun getOrGenerateGameId(folder: File): Int {
-        // First, try to read from .gamenative file
+        // Use the stored id unless another live folder owns it, e.g. an imported copy whose
+        // .gamenative was copied along with the game files
         val storedId = readGameIdFromFile(folder)
         if (storedId != null) {
-            return storedId
+            val owner = getOrRebuildCache()[storedId]
+            if (owner == null || owner == folder.absolutePath || !File(owner).isDirectory) {
+                return storedId
+            }
         }
 
-        // If not found, generate from folder name (same logic as before)
         var candidateId = abs(folder.absolutePath.hashCode()).let { if (it == 0) 1 else it }
 
-        // Check for collisions and make it unique if needed
-        val existingIds = getAllExistingGameIds(excludeFolder = folder)
+        // On a stored-id collision the colliding id must stay reserved for its owner, so
+        // nothing is excluded from the taken set
+        val existingIds = if (storedId != null) {
+            getOrRebuildCache().keys.toSet()
+        } else {
+            getAllExistingGameIds(excludeFolder = folder)
+        }
         if (candidateId in existingIds) {
             // ID collision detected, find a unique ID by incrementing
             Timber.tag("CustomGameScanner").d("ID collision detected for ${folder.absolutePath}: $candidateId, finding unique ID")

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1238,6 +1238,11 @@
     <string name="add_custom_game_content_desc">Tilføj tilpasset spil</string>
     <string name="add_custom_game_dialog_title">Tilføj tilpasset spil</string>
     <string name="add_custom_game_dialog_message">Vælg venligst mappen der indeholder spilfilerne du vil tilføje som et tilpasset spil.</string>
+    <string name="custom_game_importing">Importerer spil…</string>
+    <string name="custom_game_import_success">Spil importeret</string>
+    <string name="custom_game_import_failed">Import mislykkedes</string>
+    <string name="custom_game_import_dialog_message">Vælg mappen der indeholder spillet. Det importeres til GameNatives lager, så det kan køre uden nogen lagertilladelse. Store spil kan tage et par minutter.</string>
+    <string name="custom_game_import_remove_original">Fjern originalen efter import</string>
     <string name="add_custom_game_dont_show_again">Vis ikke denne dialog igen</string>
     <string name="base_app_shortcut_created">Genvej oprettet</string>
     <string name="base_app_shortcut_failed">Kunne ikke oprette genvej: %s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -573,6 +573,11 @@
     <string name="add_custom_game_content_desc">Eigenes Spiel hinzufügen</string>
     <string name="add_custom_game_dialog_title">Eigenes Spiel hinzufügen</string>
     <string name="add_custom_game_dialog_message">Bitte wähle den Ordner aus, der die Spieldateien enthält, die du als eigenes Spiel hinzufügen möchtest.</string>
+    <string name="custom_game_importing">Spiel wird importiert…</string>
+    <string name="custom_game_import_success">Spiel importiert</string>
+    <string name="custom_game_import_failed">Import fehlgeschlagen</string>
+    <string name="custom_game_import_dialog_message">Wähle den Ordner aus, der das Spiel enthält. Es wird in den Speicher von GameNative importiert, damit es ohne Speicherberechtigung laufen kann. Bei großen Spielen kann das einige Minuten dauern.</string>
+    <string name="custom_game_import_remove_original">Original nach dem Import entfernen</string>
     <string name="add_custom_game_dont_show_again">Diesen Hinweis nicht mehr anzeigen</string>
     <string name="base_app_shortcut_created">Verknüpfung erstellt</string>
     <string name="base_app_shortcut_failed">Verknüpfung konnte nicht erstellt werden: %s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -632,6 +632,11 @@
     <string name="add_custom_game_content_desc">Añadir juego personalizado</string>
     <string name="add_custom_game_dialog_title">Añadir juego personalizado</string>
     <string name="add_custom_game_dialog_message">Selecciona la carpeta que contiene los archivos del juego que quieres añadir como juego personalizado.</string>
+    <string name="custom_game_importing">Importando juego…</string>
+    <string name="custom_game_import_success">Juego importado</string>
+    <string name="custom_game_import_failed">Error al importar</string>
+    <string name="custom_game_import_dialog_message">Selecciona la carpeta que contiene el juego. Se importará al almacenamiento de GameNative para que pueda ejecutarse sin ningún permiso de almacenamiento. Los juegos grandes pueden tardar unos minutos.</string>
+    <string name="custom_game_import_remove_original">Eliminar el original tras la importación</string>
     <string name="add_custom_game_dont_show_again">No volver a mostrar este diálogo.</string>
     <string name="base_app_shortcut_created">Acceso directo creado.</string>
     <string name="base_app_shortcut_failed">Error al crear el acceso directo: %s.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -588,6 +588,11 @@
     <string name="add_custom_game_content_desc">Ajouter un jeu personnalisé</string>
     <string name="add_custom_game_dialog_title">Ajouter un jeu personnalisé</string>
     <string name="add_custom_game_dialog_message">Veuillez sélectionner le dossier contenant les fichiers du jeu que vous souhaitez ajouter comme jeu personnalisé.</string>
+    <string name="custom_game_importing">Importation du jeu…</string>
+    <string name="custom_game_import_success">Jeu importé</string>
+    <string name="custom_game_import_failed">Échec de l\'importation</string>
+    <string name="custom_game_import_dialog_message">Sélectionnez le dossier contenant le jeu. Il sera importé dans le stockage de GameNative afin de pouvoir fonctionner sans aucune permission de stockage. Les jeux volumineux peuvent prendre quelques minutes.</string>
+    <string name="custom_game_import_remove_original">Supprimer l\'original après l\'importation</string>
     <string name="add_custom_game_dont_show_again">Ne plus afficher ce dialogue</string>
     <string name="base_app_shortcut_created">Raccourci créé</string>
     <string name="base_app_shortcut_failed">Échec de la création du raccourci : %s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -588,6 +588,11 @@
     <string name="add_custom_game_content_desc">Aggiungi gioco personalizzato</string>
     <string name="add_custom_game_dialog_title">Aggiungi Gioco Personalizzato</string>
     <string name="add_custom_game_dialog_message">Seleziona la cartella contenente i file del gioco che vuoi aggiungere come gioco personalizzato.</string>
+    <string name="custom_game_importing">Importazione del gioco…</string>
+    <string name="custom_game_import_success">Gioco importato</string>
+    <string name="custom_game_import_failed">Importazione non riuscita</string>
+    <string name="custom_game_import_dialog_message">Seleziona la cartella contenente il gioco. Verrà importato nell\'archivio di GameNative così da poter funzionare senza alcun permesso di archiviazione. I giochi di grandi dimensioni possono richiedere alcuni minuti.</string>
+    <string name="custom_game_import_remove_original">Rimuovi l\'originale dopo l\'importazione</string>
     <string name="add_custom_game_dont_show_again">Non mostrare più questa finestra</string>
     <string name="base_app_shortcut_created">Scorciatoia creata</string>
     <string name="base_app_shortcut_failed">Impossibile creare scorciatoia: %s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -598,6 +598,11 @@
     <string name="add_custom_game_content_desc">カスタムゲームを追加する</string>
     <string name="add_custom_game_dialog_title">カスタムゲームを追加</string>
     <string name="add_custom_game_dialog_message">カスタム ゲームとして追加するゲーム ファイルが含まれるフォルダーを選択してください。</string>
+    <string name="custom_game_importing">ゲームをインポート中…</string>
+    <string name="custom_game_import_success">ゲームをインポートしました</string>
+    <string name="custom_game_import_failed">インポートに失敗しました</string>
+    <string name="custom_game_import_dialog_message">ゲームが含まれるフォルダーを選択してください。ストレージ権限なしで実行できるように、GameNative のストレージにインポートされます。大きなゲームは数分かかる場合があります。</string>
+    <string name="custom_game_import_remove_original">インポート後に元のファイルを削除</string>
     <string name="add_custom_game_dont_show_again">\'このダイアログを再度表示しないでください</string>
     <string name="base_app_shortcut_created">ショートカットが作成されました</string>
     <string name="base_app_shortcut_failed">ショートカットの作成に失敗しました: %s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -594,6 +594,11 @@
     <string name="add_custom_game_content_desc">커스텀 게임 추가</string>
     <string name="add_custom_game_dialog_title">커스텀 게임 추가</string>
     <string name="add_custom_game_dialog_message">커스텀 게임으로 추가할 게임 파일이 있는 폴더를 선택하세요.</string>
+    <string name="custom_game_importing">게임 가져오는 중…</string>
+    <string name="custom_game_import_success">게임을 가져왔습니다</string>
+    <string name="custom_game_import_failed">가져오기 실패</string>
+    <string name="custom_game_import_dialog_message">게임이 있는 폴더를 선택하세요. 저장소 권한 없이 실행할 수 있도록 GameNative 저장소로 가져옵니다. 용량이 큰 게임은 몇 분 정도 걸릴 수 있습니다.</string>
+    <string name="custom_game_import_remove_original">가져온 후 원본 삭제</string>
     <string name="add_custom_game_dont_show_again">이 대화상자 다시 표시 안 함</string>
     <string name="base_app_shortcut_created">바로가기가 생성되었습니다</string>
     <string name="base_app_shortcut_failed">바로가기 생성 실패: %s</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -596,6 +596,11 @@
     <string name="add_custom_game_content_desc">Dodaj własną grę</string>
     <string name="add_custom_game_dialog_title">Dodaj własną grę</string>
     <string name="add_custom_game_dialog_message">Wybierz folder zawierający pliki gry, którą chcesz dodać jako własną grę.</string>
+    <string name="custom_game_importing">Importowanie gry…</string>
+    <string name="custom_game_import_success">Grę zaimportowano</string>
+    <string name="custom_game_import_failed">Import nie powiódł się</string>
+    <string name="custom_game_import_dialog_message">Wybierz folder zawierający grę. Zostanie ona zaimportowana do pamięci GameNative, aby mogła działać bez żadnych uprawnień do pamięci. Duże gry mogą zająć kilka minut.</string>
+    <string name="custom_game_import_remove_original">Usuń oryginał po imporcie</string>
     <string name="add_custom_game_dont_show_again">Nie pokazuj tego ponownie</string>
     <string name="base_app_shortcut_created">Utworzono skrót</string>
     <string name="base_app_shortcut_failed">Nie udało się utworzyć skrótu: %s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1238,6 +1238,11 @@
     <string name="add_custom_game_content_desc">Adicionar jogo personalizado</string>
     <string name="add_custom_game_dialog_title">Adicionar jogo personalizado</string>
     <string name="add_custom_game_dialog_message">Por favor, selecione a pasta contendo os arquivos do jogo que você deseja adicionar como um jogo personalizado.</string>
+    <string name="custom_game_importing">Importando jogo…</string>
+    <string name="custom_game_import_success">Jogo importado</string>
+    <string name="custom_game_import_failed">Falha na importação</string>
+    <string name="custom_game_import_dialog_message">Selecione a pasta que contém o jogo. Ele será importado para o armazenamento do GameNative para poder rodar sem nenhuma permissão de armazenamento. Jogos grandes podem levar alguns minutos.</string>
+    <string name="custom_game_import_remove_original">Remover o original após a importação</string>
     <string name="add_custom_game_dont_show_again">Não mostrar este diálogo novamente</string>
     <string name="base_app_shortcut_created">Atalho criado</string>
     <string name="base_app_shortcut_failed">Falha ao criar atalho: %s</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -589,6 +589,11 @@
     <string name="add_custom_game_content_desc">Adaugă joc personalizat</string>
     <string name="add_custom_game_dialog_title">Adaugă joc personalizat</string>
     <string name="add_custom_game_dialog_message">Selectează folderul care conține fișierele jocului pe care vrei să-l adaugi ca joc personalizat.</string>
+    <string name="custom_game_importing">Se importă jocul…</string>
+    <string name="custom_game_import_success">Joc importat</string>
+    <string name="custom_game_import_failed">Importul a eșuat</string>
+    <string name="custom_game_import_dialog_message">Selectează folderul care conține jocul. Va fi importat în stocarea GameNative pentru a putea rula fără nicio permisiune de stocare. Jocurile mari pot dura câteva minute.</string>
+    <string name="custom_game_import_remove_original">Șterge originalul după import</string>
     <string name="add_custom_game_dont_show_again">Nu mai arăta acest dialog</string>
     <string name="base_app_shortcut_created">Shortcut creat</string>
     <string name="base_app_shortcut_failed">Nu s-a putut crea shortcut-ul: %s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -30,6 +30,11 @@
     <string name="add">Добавить</string>
     <string name="add_custom_game_content_desc">Добавить пользовательскую игру</string>
     <string name="add_custom_game_dialog_message">Пожалуйста, выберите папку, содержащую файлы игры, которые вы хотите добавить в качестве пользовательской игры.</string>
+    <string name="custom_game_importing">Импорт игры…</string>
+    <string name="custom_game_import_success">Игра импортирована</string>
+    <string name="custom_game_import_failed">Не удалось импортировать</string>
+    <string name="custom_game_import_dialog_message">Выберите папку с игрой. Она будет импортирована в хранилище GameNative, чтобы работать без разрешения на доступ к хранилищу. Импорт больших игр может занять несколько минут.</string>
+    <string name="custom_game_import_remove_original">Удалить оригинал после импорта</string>
     <string name="add_custom_game_dialog_title">Добавить пользовательскую игру</string>
     <string name="add_custom_game_dont_show_again">Не показывать этот диалог снова</string>
     <string name="add_drive">Добавить диск</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -583,6 +583,11 @@
     <string name="add_custom_game_content_desc">Додати власну гру</string>
     <string name="add_custom_game_dialog_title">Додати власну гру</string>
     <string name="add_custom_game_dialog_message">Будь ласка, виберіть папку з файлами гри, яку ви хочете додати як власну гру.</string>
+    <string name="custom_game_importing">Імпорт гри…</string>
+    <string name="custom_game_import_success">Гру імпортовано</string>
+    <string name="custom_game_import_failed">Не вдалося імпортувати</string>
+    <string name="custom_game_import_dialog_message">Виберіть папку з грою. Її буде імпортовано до сховища GameNative, щоб вона могла працювати без дозволу на доступ до сховища. Імпорт великих ігор може тривати кілька хвилин.</string>
+    <string name="custom_game_import_remove_original">Видалити оригінал після імпорту</string>
     <string name="add_custom_game_dont_show_again">Більше не показувати</string>
     <string name="base_app_shortcut_created">Ярлик створено</string>
     <string name="base_app_shortcut_failed">Не вдалося створити ярлик: %s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -578,6 +578,11 @@
     <string name="add_custom_game_content_desc">添加自定义游戏</string>
     <string name="add_custom_game_dialog_title">添加自定义游戏</string>
     <string name="add_custom_game_dialog_message">请选择包含您要添加为自定义游戏的文件夹</string>
+    <string name="custom_game_importing">正在导入游戏…</string>
+    <string name="custom_game_import_success">游戏已导入</string>
+    <string name="custom_game_import_failed">导入失败</string>
+    <string name="custom_game_import_dialog_message">请选择包含游戏的文件夹。游戏将被导入到 GameNative 的存储空间，无需任何存储权限即可运行。大型游戏可能需要几分钟。</string>
+    <string name="custom_game_import_remove_original">导入后删除原文件</string>
     <string name="add_custom_game_dont_show_again">不再显示</string>
     <string name="base_app_shortcut_created">快捷方式已创建</string>
     <string name="base_app_shortcut_failed">无法创建快捷方式：%s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -578,6 +578,11 @@
     <string name="add_custom_game_content_desc">添加自定義遊戲</string>
     <string name="add_custom_game_dialog_title">添加自定義遊戲</string>
     <string name="add_custom_game_dialog_message">請選擇包含您要添加為自定義遊戲的遊戲的文件夾</string>
+    <string name="custom_game_importing">正在匯入遊戲…</string>
+    <string name="custom_game_import_success">遊戲已匯入</string>
+    <string name="custom_game_import_failed">匯入失敗</string>
+    <string name="custom_game_import_dialog_message">請選擇包含遊戲的資料夾。遊戲將被匯入到 GameNative 的儲存空間，無需任何儲存權限即可執行。大型遊戲可能需要幾分鐘。</string>
+    <string name="custom_game_import_remove_original">匯入後刪除原始檔案</string>
     <string name="add_custom_game_dont_show_again">不再顯示</string>
     <string name="base_app_shortcut_created">已創建捷徑</string>
     <string name="base_app_shortcut_failed">無法創建捷徑：%s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -704,6 +704,11 @@
     <string name="add_custom_game_dialog_title">Add Custom Game</string>
     <string name="add_custom_game_dialog_message">Please select the folder containing the game files you want to add as a custom game.</string>
     <string name="add_custom_game_dont_show_again">Don\'t show this dialog again</string>
+    <string name="custom_game_importing">Importing game…</string>
+    <string name="custom_game_import_success">Game imported</string>
+    <string name="custom_game_import_failed">Import failed</string>
+    <string name="custom_game_import_dialog_message">Select the folder containing the game. It will be imported into GameNative\'s storage so it can run without any storage permission. Large games may take a few minutes.</string>
+    <string name="custom_game_import_remove_original">Remove original after import</string>
     <string name="base_app_shortcut_created">Shortcut created</string>
     <string name="base_app_shortcut_failed">Failed to create shortcut: %s</string>
     <string name="base_app_images_fetched">Images fetched successfully</string>


### PR DESCRIPTION
## Description
Adds a permission-free import flow: the folder picked via OpenDocumentTree is copied (optionally moved) into GameNative/CustomGames on the configured install volume, using public dirs to avoid the Android/data FUSE metadata penalty. The scanner discovers games in the managed roots on every volume plus the app sandbox, deleting a custom game removes managed folders from disk, and known configs now apply to custom games by folder name (auto and via the menu).

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable custom games on modern builds without all-files access by importing picked folders into app-managed storage. The import runs in the ViewModel so long copies and optional moves survive rotation.

- **New Features**
  - Import via system folder picker; copy or move into GameNative/CustomGames on the selected volume; runs in the ViewModel.
  - Show a pre-import dialog with “remove original” and a progress dialog during copy.
  - Discover games from managed roots on all volumes and the app sandbox; avoids Android/data paths.
  - Deleting a custom game also removes its managed folder; folders mapped in place are not touched.
  - Enable the Custom Games tab and Add button on all builds; gamepad X triggers Add.
  - Apply known configs to custom games by folder name (auto and from the app menu).
  - Add `androidx.documentfile:documentfile:1.0.1`.

- **Bug Fixes**
  - Reassign custom game IDs when an imported copy collides with an existing folder to avoid duplicates.

<sup>Written for commit bbd5f69a0d5b724be572d493dddd26b3d93711ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import custom games from selected folders on modern Android.
  * View import progress and success or failure feedback.
  * Optionally remove original files after a successful import.
  * Apply known configurations automatically to custom games.
  * Add games from all library layouts and supported input methods.
* **Improvements**
  * Detect custom games across supported storage locations.
  * Added safeguards for managed game folders.
  * Added localized import messaging in multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->