### PR TITLE
Create drive_c-mapped TMPDIR so Mono temp-file saves persist

### DIFF
--- a/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
@@ -251,6 +251,7 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
         envVars.put("HOME", imageFs.home_path);
         envVars.put("USER", ImageFs.USER);
         envVars.put("TMPDIR", rootDir.getPath() + "/usr/tmp");
+        new File(imageFs.home_path + "/.wine/drive_c" + rootDir.getPath() + "/usr/tmp").mkdirs();
         envVars.put("DISPLAY", ":0");
 
         String winePath = imageFs.getWinePath() + "/bin";

--- a/app/src/main/java/com/winlator/xenvironment/components/GlibcProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/GlibcProgramLauncherComponent.java
@@ -182,6 +182,7 @@ public class GlibcProgramLauncherComponent extends GuestProgramLauncherComponent
         envVars.put("HOME", imageFs.home_path);
         envVars.put("USER", ImageFs.USER);
         envVars.put("TMPDIR", imageFs.getRootDir().getPath() + "/tmp");
+        new File(imageFs.home_path + "/.wine/drive_c" + imageFs.getRootDir().getPath() + "/tmp").mkdirs();
         envVars.put("DISPLAY", ":0");
 
         String winePath = wineProfile == null ? imageFs.getWinePath() + "/bin"


### PR DESCRIPTION
## Description
Signy & Mino saves were getting lost because the temp dir was being checked under C drive by mono. Create the fake temp folder under C drive so that saves persist.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create a `drive_c`-mapped temp directory so Mono writes temp-file saves to a persistent path. Fixes lost saves for Signy & Mino by creating `TMPDIR` under `~/.wine/drive_c` for both the bionic and glibc launchers; addresses Linear issue 5a706b.

<sup>Written for commit 927cfbced3e24219ab9ac5be158e488ed3d90b09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved guest program launching by ensuring required Wine temporary directories are created automatically.
  - Increased launch reliability when configured temporary paths or Wine environments are missing their expected directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->