### PR TITLE
Fix mouse dragging in Crushed in Time

### DIFF
--- a/app/src/main/java/app/gamenative/gamefixes/GameInputCompatibility.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameInputCompatibility.kt
@@ -1,0 +1,15 @@
+package app.gamenative.gamefixes
+
+/** Input compatibility choices that must be active while a game is running. */
+object GameInputCompatibility {
+    private val mouseDragCompatibilityGames = setOf(
+        "STEAM_3858650", // Crushed in Time
+    )
+
+    /**
+     * Enables narrowly scoped XGE support and sub-pixel mouse-drag accumulation
+     * for games whose Windows pointer state diverges from the visible X11 cursor.
+     */
+    fun needsMouseDragCompatibility(appId: String, useGlibcContainer: Boolean): Boolean =
+        !useGlibcContainer && appId in mouseDragCompatibilityGames
+}

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -90,6 +90,7 @@ import app.gamenative.PrefManager
 import app.gamenative.SteamBootstrap
 import app.gamenative.data.GameSource
 import app.gamenative.gamefixes.GameFixesRegistry
+import app.gamenative.gamefixes.GameInputCompatibility
 import app.gamenative.data.LaunchInfo
 import app.gamenative.data.LibraryItem
 import app.gamenative.data.ShooterModeConfig
@@ -1812,11 +1813,16 @@ fun XServerScreen(
             performanceHudHost = frameLayout
             val appId = appId
             val usrGlibc: Boolean = container.getContainerVariant().equals(Container.GLIBC, ignoreCase = true)
+            val mouseDragCompatibility = GameInputCompatibility.needsMouseDragCompatibility(appId, usrGlibc)
             val existingXServer =
                 PluviaApp.xEnvironment
                     ?.getComponent<XServerComponent>(XServerComponent::class.java)
                     ?.xServer
-            val xServerToUse = existingXServer ?: XServer(ScreenInfo(xServerState.value.screenSize), usrGlibc)
+            val xServerToUse = existingXServer ?: XServer(
+                ScreenInfo(xServerState.value.screenSize),
+                usrGlibc,
+                mouseDragCompatibility,
+            )
             // VirGL containers always need GL (shared EGL context for the
             // VirGL passthrough). Default to the legacy GL renderer for all
             // other containers as well. Uncheck the per-container useLegacyRenderer

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -813,8 +813,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         dragButtonPressed = false;
         holdMouseButtonTouchActive = false;
         holdMouseButtonTouchAction = null;
-        relativeDragRemainderX = 0;
-        relativeDragRemainderY = 0;
+        resetRelativeDragRemainder();
         movedBeyondTapThreshold = false;
         multiFingerGestureUsed = false;
         twoFingerDragging = false;
@@ -1522,6 +1521,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         injectRelease(holdMouseButtonTouchAction);
         holdMouseButtonTouchActive = false;
         holdMouseButtonTouchAction = null;
+        resetRelativeDragRemainder();
     }
 
     private String getHoldMouseButtonTouchAction() {
@@ -1855,6 +1855,12 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     private void releaseAllDragButtons() {
         releaseTwoFingerMiddleButton();
         releaseClickDragButtons();
+        resetRelativeDragRemainder();
+    }
+
+    private void resetRelativeDragRemainder() {
+        relativeDragRemainderX = 0;
+        relativeDragRemainderY = 0;
     }
 
     private void performKeyPan(float dx, float dy, XKeycode leftKey, XKeycode rightKey, XKeycode upKey, XKeycode downKey) {

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -116,6 +116,8 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     private float touchDownRawX, touchDownRawY;
     // Last raw coordinates for single-finger drag delta
     private float singleFingerLastRawX, singleFingerLastRawY;
+    // Preserve transformed sub-pixel motion for the title-scoped relative-drag fix.
+    private float relativeDragRemainderX, relativeDragRemainderY;
     // Two-finger gesture mutual exclusion (only pan OR pinch, not both)
     private static final int TWO_FINGER_GESTURE_NONE = 0;
     private static final int TWO_FINGER_GESTURE_PAN = 1;
@@ -811,6 +813,8 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         dragButtonPressed = false;
         holdMouseButtonTouchActive = false;
         holdMouseButtonTouchAction = null;
+        relativeDragRemainderX = 0;
+        relativeDragRemainderY = 0;
         movedBeyondTapThreshold = false;
         multiFingerGestureUsed = false;
         twoFingerDragging = false;
@@ -1793,8 +1797,22 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     private void moveCursorByRelativeDelta(float dx, float dy) {
         float[] ptOrigin = XForm.transformPoint(xform, 0, 0);
         float[] ptDelta  = XForm.transformPoint(xform, dx, dy);
-        int mx = (int) (ptDelta[0] - ptOrigin[0]);
-        int my = (int) (ptDelta[1] - ptOrigin[1]);
+        float transformedDx = ptDelta[0] - ptOrigin[0];
+        float transformedDy = ptDelta[1] - ptOrigin[1];
+        int mx;
+        int my;
+        if (xServer.isMouseDragCompatibilityEnabled()) {
+            relativeDragRemainderX += transformedDx;
+            relativeDragRemainderY += transformedDy;
+            mx = (int) relativeDragRemainderX;
+            my = (int) relativeDragRemainderY;
+            relativeDragRemainderX -= mx;
+            relativeDragRemainderY -= my;
+            if (mx == 0 && my == 0) return;
+        } else {
+            mx = (int) transformedDx;
+            my = (int) transformedDy;
+        }
         if (xServer.isRelativeMouseMovement()) {
             xServer.getWinHandler().mouseEvent(MouseEventFlags.MOVE, mx, my, 0);
         } else {

--- a/app/src/main/java/com/winlator/xserver/XServer.java
+++ b/app/src/main/java/com/winlator/xserver/XServer.java
@@ -291,7 +291,7 @@ public class XServer {
         registerExtension(new PresentExtension(),   nextEventId, nextErrorId);
         registerExtension(new SyncExtension(),      nextEventId, nextErrorId);
         if (supportsXInput2(runningFromGlibc)) {
-            if (shouldAdvertiseGenericEvents(runningFromGlibc, mouseDragCompatibilityEnabled)) {
+            if (mouseDragCompatibilityEnabled) {
                 registerExtension(new GenericEventExtension(), nextEventId, nextErrorId);
             }
             registerExtension(new XInput2Extension(),   nextEventId, nextErrorId);

--- a/app/src/main/java/com/winlator/xserver/XServer.java
+++ b/app/src/main/java/com/winlator/xserver/XServer.java
@@ -10,6 +10,7 @@ import com.winlator.winhandler.WinHandler;
 import com.winlator.xserver.extensions.BigReqExtension;
 import com.winlator.xserver.extensions.DRI3Extension;
 import com.winlator.xserver.extensions.Extension;
+import com.winlator.xserver.extensions.GenericEventExtension;
 import com.winlator.xserver.extensions.MITSHMExtension;
 import com.winlator.xserver.extensions.PresentExtension;
 import com.winlator.xserver.extensions.SyncExtension;
@@ -44,10 +45,15 @@ public class XServer {
     private WinHandler winHandler;
     private final EnumMap<Lockable, ReentrantLock> locks = new EnumMap<>(Lockable.class);
     private boolean relativeMouseMovement = false;
+    private final boolean mouseDragCompatibilityEnabled;
     private boolean simulateTouchScreen = false;
-    private boolean runningFromGlibc = false;
+    private final boolean runningFromGlibc;
 
     public XServer(ScreenInfo screenInfo, boolean useGlibcContainer) {
+        this(screenInfo, useGlibcContainer, false);
+    }
+
+    public XServer(ScreenInfo screenInfo, boolean useGlibcContainer, boolean mouseDragCompatibilityEnabled) {
         Log.d("XServer", "Creating xServer " + screenInfo);
         this.screenInfo = screenInfo;
         for (Lockable lockable : Lockable.values()) locks.put(lockable, new ReentrantLock());
@@ -60,6 +66,10 @@ public class XServer {
         inputDeviceManager = new InputDeviceManager(this);
         grabManager = new GrabManager(this);
         runningFromGlibc = useGlibcContainer;
+        this.mouseDragCompatibilityEnabled = shouldAdvertiseGenericEvents(
+                useGlibcContainer,
+                mouseDragCompatibilityEnabled
+        );
 
         DesktopHelper.attachTo(this);
         setupExtensions();
@@ -71,6 +81,10 @@ public class XServer {
 
     public void setRelativeMouseMovement(boolean relativeMouseMovement) {
         this.relativeMouseMovement = relativeMouseMovement;
+    }
+
+    public boolean isMouseDragCompatibilityEnabled() {
+        return mouseDragCompatibilityEnabled;
     }
 
     public boolean isSimulateTouchScreen() { return simulateTouchScreen; }
@@ -276,8 +290,20 @@ public class XServer {
         registerExtension(new DRI3Extension(),      nextEventId, nextErrorId);
         registerExtension(new PresentExtension(),   nextEventId, nextErrorId);
         registerExtension(new SyncExtension(),      nextEventId, nextErrorId);
-        if (!runningFromGlibc)
+        if (supportsXInput2(runningFromGlibc)) {
+            if (shouldAdvertiseGenericEvents(runningFromGlibc, mouseDragCompatibilityEnabled)) {
+                registerExtension(new GenericEventExtension(), nextEventId, nextErrorId);
+            }
             registerExtension(new XInput2Extension(),   nextEventId, nextErrorId);
+        }
+    }
+
+    static boolean supportsXInput2(boolean useGlibcContainer) {
+        return !useGlibcContainer;
+    }
+
+    static boolean shouldAdvertiseGenericEvents(boolean useGlibcContainer, boolean mouseDragCompatibilityEnabled) {
+        return supportsXInput2(useGlibcContainer) && mouseDragCompatibilityEnabled;
     }
 
     public <T extends Extension> T getExtension(int opcode) {

--- a/app/src/main/java/com/winlator/xserver/extensions/GenericEventExtension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/GenericEventExtension.java
@@ -1,0 +1,73 @@
+package com.winlator.xserver.extensions;
+
+import static com.winlator.xserver.XClientRequestHandler.RESPONSE_CODE_SUCCESS;
+
+import com.winlator.xconnector.XInputStream;
+import com.winlator.xconnector.XOutputStream;
+import com.winlator.xconnector.XStreamLock;
+import com.winlator.xserver.XClient;
+import com.winlator.xserver.errors.BadImplementation;
+import com.winlator.xserver.errors.XRequestError;
+
+import java.io.IOException;
+
+/**
+ * Minimal X Generic Event Extension (XGE) 1.0 implementation.
+ *
+ * XInput2 transports its events through XGE. libXi will not initialize XI2 unless
+ * this extension is advertised and its single QueryVersion request succeeds.
+ */
+public class GenericEventExtension implements Extension {
+    public static final byte MAJOR_OPCODE = -106;
+    private static final int QUERY_VERSION = 0;
+    private static final int SERVER_MAJOR = 1;
+    private static final int SERVER_MINOR = 0;
+
+    @Override
+    public String getName() {
+        return "Generic Event Extension";
+    }
+
+    @Override
+    public byte getMajorOpcode() {
+        return MAJOR_OPCODE;
+    }
+
+    @Override
+    public byte getFirstErrorId() {
+        return 0;
+    }
+
+    @Override
+    public byte getFirstEventId() {
+        return 0;
+    }
+
+    @Override
+    public void handleRequest(XClient client, XInputStream inputStream, XOutputStream outputStream)
+            throws IOException, XRequestError {
+        if (client.getRequestData() != QUERY_VERSION) {
+            inputStream.skip(client.getRemainingRequestLength());
+            throw new BadImplementation();
+        }
+
+        int clientMajor = inputStream.readShort() & 0xffff;
+        int clientMinor = inputStream.readShort() & 0xffff;
+        inputStream.skip(client.getRemainingRequestLength());
+
+        int negotiatedMajor = Math.min(clientMajor, SERVER_MAJOR);
+        int negotiatedMinor = negotiatedMajor < SERVER_MAJOR
+                ? clientMinor
+                : Math.min(clientMinor, SERVER_MINOR);
+
+        try (XStreamLock lock = outputStream.lock()) {
+            outputStream.writeByte(RESPONSE_CODE_SUCCESS);
+            outputStream.writeByte((byte) 0);
+            outputStream.writeShort(client.getSequenceNumber());
+            outputStream.writeInt(0);
+            outputStream.writeShort((short) negotiatedMajor);
+            outputStream.writeShort((short) negotiatedMinor);
+            outputStream.writePad(20);
+        }
+    }
+}

--- a/app/src/test/java/app/gamenative/gamefixes/GameInputCompatibilityTest.kt
+++ b/app/src/test/java/app/gamenative/gamefixes/GameInputCompatibilityTest.kt
@@ -1,0 +1,23 @@
+package app.gamenative.gamefixes
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GameInputCompatibilityTest {
+    @Test
+    fun `Crushed in Time enables mouse drag compatibility in Bionic`() {
+        assertTrue(GameInputCompatibility.needsMouseDragCompatibility("STEAM_3858650", false))
+    }
+
+    @Test
+    fun `mouse drag compatibility remains disabled for other games`() {
+        assertFalse(GameInputCompatibility.needsMouseDragCompatibility("STEAM_3858651", false))
+        assertFalse(GameInputCompatibility.needsMouseDragCompatibility("GOG_3858650", false))
+    }
+
+    @Test
+    fun `mouse drag compatibility remains disabled in glibc`() {
+        assertFalse(GameInputCompatibility.needsMouseDragCompatibility("STEAM_3858650", true))
+    }
+}

--- a/app/src/test/java/com/winlator/xserver/XServerExtensionPolicyTest.kt
+++ b/app/src/test/java/com/winlator/xserver/XServerExtensionPolicyTest.kt
@@ -1,0 +1,25 @@
+package com.winlator.xserver
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class XServerExtensionPolicyTest {
+    @Test
+    fun `targeted Bionic compatibility advertises XGE and XI2`() {
+        assertTrue(XServer.supportsXInput2(false))
+        assertTrue(XServer.shouldAdvertiseGenericEvents(false, true))
+    }
+
+    @Test
+    fun `ordinary Bionic behavior does not advertise XGE`() {
+        assertTrue(XServer.supportsXInput2(false))
+        assertFalse(XServer.shouldAdvertiseGenericEvents(false, false))
+    }
+
+    @Test
+    fun `glibc ignores mouse compatibility and preserves disabled XI2 behavior`() {
+        assertFalse(XServer.supportsXInput2(true))
+        assertFalse(XServer.shouldAdvertiseGenericEvents(true, true))
+    }
+}


### PR DESCRIPTION
## Description
Fix mouse and touchscreen dragging in Crushed in Time when using Proton 10.0-4 ARM64EC.

Small transformed touch deltas could also be truncated to zero on every event, preventing slow or diagonal dragging.

User bug report here: https://discord.com/channels/1378308569287622737/1510980477769617408/1514518634477912134

## Recording

https://github.com/user-attachments/assets/92d9f0a6-9f28-49ac-91b3-6970d482c6d5

## Type of Change
- [X] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [X] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [X] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [X] I have attached a recording of the change.
- [X] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stuck/jerky mouse and touchscreen dragging in Crushed in Time on Bionic containers by advertising XGE for XI2 and preserving sub‑pixel drag deltas. Previously, tiny transformed deltas were truncated to 0 and XI2 failed without XGE; now XGE is advertised only for this title, we accumulate fractional motion, and we reset remainders on gesture transitions to prevent carry‑over jumps.

- Adds `GenericEventExtension` implementing XGE 1.0 QueryVersion; advertised only when `GameInputCompatibility.needsMouseDragCompatibility` is true.
- Gates to `STEAM_3858650` on non‑glibc via `app.gamenative.gamefixes.GameInputCompatibility`; `XServerScreen` passes the flag; `XServer` provides `supportsXInput2`, `shouldAdvertiseGenericEvents`, and `isMouseDragCompatibilityEnabled`.
- Updates `com.winlator.widget.TouchpadView` to accumulate fractional relative motion and reset remainders on touch/drag state changes.
- Default behavior for other games and `glibc` containers is unchanged; tests (`GameInputCompatibilityTest`, `XServerExtensionPolicyTest`) cover gating and extension policy.

<sup>Written for commit 52760b588de0e2de868387460d9a937f54cfeb1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved mouse-drag input compatibility for supported games.
  * Added compatibility support for environments using XInput2.
  * Preserved smoother drag movement by retaining fractional motion between touch events.

* **Bug Fixes**
  * Reduced dropped or inconsistent movement during touchscreen mouse-drag interactions.
  * Applied compatibility behavior only where supported, without changing standard input handling.
  * Improved input consistency across supported container environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->