### PR TITLE
Fix hardcoded app.gamenative paths breaking id-suffixed builds (including release-gold)

### DIFF
--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -52,6 +52,16 @@ class PluviaApp : SplitCompatApplication() {
     override fun onCreate() {
         super.onCreate()
 
+        // Must be set before any class triggers System.loadLibrary("evshim"):
+        // its constructor resolves the gamepad shm dir from EVSHIM_BASE_PATH at
+        // load time, and its fallback hardcodes /data/data/app.gamenative, which
+        // is another package's private dir in id-suffixed builds (.dev).
+        try {
+            android.system.Os.setenv("EVSHIM_BASE_PATH", filesDir.path, true)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to set EVSHIM_BASE_PATH")
+        }
+
         preloadSystemLibraries()
 
         // Allows to find resource streams not closed within GameNative and JavaSteam

--- a/app/src/main/java/com/winlator/container/Container.java
+++ b/app/src/main/java/com/winlator/container/Container.java
@@ -47,15 +47,18 @@ public class Container {
     public static final String DEFAULT_GRAPHICSDRIVERCONFIG = "vulkanVersion=1.3" + ",version=" + DefaultVersion.WRAPPER + ",blacklistedExtensions=" + ",maxDeviceMemory=0" + ",presentMode=mailbox" + ",syncFrame=0" + ",disablePresentWait=0" + ",resourceType=auto" + ",bcnEmulation=auto" + ",bcnEmulationType=compute" + ",bcnEmulationCache=0" + ",gpuName=Device";
     public static final String DEFAULT_WINCOMPONENTS = "direct3d=1,directsound=1,directinput8=0,directinput=0,directmusic=0,directshow=0,directplay=0,vcrun2010=1,wmdecoder=1,opengl=0";
     public static final String FALLBACK_WINCOMPONENTS = "direct3d=1,directsound=1,directinput8=0,directinput=0,directmusic=1,directshow=1,directplay=1,vcrun2010=1,wmdecoder=1,opengl=0";
+    // Keyed to the real applicationId so builds with an id suffix (e.g. .dev
+    // sideload builds) don't point into another package's private data dir.
+    public static final String DATA_ROOT = "/data/data/" + app.gamenative.BuildConfig.APPLICATION_ID;
     public static final String[] MEDIACONV_ENV_VARS = {
-            "MEDIACONV_AUDIO_DUMP_FILE=/data/data/app.gamenative/files/imagefs/home/xuser/audio.dmp",
-            "MEDIACONV_VIDEO_DUMP_FILE=/data/data/app.gamenative/files/imagefs/home/xuser/video.dmp",
-            "MEDIACONV_VIDEO_TRANSCODED_FILE=/data/data/app.gamenative/files/imagefs/home/xuser/transcoded.mkv",
-            "MEDIACONV_AUDIO_TRANSCODED_FILE=/data/data/app.gamenative/files/imagefs/home/xuser/transcoded.wav",
-            "MEDIACONV_BLANK_AUDIO_FILE=/data/data/app.gamenative/files/imagefs/home/xuser/blank.wav",
-            "MEDIACONV_BLANK_VIDEO_FILE=/data/data/app.gamenative/files/imagefs/home/xuser/blank.mkv",
+            "MEDIACONV_AUDIO_DUMP_FILE="+DATA_ROOT+"/files/imagefs/home/xuser/audio.dmp",
+            "MEDIACONV_VIDEO_DUMP_FILE="+DATA_ROOT+"/files/imagefs/home/xuser/video.dmp",
+            "MEDIACONV_VIDEO_TRANSCODED_FILE="+DATA_ROOT+"/files/imagefs/home/xuser/transcoded.mkv",
+            "MEDIACONV_AUDIO_TRANSCODED_FILE="+DATA_ROOT+"/files/imagefs/home/xuser/transcoded.wav",
+            "MEDIACONV_BLANK_AUDIO_FILE="+DATA_ROOT+"/files/imagefs/home/xuser/blank.wav",
+            "MEDIACONV_BLANK_VIDEO_FILE="+DATA_ROOT+"/files/imagefs/home/xuser/blank.mkv",
     };
-    public static final String DEFAULT_DRIVES = "D:"+Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)+"E:/data/data/app.gamenative/storage";
+    public static final String DEFAULT_DRIVES = "D:"+Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)+"E:"+DATA_ROOT+"/storage";
     public static final String DEFAULT_VARIANT = DefaultVersion.VARIANT;
     public static final String DEFAULT_WINE_VERSION = DefaultVersion.WINE_VERSION;
     public static final byte STARTUP_SELECTION_NORMAL = 0;

--- a/app/src/main/java/com/winlator/core/DXVKHelper.java
+++ b/app/src/main/java/com/winlator/core/DXVKHelper.java
@@ -17,7 +17,7 @@ public class DXVKHelper {
 
     public static void setEnvVars(Context context, KeyValueSet config, EnvVars envVars) {
         ImageFs imageFs = ImageFs.find(context);
-        envVars.put("DXVK_STATE_CACHE_PATH", "/data/data/app.gamenative/files/imagefs"+ImageFs.CACHE_PATH);
+        envVars.put("DXVK_STATE_CACHE_PATH", imageFs.getRootDir().getPath()+ImageFs.CACHE_PATH);
         envVars.put("DXVK_LOG_LEVEL", "none");
 
         File rootDir = ImageFs.find(context).getRootDir();

--- a/app/src/main/java/com/winlator/core/WineUtils.java
+++ b/app/src/main/java/com/winlator/core/WineUtils.java
@@ -45,7 +45,7 @@ public abstract class WineUtils {
                 missingDrives += "D:" + android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DOWNLOADS);
             }
             if (!currentDrives.contains("E:")) {
-                missingDrives += "E:/data/data/app.gamenative/storage";
+                missingDrives += "E:" + com.winlator.container.Container.DATA_ROOT + "/storage";
             }
             String updatedDrives = missingDrives + currentDrives;
             container.setDrives(updatedDrives);
@@ -57,7 +57,7 @@ public abstract class WineUtils {
         for (String[] drive : container.drivesIterator()) {
             File linkTarget = new File(drive[1]);
             String path = linkTarget.getAbsolutePath();
-            if (!linkTarget.isDirectory() && path.endsWith("/app.gamenative/storage")) {
+            if (!linkTarget.isDirectory() && path.equals(com.winlator.container.Container.DATA_ROOT + "/storage")) {
                 linkTarget.mkdirs();
                 FileUtils.chmod(linkTarget, 0771);
             }

--- a/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/BionicProgramLauncherComponent.java
@@ -189,18 +189,17 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
 
         final int MAX_PLAYERS = 4;
 
-        // Get the number of enabled players directly from ControllerManager.
-        for (int i = 0; i < MAX_PLAYERS; i++) {
-            String memPath;
-            if (i == 0) {
-                // Player 1 uses the original, non-numbered path that is known to work.
-                memPath = "/data/data/app.gamenative/files/imagefs/tmp/gamepad.mem";
-            } else {
-                // Players 2, 3, 4 use a 1-based index.
-                memPath = "/data/data/app.gamenative/files/imagefs/tmp/gamepad" + i + ".mem";
-            }
+        Context context = environment.getContext();
+        ImageFs imageFs = ImageFs.find(context);
+        File rootDir = imageFs.getRootDir();
 
-            File memFile = new File(memPath);
+        // Get the number of enabled players directly from ControllerManager.
+        // Paths derive from the imagefs root so id-suffixed builds (.dev) don't
+        // point into another package's private data dir.
+        File gamepadTmpDir = new File(rootDir, "tmp");
+        for (int i = 0; i < MAX_PLAYERS; i++) {
+            // Player 1 uses the original, non-numbered path; players 2-4 are 1-indexed.
+            File memFile = new File(gamepadTmpDir, i == 0 ? "gamepad.mem" : "gamepad" + i + ".mem");
             memFile.getParentFile().mkdirs();
             try (RandomAccessFile raf = new RandomAccessFile(memFile, "rw")) {
                 raf.setLength(64);
@@ -208,9 +207,6 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
                 Log.e("EVSHIM_HOST", "Failed to create mem file for player index "+i, e);
             }
         }
-        Context context = environment.getContext();
-        ImageFs imageFs = ImageFs.find(context);
-        File rootDir = imageFs.getRootDir();
 
         PrefManager.init(context);
         boolean enableBox86_64Logs = PrefManager.getBoolean("enable_box86_64_logs", true);
@@ -233,6 +229,9 @@ public class BionicProgramLauncherComponent extends GuestProgramLauncherComponen
 
         // Use the ControllerManager's dynamic count for the environment variable
         envVars.put("EVSHIM_MAX_PLAYERS", String.valueOf(MAX_PLAYERS));
+        // evshim falls back to a hardcoded /data/data/app.gamenative/files when
+        // unset, which is another package's private dir in id-suffixed builds.
+        envVars.put("EVSHIM_BASE_PATH", context.getFilesDir().getPath());
         if (true) {
             envVars.put("EVSHIM_SHM_ID", 1);
         }


### PR DESCRIPTION
Several code paths hardcode `/data/data/app.gamenative`, which resolves to another package's private (and inaccessible) directory in any build whose `applicationId` carries a suffix — including the `release-gold` build type (`app.gamenative.gold`) that this repo ships.

The most visible casualty is controller input. `libevshim` resolves its gamepad shared-memory directory from `EVSHIM_BASE_PATH` with a hardcoded fallback, and the futex word used to signal state changes lives inside that mapping. In a suffixed build the app-process side fails to map the file, so the virtual gamepad still *registers* (the UDP path works) but button presses never wake the guest-side reader — controls silently dead, with `evshim: notifyStateChanged missing shm for slot=0` in logcat. Titles using the emulated Steam Input path are hit hardest.

This PR:

- sets `EVSHIM_BASE_PATH` in both the app process (in `PluviaApp.onCreate`, before the library constructor can run) and the guest environment
- derives the gamepad mem files, DXVK state cache, E: drive target, and MEDIACONV paths from `BuildConfig.APPLICATION_ID` / `ImageFs`

Behavior is unchanged for the stock package id.

**Testing:** root-caused and verified on a Galaxy Z Fold 8 (Snapdragon), modern flavor — reproduced the dead-controller state in an id-suffixed debug build, confirmed on-screen controls working after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hardcoded `/data/data/app.gamenative` paths so id-suffixed builds (e.g., `app.gamenative.gold`) use their own private data directories. Previously, controller input registered but button presses were dead because `libevshim` fell back to another package’s dir; now paths derive from the actual `applicationId` and `ImageFs`. Behavior is unchanged for the stock `app.gamenative` package.

**Changes**
- Set `EVSHIM_BASE_PATH` in `PluviaApp.onCreate` before `System.loadLibrary("evshim")`, and in the guest environment.
- Replace hardcoded paths with `BuildConfig.APPLICATION_ID`/`ImageFs`-derived locations:
  - Gamepad shared-memory files (`gamepad.mem`, `gamepad{2..4}.mem`) under `imagefs/tmp`.
  - `DXVK_STATE_CACHE_PATH` from `ImageFs`.
  - `E:` drive target via `Container.DATA_ROOT`.
  - `MEDIACONV_*` env vars via `Container.DATA_ROOT`.
- Update `WineUtils` to create the `E:` drive directory when missing.

**Review notes**
- Verify env var initialization order in `PluviaApp.kt` prevents `libevshim` fallback.
- Confirm `Container.DATA_ROOT` uses `app.gamenative.BuildConfig.APPLICATION_ID` and that path equality checks in `WineUtils` match the new target.
- Exercise controller input in an id-suffixed build to confirm shm creation and wake behavior.

<sup>Written for commit 90c3ebdfacb0449eed63f4a3dcc82e0a3177dafd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility across different app installations and package configurations.
  - Fixed storage, media conversion, graphics cache, and controller-related paths to use the app’s active data locations.
  - Improved game launch reliability by ensuring required runtime environment paths are configured automatically.
  - Initialization now handles environment setup failures gracefully without preventing the app from starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->