### PR TITLE
Add Screen position controls to move the game viewport

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
+++ b/app/src/main/java/app/gamenative/ui/component/ScreenEffectsPanel.kt
@@ -257,6 +257,12 @@ fun GLScreenEffectsTabContent(
     var enableNTSC by remember(renderer, container) {
         mutableStateOf(initialConfig.enableNTSC)
     }
+    var viewportOffsetX by remember(renderer, container) {
+        mutableFloatStateOf(initialConfig.viewportOffsetX)
+    }
+    var viewportOffsetY by remember(renderer, container) {
+        mutableFloatStateOf(initialConfig.viewportOffsetY)
+    }
 
     LaunchedEffect(
         brightness,
@@ -269,6 +275,8 @@ fun GLScreenEffectsTabContent(
         enableVivid,
         enableCRT,
         enableNTSC,
+        viewportOffsetX,
+        viewportOffsetY,
     ) {
         val config = ScreenEffectsConfig(
             brightness = brightness,
@@ -281,6 +289,8 @@ fun GLScreenEffectsTabContent(
             enableVivid = enableVivid,
             enableCRT = enableCRT,
             enableNTSC = enableNTSC,
+            viewportOffsetX = viewportOffsetX,
+            viewportOffsetY = viewportOffsetY,
         )
         applyScreenEffectsConfig(renderer, config)
         delay(300)
@@ -299,6 +309,8 @@ fun GLScreenEffectsTabContent(
         enableVivid = false
         enableCRT = false
         enableNTSC = false
+        viewportOffsetX = 0f
+        viewportOffsetY = 0f
     }
 
     Column(
@@ -360,6 +372,15 @@ fun GLScreenEffectsTabContent(
                 onSelect = { scalingMode = mode },
             )
         }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        ViewportPositionSection(
+            viewportOffsetX = viewportOffsetX,
+            viewportOffsetY = viewportOffsetY,
+            onOffsetXChanged = { viewportOffsetX = it },
+            onOffsetYChanged = { viewportOffsetY = it },
+        )
 
         Spacer(modifier = Modifier.height(20.dp))
 
@@ -493,6 +514,12 @@ fun ScreenEffectsTabContent(
     var enableNTSC by remember(renderer, container) {
         mutableStateOf(initialConfig.enableNTSC)
     }
+    var viewportOffsetX by remember(renderer, container) {
+        mutableFloatStateOf(initialConfig.viewportOffsetX)
+    }
+    var viewportOffsetY by remember(renderer, container) {
+        mutableFloatStateOf(initialConfig.viewportOffsetY)
+    }
 
     LaunchedEffect(
         scalingMode,
@@ -505,6 +532,8 @@ fun ScreenEffectsTabContent(
         enableVivid,
         enableCRT,
         enableNTSC,
+        viewportOffsetX,
+        viewportOffsetY,
     ) {
         val config = initialConfig.copy(
             scalingMode = scalingMode,
@@ -517,6 +546,8 @@ fun ScreenEffectsTabContent(
             enableVivid = enableVivid,
             enableCRT = enableCRT,
             enableNTSC = enableNTSC,
+            viewportOffsetX = viewportOffsetX,
+            viewportOffsetY = viewportOffsetY,
         )
         // Apply immediately for live preview
         applyScreenEffectsConfig(renderer, config)
@@ -537,6 +568,8 @@ fun ScreenEffectsTabContent(
         enableVivid = false
         enableCRT = false
         enableNTSC = false
+        viewportOffsetX = 0f
+        viewportOffsetY = 0f
     }
 
     Column(
@@ -599,6 +632,15 @@ fun ScreenEffectsTabContent(
                 onSelect = { scalingMode = mode },
             )
         }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        ViewportPositionSection(
+            viewportOffsetX = viewportOffsetX,
+            viewportOffsetY = viewportOffsetY,
+            onOffsetXChanged = { viewportOffsetX = it },
+            onOffsetYChanged = { viewportOffsetY = it },
+        )
 
         Spacer(modifier = Modifier.height(20.dp))
 
@@ -958,6 +1000,45 @@ fun ScreenEffectsPanel(
         }
     }
 }
+}
+
+@Composable
+private fun ViewportPositionSection(
+    viewportOffsetX: Float,
+    viewportOffsetY: Float,
+    onOffsetXChanged: (Float) -> Unit,
+    onOffsetYChanged: (Float) -> Unit,
+) {
+    OptionSectionHeader(text = stringResource(R.string.screen_effects_viewport_position))
+
+    ScreenEffectAdjustmentRow(
+        title = stringResource(R.string.screen_effects_viewport_offset_x),
+        valueText = formatPercent(viewportOffsetX),
+        progress = normalizedProgress(viewportOffsetX, -100f, 100f),
+        onDecrease = {
+            onOffsetXChanged((viewportOffsetX - SCREEN_EFFECT_PERCENT_STEP).coerceIn(-100f, 100f))
+        },
+        onIncrease = {
+            onOffsetXChanged((viewportOffsetX + SCREEN_EFFECT_PERCENT_STEP).coerceIn(-100f, 100f))
+        },
+    )
+    ScreenEffectAdjustmentRow(
+        title = stringResource(R.string.screen_effects_viewport_offset_y),
+        valueText = formatPercent(viewportOffsetY),
+        progress = normalizedProgress(viewportOffsetY, -100f, 100f),
+        onDecrease = {
+            onOffsetYChanged((viewportOffsetY - SCREEN_EFFECT_PERCENT_STEP).coerceIn(-100f, 100f))
+        },
+        onIncrease = {
+            onOffsetYChanged((viewportOffsetY + SCREEN_EFFECT_PERCENT_STEP).coerceIn(-100f, 100f))
+        },
+    )
+    Text(
+        text = stringResource(R.string.screen_effects_viewport_position_description),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(horizontal = 24.dp, vertical = 4.dp),
+    )
 }
 
 @Composable

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ScreenEffectDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ScreenEffectDialog.kt
@@ -41,7 +41,6 @@ import app.gamenative.R
 import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.ui.theme.settingsTileColors
 import app.gamenative.ui.theme.settingsTileColorsAlt
-import app.gamenative.ui.util.ScreenEffectsConfig
 import app.gamenative.ui.util.applyScreenEffectsConfig
 import app.gamenative.ui.util.loadScreenEffectsConfig
 import app.gamenative.ui.util.persistScreenEffectsConfig
@@ -84,7 +83,9 @@ fun ScreenEffectDialog(
     }
 
     LaunchedEffect(brightness, contrast, gamma, enableToon, enableFXAA, enableVivid, enableCRT, enableNTSC) {
-        val config = ScreenEffectsConfig(
+        // copy() so settings this dialog doesn't edit (scaling mode, viewport offset)
+        // survive the round-trip instead of being reset to defaults.
+        val config = initialConfig.copy(
             brightness = brightness,
             contrast = contrast,
             gamma = gamma,

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -77,6 +77,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import app.gamenative.R
 import app.gamenative.ui.util.SnackbarManager
 import app.gamenative.ui.util.applyScreenEffectsConfig
+import app.gamenative.ui.util.applyViewportOffsetConfig
 import app.gamenative.ui.util.loadScreenEffectsConfig
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
@@ -622,6 +623,10 @@ fun XServerScreen(
         when (val renderer = xServerView?.renderer) {
             is VulkanRenderer -> applyScreenEffectsConfig(renderer, screenEffectsConfig)
             is GLRenderer -> applyScreenEffectsConfig(renderer, screenEffectsConfig)
+            // No screen effects on the SurfaceFlinger renderer, but the viewport
+            // offset still applies (and the process-wide offset must be reset when
+            // this container has none saved).
+            is ASurfaceRenderer -> applyViewportOffsetConfig(renderer, screenEffectsConfig)
         }
     }
 

--- a/app/src/main/java/app/gamenative/ui/util/ScreenEffectsConfig.kt
+++ b/app/src/main/java/app/gamenative/ui/util/ScreenEffectsConfig.kt
@@ -1,7 +1,9 @@
 package app.gamenative.ui.util
 
 import com.winlator.container.Container
+import com.winlator.renderer.ASurfaceRenderer
 import com.winlator.renderer.GLRenderer
+import com.winlator.renderer.ViewTransformation
 import com.winlator.renderer.VulkanRenderer
 import com.winlator.renderer.effects.ColorEffect
 import com.winlator.renderer.effects.CRTEffect
@@ -26,6 +28,10 @@ data class ScreenEffectsConfig(
     val enableVivid: Boolean = false,
     val enableCRT: Boolean = false,
     val enableNTSC: Boolean = false,
+    // Shift of the letterboxed image within its free space, in percent:
+    // -100 = flush left/top, 0 = centered, +100 = flush right/bottom.
+    val viewportOffsetX: Float = 0f,
+    val viewportOffsetY: Float = 0f,
 ) {
     companion object {
         const val SCALING_MODE_NONE = 0
@@ -52,6 +58,8 @@ data class ScreenEffectsConfig(
         const val KEY_ENABLE_VIVID = "screenEffectsEnableVivid"
         const val KEY_ENABLE_CRT = "screenEffectsEnableCRT"
         const val KEY_ENABLE_NTSC = "screenEffectsEnableNTSC"
+        const val KEY_VIEWPORT_OFFSET_X = "screenEffectsViewportOffsetX"
+        const val KEY_VIEWPORT_OFFSET_Y = "screenEffectsViewportOffsetY"
     }
 }
 
@@ -69,6 +77,8 @@ fun loadScreenEffectsConfig(container: Container?): ScreenEffectsConfig {
         enableVivid = container.getExtra(ScreenEffectsConfig.KEY_ENABLE_VIVID)?.toBooleanStrictOrNull() ?: false,
         enableCRT = container.getExtra(ScreenEffectsConfig.KEY_ENABLE_CRT)?.toBooleanStrictOrNull() ?: false,
         enableNTSC = container.getExtra(ScreenEffectsConfig.KEY_ENABLE_NTSC)?.toBooleanStrictOrNull() ?: false,
+        viewportOffsetX = container.getExtra(ScreenEffectsConfig.KEY_VIEWPORT_OFFSET_X)?.toFloatOrNull() ?: 0f,
+        viewportOffsetY = container.getExtra(ScreenEffectsConfig.KEY_VIEWPORT_OFFSET_Y)?.toFloatOrNull() ?: 0f,
     )
 }
 
@@ -88,6 +98,23 @@ fun persistScreenEffectsConfig(container: Container?, config: ScreenEffectsConfi
     container.putExtra(ScreenEffectsConfig.KEY_ENABLE_VIVID, config.enableVivid)
     container.putExtra(ScreenEffectsConfig.KEY_ENABLE_CRT, config.enableCRT)
     container.putExtra(ScreenEffectsConfig.KEY_ENABLE_NTSC, config.enableNTSC)
+    container.putExtra(ScreenEffectsConfig.KEY_VIEWPORT_OFFSET_X, config.viewportOffsetX)
+    container.putExtra(ScreenEffectsConfig.KEY_VIEWPORT_OFFSET_Y, config.viewportOffsetY)
+}
+
+/**
+ * Push the viewport offset into the shared ViewTransformation state. Touch mappers
+ * (TouchpadView/TouchMouse) pick the change up on their next event; the renderer
+ * must be told to recompute explicitly, which the applyScreenEffectsConfig
+ * overloads do.
+ */
+fun applyViewportOffsetConfig(config: ScreenEffectsConfig) {
+    ViewTransformation.setUserOffset(config.viewportOffsetX / 100f, config.viewportOffsetY / 100f)
+}
+
+fun applyViewportOffsetConfig(renderer: ASurfaceRenderer, config: ScreenEffectsConfig) {
+    applyViewportOffsetConfig(config)
+    renderer.updateViewTransformation()
 }
 
 fun fsrQuickMenuLevelToStops(level: Int): Float {
@@ -154,6 +181,9 @@ fun applyScreenEffectsConfig(renderer: GLRenderer, config: ScreenEffectsConfig) 
     }
 
     composer.setEffects(effects)
+
+    applyViewportOffsetConfig(config)
+    renderer.updateViewTransformation()
 }
 
 fun applyScreenEffectsConfig(renderer: VulkanRenderer, config: ScreenEffectsConfig) {
@@ -198,4 +228,7 @@ fun applyScreenEffectsConfig(renderer: VulkanRenderer, config: ScreenEffectsConf
         config.contrast / 100f,
         config.gamma,
     )
+
+    applyViewportOffsetConfig(config)
+    renderer.updateViewTransformation()
 }

--- a/app/src/main/java/com/winlator/inputcontrols/TouchMouse.java
+++ b/app/src/main/java/com/winlator/inputcontrols/TouchMouse.java
@@ -43,7 +43,16 @@ public class TouchMouse {
         updateXform(AppUtils.getScreenWidth(), AppUtils.getScreenHeight(), xServer.screenInfo.width, xServer.screenInfo.height);
     }
 
+    private int seenUserOffsetVersion = -1;
+
+    private void ensureXformUpToDate() {
+        if (seenUserOffsetVersion != ViewTransformation.getUserOffsetVersion()) {
+            updateXform(AppUtils.getScreenWidth(), AppUtils.getScreenHeight(), xServer.screenInfo.width, xServer.screenInfo.height);
+        }
+    }
+
     private void updateXform(int outerWidth, int outerHeight, int innerWidth, int innerHeight) {
+        seenUserOffsetVersion = ViewTransformation.getUserOffsetVersion();
         ViewTransformation viewTransformation = new ViewTransformation();
         viewTransformation.update(outerWidth, outerHeight, innerWidth, innerHeight);
 
@@ -101,6 +110,7 @@ public class TouchMouse {
     }
 
     public boolean onTouchEvent(MotionEvent event) {
+        ensureXformUpToDate();
         int actionIndex = event.getActionIndex();
         int pointerId = event.getPointerId(actionIndex);
         int actionMasked = event.getActionMasked();
@@ -301,6 +311,7 @@ public class TouchMouse {
     }
 
     public boolean onExternalMouseEvent(MotionEvent event) {
+        ensureXformUpToDate();
         boolean handled = false;
         // if (event.isFromSource(InputDevice.SOURCE_MOUSE)) {
         if (isMouseDevice(event.getDevice())) {

--- a/app/src/main/java/com/winlator/renderer/ASurfaceRenderer.java
+++ b/app/src/main/java/com/winlator/renderer/ASurfaceRenderer.java
@@ -317,6 +317,12 @@ public class ASurfaceRenderer implements WindowManager.OnWindowModificationListe
                 viewTransformation.viewHeight);
     }
 
+    public void updateViewTransformation() {
+        if (surfaceWidth <= 0 || surfaceHeight <= 0) return;
+        viewTransformation.update(surfaceWidth, surfaceHeight, xServer.screenInfo.width, xServer.screenInfo.height);
+        updateTransform();
+    }
+
     public void updateScene() {
         renderListSize = 0;
         try (XLock xl = xServer.lock(XServer.Lockable.WINDOW_MANAGER, XServer.Lockable.DRAWABLE_MANAGER)) {

--- a/app/src/main/java/com/winlator/renderer/GLRenderer.java
+++ b/app/src/main/java/com/winlator/renderer/GLRenderer.java
@@ -162,9 +162,10 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
                 GLES20.glViewport(0, 0, targetWidth, targetHeight);
             }
             else if (magnifierEnabled) {
+                // viewOffsetY is top-left based; glViewport wants bottom-left.
                 GLES20.glViewport(
                     Math.round(viewTransformation.viewOffsetX * viewportScaleX),
-                    Math.round(viewTransformation.viewOffsetY * viewportScaleY),
+                    Math.round((surfaceHeight - viewTransformation.viewOffsetY - viewTransformation.viewHeight) * viewportScaleY),
                     Math.round(viewTransformation.viewWidth * viewportScaleX),
                     Math.round(viewTransformation.viewHeight * viewportScaleY)
                 );
@@ -206,9 +207,10 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
                 XForm.makeTransform(tmpXForm2, viewTransformation.sceneOffsetX, viewTransformation.sceneOffsetY - pointerY, viewTransformation.sceneScaleX, viewTransformation.sceneScaleY, 0);
 
                 GLES20.glEnable(GLES20.GL_SCISSOR_TEST);
+                // viewOffsetY is top-left based; glScissor wants bottom-left.
                 GLES20.glScissor(
                     Math.round(viewTransformation.viewOffsetX * viewportScaleX),
-                    Math.round(viewTransformation.viewOffsetY * viewportScaleY),
+                    Math.round((surfaceHeight - viewTransformation.viewOffsetY - viewTransformation.viewHeight) * viewportScaleY),
                     Math.round(viewTransformation.viewWidth * viewportScaleX),
                     Math.round(viewTransformation.viewHeight * viewportScaleY)
                 );
@@ -334,6 +336,16 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
 
     public void toggleFullscreen() {
         toggleFullscreen = true;
+        xServerView.requestRender();
+    }
+
+    public void updateViewTransformation() {
+        xServerView.queueEvent(() -> {
+            if (surfaceWidth > 0 && surfaceHeight > 0) {
+                viewTransformation.update(surfaceWidth, surfaceHeight, xServer.screenInfo.width, xServer.screenInfo.height);
+                viewportNeedsUpdate = true;
+            }
+        });
         xServerView.requestRender();
     }
 

--- a/app/src/main/java/com/winlator/renderer/ViewTransformation.java
+++ b/app/src/main/java/com/winlator/renderer/ViewTransformation.java
@@ -1,6 +1,15 @@
 package com.winlator.renderer;
 
 public class ViewTransformation {
+    // User-requested shift of the letterboxed image within the free space around it,
+    // as a fraction of the available slack: -1 = flush left/top, 0 = centered,
+    // +1 = flush right/bottom. Shared by every renderer and touch mapper so the
+    // picture and the input mapping always move together. viewOffsetX/Y are
+    // expressed with a top-left origin; GL consumers must flip Y themselves.
+    private static volatile float userOffsetXFraction = 0.0f;
+    private static volatile float userOffsetYFraction = 0.0f;
+    private static volatile int userOffsetVersion = 0;
+
     public int viewOffsetX;
     public int viewOffsetY;
     public int viewWidth;
@@ -11,6 +20,16 @@ public class ViewTransformation {
     public float sceneOffsetX;
     public float sceneOffsetY;
 
+    public static void setUserOffset(float xFraction, float yFraction) {
+        userOffsetXFraction = Math.max(-1.0f, Math.min(1.0f, xFraction));
+        userOffsetYFraction = Math.max(-1.0f, Math.min(1.0f, yFraction));
+        userOffsetVersion++;
+    }
+
+    public static int getUserOffsetVersion() {
+        return userOffsetVersion;
+    }
+
     public void update(int outerWidth, int outerHeight, int innerWidth, int innerHeight) {
         aspect = Math.min((float)outerWidth / innerWidth, (float)outerHeight / innerHeight);
         viewWidth = (int)Math.ceil(innerWidth * aspect);
@@ -18,9 +37,17 @@ public class ViewTransformation {
         viewOffsetX = (int)((outerWidth - innerWidth * aspect) * 0.5f);
         viewOffsetY = (int)((outerHeight - innerHeight * aspect) * 0.5f);
 
+        int shiftX = Math.round(userOffsetXFraction * (outerWidth - viewWidth) * 0.5f);
+        int shiftY = Math.round(userOffsetYFraction * (outerHeight - viewHeight) * 0.5f);
+        viewOffsetX += shiftX;
+        viewOffsetY += shiftY;
+
         sceneScaleX = (innerWidth * aspect) / outerWidth;
         sceneScaleY = (innerHeight * aspect) / outerHeight;
         sceneOffsetX = (innerWidth - innerWidth * sceneScaleX) * 0.5f;
         sceneOffsetY = (innerHeight - innerHeight * sceneScaleY) * 0.5f;
+        // Same shift in scene units: scene coords map to screen px by outer/inner.
+        sceneOffsetX += shiftX * ((float)innerWidth / outerWidth);
+        sceneOffsetY += shiftY * ((float)innerHeight / outerHeight);
     }
 }

--- a/app/src/main/java/com/winlator/renderer/VulkanRenderer.java
+++ b/app/src/main/java/com/winlator/renderer/VulkanRenderer.java
@@ -790,6 +790,12 @@ public class VulkanRenderer implements WindowManager.OnWindowModificationListene
     public boolean isFullscreen() { return fullscreen; }
     public void toggleFullscreen() { fullscreen = !fullscreen; synchronized (lock) { updateTransform(); } xServerView.queueEvent(this::updateScene); }
     public void setScreenOffsetYRelativeToCursor(boolean b) { screenOffsetYRelativeToCursor = b; synchronized (lock) { updateTransform(); } }
+
+    public void updateViewTransformation() {
+        if (surfaceWidth <= 0 || surfaceHeight <= 0) return;
+        viewTransformation.update(surfaceWidth, surfaceHeight, xServer.screenInfo.width, xServer.screenInfo.height);
+        synchronized (lock) { if (nativeHandle != 0) updateTransform(); }
+    }
     public boolean isScreenOffsetYRelativeToCursor() { return screenOffsetYRelativeToCursor; }
     public void setMagnifierZoom(float zoom) { magnifierZoom = zoom; }
     public float getMagnifierZoom() { return magnifierZoom; }

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -273,6 +273,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     }
 
     private void updateXform(int outerWidth, int outerHeight, int innerWidth, int innerHeight) {
+        seenUserOffsetVersion = ViewTransformation.getUserOffsetVersion();
         ViewTransformation viewTransformation = new ViewTransformation();
         viewTransformation.update(outerWidth, outerHeight, innerWidth, innerHeight);
         float invAspect = 1.0f / viewTransformation.aspect;
@@ -281,6 +282,16 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
             XForm.scale(this.xform, invAspect, invAspect);
         } else {
             XForm.makeScale(this.xform, invAspect, invAspect);
+        }
+    }
+
+    private int seenUserOffsetVersion = -1;
+
+    private void ensureXformUpToDate() {
+        if (seenUserOffsetVersion != ViewTransformation.getUserOffsetVersion()) {
+            int w = getWidth() > 0 ? getWidth() : AppUtils.getScreenWidth();
+            int h = getHeight() > 0 ? getHeight() : AppUtils.getScreenHeight();
+            updateXform(w, h, xServer.screenInfo.width, xServer.screenInfo.height);
         }
     }
 
@@ -331,6 +342,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
+        ensureXformUpToDate();
         boolean isStylus = isEventTriggeredByStylus(event);
         if (touchscreenMouseDisabled
                 && !isStylus
@@ -2094,6 +2106,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
     }
 
     public boolean onExternalMouseEvent(MotionEvent event) {
+        ensureXformUpToDate();
         boolean handled = false;
         if (event.isFromSource(InputDevice.SOURCE_MOUSE)) {
             int actionButton = event.getActionButton();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -258,6 +258,10 @@
     <string name="screen_effects_scaling">Scaling</string>
     <string name="screen_effects_upscaling">Upscaling</string>
     <string name="screen_effects_basic_scaling">Basic scaling</string>
+    <string name="screen_effects_viewport_position">Screen position</string>
+    <string name="screen_effects_viewport_offset_x">Horizontal position</string>
+    <string name="screen_effects_viewport_offset_y">Vertical position</string>
+    <string name="screen_effects_viewport_position_description">Moves the game image within the unused screen space, e.g. shift it up to free the bottom for on-screen controls. Only applies when the image doesn\'t fill the screen.</string>
     <string name="screen_effects_color_adjustments">Color adjustments</string>
     <string name="screen_effects_shader_toggles">Shader effects</string>
     <string name="screen_effects_scaling_mode">Scaling mode</string>


### PR DESCRIPTION
Adds a **Screen position** section (Horizontal/Vertical sliders) to the Screen Effects tab of the in-game quick menu, letting the letterboxed game image be shifted within the unused screen space. The motivating case is tall/squarish displays like foldables: shift the picture flush against the top and the freed black space at the bottom becomes a natural home for the on-screen controls, instead of the overlay covering the game.

## How it works

- The offset is stored as a fraction of the free letterbox space (−100% = flush left/top, 0 = centered, +100% = flush right/bottom) and applied inside `ViewTransformation`, so every consumer moves together:
  - `VulkanRenderer` (scanout dst rect + scene transform)
  - `GLRenderer` (`glViewport`/`glScissor`, with an explicit top-left → bottom-left Y conversion, since the rect is no longer origin-symmetric)
  - `ASurfaceRenderer` (scanout dst rect)
  - `TouchpadView` / `TouchMouse` pick up offset changes at event time, so pointer input stays aligned with the shifted image
- Persisted per-container alongside the other screen effects; included in the tab's Reset.
- No-op in FILL/STRETCH scaling modes (no free space) and when the image already fills the screen.

Also makes `ScreenEffectDialog` build its config with `initialConfig.copy()` so settings it doesn't edit (scaling mode, viewport offset) survive a save instead of resetting to defaults.

## Testing

Verified on a Galaxy Z Fold 8 (modern flavor, Vulkan renderer): image shifts as expected, taps/cursor stay aligned after shifting, per-game persistence works across restarts, 0% offset is pixel-identical to current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets players move the letterboxed game image with new Screen position sliders in the Screen Effects tab, so controls can sit in the freed space. Previously the image was always centered; now horizontal/vertical offsets (−100% to +100%) are supported, default 0% matches old behavior, and shifts are ignored when the image fills the screen.

- Applies a shared viewport offset via `ViewTransformation` across `VulkanRenderer`, `GLRenderer` (adds top-left to bottom-left Y flip in `glViewport`/`glScissor`), and `ASurfaceRenderer`; touch input in `TouchpadView` and `TouchMouse` remains aligned using a versioned offset.
- Persists per container in `ScreenEffectsConfig`; Reset clears offsets; `XServerScreen` loads/applies on renderer init (including `ASurfaceRenderer` through `applyViewportOffsetConfig`); adds `updateViewTransformation()` on all renderers to recompute immediately.
- Builds `ScreenEffectDialog` config with `initialConfig.copy()` so settings it doesn’t edit (scaling mode, viewport offset) are preserved on save.

<sup>Written for commit 3f5cea3c27794864d1f764e46e980e3a3174a616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added horizontal and vertical viewport positioning controls to GL and Vulkan screen-effects settings.
  - Viewport offsets are applied live, saved automatically, and can be reset to the default position.
  - Vulkan sharpness adjustments now also apply when using DLS mode.

- **Bug Fixes**
  - Touch, mouse, and touchpad input now stay aligned after viewport repositioning.
  - Viewport positioning is consistently applied across supported rendering modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->