### PR TITLE
attribute steam wishlisting via webview

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamWishlistService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamWishlistService.kt
@@ -1,5 +1,6 @@
 package app.gamenative.service
 
+import android.content.Context
 import app.gamenative.PrefManager
 import app.gamenative.utils.Net
 import `in`.dragonbra.javasteam.enums.EResult
@@ -39,17 +40,40 @@ object SteamWishlistService {
         }
     }
 
-    // UTM attribution requires the visit and the wishlist add to happen in the same web session;
-    // a CM add after a web visit is a different "browser" to Valve and may not attribute.
-    suspend fun addToWishlistAttributed(appId: Int, campaignId: String): Outcome = withContext(Dispatchers.IO) {
-        val webOk = try {
-            webAttributedAdd(appId, campaignId)
+    // UTM attribution requires the visit and the wishlist add to happen in the same web session.
+    // A real WebView earns the bot-manager/browserid cookies that let Valve count the visit as
+    // tracked, so it is the primary path; the bare-HTTP add and the CM add are fallbacks.
+    suspend fun addToWishlistAttributed(context: Context, appId: Int, campaignId: String): Outcome =
+        withContext(Dispatchers.IO) {
+            val steamId = SteamService.userSteamId?.convertToUInt64()
+            if (steamId != null && steamId != 0L) {
+                var token = PrefManager.accessToken.ifEmpty { null } ?: refreshAccessToken()
+                if (!token.isNullOrEmpty()) {
+                    if (tryWebView(context, steamId, token, appId, campaignId)) return@withContext Outcome.Success
+                    val fresh = refreshAccessToken()
+                    if (!fresh.isNullOrEmpty() && fresh != token &&
+                        tryWebView(context, steamId, fresh, appId, campaignId)
+                    ) {
+                        return@withContext Outcome.Success
+                    }
+                }
+            }
+            val webOk = try {
+                webAttributedAdd(appId, campaignId)
+            } catch (e: Exception) {
+                Timber.tag(TAG).w(e, "attributed add failed")
+                false
+            }
+            if (webOk) Outcome.Success else addToWishlist(appId)
+        }
+
+    private suspend fun tryWebView(context: Context, steamId: Long, token: String, appId: Int, campaignId: String): Boolean =
+        try {
+            WishlistWebViewAdder.add(context, steamId, token, appId, campaignId)
         } catch (e: Exception) {
-            Timber.tag(TAG).w(e, "attributed add failed")
+            Timber.tag(TAG).w(e, "webview attributed add failed")
             false
         }
-        if (webOk) Outcome.Success else addToWishlist(appId)
-    }
 
     private suspend fun webAttributedAdd(appId: Int, campaignId: String): Boolean {
         val steamId = SteamService.userSteamId?.convertToUInt64() ?: return false

--- a/app/src/main/java/app/gamenative/service/SteamWishlistService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamWishlistService.kt
@@ -9,6 +9,7 @@ import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesWishlistSteam
 import `in`.dragonbra.javasteam.rpc.service.Wishlist
 import `in`.dragonbra.javasteam.steam.handlers.steamunifiedmessages.SteamUnifiedMessages
 import java.net.URLEncoder
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withContext
@@ -60,6 +61,8 @@ object SteamWishlistService {
             }
             val webOk = try {
                 webAttributedAdd(appId, campaignId)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Timber.tag(TAG).w(e, "attributed add failed")
                 false
@@ -70,6 +73,8 @@ object SteamWishlistService {
     private suspend fun tryWebView(context: Context, steamId: Long, token: String, appId: Int, campaignId: String): Boolean =
         try {
             WishlistWebViewAdder.add(context, steamId, token, appId, campaignId)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Timber.tag(TAG).w(e, "webview attributed add failed")
             false
@@ -83,7 +88,7 @@ object SteamWishlistService {
             val cookie = "steamLoginSecure=$steamId%7C%7C${URLEncoder.encode(token, "UTF-8")}; " +
                 "birthtime=0; lastagecheckage=1-January-1970; wantsmatureconctent=1"
             val utmUrl = "https://store.steampowered.com/app/$appId/" +
-                "?utm_source=gamenative&utm_medium=app&utm_campaign=$campaignId"
+                "?utm_source=gamenative&utm_medium=app&utm_campaign=${URLEncoder.encode(campaignId, "UTF-8")}"
             var sessionId: String? = null
             var loggedIn = false
             Net.http.newCall(

--- a/app/src/main/java/app/gamenative/service/WishlistWebViewAdder.kt
+++ b/app/src/main/java/app/gamenative/service/WishlistWebViewAdder.kt
@@ -1,0 +1,158 @@
+package app.gamenative.service
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.ViewGroup
+import android.webkit.CookieManager
+import android.webkit.JavascriptInterface
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import java.net.URLEncoder
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.json.JSONObject
+import timber.log.Timber
+
+/**
+ * Wishlists through a real (offscreen) WebView so the page's own JavaScript runs first. That earns
+ * the cookies a bare HTTP client can't fake — Akamai's bot-manager token (bm_sv) and browserid —
+ * which is what makes the UTM visit count as a *tracked* visit. The add then runs as an in-page
+ * fetch, so it carries every one of those cookies and attributes to the visit.
+ *
+ * The WebView is attached to the window as a 1x1 transparent view so its renderer stays alive, and
+ * heavy resources (images, video, css, fonts) are blocked so a memory-limited device can load the
+ * page without crashing the renderer.
+ */
+object WishlistWebViewAdder {
+
+    private const val TAG = "SteamWishlist"
+    private const val STORE = "https://store.steampowered.com"
+    private const val STORE_UA =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+    private const val TIMEOUT_MS = 15_000L
+    private val BLOCKED = Regex("\\.(jpg|jpeg|png|gif|webp|avif|svg|ico|mp4|m4s|webm|ttf|woff2?|css)(\\?|$)")
+
+    @SuppressLint("SetJavaScriptEnabled")
+    suspend fun add(context: Context, steamId: Long, token: String, appId: Int, campaignId: String): Boolean =
+        withContext(Dispatchers.Main) {
+            val activity = context.findActivity()
+            val parent = activity?.findViewById<ViewGroup>(android.R.id.content)
+            if (activity == null || parent == null) {
+                Timber.tag(TAG).w("no activity window for webview add")
+                return@withContext false
+            }
+            val done = CompletableDeferred<Boolean>()
+
+            val cookieManager = CookieManager.getInstance()
+            cookieManager.setAcceptCookie(true)
+            val opts = "; path=/; domain=.steampowered.com; secure"
+            cookieManager.setCookie(STORE, "steamLoginSecure=$steamId%7C%7C${URLEncoder.encode(token, "UTF-8")}$opts")
+            cookieManager.setCookie(STORE, "birthtime=0$opts")
+            cookieManager.setCookie(STORE, "lastagecheckage=1-January-1970$opts")
+            cookieManager.setCookie(STORE, "wantsmatureconctent=1$opts")
+            cookieManager.flush()
+
+            val webView = WebView(activity)
+            cookieManager.setAcceptThirdPartyCookies(webView, true)
+            webView.settings.apply {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                blockNetworkImage = true
+                loadsImagesAutomatically = false
+                mediaPlaybackRequiresUserGesture = true
+                userAgentString = STORE_UA
+            }
+            webView.alpha = 0f
+            parent.addView(webView, ViewGroup.LayoutParams(1, 1))
+
+            fun finish(result: Boolean) {
+                if (done.isCompleted) return
+                done.complete(result)
+            }
+
+            webView.addJavascriptInterface(
+                object {
+                    @JavascriptInterface
+                    fun onResult(json: String) {
+                        val ok = try {
+                            JSONObject(json).optBoolean("success")
+                        } catch (e: Exception) {
+                            false
+                        }
+                        Timber.tag(TAG).i("webview addtowishlist result=$json -> $ok")
+                        finish(ok)
+                    }
+                },
+                "AndroidWishlist",
+            )
+
+            var posted = false
+            webView.webViewClient = object : WebViewClient() {
+                override fun shouldInterceptRequest(view: WebView?, request: WebResourceRequest?): WebResourceResponse? {
+                    val u = request?.url?.toString()?.lowercase() ?: return null
+                    val block = u.contains("/store_trailers/") || u.contains("video.akamai") || BLOCKED.containsMatchIn(u)
+                    return if (block) WebResourceResponse("text/plain", "utf-8", null) else null
+                }
+
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    if (posted || view == null || url == null || !url.contains("/app/$appId")) return
+                    posted = true
+                    // Give Akamai's inline bot-manager script a beat to set bm_sv before the add.
+                    view.postDelayed({ view.evaluateJavascript(addScript(appId), null) }, 800)
+                }
+
+                override fun onRenderProcessGone(view: WebView?, detail: RenderProcessGoneDetail?): Boolean {
+                    Timber.tag(TAG).w("webview renderer gone, aborting add")
+                    finish(false)
+                    return true
+                }
+            }
+
+            val utmUrl = "$STORE/app/$appId/?utm_source=gamenative&utm_medium=app&utm_campaign=$campaignId"
+            Timber.tag(TAG).i("webview loading $utmUrl")
+            webView.loadUrl(utmUrl)
+
+            val result = withTimeoutOrNull(TIMEOUT_MS) { done.await() } ?: false
+            if (!done.isCompleted) Timber.tag(TAG).w("webview wishlist timed out")
+            (webView.parent as? ViewGroup)?.removeView(webView)
+            webView.stopLoading()
+            webView.destroy()
+            result
+        }
+
+    private fun Context.findActivity(): Activity? {
+        var c: Context? = this
+        while (c is ContextWrapper) {
+            if (c is Activity) return c
+            c = c.baseContext
+        }
+        return null
+    }
+
+    private fun addScript(appId: Int): String =
+        """
+        (function(){
+          try {
+            var sid = window.g_sessionID || (document.cookie.match(/sessionid=([^;]+)/) || [])[1] || '';
+            fetch('/api/addtowishlist', {
+              method: 'POST',
+              credentials: 'include',
+              headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+              body: 'appid=$appId&sessionid=' + encodeURIComponent(sid)
+            })
+            .then(function(r){ return r.text(); })
+            .then(function(t){ AndroidWishlist.onResult(t); })
+            .catch(function(e){ AndroidWishlist.onResult('{"success":false,"error":"fetch"}'); });
+          } catch (e) {
+            AndroidWishlist.onResult('{"success":false,"error":"exc"}');
+          }
+        })();
+        """.trimIndent()
+}

--- a/app/src/main/java/app/gamenative/service/WishlistWebViewAdder.kt
+++ b/app/src/main/java/app/gamenative/service/WishlistWebViewAdder.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.net.Uri
 import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.JavascriptInterface
@@ -13,6 +14,7 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import java.net.URLEncoder
+import java.util.UUID
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -34,10 +36,12 @@ object WishlistWebViewAdder {
 
     private const val TAG = "SteamWishlist"
     private const val STORE = "https://store.steampowered.com"
+    private const val STORE_HOST = "store.steampowered.com"
     private const val STORE_UA =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
     private const val TIMEOUT_MS = 15_000L
     private val BLOCKED = Regex("\\.(jpg|jpeg|png|gif|webp|avif|svg|ico|mp4|m4s|webm|ttf|woff2?|css)(\\?|$)")
+    private val STORE_COOKIES = listOf("steamLoginSecure", "birthtime", "lastagecheckage", "wantsmatureconctent")
 
     @SuppressLint("SetJavaScriptEnabled")
     suspend fun add(context: Context, steamId: Long, token: String, appId: Int, campaignId: String): Boolean =
@@ -49,6 +53,9 @@ object WishlistWebViewAdder {
                 return@withContext false
             }
             val done = CompletableDeferred<Boolean>()
+            // Secret shared only with the main frame's injected script; a foreign frame that also
+            // sees the AndroidWishlist bridge cannot fabricate a result without it.
+            val nonce = UUID.randomUUID().toString().replace("-", "")
 
             val cookieManager = CookieManager.getInstance()
             cookieManager.setAcceptCookie(true)
@@ -60,71 +67,97 @@ object WishlistWebViewAdder {
             cookieManager.flush()
 
             val webView = WebView(activity)
-            cookieManager.setAcceptThirdPartyCookies(webView, true)
-            webView.settings.apply {
-                javaScriptEnabled = true
-                domStorageEnabled = true
-                blockNetworkImage = true
-                loadsImagesAutomatically = false
-                mediaPlaybackRequiresUserGesture = true
-                userAgentString = STORE_UA
-            }
-            webView.alpha = 0f
-            parent.addView(webView, ViewGroup.LayoutParams(1, 1))
+            var injectRunnable: Runnable? = null
+            var destroyed = false
+            try {
+                cookieManager.setAcceptThirdPartyCookies(webView, true)
+                webView.settings.apply {
+                    javaScriptEnabled = true
+                    domStorageEnabled = true
+                    blockNetworkImage = true
+                    loadsImagesAutomatically = false
+                    mediaPlaybackRequiresUserGesture = true
+                    userAgentString = STORE_UA
+                }
+                webView.alpha = 0f
+                parent.addView(webView, ViewGroup.LayoutParams(1, 1))
 
-            fun finish(result: Boolean) {
-                if (done.isCompleted) return
-                done.complete(result)
-            }
+                fun finish(result: Boolean) {
+                    if (!done.isCompleted) done.complete(result)
+                }
 
-            webView.addJavascriptInterface(
-                object {
-                    @JavascriptInterface
-                    fun onResult(json: String) {
-                        val ok = try {
-                            JSONObject(json).optBoolean("success")
-                        } catch (e: Exception) {
-                            false
+                webView.addJavascriptInterface(
+                    object {
+                        @JavascriptInterface
+                        fun onResult(callbackNonce: String, json: String) {
+                            if (callbackNonce != nonce) {
+                                Timber.tag(TAG).w("ignoring bridge call with bad nonce")
+                                return
+                            }
+                            val ok = try {
+                                JSONObject(json).optBoolean("success")
+                            } catch (e: Exception) {
+                                false
+                            }
+                            Timber.tag(TAG).i("webview addtowishlist result=$json -> $ok")
+                            finish(ok)
                         }
-                        Timber.tag(TAG).i("webview addtowishlist result=$json -> $ok")
-                        finish(ok)
+                    },
+                    "AndroidWishlist",
+                )
+
+                var posted = false
+                webView.webViewClient = object : WebViewClient() {
+                    override fun shouldInterceptRequest(view: WebView?, request: WebResourceRequest?): WebResourceResponse? {
+                        val u = request?.url?.toString()?.lowercase() ?: return null
+                        val block = u.contains("/store_trailers/") || u.contains("video.akamai") || BLOCKED.containsMatchIn(u)
+                        return if (block) WebResourceResponse("text/plain", "utf-8", null) else null
                     }
-                },
-                "AndroidWishlist",
-            )
 
-            var posted = false
-            webView.webViewClient = object : WebViewClient() {
-                override fun shouldInterceptRequest(view: WebView?, request: WebResourceRequest?): WebResourceResponse? {
-                    val u = request?.url?.toString()?.lowercase() ?: return null
-                    val block = u.contains("/store_trailers/") || u.contains("video.akamai") || BLOCKED.containsMatchIn(u)
-                    return if (block) WebResourceResponse("text/plain", "utf-8", null) else null
+                    override fun onPageFinished(view: WebView?, url: String?) {
+                        if (posted || view == null || url == null) return
+                        val uri = runCatching { Uri.parse(url) }.getOrNull()
+                        if (uri?.host != STORE_HOST || uri.path?.contains("/app/$appId") != true) return
+                        posted = true
+                        val target = view
+                        // Give Akamai's inline bot-manager script a beat to set bm_sv before the add.
+                        val r = Runnable {
+                            if (!done.isCompleted && !destroyed) {
+                                target.evaluateJavascript(addScript(appId, nonce), null)
+                            }
+                        }
+                        injectRunnable = r
+                        target.postDelayed(r, 800)
+                    }
+
+                    override fun onRenderProcessGone(view: WebView?, detail: RenderProcessGoneDetail?): Boolean {
+                        Timber.tag(TAG).w("webview renderer gone, aborting add")
+                        finish(false)
+                        return true
+                    }
                 }
 
-                override fun onPageFinished(view: WebView?, url: String?) {
-                    if (posted || view == null || url == null || !url.contains("/app/$appId")) return
-                    posted = true
-                    // Give Akamai's inline bot-manager script a beat to set bm_sv before the add.
-                    view.postDelayed({ view.evaluateJavascript(addScript(appId), null) }, 800)
-                }
+                val utmUrl = "$STORE/app/$appId/?utm_source=gamenative&utm_medium=app" +
+                    "&utm_campaign=${URLEncoder.encode(campaignId, "UTF-8")}"
+                Timber.tag(TAG).i("webview loading $utmUrl")
+                webView.loadUrl(utmUrl)
 
-                override fun onRenderProcessGone(view: WebView?, detail: RenderProcessGoneDetail?): Boolean {
-                    Timber.tag(TAG).w("webview renderer gone, aborting add")
-                    finish(false)
-                    return true
+                val result = withTimeoutOrNull(TIMEOUT_MS) { done.await() } ?: false
+                if (!done.isCompleted) Timber.tag(TAG).w("webview wishlist timed out")
+                result
+            } finally {
+                destroyed = true
+                injectRunnable?.let { webView.removeCallbacks(it) }
+                (webView.parent as? ViewGroup)?.removeView(webView)
+                webView.stopLoading()
+                webView.destroy()
+                // Don't leave this account's login cookie in the shared WebView store for the next
+                // WebView (or the next signed-in account) to inherit.
+                STORE_COOKIES.forEach {
+                    cookieManager.setCookie(STORE, "$it=; path=/; domain=.steampowered.com; expires=Thu, 01 Jan 1970 00:00:00 GMT")
                 }
+                cookieManager.flush()
             }
-
-            val utmUrl = "$STORE/app/$appId/?utm_source=gamenative&utm_medium=app&utm_campaign=$campaignId"
-            Timber.tag(TAG).i("webview loading $utmUrl")
-            webView.loadUrl(utmUrl)
-
-            val result = withTimeoutOrNull(TIMEOUT_MS) { done.await() } ?: false
-            if (!done.isCompleted) Timber.tag(TAG).w("webview wishlist timed out")
-            (webView.parent as? ViewGroup)?.removeView(webView)
-            webView.stopLoading()
-            webView.destroy()
-            result
         }
 
     private fun Context.findActivity(): Activity? {
@@ -136,7 +169,7 @@ object WishlistWebViewAdder {
         return null
     }
 
-    private fun addScript(appId: Int): String =
+    private fun addScript(appId: Int, nonce: String): String =
         """
         (function(){
           try {
@@ -148,10 +181,10 @@ object WishlistWebViewAdder {
               body: 'appid=$appId&sessionid=' + encodeURIComponent(sid)
             })
             .then(function(r){ return r.text(); })
-            .then(function(t){ AndroidWishlist.onResult(t); })
-            .catch(function(e){ AndroidWishlist.onResult('{"success":false,"error":"fetch"}'); });
+            .then(function(t){ AndroidWishlist.onResult('$nonce', t); })
+            .catch(function(e){ AndroidWishlist.onResult('$nonce', '{"success":false,"error":"fetch"}'); });
           } catch (e) {
-            AndroidWishlist.onResult('{"success":false,"error":"exc"}');
+            AndroidWishlist.onResult('$nonce', '{"success":false,"error":"exc"}');
           }
         })();
         """.trimIndent()

--- a/app/src/main/java/app/gamenative/ui/screen/library/FeaturedCtaButton.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/FeaturedCtaButton.kt
@@ -1,5 +1,6 @@
 package app.gamenative.ui.screen.library
 
+import android.content.Context
 import android.content.Intent
 import androidx.annotation.StringRes
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -79,7 +80,7 @@ internal fun FeaturedCtaButton(
         } else {
             busy = true
             scope.launch {
-                val ok = cta.run()
+                val ok = cta.run(context)
                 busy = false
                 if (ok) {
                     done = true
@@ -139,19 +140,19 @@ private sealed class InAppCta(
 ) {
     abstract suspend fun isDone(): Boolean?
 
-    abstract suspend fun run(): Boolean
+    abstract suspend fun run(context: Context): Boolean
 
     private class Wishlist(appId: Int, private val campaignId: String) : InAppCta(appId, R.string.featured_action_wishlisted) {
         override suspend fun isDone(): Boolean? = SteamWishlistService.isWishlisted(appId)
 
-        override suspend fun run(): Boolean =
-            SteamWishlistService.addToWishlistAttributed(appId, campaignId) is SteamWishlistService.Outcome.Success
+        override suspend fun run(context: Context): Boolean =
+            SteamWishlistService.addToWishlistAttributed(context, appId, campaignId) is SteamWishlistService.Outcome.Success
     }
 
     private class GetDemo(appId: Int) : InAppCta(appId, R.string.featured_action_in_library) {
         override suspend fun isDone(): Boolean = SteamService.isAppInLibrary(appId)
 
-        override suspend fun run(): Boolean = SteamService.requestFreeLicense(appId)
+        override suspend fun run(context: Context): Boolean = SteamService.requestFreeLicense(appId)
     }
 
     companion object {


### PR DESCRIPTION
## Description
Steam wishlisting in the app wasn't being attributed. This should fix it.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes Steam wishlisting by loading the store page with UTM params in an offscreen WebView and posting the wishlist in-page. Previously we used bare HTTP/CM and often missed attribution; now we earn tracking cookies in a real session, then fall back to HTTP-attributed add and finally CM.

- Adds WishlistWebViewAdder: attaches a hidden 1x1 WebView, sets `steamLoginSecure` and age-gate cookies, accepts third‑party cookies, blocks heavy assets, uses a desktop UA, delays JS injection to allow bot-manager cookies, posts /api/addtowishlist, verifies via a nonce‑guarded JS bridge, times out after 15s, and clears cookies on cleanup.
- Changes SteamWishlistService.addToWishlistAttributed to require a Context and try WebView (with current then refreshed token) → HTTP attributed add (URL‑encodes `campaignId`) → CM add; logs under SteamWishlist.
- Updates FeaturedCtaButton/InAppCta to pass Context to wishlist and demo actions; no UI changes.

**Required migration**
- Update callers of SteamWishlistService.addToWishlistAttributed to pass an Activity-backed Context.

<sup>Written for commit 383ecc00df4a15bd8c67dc2eaf89d30d09ab74cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a more reliable wishlist attribution flow using an in-app web experience.
  * Wishlist actions now retry after refreshing authentication and use fallback methods when needed.
  * Featured call-to-action actions now support context-aware wishlist and demo requests.
  * Campaign information is now handled more reliably when adding wishlist items.

* **Bug Fixes**
  * Improved handling of wishlist attribution failures, timeouts, and rendering errors.
  * Added cleanup and fallback behavior to help ensure wishlist additions complete successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->