### PR TITLE
Added bionic steam client gamefixes for Whisk and Whisk Demo

### DIFF
--- a/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/GameFixesRegistry.kt
@@ -44,6 +44,8 @@ object GameFixesRegistry {
         STEAM_Fix_1962700,
         STEAM_Fix_2868840,
         STEAM_Fix_3373660,
+        STEAM_Fix_3602270,
+        STEAM_Fix_4320000,
         STEAM_Fix_990080,
         EPIC_Fix_b1b4e0b67a044575820cb5e63028dcae,
         EPIC_Fix_dabb52e328834da7bbe99691e374cb84,

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_3602270.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_3602270.kt
@@ -1,0 +1,11 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Whisk (Steam)
+ */
+val STEAM_Fix_3602270: KeyedGameFix = KeyedBionicSteamClientFix(
+    gameSource = GameSource.STEAM,
+    gameId = "3602270",
+)

--- a/app/src/main/java/app/gamenative/gamefixes/STEAM_4320000.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/STEAM_4320000.kt
@@ -1,0 +1,11 @@
+package app.gamenative.gamefixes
+
+import app.gamenative.data.GameSource
+
+/**
+ * Whisk Demo (Steam)
+ */
+val STEAM_Fix_4320000: KeyedGameFix = KeyedBionicSteamClientFix(
+    gameSource = GameSource.STEAM,
+    gameId = "4320000",
+)

--- a/app/src/main/java/app/gamenative/gamefixes/types/BionicSteamClientFix.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/types/BionicSteamClientFix.kt
@@ -14,6 +14,13 @@ class BionicSteamClientFix : GameFix {
         container: Container,
     ): Boolean {
         return try {
+            if (!container.containerVariant.equals(Container.BIONIC, ignoreCase = true)) {
+                // The bionic Steam bridge is only bootstrapped by the bionic launcher.
+                // On a glibc container the flag would have no launcher support, so leave it off.
+                Timber.tag("GameFixes").i("Skipping bionic Steam client for game $gameId on non-bionic container")
+                return true
+            }
+
             if (container.isLaunchBionicSteam) {
                 return true
             }

--- a/app/src/main/java/app/gamenative/gamefixes/types/BionicSteamClientFix.kt
+++ b/app/src/main/java/app/gamenative/gamefixes/types/BionicSteamClientFix.kt
@@ -1,0 +1,36 @@
+package app.gamenative.gamefixes
+
+import android.content.Context
+import app.gamenative.data.GameSource
+import com.winlator.container.Container
+import timber.log.Timber
+
+class BionicSteamClientFix : GameFix {
+    override fun apply(
+        context: Context,
+        gameId: String,
+        installPath: String,
+        installPathWindows: String,
+        container: Container,
+    ): Boolean {
+        return try {
+            if (container.isLaunchBionicSteam) {
+                return true
+            }
+
+            container.setLaunchBionicSteam(true)
+            container.setLaunchRealSteam(false)
+            container.saveData()
+            Timber.tag("GameFixes").i("Enabled bionic Steam client for game $gameId")
+            true
+        } catch (e: Exception) {
+            Timber.tag("GameFixes").e(e, "Failed to enable bionic Steam client for game $gameId")
+            false
+        }
+    }
+}
+
+class KeyedBionicSteamClientFix(
+    override val gameSource: GameSource,
+    override val gameId: String,
+) : KeyedGameFix, GameFix by BionicSteamClientFix()

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -63,6 +63,7 @@ import app.gamenative.enums.PathType
 import app.gamenative.enums.SaveLocation
 import app.gamenative.enums.SyncResult
 import app.gamenative.events.AndroidEvent
+import app.gamenative.gamefixes.GameFixesRegistry
 import app.gamenative.service.ActiveGameRegistry
 import app.gamenative.service.SteamService
 import app.gamenative.service.amazon.AmazonService
@@ -1624,6 +1625,15 @@ fun preLaunchApp(
 
         // Clear session metadata on every launch to ensure fresh values
         container.clearSessionMetadata()
+
+        // Apply game-specific fixes before anything reads the container config. Some fixes
+        // change launch-mode flags (e.g. bionic Steam) that the download/dependency steps
+        // below and MainViewModel.launchApp consume, so this must run first.
+        try {
+            GameFixesRegistry.applyFor(context, appId, container)
+        } catch (e: Exception) {
+            Timber.tag("GameFixes").w(e, "Game fixes failed in preLaunchApp")
+        }
 
         val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
         val isLocalSavesOnly = ContainerUtils.isLocalSavesOnly(context, appId)


### PR DESCRIPTION
## Description
Whisk and Whisk Demo need bionic steam. Enable by default. Also add gamefix application earlier in boot so that env vars are applied too.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the bionic Steam client for Whisk and Whisk Demo and applies game fixes at pre-launch. Previously these titles launched with real Steam and fixes ran later; now fixes run first and, on bionic containers, switch launch mode to bionic Steam. On glibc containers, the fix is skipped.

**Review notes**
- Adds `app.gamenative.gamefixes.BionicSteamClientFix` to set `isLaunchBionicSteam=true`, disable real Steam, and save the container; no-op on non-bionic containers.
- Registers `app.gamenative.gamefixes.STEAM_Fix_3602270` (Whisk) and `app.gamenative.gamefixes.STEAM_Fix_4320000` (Whisk Demo) in `app.gamenative.gamefixes.GameFixesRegistry`.
- Applies fixes at the start of `preLaunchApp` in `app.gamenative.ui.PluviaMain` with error logging, so dependency/download steps read the correct launch mode.
- Verify first launch and logs for Steam app IDs 3602270 and 4320000; confirm glibc containers log a skip and bionic flags persist after save.

<sup>Written for commit 3d9c09ba7fd0c05265b27b2ea4625bbc3a0a5f6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic launch fixes for Whisk (Steam) and Whisk Demo.
  * Game-specific compatibility adjustments are now applied automatically before launching supported games.
  * Launches continue even if a compatibility fix cannot be applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->