### PR TITLE
Set EVSHIM_BASE_PATH in the host process so gamepad shm is not hardcoded to app.gamenative

### DIFF
--- a/app/src/main/java/app/gamenative/PluviaApp.kt
+++ b/app/src/main/java/app/gamenative/PluviaApp.kt
@@ -53,6 +53,23 @@ class PluviaApp : SplitCompatApplication() {
     override fun onCreate() {
         super.onCreate()
 
+        // libevshim.so sets up its gamepad shared memory in a C constructor at
+        // library load, deriving the directory from getenv("EVSHIM_BASE_PATH") and
+        // otherwise falling back to a hardcoded "/data/data/app.gamenative/files".
+        // That env var is set for the guest (wine) process but not for THIS host
+        // process, so on any build whose applicationId is not exactly
+        // "app.gamenative" (e.g. the release-gold flavor -> app.gamenative.gold, or
+        // a fork/rename) the host builds the pad shm under the wrong app's data
+        // dir, cannot create/mmap it, and no controller input reaches games. Set it
+        // explicitly here, before any evshim load. On the stock package this
+        // resolves to the same path the hardcoded fallback uses, so there is no
+        // behavior change there.
+        try {
+            android.system.Os.setenv("EVSHIM_BASE_PATH", filesDir.absolutePath, true)
+        } catch (e: Exception) {
+            android.util.Log.w("PluviaApp", "Failed to set EVSHIM_BASE_PATH for host process", e)
+        }
+
         preloadSystemLibraries()
 
         // Allows to find resource streams not closed within GameNative and JavaSteam


### PR DESCRIPTION
### Problem
On any build whose `applicationId` is not exactly `app.gamenative`, **no controller input reaches any game**. This includes this repo's own `release-gold` flavor (`app.gamenative.gold`) and any fork/rename.

### Root cause
`libevshim.so` sets up its gamepad shared memory in a C constructor (`initialize_all_pads`, `__attribute__((constructor))`) that runs at library load. `build_gamepad_dir()` derives the directory from `getenv("EVSHIM_BASE_PATH")`, otherwise falling back to a hardcoded `"/data/data/app.gamenative/files"`.

`EVSHIM_BASE_PATH` is exported into the **guest** (wine) process env in `BionicProgramLauncherComponent`, but it is **not** set in the **host** process that loads `libevshim` and calls `notifyStateChanged`. On the stock package the host's `getenv` is unset so it uses the hardcoded fallback, which happens to be correct. On a renamed package that fallback points at the wrong app's data dir, which the app cannot create or `mmap`, so:

- host `shm[i]` is null;
- logcat spams `evshim: notifyStateChanged missing shm for slot=0`;
- Java (`WinHandler`) writes pad state to `getFilesDir()/gamepad_shm` (correct dir) while native reads the stock dir, so they never meet and no game sees the pad.

Stock `app.gamenative` is **not** affected. The `release-gold` build type (`applicationIdSuffix = ".gold"`) is.

### Fix
Set `EVSHIM_BASE_PATH = filesDir` in `PluviaApp.onCreate`, before any evshim load. Package-agnostic: on stock it equals the hardcoded fallback (no behavior change); on renamed/gold builds the host now uses the correct data dir.

### Verification
On a renamed build (`applicationId app.gamenative.mali`, RK3588 / Mali-G610): before, continuous "missing shm for slot=0" and a dead controller; after, the host mmaps all player slots (`java P0-P3 mmap'd`), zero "missing shm" errors, and controller input works in-game.

(Issues are disabled on the repo, so filing this as a PR with the full report.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure host process sets the gamepad SHM base path so controllers work on renamed builds. Previously the host defaulted to `/data/data/app.gamenative/files` when `EVSHIM_BASE_PATH` was unset, breaking input on builds whose `applicationId` isn’t `app.gamenative`; now it sets the env var to `filesDir` at startup with no behavior change on stock.

**Review notes**
- Sets `EVSHIM_BASE_PATH` via `android.system.Os.setenv(filesDir.absolutePath, overwrite=true)` in `PluviaApp.onCreate` before any evshim load.
- Host-only change; the guest (Wine) env is unchanged.
- On stock `app.gamenative` this matches the fallback path; failures only log a warning.

<sup>Written for commit 72753e45dc4640670356db955f7e092ea429b18f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup reliability by configuring required runtime storage before native components load.
  * Startup now continues gracefully if the runtime path cannot be configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->