### PR TITLE
Fix fps limiting on non-directx games, remove Odin 3 from default list for power management

### DIFF
--- a/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
@@ -457,6 +457,7 @@ object PowerManager {
         val apply = Runnable {
             xServerView.setFrameRateLimit(limitFps)
             presentExtension?.setFrameRateLimit(limitFps)
+            com.winlator.xserver.ShmFramePacer.setFrameRateLimit(limitFps)
         }
         if (Looper.myLooper() == Looper.getMainLooper()) {
             apply.run()

--- a/app/src/main/java/app/gamenative/powercontrol/autotuning/DeviceGate.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/autotuning/DeviceGate.kt
@@ -9,11 +9,9 @@ import android.os.Build
  */
 object DeviceGate {
     private const val MODEL_RETROID_POCKET_6 = "retroid pocket 6"
-    private const val MODEL_AYN_ODIN3 = "odin3"
 
     private val testedModels = arrayOf(
         MODEL_RETROID_POCKET_6,
-        MODEL_AYN_ODIN3,
     )
 
     fun isDeviceSupported(model: String = Build.MODEL ?: ""): Boolean {

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -702,6 +702,7 @@ fun XServerScreen(
             if (!isLsfgAvailable || lsfgMultiplier < 2) return@applier false
             PowerManager.targetFps = capFps
             LsfgQuickMenuHelper.applyLiveFpsCap(container, capFps)
+            ShmFramePacer.setFrameRateLimit(capFps)
             true
         }
         val detectedMax = detectMaxRefreshRateHz(context, xServerView as? View)
@@ -2514,6 +2515,7 @@ fun XServerScreen(
             removePerformanceHud()
             performanceHudHost = null
             shouldTrackDisplayedFrames.set(false)
+            ShmFramePacer.setFrameRateLimit(0)
 
             val releaseBinding = view.tag as? XServerViewReleaseBinding
             releaseBinding?.let { binding ->

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -194,6 +194,7 @@ import com.winlator.xenvironment.components.XServerComponent
 import com.winlator.xserver.Keyboard
 import com.winlator.xserver.Property
 import com.winlator.xserver.ScreenInfo
+import com.winlator.xserver.ShmFramePacer
 import com.winlator.xserver.Window
 import com.winlator.xserver.WindowManager
 import com.winlator.xserver.XServer
@@ -637,6 +638,10 @@ fun XServerScreen(
         xServerView?.getxServer()
             ?.getExtension<PresentExtension>(PresentExtension.MAJOR_OPCODE.toInt())
             ?.setFrameRateLimit(if (isLsfgAvailable && lsfgMultiplier >= 2) 0 else limit)
+        // Not disarmed with LSFG: the layer only multiplies Vulkan-swapchain
+        // presents, so SHM-presenting games never pass through it and would
+        // otherwise run uncapped whenever LSFG is armed.
+        ShmFramePacer.setFrameRateLimit(limit)
         PowerManager.targetFps = limit
         // keeps frame stats in base units while generated frames tick the ring
         PowerManager.frameSampleStride =
@@ -781,10 +786,10 @@ fun XServerScreen(
             fpsProvider = {
                 val raw = frameRating?.currentFPS ?: 0f
                 if (isLsfgAvailable && lsfgMultiplier >= 2) {
-                    // Prefer the layer's on-device measurement; it accounts for
-                    // skipped generated frames. Fall back to the naive estimate
-                    // until the stats file is fresh.
-                    LsfgVkManager.readMeasuredFps(container) ?: (raw * lsfgMultiplier)
+                    // Only trust the layer's own measurement; multiplying raw
+                    // fabricates fps for games the layer never attaches to
+                    // (SHM-presenting games have no Vulkan swapchain).
+                    LsfgVkManager.readMeasuredFps(container) ?: raw
                 } else {
                     raw
                 }

--- a/app/src/main/java/com/winlator/xconnector/Client.java
+++ b/app/src/main/java/com/winlator/xconnector/Client.java
@@ -15,6 +15,8 @@ public class Client {
     protected Thread pollThread;
     protected int shutdownFd;
     protected boolean connected;
+    protected java.util.concurrent.ScheduledFuture<?> pauseTask;
+    protected long pauseDeadlineNs;
 
     public Client(XConnectorEpoll connector, ClientSocket clientSocket) {
         this.connector = connector;

--- a/app/src/main/java/com/winlator/xconnector/Client.java
+++ b/app/src/main/java/com/winlator/xconnector/Client.java
@@ -29,6 +29,10 @@ public class Client {
         outputStream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
     }
 
+    public XConnectorEpoll getConnector() {
+        return connector;
+    }
+
     public XInputStream getInputStream() {
         return inputStream;
     }

--- a/app/src/main/java/com/winlator/xconnector/XConnectorEpoll.java
+++ b/app/src/main/java/com/winlator/xconnector/XConnectorEpoll.java
@@ -183,6 +183,30 @@ public class XConnectorEpoll implements Runnable {
         return this.connectedClients.get(fd);
     }
 
+    // Frame-pacing back-pressure: the fd leaves epoll until delayNs elapses, so
+    // the client stalls in its own blocking call while the epoll thread stays
+    // free. Single-threaded mode only.
+    private java.util.concurrent.ScheduledExecutorService pauseScheduler;
+
+    public void pauseClientReads(Client client, long delayNs) {
+        if (this.multithreadedClients || !client.connected || !this.running) return;
+        removeFdFromEpoll(this.epollFd, client.clientSocket.fd);
+        synchronized (this) {
+            if (pauseScheduler == null) {
+                pauseScheduler = java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
+                    Thread t = new Thread(r, "XConnectorPause");
+                    t.setDaemon(true);
+                    return t;
+                });
+            }
+        }
+        pauseScheduler.schedule(() -> {
+            if (client.connected && this.running) {
+                addFdToEpoll(this.epollFd, client.clientSocket.fd);
+            }
+        }, delayNs, java.util.concurrent.TimeUnit.NANOSECONDS);
+    }
+
     public void killConnection(Client client) {
         client.connected = false;
         if (this.multithreadedClients) {

--- a/app/src/main/java/com/winlator/xconnector/XConnectorEpoll.java
+++ b/app/src/main/java/com/winlator/xconnector/XConnectorEpoll.java
@@ -186,22 +186,22 @@ public class XConnectorEpoll implements Runnable {
     // Frame-pacing back-pressure: the fd leaves epoll until delayNs elapses, so
     // the client stalls in its own blocking call while the epoll thread stays
     // free. Single-threaded mode only.
-    private java.util.concurrent.ScheduledExecutorService pauseScheduler;
-
-    public void pauseClientReads(Client client, long delayNs) {
-        if (this.multithreadedClients || !client.connected || !this.running) return;
-        long deadlineNs = System.nanoTime() + delayNs;
-        final java.util.concurrent.ScheduledExecutorService sched;
-        synchronized (this) {
-            if (pauseScheduler == null) {
-                pauseScheduler = java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
+    // Process-wide daemon scheduler, never shut down: connector teardown must
+    // not be involved — stop() is synchronized and joins the epoll thread, so
+    // any scheduler cleanup on the shutdown path can deadlock against it.
+    private static final class PauseScheduler {
+        static final java.util.concurrent.ScheduledExecutorService INSTANCE =
+                java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
                     Thread t = new Thread(r, "XConnectorPause");
                     t.setDaemon(true);
                     return t;
                 });
-            }
-            sched = pauseScheduler;
-        }
+    }
+
+    public void pauseClientReads(Client client, long delayNs) {
+        if (this.multithreadedClients || !client.connected || !this.running) return;
+        long deadlineNs = System.nanoTime() + delayNs;
+        final java.util.concurrent.ScheduledExecutorService sched = PauseScheduler.INSTANCE;
         synchronized (client) {
             // One pending re-arm per client, keyed to the latest deadline; an
             // earlier task firing first would resume reads before the newest
@@ -212,19 +212,14 @@ public class XConnectorEpoll implements Runnable {
             }
             removeFdFromEpoll(this.epollFd, client.clientSocket.fd);
             client.pauseDeadlineNs = deadlineNs;
-            try {
-                client.pauseTask = sched.schedule(() -> {
-                    synchronized (client) {
-                        client.pauseTask = null;
-                        if (client.connected && this.running) {
-                            addFdToEpoll(this.epollFd, client.clientSocket.fd);
-                        }
+            client.pauseTask = sched.schedule(() -> {
+                synchronized (client) {
+                    client.pauseTask = null;
+                    if (client.connected && this.running) {
+                        addFdToEpoll(this.epollFd, client.clientSocket.fd);
                     }
-                }, delayNs, java.util.concurrent.TimeUnit.NANOSECONDS);
-            } catch (java.util.concurrent.RejectedExecutionException e) {
-                client.pauseTask = null;
-                if (client.connected) addFdToEpoll(this.epollFd, client.clientSocket.fd);
-            }
+                }
+            }, delayNs, java.util.concurrent.TimeUnit.NANOSECONDS);
         }
     }
 
@@ -271,12 +266,6 @@ public class XConnectorEpoll implements Runnable {
         closeTrackedFd(this.serverFd);
         closeTrackedFd(this.shutdownFd);
         closeTrackedFd(this.epollFd);
-        synchronized (this) {
-            if (pauseScheduler != null) {
-                pauseScheduler.shutdownNow();
-                pauseScheduler = null;
-            }
-        }
     }
 
     public int getInitialInputBufferCapacity() {

--- a/app/src/main/java/com/winlator/xconnector/XConnectorEpoll.java
+++ b/app/src/main/java/com/winlator/xconnector/XConnectorEpoll.java
@@ -190,7 +190,8 @@ public class XConnectorEpoll implements Runnable {
 
     public void pauseClientReads(Client client, long delayNs) {
         if (this.multithreadedClients || !client.connected || !this.running) return;
-        removeFdFromEpoll(this.epollFd, client.clientSocket.fd);
+        long deadlineNs = System.nanoTime() + delayNs;
+        final java.util.concurrent.ScheduledExecutorService sched;
         synchronized (this) {
             if (pauseScheduler == null) {
                 pauseScheduler = java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
@@ -199,16 +200,46 @@ public class XConnectorEpoll implements Runnable {
                     return t;
                 });
             }
+            sched = pauseScheduler;
         }
-        pauseScheduler.schedule(() -> {
-            if (client.connected && this.running) {
-                addFdToEpoll(this.epollFd, client.clientSocket.fd);
+        synchronized (client) {
+            // One pending re-arm per client, keyed to the latest deadline; an
+            // earlier task firing first would resume reads before the newest
+            // frame's slot.
+            if (client.pauseTask != null && !client.pauseTask.isDone()) {
+                if (client.pauseDeadlineNs >= deadlineNs) return;
+                client.pauseTask.cancel(false);
             }
-        }, delayNs, java.util.concurrent.TimeUnit.NANOSECONDS);
+            removeFdFromEpoll(this.epollFd, client.clientSocket.fd);
+            client.pauseDeadlineNs = deadlineNs;
+            try {
+                client.pauseTask = sched.schedule(() -> {
+                    synchronized (client) {
+                        client.pauseTask = null;
+                        if (client.connected && this.running) {
+                            addFdToEpoll(this.epollFd, client.clientSocket.fd);
+                        }
+                    }
+                }, delayNs, java.util.concurrent.TimeUnit.NANOSECONDS);
+            } catch (java.util.concurrent.RejectedExecutionException e) {
+                client.pauseTask = null;
+                if (client.connected) addFdToEpoll(this.epollFd, client.clientSocket.fd);
+            }
+        }
+    }
+
+    private void cancelPendingPause(Client client) {
+        synchronized (client) {
+            if (client.pauseTask != null) {
+                client.pauseTask.cancel(false);
+                client.pauseTask = null;
+            }
+        }
     }
 
     public void killConnection(Client client) {
         client.connected = false;
+        cancelPendingPause(client);
         if (this.multithreadedClients) {
             if (Thread.currentThread() != client.pollThread) {
                 client.requestShutdown();
@@ -240,6 +271,12 @@ public class XConnectorEpoll implements Runnable {
         closeTrackedFd(this.serverFd);
         closeTrackedFd(this.shutdownFd);
         closeTrackedFd(this.epollFd);
+        synchronized (this) {
+            if (pauseScheduler != null) {
+                pauseScheduler.shutdownNow();
+                pauseScheduler = null;
+            }
+        }
     }
 
     public int getInitialInputBufferCapacity() {

--- a/app/src/main/java/com/winlator/xserver/Drawable.java
+++ b/app/src/main/java/com/winlator/xserver/Drawable.java
@@ -148,9 +148,6 @@ public class Drawable extends XResource {
 
                 copyArea(srcX, srcY, dstX, dstY, width, height, totalWidth, this.getStride(), data, this.data);
             }
-            this.data.rewind();
-            data.rewind();
-            forceUpdate();
         }
         this.data.rewind();
         data.rewind();

--- a/app/src/main/java/com/winlator/xserver/ShmFramePacer.java
+++ b/app/src/main/java/com/winlator/xserver/ShmFramePacer.java
@@ -1,0 +1,33 @@
+package com.winlator.xserver;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+// FPS limiter for clients that present via full-drawable SHM blits instead of
+// the Present extension. The caller suspends the client's socket reads for the
+// returned delay, which blocks the game inside its own per-frame XSync; the
+// blitted frame is still displayed immediately.
+public class ShmFramePacer {
+    private static volatile int frameRateLimit = 0;
+
+    private static class Timing { long nextNs; }
+    private static final ConcurrentHashMap<Integer, Timing> timings = new ConcurrentHashMap<>();
+
+    public static void setFrameRateLimit(int limit) {
+        frameRateLimit = Math.max(0, limit);
+    }
+
+    // Returns how long (ns) the caller should suspend this client's reads, or 0.
+    public static long framePresented(int drawableId) {
+        int fps = frameRateLimit;
+        Timing t = timings.computeIfAbsent(drawableId, k -> new Timing());
+        if (fps <= 0) {
+            t.nextNs = 0;
+            return 0;
+        }
+        long now = System.nanoTime();
+        if (t.nextNs < now) t.nextNs = now;
+        long delay = t.nextNs - now;
+        t.nextNs += 1_000_000_000L / fps;
+        return delay;
+    }
+}

--- a/app/src/main/java/com/winlator/xserver/ShmFramePacer.java
+++ b/app/src/main/java/com/winlator/xserver/ShmFramePacer.java
@@ -23,12 +23,28 @@ public class ShmFramePacer {
     public static long framePresented(int drawableId) {
         int fps = frameRateLimit;
         if (fps <= 0) return 0;
-        if (timings.size() > MAX_TRACKED_DRAWABLES) timings.clear();
+        if (timings.size() > MAX_TRACKED_DRAWABLES) evictStalest(drawableId);
         Timing t = timings.computeIfAbsent(drawableId, k -> new Timing());
         long now = System.nanoTime();
         if (t.nextNs < now) t.nextNs = now;
         long delay = t.nextNs - now;
         t.nextNs += 1_000_000_000L / fps;
         return delay;
+    }
+
+    // Evicts the longest-idle entry (smallest nextNs), never the presenting
+    // drawable, so an overflow frees one slot without resetting active pacing.
+    private static void evictStalest(int presentingDrawableId) {
+        Integer evict = null;
+        long oldest = Long.MAX_VALUE;
+        for (java.util.Map.Entry<Integer, Timing> e : timings.entrySet()) {
+            if (e.getKey() == presentingDrawableId) continue;
+            long nextNs = e.getValue().nextNs;
+            if (nextNs < oldest) {
+                oldest = nextNs;
+                evict = e.getKey();
+            }
+        }
+        if (evict != null) timings.remove(evict);
     }
 }

--- a/app/src/main/java/com/winlator/xserver/ShmFramePacer.java
+++ b/app/src/main/java/com/winlator/xserver/ShmFramePacer.java
@@ -12,18 +12,19 @@ public class ShmFramePacer {
     private static class Timing { long nextNs; }
     private static final ConcurrentHashMap<Integer, Timing> timings = new ConcurrentHashMap<>();
 
+    private static final int MAX_TRACKED_DRAWABLES = 128;
+
     public static void setFrameRateLimit(int limit) {
         frameRateLimit = Math.max(0, limit);
+        if (frameRateLimit == 0) timings.clear();
     }
 
     // Returns how long (ns) the caller should suspend this client's reads, or 0.
     public static long framePresented(int drawableId) {
         int fps = frameRateLimit;
+        if (fps <= 0) return 0;
+        if (timings.size() > MAX_TRACKED_DRAWABLES) timings.clear();
         Timing t = timings.computeIfAbsent(drawableId, k -> new Timing());
-        if (fps <= 0) {
-            t.nextNs = 0;
-            return 0;
-        }
         long now = System.nanoTime();
         if (t.nextNs < now) t.nextNs = now;
         long delay = t.nextNs - now;

--- a/app/src/main/java/com/winlator/xserver/XClient.java
+++ b/app/src/main/java/com/winlator/xserver/XClient.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 
 public class XClient implements XResourceManager.OnResourceLifecycleListener {
     public final XServer xServer;
+    public com.winlator.xconnector.Client connectorClient;
     private boolean authenticated = false;
     public final Integer resourceIDBase;
     private short sequenceNumber = 0;

--- a/app/src/main/java/com/winlator/xserver/XClientConnectionHandler.java
+++ b/app/src/main/java/com/winlator/xserver/XClientConnectionHandler.java
@@ -13,7 +13,9 @@ public class XClientConnectionHandler implements ConnectionHandler {
     @Override
     public void handleNewConnection(Client client) {
         client.createIOStreams();
-        client.setTag(new XClient(xServer, client.getInputStream(), client.getOutputStream()));
+        XClient xClient = new XClient(xServer, client.getInputStream(), client.getOutputStream());
+        xClient.connectorClient = client;
+        client.setTag(xClient);
     }
 
     @Override

--- a/app/src/main/java/com/winlator/xserver/extensions/MITSHMExtension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/MITSHMExtension.java
@@ -114,6 +114,14 @@ public class MITSHMExtension implements Extension {
         }
 
         drawable.drawImage(srcX, srcY, dstX, dstY, srcWidth, srcHeight, depth, data, totalWidth, totalHeight);
+
+        // Only a blit covering >=80% of the drawable counts as a presented frame.
+        if (srcWidth * srcHeight * 5 >= drawable.width * drawable.height * 4 && client.connectorClient != null) {
+            long delayNs = com.winlator.xserver.ShmFramePacer.framePresented(drawableId);
+            if (delayNs > 0) {
+                client.connectorClient.getConnector().pauseClientReads(client.connectorClient, delayNs);
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/com/winlator/xserver/extensions/MITSHMExtension.java
+++ b/app/src/main/java/com/winlator/xserver/extensions/MITSHMExtension.java
@@ -115,8 +115,13 @@ public class MITSHMExtension implements Extension {
 
         drawable.drawImage(srcX, srcY, dstX, dstY, srcWidth, srcHeight, depth, data, totalWidth, totalHeight);
 
-        // Only a blit covering >=80% of the drawable counts as a presented frame.
-        if (srcWidth * srcHeight * 5 >= drawable.width * drawable.height * 4 && client.connectorClient != null) {
+        // Only a blit whose clipped destination covers >=80% of the drawable
+        // counts as a presented frame.
+        int clippedW = Math.min((int) srcWidth, drawable.width - Math.max(0, (int) dstX));
+        int clippedH = Math.min((int) srcHeight, drawable.height - Math.max(0, (int) dstY));
+        if (clippedW > 0 && clippedH > 0
+                && clippedW * clippedH * 5 >= drawable.width * drawable.height * 4
+                && client.connectorClient != null) {
             long delayNs = com.winlator.xserver.ShmFramePacer.framePresented(drawableId);
             if (delayNs > 0) {
                 client.connectorClient.getConnector().pauseClientReads(client.connectorClient, delayNs);

--- a/app/src/test/java/app/gamenative/powercontrol/autotuning/DeviceGateTest.kt
+++ b/app/src/test/java/app/gamenative/powercontrol/autotuning/DeviceGateTest.kt
@@ -47,48 +47,18 @@ class DeviceGateTest {
     }
 
     @Test
-    fun `odin3 is supported with exact lowercase match`() {
-        assertTrue(DeviceGate.isDeviceSupported("odin3"))
+    fun `odin3 is not supported`() {
+        assertFalse(DeviceGate.isDeviceSupported("odin3"))
     }
 
     @Test
-    fun `odin3 is supported with mixed case`() {
-        assertTrue(DeviceGate.isDeviceSupported("Odin3"))
+    fun `odin3 is not supported with mixed case`() {
+        assertFalse(DeviceGate.isDeviceSupported("Odin3"))
     }
 
     @Test
-    fun `odin3 is supported with uppercase`() {
-        assertTrue(DeviceGate.isDeviceSupported("ODIN3"))
-    }
-
-    @Test
-    fun `odin_3 is not supported because normalization adds space`() {
-        assertFalse(DeviceGate.isDeviceSupported("odin_3"))
-    }
-
-    @Test
-    fun `odin-3 is not supported because normalization adds space`() {
-        assertFalse(DeviceGate.isDeviceSupported("odin-3"))
-    }
-
-    @Test
-    fun `odin 3 with space is not supported`() {
-        assertFalse(DeviceGate.isDeviceSupported("odin  3"))
-    }
-
-    @Test
-    fun `odin3 is supported with leading and trailing whitespace`() {
-        assertTrue(DeviceGate.isDeviceSupported("  odin3  "))
-    }
-
-    @Test
-    fun `odin3 is supported as substring in longer model name`() {
-        assertTrue(DeviceGate.isDeviceSupported("AYN Odin3 Pro"))
-    }
-
-    @Test
-    fun `odin3 is supported with manufacturer prefix`() {
-        assertTrue(DeviceGate.isDeviceSupported("AYN_Odin3"))
+    fun `odin3 is not supported as substring in longer model name`() {
+        assertFalse(DeviceGate.isDeviceSupported("AYN Odin3 Pro"))
     }
 
     @Test
@@ -147,7 +117,7 @@ class DeviceGateTest {
     }
 
     @Test
-    fun `normalization handles complex manufacturer prefix`() {
-        assertTrue(DeviceGate.isDeviceSupported("AYN-Technologies_Odin3-Gaming"))
+    fun `odin3 with complex manufacturer prefix is not supported`() {
+        assertFalse(DeviceGate.isDeviceSupported("AYN-Technologies_Odin3-Gaming"))
     }
 }


### PR DESCRIPTION


## Description
FPS cap was not working on non directx games. This fixes it and allows lower power usage

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores FPS limiting for non‑DirectX games that present via SHM by pacing client socket reads, reducing power use without delaying display. Also removes Odin 3 from the default power‑management list and fixes an ANR on game exit.

- Adds `com.winlator.xserver.ShmFramePacer`; `com.winlator.xserver.extensions.MITSHMExtension.putImage` treats SHM blits covering >=80% of a drawable as presents and calls `com.winlator.xconnector.XConnectorEpoll.pauseClientReads` to apply per‑drawable back‑pressure; effective in single‑threaded connector mode. Wires `XClient` to its connector `Client` so MIT‑SHM can pause reads.
- `XServerScreen` and `PowerManager` set the `ShmFramePacer` limit; keep `PresentExtension` cap disabled when LSFG multiplier >=2 while leaving `ShmFramePacer` armed; FPS HUD now uses the LSFG layer’s measured value or raw only to avoid fabricating FPS for SHM games. Disarms `ShmFramePacer` when the XServer view is released.
- Removes redundant immediate updates from `com.winlator.xserver.Drawable.drawImage`.
- Drops `odin3` from supported models and updates tests.
- Prevents ANR on game exit by cancelling pending pauses in `com.winlator.xconnector.XConnectorEpoll.killConnection`.

<sup>Written for commit a29231939184f25fbf985f58405997b369d52220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added frame-rate limiting for shared-memory game presentation to provide smoother, more consistent gameplay.
  * Frame pacing now works with LSFG and responds to live frame-rate cap updates.
  * Frame pacing resets automatically when the XServer view is released.

* **Bug Fixes**
  * Improved performance HUD FPS reporting when LSFG data is unavailable.
  * Corrected frame update handling to reduce unnecessary refresh operations.
  * Updated hand-tuned device support listings to reflect currently supported hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->