### PR TITLE
Fix installs on adopted primary storage

### DIFF
--- a/app/src/main/java/app/gamenative/service/DownloadService.kt
+++ b/app/src/main/java/app/gamenative/service/DownloadService.kt
@@ -26,7 +26,7 @@ object DownloadService {
             field = value
         }
 
-    // all mounted non-primary external volumes (SD cards, USB), discovered at init
+    // All mounted install target volumes (SD cards, USB, and adopted primary storage), discovered at init
     var externalVolumePaths: List<String> = emptyList()
         private set
 
@@ -40,7 +40,7 @@ object DownloadService {
         val sm = context.getSystemService(android.os.storage.StorageManager::class.java)
         val appFilesDirs = StorageUtils.getAllExternalFilesDirs(context)
             .filter { Environment.getExternalStorageState(it) == Environment.MEDIA_MOUNTED }
-            .filter { sm?.getStorageVolume(it)?.isPrimary != true }
+            .filter { StorageUtils.isExternalInstallTarget(sm, it) }
         // both layouts per volume: legacy Android/data (existing installs) + public root (new installs)
         externalVolumePaths = appFilesDirs
             .flatMap { dir -> listOfNotNull(dir.absolutePath, StorageUtils.publicInstallRoot(dir)?.absolutePath) }

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInterface.kt
@@ -525,7 +525,7 @@ fun SettingsGroupInterface(
         val ctx = LocalContext.current
         val sm = ctx.getSystemService(StorageManager::class.java)
 
-        // All writable non-primary volumes (SD / USB).
+        // All writable install target volumes (SD / USB / adopted primary storage).
         // getExternalFilesDirs misses USB OTG on most devices, so StorageUtils also
         // enumerates StorageManager.storageVolumes and synthesizes the per-app files dir.
         // Runs off the composition thread because synthesizing the USB candidate
@@ -535,7 +535,7 @@ fun SettingsGroupInterface(
             value = withContext(Dispatchers.IO) {
                 StorageUtils.getAllExternalFilesDirs(ctx)
                     .filter { Environment.getExternalStorageState(it) == Environment.MEDIA_MOUNTED }
-                    .filter { sm?.getStorageVolume(it)?.isPrimary != true }
+                    .filter { StorageUtils.isExternalInstallTarget(sm, it) }
             }
         }
 
@@ -804,4 +804,3 @@ private fun Preview_SettingsScreen() {
         )
     }
 }
-

--- a/app/src/main/java/app/gamenative/utils/StorageUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/StorageUtils.kt
@@ -148,6 +148,49 @@ object StorageUtils {
     }
 
     /**
+     * Returns whether [appFilesDir] should be offered as a separate install target.
+     *
+     * Primary storage is not always backed by built-in storage. When Android migrates primary
+     * shared storage to adopted media, the SD-backed volume remains primary but has a non-default
+     * storage UUID.
+     */
+    fun isExternalInstallTarget(storageManager: StorageManager?, appFilesDir: File): Boolean {
+        val volume = storageManager?.getStorageVolume(appFilesDir)
+            ?: return runCatching { Environment.isExternalStorageRemovable(appFilesDir) }.getOrDefault(false)
+        if (!volume.isPrimary) return true
+
+        val resolvedStorageUuid = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            volume.storageUuid
+        } else {
+            try {
+                storageManager.getUuidForPath(appFilesDir)
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        return isNonDefaultPrimaryStorage(
+            resolvedStorageUuid = resolvedStorageUuid,
+            legacyVolumeUuid = volume.uuid,
+            isPhysicalPrimary = volume.isRemovable && !volume.isEmulated,
+            allowLegacyUuidFallback = Build.VERSION.SDK_INT < Build.VERSION_CODES.S,
+            defaultStorageUuid = StorageManager.UUID_DEFAULT,
+        )
+    }
+
+    internal fun isNonDefaultPrimaryStorage(
+        resolvedStorageUuid: java.util.UUID?,
+        legacyVolumeUuid: String?,
+        isPhysicalPrimary: Boolean,
+        allowLegacyUuidFallback: Boolean,
+        defaultStorageUuid: java.util.UUID,
+    ): Boolean {
+        if (resolvedStorageUuid != null) return resolvedStorageUuid != defaultStorageUuid
+        if (isPhysicalPrimary) return true
+        return allowLegacyUuidFallback && !legacyVolumeUuid.isNullOrBlank()
+    }
+
+    /**
      * Gets all app-specific external files directories, using StorageManager as a fallback
      * for cases where context.getExternalFilesDirs(null) might return null or incomplete results
      * (e.g. USB OTG drives, which most devices omit from getExternalFilesDirs).

--- a/app/src/test/java/app/gamenative/utils/StorageUtilsTest.kt
+++ b/app/src/test/java/app/gamenative/utils/StorageUtilsTest.kt
@@ -1,0 +1,102 @@
+package app.gamenative.utils
+
+import java.util.UUID
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StorageUtilsTest {
+
+    private val defaultStorageUuid = UUID.fromString("41217664-9172-527a-b3d5-edabb50a7d69")
+
+    @Test
+    fun `built-in primary storage is not a separate install target`() {
+        assertFalse(
+            StorageUtils.isNonDefaultPrimaryStorage(
+                resolvedStorageUuid = defaultStorageUuid,
+                legacyVolumeUuid = null,
+                isPhysicalPrimary = false,
+                allowLegacyUuidFallback = false,
+                defaultStorageUuid = defaultStorageUuid,
+            ),
+        )
+    }
+
+    @Test
+    fun `default UUID overrides weaker physical and legacy signals`() {
+        assertFalse(
+            StorageUtils.isNonDefaultPrimaryStorage(
+                resolvedStorageUuid = defaultStorageUuid,
+                legacyVolumeUuid = "ABCD-1234",
+                isPhysicalPrimary = true,
+                allowLegacyUuidFallback = true,
+                defaultStorageUuid = defaultStorageUuid,
+            ),
+        )
+    }
+
+    @Test
+    fun `adopted primary storage is an install target`() {
+        assertTrue(
+            StorageUtils.isNonDefaultPrimaryStorage(
+                resolvedStorageUuid = UUID.fromString("12345678-1234-1234-1234-123456789abc"),
+                legacyVolumeUuid = null,
+                isPhysicalPrimary = false,
+                allowLegacyUuidFallback = false,
+                defaultStorageUuid = defaultStorageUuid,
+            ),
+        )
+    }
+
+    @Test
+    fun `legacy adopted primary falls back to its volume UUID`() {
+        assertTrue(
+            StorageUtils.isNonDefaultPrimaryStorage(
+                resolvedStorageUuid = null,
+                legacyVolumeUuid = "ABCD-1234",
+                isPhysicalPrimary = false,
+                allowLegacyUuidFallback = true,
+                defaultStorageUuid = defaultStorageUuid,
+            ),
+        )
+    }
+
+    @Test
+    fun `modern primary does not use a raw UUID when its typed UUID is unavailable`() {
+        assertFalse(
+            StorageUtils.isNonDefaultPrimaryStorage(
+                resolvedStorageUuid = null,
+                legacyVolumeUuid = "ABCD-1234",
+                isPhysicalPrimary = false,
+                allowLegacyUuidFallback = false,
+                defaultStorageUuid = defaultStorageUuid,
+            ),
+        )
+    }
+
+    @Test
+    fun `physical primary storage remains an install target when UUID lookup fails`() {
+        assertTrue(
+            StorageUtils.isNonDefaultPrimaryStorage(
+                resolvedStorageUuid = null,
+                legacyVolumeUuid = null,
+                isPhysicalPrimary = true,
+                allowLegacyUuidFallback = false,
+                defaultStorageUuid = defaultStorageUuid,
+            ),
+        )
+    }
+
+    @Test
+    fun `unidentified emulated primary storage is not an install target`() {
+        assertFalse(
+            StorageUtils.isNonDefaultPrimaryStorage(
+                resolvedStorageUuid = null,
+                legacyVolumeUuid = null,
+                isPhysicalPrimary = false,
+                allowLegacyUuidFallback = true,
+                defaultStorageUuid = defaultStorageUuid,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Description

Android can migrate primary shared storage onto adopted SD media. GameNative currently rejects every primary `StorageVolume` in both Settings and `DownloadService`, so adopted-primary storage is hidden even though it is the device's large writable backing volume.

This change:

- centralizes install-target eligibility in `StorageUtils`
- uses `StorageVolume.storageUuid` on Android 12+ and `StorageManager.getUuidForPath` on Android 8-11 to distinguish adopted backing storage from `UUID_DEFAULT`
- preserves existing portable SD and USB behavior, with conservative compatibility fallbacks when an OEM cannot map a path
- applies the same predicate to the Settings selector and background install discovery, so existing installs remain discoverable after the toggle is changed
- adds regression coverage for built-in primary, adopted primary, physical primary, legacy raw UUID fallback, and modern typed-UUID precedence

Related discussion: https://github.com/utkarshdalal/GameNative/discussions/1718

Related prior work: #1585 (volume enumeration), #809 (toggle-off discovery), and #1768 (modern external storage)

Android background: https://source.android.com/docs/core/storage/adoptable

## Recording

Not available yet because this requires a physical device with adopted storage migrated to primary. Please run the **Ad-hoc Signed Build** workflow for this PR so affected users can install it over their existing GameNative app and validate the fix without clearing app data or redownloading their libraries.

## Type of Change

- [x] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Testing

- `./gradlew :app:testLegacyDebugUnitTest --tests app.gamenative.utils.StorageUtilsTest`
- `./gradlew :app:testModernDebugUnitTest --tests app.gamenative.utils.StorageUtilsTest`
- 7 tests passed in each variant
- `git diff --check`

Real-device validation is still required before merge.

## Scope and non-goals

This supports adopted media when Android exposes it as the backing volume for primary shared storage. It does not synthesize private paths such as `/mnt/expand/<UUID>`, request broader storage permissions, or claim support for an adopted private volume that Android does not return through the app's external-files APIs.

## Device test plan

Test target: any GameNative-supported Android device where a microSD card has been formatted as adopted/internal storage and migrated to primary shared storage.

1. Record the device model, Android version, OEM firmware or custom ROM, and whether primary storage was migrated to the adopted card.
2. Open Settings and verify **Write to external storage** is enabled and the adopted-primary volume is offered.
3. Select it and confirm the displayed free space corresponds to the card.
4. Install a small game and verify its data is written to the selected volume.
5. Restart GameNative and verify the game is still discovered and launchable.
6. Disable external storage, restart, and verify the completed game remains discoverable, launchable, and deletable (regression coverage for #809).
7. Re-enable external storage, select the adopted volume again, uninstall the test game, and verify its files are removed from that volume.

Regression controls: a built-in-only primary volume must remain excluded, while existing portable SD and USB targets must remain available.

## Checklist

- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes install discovery on devices where primary shared storage is migrated to adopted SD. Previously we hid all primary volumes; now we expose adopted-primary as an install target while keeping built-in primary hidden.

- Centralizes eligibility in `StorageUtils.isExternalInstallTarget`, using `StorageVolume.storageUuid` on Android 12+ and `StorageManager.getUuidForPath` on Android 8–11, with fallbacks for physical primary and conservative behavior when UUIDs are unavailable.
- Applies the same predicate to `DownloadService` and the settings volume selector, so selection and background discovery match and existing installs remain discoverable.
- Keeps portable SD/USB behavior unchanged; adds unit coverage in `StorageUtilsTest` for built-in primary, adopted primary, physical primary, legacy fallback, and typed-UUID precedence.

<sup>Written for commit a94949d5ef46ad14ed30da607723a3be7fbe28cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of available installation storage.
  * Adopted, removable, and other writable primary storage volumes are now correctly recognized as install destinations.

* **Tests**
  * Added coverage for default, adopted, legacy, removable, emulated, and UUID-unavailable storage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->