### PR TITLE
Make membership popups less frequent

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -981,6 +981,27 @@ object PrefManager {
             setPref(TIPPED, value)
         }
 
+    private val HAS_ATTEMPTED_GAME_LAUNCH = booleanPreferencesKey("has_attempted_game_launch")
+    var hasAttemptedGameLaunch: Boolean
+        get() = getPref(HAS_ATTEMPTED_GAME_LAUNCH, false)
+        set(value) {
+            setPref(HAS_ATTEMPTED_GAME_LAUNCH, value)
+        }
+
+    private val LAST_LAUNCH_PITCH_TIME = longPreferencesKey("last_launch_pitch_time")
+    var lastLaunchPitchTime: Long
+        get() = getPref(LAST_LAUNCH_PITCH_TIME, 0L)
+        set(value) {
+            setPref(LAST_LAUNCH_PITCH_TIME, value)
+        }
+
+    private val LAST_WARM_PITCH_TIME = longPreferencesKey("last_warm_pitch_time")
+    var lastWarmPitchTime: Long
+        get() = getPref(LAST_WARM_PITCH_TIME, 0L)
+        set(value) {
+            setPref(LAST_WARM_PITCH_TIME, value)
+        }
+
     private val APP_THEME = intPreferencesKey("app_theme")
     var appTheme: AppTheme
         get() {

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -262,6 +262,17 @@ private fun consumePendingSteamLoginError(context: Context) {
     SnackbarManager.show(context.getString(R.string.intent_launch_steam_login_failed))
 }
 
+private const val LAUNCH_PITCH_COOLDOWN_MS = 5 * 24 * 60 * 60 * 1000L
+
+private fun trackMembershipPrompt(event: String, trigger: String) {
+    if (PrefManager.usageAnalyticsEnabled) {
+        PostHog.capture(
+            event = event,
+            properties = mapOf("trigger" to trigger),
+        )
+    }
+}
+
 private fun trackGameLaunched(appId: String) {
     val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
     val gameName = ContainerUtils.resolveGameName(appId)
@@ -293,6 +304,7 @@ fun PluviaMain(
         mutableStateOf(MessageDialogState(false))
     }
     val setMessageDialogState: (MessageDialogState) -> Unit = { msgDialogState = it }
+    var membershipPitchTrigger by rememberSaveable { mutableStateOf("launch") }
 
     var gameFeedbackState by rememberSaveable(stateSaver = GameFeedbackDialogState.Saver) {
         mutableStateOf(GameFeedbackDialogState(false))
@@ -622,6 +634,25 @@ fun PluviaMain(
                         appId = event.appId,
                     )
                 }
+
+                is MainViewModel.MainUiEvent.ShowMembershipPitch -> {
+                    val gameName = ContainerUtils.resolveGameName(event.appId)
+                    PrefManager.lastWarmPitchTime = System.currentTimeMillis()
+                    membershipPitchTrigger = event.trigger
+                    trackMembershipPrompt("membership_prompt_shown", event.trigger)
+                    msgDialogState = MessageDialogState(
+                        visible = true,
+                        type = DialogType.SUPPORT,
+                        title = if (event.trigger == "five_star") {
+                            context.getString(R.string.pitch_five_star_title, gameName)
+                        } else {
+                            context.getString(R.string.pitch_session_title, gameName)
+                        },
+                        message = context.getString(R.string.main_thank_you_message),
+                        confirmBtnText = context.getString(R.string.main_join_kofi),
+                        dismissBtnText = context.getString(R.string.close),
+                    )
+                }
             }
         }
     }
@@ -794,7 +825,7 @@ fun PluviaMain(
         DialogType.SUPPORT -> {
             onConfirmClick = {
                 uriHandler.openUri(Constants.Misc.KO_FI_LINK)
-                PrefManager.tipped = true
+                trackMembershipPrompt("membership_prompt_clicked", membershipPitchTrigger)
                 msgDialogState = MessageDialogState(visible = false)
             }
             onDismissRequest = {
@@ -802,14 +833,6 @@ fun PluviaMain(
             }
             onDismissClick = {
                 msgDialogState = MessageDialogState(visible = false)
-            }
-            onActionClick = {
-                val shareIntent = Intent().apply {
-                    action = Intent.ACTION_SEND
-                    putExtra(Intent.EXTRA_TEXT, context.getString(R.string.main_share_text))
-                    type = "text/plain"
-                }
-                context.startActivity(Intent.createChooser(shareIntent, context.getString(R.string.main_share)))
             }
         }
 
@@ -1259,10 +1282,12 @@ fun PluviaMain(
                         // Close the dialog regardless of success
                         Timber.d("GameFeedback: Closing dialog")
                         gameFeedbackState = GameFeedbackDialogState(visible = false)
+                        viewModel.onGameFeedbackResolved(feedbackState.rating)
                     }
                 },
                 onDismiss = {
                     gameFeedbackState = GameFeedbackDialogState(visible = false)
+                    viewModel.onGameFeedbackResolved(null)
                 },
                 onDiscordSupport = {
                     uriHandler.openUri("https://discord.gg/2hKv4VfZfE")
@@ -1374,8 +1399,15 @@ fun PluviaMain(
                                     message = context.getString(R.string.main_recent_crash_message),
                                     confirmBtnText = context.getString(R.string.ok),
                                 )
-                            } else if (!(PrefManager.tipped || BuildConfig.GOLD)) {
+                            } else if (!(PrefManager.tipped || BuildConfig.GOLD) &&
+                                PrefManager.hasAttemptedGameLaunch &&
+                                !MainViewModel.gamePlayedThisSession &&
+                                System.currentTimeMillis() - PrefManager.lastLaunchPitchTime >= LAUNCH_PITCH_COOLDOWN_MS
+                            ) {
                                 viewModel.setAnnoyingDialogShown(true)
+                                PrefManager.lastLaunchPitchTime = System.currentTimeMillis()
+                                membershipPitchTrigger = "launch"
+                                trackMembershipPrompt("membership_prompt_shown", "launch")
                                 msgDialogState = MessageDialogState(
                                     visible = true,
                                     type = DialogType.SUPPORT,
@@ -1383,7 +1415,6 @@ fun PluviaMain(
                                     message = context.getString(R.string.main_thank_you_message),
                                     confirmBtnText = context.getString(R.string.main_join_kofi),
                                     dismissBtnText = context.getString(R.string.close),
-                                    actionBtnText = context.getString(R.string.main_share),
                                 )
                             }
                         }

--- a/app/src/main/java/app/gamenative/ui/component/dialog/GameFeedbackDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/GameFeedbackDialog.kt
@@ -49,95 +49,102 @@ fun GameFeedbackDialog(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(24.dp)
-                        .verticalScroll(rememberScrollState()),
+                        .padding(24.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    // Title
-                    Text(
-                        text = stringResource(R.string.game_feedback_game_run),
-                        style = MaterialTheme.typography.headlineSmall,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(bottom = 16.dp)
-                    )
-
-                    // Rating Stars
-                    Row(
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(bottom = 16.dp),
-                        horizontalArrangement = Arrangement.Center
+                            .weight(1f, fill = false)
+                            .verticalScroll(rememberScrollState()),
+                        horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        for (i in 1..5) {
-                            Icon(
-                                imageVector = if (i <= state.rating) Icons.Filled.Star else Icons.Filled.StarOutline,
-                                contentDescription = "Star $i",
-                                tint = if (i <= state.rating) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
-                                modifier = Modifier
-                                    .size(48.dp)
-                                    .clickable {
-                                        onStateChange(state.copy(rating = i))
-                                    }
-                                    .padding(4.dp)
-                            )
+                        // Title
+                        Text(
+                            text = stringResource(R.string.game_feedback_game_run),
+                            style = MaterialTheme.typography.headlineSmall,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(bottom = 16.dp)
+                        )
+
+                        // Rating Stars
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = 16.dp),
+                            horizontalArrangement = Arrangement.Center
+                        ) {
+                            for (i in 1..5) {
+                                Icon(
+                                    imageVector = if (i <= state.rating) Icons.Filled.Star else Icons.Filled.StarOutline,
+                                    contentDescription = "Star $i",
+                                    tint = if (i <= state.rating) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                                    modifier = Modifier
+                                        .size(48.dp)
+                                        .clickable {
+                                            onStateChange(state.copy(rating = i))
+                                        }
+                                        .padding(4.dp)
+                                )
+                            }
                         }
-                    }
 
-                    // Tags Selection
-                    Text(
-                        text = stringResource(R.string.game_feedback_issues_question),
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier
-                            .align(Alignment.Start)
-                            .padding(bottom = 8.dp)
-                    )
+                        // Tags Selection
+                        Text(
+                            text = stringResource(R.string.game_feedback_issues_question),
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier
+                                .align(Alignment.Start)
+                                .padding(bottom = 8.dp)
+                        )
 
-                    FlowRow(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 16.dp)
-                    ) {
-                        for (tag in GameFeedbackDialogState.AVAILABLE_TAGS) {
-                            val isSelected = tag in state.selectedTags
-                            FilterChip(
-                                selected = isSelected,
-                                onClick = {
-                                    val newTags = if (isSelected) {
-                                        state.selectedTags - tag
-                                    } else {
-                                        state.selectedTags + tag
-                                    }
-                                    onStateChange(state.copy(selectedTags = newTags))
-                                },
-                                label = {
-                                    Text(
-                                        text = tag.replace("_", " ").capitalize(),
-                                        style = MaterialTheme.typography.bodySmall
-                                    )
-                                },
-                                modifier = Modifier.padding(end = 8.dp, bottom = 8.dp)
-                            )
+                        FlowRow(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = 16.dp)
+                        ) {
+                            for (tag in GameFeedbackDialogState.AVAILABLE_TAGS) {
+                                val isSelected = tag in state.selectedTags
+                                FilterChip(
+                                    selected = isSelected,
+                                    onClick = {
+                                        val newTags = if (isSelected) {
+                                            state.selectedTags - tag
+                                        } else {
+                                            state.selectedTags + tag
+                                        }
+                                        onStateChange(state.copy(selectedTags = newTags))
+                                    },
+                                    label = {
+                                        Text(
+                                            text = tag.replace("_", " ").capitalize(),
+                                            style = MaterialTheme.typography.bodySmall
+                                        )
+                                    },
+                                    modifier = Modifier.padding(end = 8.dp, bottom = 8.dp)
+                                )
+                            }
                         }
-                    }
 
-                    // Feedback text box
-                    NoExtractOutlinedTextField(
-                        value = state.feedbackText,
-                        onValueChange = { onStateChange(state.copy(feedbackText = it)) },
-                        label = { Text(stringResource(R.string.describe_what_happened)) },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 100.dp)
-                            .padding(bottom = 16.dp),
-                        maxLines = 5,
-                    )
+                        // Feedback text box
+                        NoExtractOutlinedTextField(
+                            value = state.feedbackText,
+                            onValueChange = { onStateChange(state.copy(feedbackText = it)) },
+                            label = { Text(stringResource(R.string.describe_what_happened)) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(min = 100.dp)
+                                .padding(bottom = 16.dp),
+                            maxLines = 5,
+                        )
 
-                    // Discord support link
-                    TextButton(
-                        onClick = onDiscordSupport,
-                        modifier = Modifier.padding(bottom = 16.dp)
-                    ) {
-                        Text(stringResource(R.string.get_support_on_discord))
+                        // Discord support link
+                        TextButton(
+                            onClick = onDiscordSupport,
+                            modifier = Modifier.padding(bottom = 16.dp)
+                        ) {
+                            Text(stringResource(R.string.get_support_on_discord))
+                        }
                     }
 
                     // Dialog action buttons

--- a/app/src/main/java/app/gamenative/ui/component/dialog/MessageDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/MessageDialog.kt
@@ -1,7 +1,10 @@
 package app.gamenative.ui.component.dialog
 
 import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Gamepad
 import androidx.compose.material3.AlertDialog
@@ -9,6 +12,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.AnnotatedString
@@ -42,21 +46,23 @@ fun MessageDialog(
                 title = title?.let { { Text(it) } },
                 text = message?.let {
                     {
-                        if (useHtmlInMsg) {
-                            Text(
-                                text = AnnotatedString.fromHtml(
-                                    htmlString = it,
-                                    linkStyles = TextLinkStyles(
-                                        style = SpanStyle(
-                                            textDecoration = TextDecoration.Underline,
-                                            fontStyle = FontStyle.Italic,
-                                            color = Color.Blue,
+                        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                            if (useHtmlInMsg) {
+                                Text(
+                                    text = AnnotatedString.fromHtml(
+                                        htmlString = it,
+                                        linkStyles = TextLinkStyles(
+                                            style = SpanStyle(
+                                                textDecoration = TextDecoration.Underline,
+                                                fontStyle = FontStyle.Italic,
+                                                color = Color.Blue,
+                                            ),
                                         ),
                                     ),
-                                ),
-                            )
-                        } else {
-                            Text(it)
+                                )
+                            } else {
+                                Text(it)
+                            }
                         }
                     }
                 },

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -5,6 +5,7 @@ import android.os.Process
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.gamenative.BuildConfig
 import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
 import app.gamenative.data.GameProcessInfo
@@ -65,6 +66,33 @@ class MainViewModel @Inject constructor(
 
     companion object {
         private const val KEY_CURRENT_SCREEN_ROUTE = "current_screen_route"
+        private const val MIN_WARM_PITCH_SESSION_MS = 7 * 60 * 1000L
+        private const val WARM_PITCH_COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000L
+
+        var gamePlayedThisSession = false
+            private set
+    }
+
+    private var gameSessionStartTime = 0L
+    private var pendingWarmPitch: Pair<String, Boolean>? = null
+
+    private fun warmPitchAllowed(): Boolean {
+        if (PrefManager.tipped || BuildConfig.GOLD) return false
+        return System.currentTimeMillis() - PrefManager.lastWarmPitchTime >= WARM_PITCH_COOLDOWN_MS
+    }
+
+    fun onGameFeedbackResolved(rating: Int?) {
+        val (appId, sessionLongEnough) = pendingWarmPitch ?: return
+        pendingWarmPitch = null
+        val trigger = when {
+            rating == 5 -> "five_star"
+            rating == null && sessionLongEnough -> "long_session"
+            else -> return
+        }
+        if (!warmPitchAllowed()) return
+        viewModelScope.launch {
+            _uiEvent.send(MainUiEvent.ShowMembershipPitch(appId, trigger))
+        }
     }
 
     sealed class MainUiEvent {
@@ -76,6 +104,7 @@ class MainViewModel @Inject constructor(
         data class SteamDisconnected(val isTerminal: Boolean) : MainUiEvent()
         data object ShowDiscordSupportDialog : MainUiEvent()
         data class ShowGameFeedbackDialog(val appId: String) : MainUiEvent()
+        data class ShowMembershipPitch(val appId: String, val trigger: String) : MainUiEvent()
         data object ServiceReady : MainUiEvent()
     }
 
@@ -463,6 +492,9 @@ class MainViewModel @Inject constructor(
     }
 
     fun launchApp(context: Context, appId: String) {
+        gameSessionStartTime = System.currentTimeMillis()
+        gamePlayedThisSession = true
+        PrefManager.hasAttemptedGameLaunch = true
         // Show booting splash before launching the app
         viewModelScope.launch {
             viewModelScope.launch(Dispatchers.IO) {
@@ -564,6 +596,10 @@ class MainViewModel @Inject constructor(
 
                 // After app closes, check if we need to show the feedback dialog
                 // Show feedback if: first time running this game OR config was changed
+                val sessionLongEnough = gameSessionStartTime > 0 &&
+                    System.currentTimeMillis() - gameSessionStartTime >= MIN_WARM_PITCH_SESSION_MS
+                gameSessionStartTime = 0L
+                var feedbackRequested = false
                 try {
                     // Show feedback for all stores except custom games.
                     val feedbackGameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
@@ -575,6 +611,7 @@ class MainViewModel @Inject constructor(
                         if (!shown) {
                             container.putExtra("discord_support_prompt_shown", "true")
                             container.saveData()
+                            feedbackRequested = true
                             _uiEvent.send(MainUiEvent.ShowGameFeedbackDialog(appId))
                         }
 
@@ -584,6 +621,7 @@ class MainViewModel @Inject constructor(
                             container.putExtra("config_changed", "false")
                             container.saveData()
                             // Show the feedback dialog
+                            feedbackRequested = true
                             _uiEvent.send(MainUiEvent.ShowGameFeedbackDialog(appId))
                         }
                     } else {
@@ -591,6 +629,12 @@ class MainViewModel @Inject constructor(
                     }
                 } catch (e: Exception) {
                     Timber.w(e, "Failed to check/update feedback dialog state for $appId")
+                }
+
+                if (feedbackRequested) {
+                    pendingWarmPitch = appId to sessionLongEnough
+                } else if (sessionLongEnough && warmPitchAllowed()) {
+                    _uiEvent.send(MainUiEvent.ShowMembershipPitch(appId, "long_session"))
                 }
             } finally {
                 onComplete?.invoke()

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInfo.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupInfo.kt
@@ -40,8 +40,6 @@ fun SettingsGroupInfo() {
             icon = { Icon(imageVector = Icons.Filled.MonetizationOn, contentDescription = "Tip") },
             onClick = {
                 uriHandler.openUri(Constants.Misc.KO_FI_LINK)
-                askForTip = false
-                PrefManager.tipped = !askForTip
             },
         )
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -791,10 +791,10 @@
 
     <!-- Settings: Info Group -->
     <string name="settings_info_title">Info</string>
-    <string name="settings_info_send_tip_title">Send drikkepenge</string>
-    <string name="settings_info_send_tip_subtitle">Bidrag til løbende udvikling</string>
-    <string name="settings_info_ask_tip_title">Spørg efter drikkepenge ved opstart</string>
-    <string name="settings_info_ask_tip_subtitle">Forhindrer drikkepengebeskeden i at vises</string>
+    <string name="settings_info_send_tip_title">Bliv medlem</string>
+    <string name="settings_info_send_tip_subtitle">Tidlig adgang til udgivelser, prioriteret hjælp og mere</string>
+    <string name="settings_info_ask_tip_title">Medlemstilbud</string>
+    <string name="settings_info_ask_tip_subtitle">Vis lejlighedsvise tilbud om at blive GameNative-medlem</string>
     <string name="settings_info_source_title">Kildekode</string>
     <string name="settings_info_source_subtitle">Se kildekoden til dette projekt</string>
     <string name="settings_info_libraries_title">Anvendte biblioteker</string>
@@ -913,9 +913,11 @@
     <!-- TODO: Manual review - PluviaMain: Crash & Support -->
     <string name="main_recent_crash_title">Nylig crash</string>
     <string name="main_recent_crash_message">Beklager det!\nDet ville være dejligt at vide om det nylige problem, du har haft.\nDu kan se og eksportere den nyeste crash-log i appens indstillinger og vedhæfte den som et Github-problem i projektets repository.\nLink til Github-repo er også i indstillinger!</string>
-    <string name="main_thank_you_title">Tak for at bruge GameNative!</string>
-    <string name="main_thank_you_message">Støt open-source PC-gaming på Android ved at dele appen med dine venner eller ved at blive medlem på Ko-fi.</string>
-    <string name="main_join_kofi">Tilmeld dig på Ko-fi</string>
+    <string name="main_thank_you_title">Nyder du GameNative?</string>
+    <string name="main_thank_you_message">Bliv medlem i dag. Medlemmer får:\n\n• Tidlig adgang til nye udgivelser\n• Prioriteret hjælp til at få dine spil til at køre\n• Premium-roller og eksklusive kanaler på Discord\n• …og mere\n\nFra $5/måned</string>
+    <string name="main_join_kofi">Bliv medlem</string>
+    <string name="pitch_session_title">Nyder du %1$s?</string>
+    <string name="pitch_five_star_title">Godt, at %1$s kørte perfekt!</string>
     <string name="main_share">Del</string>
     <string name="main_share_text">Prøv GameNative - spil dine PC Steam-spil på Android med fuld understøttelse af cloud-gemmer!\nhttps://gamenative.app\nTilmeld dig fællesskabet: https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">Virkede spillet?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -940,10 +940,10 @@
     <string name="settings_debug_clear_cache_subtitle">Alle geladenen Bilder entfernen.</string>
     <!-- Settings: Info Group -->
     <string name="settings_info_title">Info</string>
-    <string name="settings_info_send_tip_title">Trinkgeld senden</string>
-    <string name="settings_info_send_tip_subtitle">Unterstütze die Weiterentwicklung</string>
-    <string name="settings_info_ask_tip_title">Nach Start Trinkgeld erfragen</string>
-    <string name="settings_info_ask_tip_subtitle">Blendet die Trinkgeld-Frage aus</string>
+    <string name="settings_info_send_tip_title">Mitglied werden</string>
+    <string name="settings_info_send_tip_subtitle">Frühzugang zu Versionen, bevorzugte Hilfe und mehr</string>
+    <string name="settings_info_ask_tip_title">Mitgliedschaftsangebote</string>
+    <string name="settings_info_ask_tip_subtitle">Gelegentlich Angebote anzeigen, GameNative-Mitglied zu werden</string>
     <string name="settings_info_source_title">Quellcode</string>
     <string name="settings_info_source_subtitle">Projektquellcode ansehen</string>
     <string name="settings_info_libraries_title">Verwendete Bibliotheken</string>
@@ -1049,9 +1049,11 @@
     <!-- PluviaMain: Crash & Support -->
     <string name="main_recent_crash_title">Kürzlicher Absturz</string>
     <string name="main_recent_crash_message">Tut uns leid!\nTeile uns gern mit, was passiert ist.\nDu kannst das letzte Crash-Log im App-Setup anzeigen/exportieren und bei Github als Issue einreichen.\nDer Link ist auch in den Einstellungen!</string>
-    <string name="main_thank_you_title">Danke, dass du GameNative nutzt!</string>
-    <string name="main_thank_you_message">Unterstütze Open-Source-PC-Gaming auf Android, indem du die App weiterempfiehlst oder Mitglied auf Ko-fi wirst.</string>
-    <string name="main_join_kofi">Auf Ko-fi unterstützen</string>
+    <string name="main_thank_you_title">Gefällt dir GameNative?</string>
+    <string name="main_thank_you_message">Werde noch heute Mitglied. Mitglieder erhalten:\n\n• Frühzugang zu neuen Versionen\n• Bevorzugte Hilfe, um deine Spiele zum Laufen zu bringen\n• Premium-Rollen und exklusive Kanäle auf Discord\n• …und mehr\n\nAb 5 $/Monat</string>
+    <string name="main_join_kofi">Mitglied werden</string>
+    <string name="pitch_session_title">Gefällt dir %1$s?</string>
+    <string name="pitch_five_star_title">Schön, dass %1$s super lief!</string>
     <string name="main_share">Teilen</string>
     <string name="main_share_text">Check out GameNative - play your PC Steam games on Android, with full support for cloud saves!\nhttps://gamenative.app\nJoin the community: https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">Hat das Spiel funktioniert?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -983,10 +983,10 @@
 
     <!-- Settings: Info Group -->
     <string name="settings_info_title">Información</string>
-    <string name="settings_info_send_tip_title">Enviar propina</string>
-    <string name="settings_info_send_tip_subtitle">Contribuye al desarrollo continuo.</string>
-    <string name="settings_info_ask_tip_title">Pedir propina al inicio</string>
-    <string name="settings_info_ask_tip_subtitle">Evita que aparezca el mensaje de propina.</string>
+    <string name="settings_info_send_tip_title">Hazte miembro</string>
+    <string name="settings_info_send_tip_subtitle">Acceso anticipado a versiones, ayuda prioritaria y más</string>
+    <string name="settings_info_ask_tip_title">Ofertas de membresía</string>
+    <string name="settings_info_ask_tip_subtitle">Mostrar ofertas ocasionales para hacerte miembro de GameNative</string>
     <string name="settings_info_source_title">Código fuente</string>
     <string name="settings_info_source_subtitle">Ve el código fuente de este proyecto.</string>
     <string name="settings_info_libraries_title">Librerías utilizadas</string>
@@ -1102,9 +1102,11 @@
     <!-- PluviaMain: Crash & Support -->
     <string name="main_recent_crash_title">Fallo reciente</string>
     <string name="main_recent_crash_message">¡Lo sentimos!\nSería de gran ayuda conocer el problema reciente que has tenido.\nPuedes ver y exportar el registro del fallo más reciente en los ajustes de la aplicación y adjuntarlo como un \'issue\' de GitHub en el repositorio del proyecto.\n¡El enlace al repositorio de GitHub también está en los ajustes!</string>
-    <string name="main_thank_you_title">¡Gracias por usar GameNative!</string>
-    <string name="main_thank_you_message">Apoya el proyecto de código abierto para juegos de PC en Android compartiendo la aplicación con tus amigos o haciéndote miembro en Ko-fi.</string>
-    <string name="main_join_kofi">Apoyar en Ko-fi</string>
+    <string name="main_thank_you_title">¿Disfrutas de GameNative?</string>
+    <string name="main_thank_you_message">Hazte miembro hoy. Los miembros obtienen:\n\n• Acceso anticipado a nuevas versiones\n• Ayuda prioritaria para hacer funcionar tus juegos\n• Roles premium y canales exclusivos en Discord\n• …y más\n\nDesde $5/mes</string>
+    <string name="main_join_kofi">Hazte miembro</string>
+    <string name="pitch_session_title">¿Disfrutando de %1$s?</string>
+    <string name="pitch_five_star_title">¡Genial que %1$s haya funcionado de maravilla!</string>
     <string name="main_share">Compartir</string>
     <string name="main_share_text">Descubre GameNative: juega a tus juegos Steam de PC en Android, con soporte completo de guardados en la nube.\nhttps://gamenative.app\nÚnete a la comunidad: https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">¿Ha funcionado el juego?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -975,10 +975,10 @@
 
     <!-- Settings: Info Group -->
     <string name="settings_info_title">Informations</string>
-    <string name="settings_info_send_tip_title">Envoyer un pourboire</string>
-    <string name="settings_info_send_tip_subtitle">Contribuer au développement continu</string>
-    <string name="settings_info_ask_tip_title">Demander un pourboire au démarrage</string>
-    <string name="settings_info_ask_tip_subtitle">Empêche le message de pourboire d\'apparaître</string>
+    <string name="settings_info_send_tip_title">Devenir membre</string>
+    <string name="settings_info_send_tip_subtitle">Accès anticipé aux versions, aide prioritaire et plus encore</string>
+    <string name="settings_info_ask_tip_title">Offres d\'adhésion</string>
+    <string name="settings_info_ask_tip_subtitle">Afficher occasionnellement des offres pour devenir membre de GameNative</string>
     <string name="settings_info_source_title">Code source</string>
     <string name="settings_info_source_subtitle">Voir le code source de ce projet</string>
     <string name="settings_info_libraries_title">Bibliothèques utilisées</string>
@@ -1095,9 +1095,11 @@
     <!-- PluviaMain: Crash & Support -->
     <string name="main_recent_crash_title">Plantage récent</string>
     <string name="main_recent_crash_message">Désolé pour ça !\nIl serait utile de connaître le problème récent que vous avez rencontré.\nVous pouvez consulter et exporter le journal de plantage le plus récent dans les paramètres de l\'application et le joindre comme problème Github dans le dépôt du projet.\nLe lien vers le dépôt Github se trouve également dans les paramètres !</string>
-    <string name="main_thank_you_title">Merci d\'utiliser GameNative !</string>
-    <string name="main_thank_you_message">Soutenez le jeu PC open source sur Android en partageant l\'application avec vos amis ou en devenant membre sur Ko-fi.</string>
-    <string name="main_join_kofi">Rejoindre sur Ko-fi</string>
+    <string name="main_thank_you_title">Vous appréciez GameNative ?</string>
+    <string name="main_thank_you_message">Devenez membre dès aujourd\'hui. Les membres bénéficient de :\n\n• Accès anticipé aux nouvelles versions\n• Aide prioritaire pour faire fonctionner vos jeux\n• Rôles premium et salons exclusifs sur Discord\n• …et plus encore\n\nÀ partir de 5 $/mois</string>
+    <string name="main_join_kofi">Devenir membre</string>
+    <string name="pitch_session_title">Vous appréciez %1$s ?</string>
+    <string name="pitch_five_star_title">Ravi que %1$s ait bien tourné !</string>
     <string name="main_share">Partager</string>
     <string name="main_share_text">Découvrez GameNative - jouez à vos jeux Steam PC sur Android, avec support complet des sauvegardes cloud !\nhttps://gamenative.app\nRejoignez la communauté : https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">Le jeu a-t-il fonctionné ?</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -967,10 +967,10 @@
 
     <!-- Settings: Info Group -->
     <string name="settings_info_title">Info</string>
-    <string name="settings_info_send_tip_title">Invia mancia</string>
-    <string name="settings_info_send_tip_subtitle">Contribuisci allo sviluppo in corso</string>
-    <string name="settings_info_ask_tip_title">Chiedi mancia all\'avvio</string>
-    <string name="settings_info_ask_tip_subtitle">Impedisce la comparsa del messaggio mancia</string>
+    <string name="settings_info_send_tip_title">Diventa membro</string>
+    <string name="settings_info_send_tip_subtitle">Accesso anticipato alle versioni, aiuto prioritario e altro</string>
+    <string name="settings_info_ask_tip_title">Offerte per i membri</string>
+    <string name="settings_info_ask_tip_subtitle">Mostra occasionalmente offerte per diventare membro di GameNative</string>
     <string name="settings_info_source_title">Codice sorgente</string>
     <string name="settings_info_source_subtitle">Visualizza il codice sorgente di questo progetto</string>
     <string name="settings_info_libraries_title">Librerie Usate</string>
@@ -1086,9 +1086,11 @@
     <!-- PluviaMain: Crash & Support -->
     <string name="main_recent_crash_title">Crash Recente</string>
     <string name="main_recent_crash_message">Ci dispiace!\nSarebbe utile conoscere il problema recente che hai avuto.\nPuoi visualizzare ed esportare il log del crash più recente nelle impostazioni dell\'app e allegarlo come issue GitHub nel repository del progetto.\nIl link al repository Github è anche nelle impostazioni!</string>
-    <string name="main_thank_you_title">Grazie per aver usato GameNative!</string>
-    <string name="main_thank_you_message">Supporta il gaming PC open-source su Android condividendo l\'app con i tuoi amici o diventando membro su Ko-fi.</string>
-    <string name="main_join_kofi">Unisciti su Ko-fi</string>
+    <string name="main_thank_you_title">Ti piace GameNative?</string>
+    <string name="main_thank_you_message">Diventa membro oggi. I membri ottengono:\n\n• Accesso anticipato alle nuove versioni\n• Aiuto prioritario per far funzionare i tuoi giochi\n• Ruoli premium e canali esclusivi su Discord\n• …e altro ancora\n\nDa $5/mese</string>
+    <string name="main_join_kofi">Diventa membro</string>
+    <string name="pitch_session_title">Ti stai divertendo con %1$s?</string>
+    <string name="pitch_five_star_title">Bello che %1$s abbia funzionato alla grande!</string>
     <string name="main_share">Condividi</string>
     <string name="main_share_text">Scopri GameNative - gioca ai tuoi giochi Steam PC su Android, con supporto completo per i salvataggi cloud!\nhttps://gamenative.app\nUnisciti alla community: https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">Il gioco ha funzionato?</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -945,10 +945,10 @@
 
     <!-- Settings: Info Group -->
     <string name="settings_info_title">情報</string>
-    <string name="settings_info_send_tip_title">チップを送信する</string>
-    <string name="settings_info_send_tip_subtitle">継続的な開発に貢献する</string>
-    <string name="settings_info_ask_tip_title">起動時にヒントを求める</string>
-    <string name="settings_info_ask_tip_subtitle">ヒントメッセージの表示を停止します</string>
+    <string name="settings_info_send_tip_title">メンバーになる</string>
+    <string name="settings_info_send_tip_subtitle">リリースへの早期アクセス、優先サポートなど</string>
+    <string name="settings_info_ask_tip_title">メンバーシップのご案内</string>
+    <string name="settings_info_ask_tip_subtitle">GameNativeメンバーになるための案内を時々表示します</string>
     <string name="settings_info_source_title">ソースコード</string>
     <string name="settings_info_source_subtitle">このプロジェクトのソースコードを表示する</string>
     <string name="settings_info_libraries_title">使用するライブラリ</string>
@@ -1122,9 +1122,11 @@
     <!-- PluviaMain: Crash & Support -->
     <string name="main_recent_crash_title">最近のクラッシュ</string>
     <string name="main_recent_crash_message">申し訳ありません!\n\' が抱えていた最近の問題について知っていただければ幸いです。\nアプリ\'s の設定で最新のクラッシュ ログを表示およびエクスポートし、プロジェクト ZESC4ZZs リポジトリの Github の問題として添付できます。\nGithub リポジトリへのリンクも設定にあります。</string>
-    <string name="main_thank_you_title">GameNative をご利用いただきありがとうございます。</string>
-    <string name="main_thank_you_message">アプリを友達と共有するか、Ko-fi のメンバーになることで、Android でのオープンソース PC ゲームをサポートします。</string>
-    <string name="main_join_kofi">Ko-fi に参加する</string>
+    <string name="main_thank_you_title">GameNativeを楽しんでいますか？</string>
+    <string name="main_thank_you_message">今すぐメンバーになりましょう。メンバー特典:\n\n• 新リリースへの早期アクセス\n• ゲームを動かすための優先サポート\n• Discordのプレミアムロールと限定チャンネル\n• …その他多数\n\n月額$5から</string>
+    <string name="main_join_kofi">メンバーになる</string>
+    <string name="pitch_session_title">%1$sを楽しんでいますか？</string>
+    <string name="pitch_five_star_title">%1$sが快適に動いてよかったです！</string>
     <string name="main_share">共有</string>
     <string name="main_share_text">GameNative をチェックしてください - クラウド セーブを完全にサポートし、Android で PC Steam ゲームをプレイしましょう!\nhttps://gamenative.app\nコミュニティに参加してください: https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">ゲームはうまくいきましたか？</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -974,10 +974,10 @@
 
     <!-- Settings: Info Group -->
     <string name="settings_info_title">정보</string>
-    <string name="settings_info_send_tip_title">팁 보내기</string>
-    <string name="settings_info_send_tip_subtitle">지속적인 개발에 기여</string>
-    <string name="settings_info_ask_tip_title">시작 시 팁 요청</string>
-    <string name="settings_info_ask_tip_subtitle">시작 시 팁 메시지가 나타나지 않도록 중지</string>
+    <string name="settings_info_send_tip_title">멤버 되기</string>
+    <string name="settings_info_send_tip_subtitle">릴리스 조기 이용, 우선 지원 등</string>
+    <string name="settings_info_ask_tip_title">멤버십 안내</string>
+    <string name="settings_info_ask_tip_subtitle">GameNative 멤버가 될 수 있는 안내를 가끔 표시합니다</string>
     <string name="settings_info_source_title">소스 코드</string>
     <string name="settings_info_source_subtitle">이 프로젝트의 소스 코드 보기</string>
     <string name="settings_info_libraries_title">사용된 라이브러리</string>
@@ -1091,9 +1091,11 @@
     <!-- PluviaMain: Crash & Support -->
     <string name="main_recent_crash_title">최근 충돌</string>
     <string name="main_recent_crash_message">죄송합니다!\n최근 발생한 문제에 대해 알려주시면 감사하겠습니다.\n앱 설정에서 가장 최근의 충돌 로그를 보고 내보낼 수 있으며 프로젝트 저장소에 Github 이슈로 첨부할 수 있습니다.\nGithub 저장소 링크도 설정에 있습니다!</string>
-    <string name="main_thank_you_title">GameNative를 사용해 주셔서 감사합니다!</string>
-    <string name="main_thank_you_message">친구들과 앱을 공유하거나 Ko-fi에서 회원이 되어 Android에서 오픈 소스 PC 게임을 지원하세요.</string>
-    <string name="main_join_kofi">Ko-fi에서 참여</string>
+    <string name="main_thank_you_title">GameNative를 즐기고 계신가요?</string>
+    <string name="main_thank_you_message">지금 멤버가 되세요. 멤버 혜택:\n\n• 새 릴리스 조기 이용\n• 게임 실행을 위한 우선 지원\n• Discord 프리미엄 역할 및 전용 채널\n• …그 외 다수\n\n월 $5부터</string>
+    <string name="main_join_kofi">멤버 되기</string>
+    <string name="pitch_session_title">%1$s 재미있으신가요?</string>
+    <string name="pitch_five_star_title">%1$s이(가) 잘 실행되어 다행이에요!</string>
     <string name="main_share">공유</string>
     <string name="main_share_text">GameNative를 확인하세요 - 클라우드 저장을 완전히 지원하며 Android에서 PC Steam 게임을 플레이하세요!\nhttps://gamenative.app\n커뮤니티 참여: https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">게임이 작동했나요?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -984,10 +984,10 @@
 
     <!-- Settings: Info Group -->
     <string name="settings_info_title">Informacje</string>
-    <string name="settings_info_send_tip_title">Wyślij napiwek</string>
-    <string name="settings_info_send_tip_subtitle">Wesprzyj ciągły rozwój</string>
-    <string name="settings_info_ask_tip_title">Pytaj o napiwek przy uruchomieniu</string>
-    <string name="settings_info_ask_tip_subtitle">Zatrzymuje wyświetlanie wiadomości o napiwku</string>
+    <string name="settings_info_send_tip_title">Zostań członkiem</string>
+    <string name="settings_info_send_tip_subtitle">Wcześniejszy dostęp do wydań, priorytetowa pomoc i więcej</string>
+    <string name="settings_info_ask_tip_title">Oferty członkostwa</string>
+    <string name="settings_info_ask_tip_subtitle">Pokazuj od czasu do czasu oferty członkostwa GameNative</string>
     <string name="settings_info_source_title">Kod źródłowy</string>
     <string name="settings_info_source_subtitle">Zobacz kod źródłowy tego projektu</string>
     <string name="settings_info_libraries_title">Użyte biblioteki</string>
@@ -1103,9 +1103,11 @@
     <!-- PluviaMain: Crash & Support -->
     <string name="main_recent_crash_title">Ostatnia awaria</string>
     <string name="main_recent_crash_message">Przykro nam!\nDobrze byłoby wiedzieć o ostatnim problemie, który wystąpił.\nMożesz zobaczyć i wyeksportować log ostatniej awarii w ustawieniach aplikacji i dołączyć go jako zgłoszenie w repozytorium projektu na Githubie.\nLink do repozytorium Github znajduje się również w ustawieniach!</string>
-    <string name="main_thank_you_title">Dziękujemy za korzystanie z GameNative!</string>
-    <string name="main_thank_you_message">Wspieraj otwarty gaming na PC na Androidzie, udostępniając aplikację znajomym lub zostając członkiem na Ko-fi.</string>
-    <string name="main_join_kofi">Dołącz na Ko-fi</string>
+    <string name="main_thank_you_title">Podoba Ci się GameNative?</string>
+    <string name="main_thank_you_message">Zostań członkiem już dziś. Członkowie otrzymują:\n\n• Wcześniejszy dostęp do nowych wydań\n• Priorytetową pomoc w uruchamianiu gier\n• Role premium i ekskluzywne kanały na Discordzie\n• …i więcej\n\nOd 5 $/mies.</string>
+    <string name="main_join_kofi">Zostań członkiem</string>
+    <string name="pitch_session_title">Podoba Ci się %1$s?</string>
+    <string name="pitch_five_star_title">Świetnie, że %1$s działa doskonale!</string>
     <string name="main_share">Udostępnij</string>
     <string name="main_share_text">Sprawdź GameNative - graj w gry Steam z PC na Androidzie, z pełnym wsparciem zapisów w chmurze!\nhttps://gamenative.app\nDołącz do społeczności: https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">Czy gra zadziałała?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -791,10 +791,10 @@
 
     <!-- Settings: Info Group -->
     <string name="settings_info_title">Informações</string>
-    <string name="settings_info_send_tip_title">Enviar gorjeta</string>
-    <string name="settings_info_send_tip_subtitle">Contribuir para o desenvolvimento contínuo</string>
-    <string name="settings_info_ask_tip_title">Pedir gorjeta na inicialização</string>
-    <string name="settings_info_ask_tip_subtitle">Impede que a mensagem de gorjeta apareça</string>
+    <string name="settings_info_send_tip_title">Tornar-se membro</string>
+    <string name="settings_info_send_tip_subtitle">Acesso antecipado a lançamentos, ajuda prioritária e mais</string>
+    <string name="settings_info_ask_tip_title">Ofertas para membros</string>
+    <string name="settings_info_ask_tip_subtitle">Mostrar ofertas ocasionais para se tornar membro do GameNative</string>
     <string name="settings_info_source_title">Código-fonte</string>
     <string name="settings_info_source_subtitle">Ver o código-fonte deste projeto</string>
     <string name="settings_info_libraries_title">Bibliotecas utilizadas</string>
@@ -913,9 +913,11 @@
     <!-- TODO: Revisão manual - PluviaMain: Falha e suporte -->
     <string name="main_recent_crash_title">Falha recente</string>
     <string name="main_recent_crash_message">Desculpe por isso!\nSeria bom saber sobre o problema recente que você teve.\nVocê pode visualizar e exportar o log de falha mais recente nas configurações do aplicativo e anexá-lo como um problema do Github no repositório do projeto.\nO link para o repositório do Github também está nas configurações!</string>
-    <string name="main_thank_you_title">Obrigado por usar o GameNative!</string>
-    <string name="main_thank_you_message">Apoie jogos de PC de código aberto no Android compartilhando o aplicativo com seus amigos ou se tornando um membro no Ko-fi.</string>
-    <string name="main_join_kofi">Junte-se no Ko-fi</string>
+    <string name="main_thank_you_title">Curtindo o GameNative?</string>
+    <string name="main_thank_you_message">Torne-se membro hoje. Membros recebem:\n\n• Acesso antecipado a novos lançamentos\n• Ajuda prioritária para fazer seus jogos rodarem\n• Cargos premium e canais exclusivos no Discord\n• …e mais\n\nA partir de $5/mês</string>
+    <string name="main_join_kofi">Tornar-se membro</string>
+    <string name="pitch_session_title">Curtindo %1$s?</string>
+    <string name="pitch_five_star_title">Que bom que %1$s rodou muito bem!</string>
     <string name="main_share">Compartilhar</string>
     <string name="main_share_text">Confira o GameNative - jogue seus jogos Steam de PC no Android, com suporte completo a salvamentos na nuvem!\nhttps://gamenative.app\nJunte-se à comunidade: https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">O jogo funcionou?</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -976,10 +976,10 @@
 
 	<!-- Settings: Info Group -->
 	<string name="settings_info_title">Informații</string>
-	<string name="settings_info_send_tip_title">Trimite un tip</string>
-	<string name="settings_info_send_tip_subtitle">Contribuie la dezvoltarea continuă</string>
-	<string name="settings_info_ask_tip_title">Cere tip la pornire</string>
-	<string name="settings_info_ask_tip_subtitle">Oprește afișarea mesajului de tip</string>
+    <string name="settings_info_send_tip_title">Devino membru</string>
+    <string name="settings_info_send_tip_subtitle">Acces anticipat la versiuni, ajutor prioritar și altele</string>
+    <string name="settings_info_ask_tip_title">Oferte de membru</string>
+    <string name="settings_info_ask_tip_subtitle">Afișează ocazional oferte pentru a deveni membru GameNative</string>
 	<string name="settings_info_source_title">Cod sursă</string>
 	<string name="settings_info_source_subtitle">Vezi codul sursă al acestui proiect</string>
 	<string name="settings_info_libraries_title">Biblioteci utilizate</string>
@@ -1095,9 +1095,11 @@
 	<!-- PluviaMain: Crash & Support -->
 	<string name="main_recent_crash_title">Crash recent</string>
 	<string name="main_recent_crash_message">Ne pare rău!\nAr fi util să știm ce problemă ai întâmpinat.\nPoți vizualiza și exporta cel mai recent crash log din setările aplicației și îl poți atașa ca issue pe Github în repository-ul proiectului.\nLinkul către repo este tot în setări!</string>
-	<string name="main_thank_you_title">Mulțumim că folosești GameNative!</string>
-	<string name="main_thank_you_message">Susține gaming-ul open‑source pe Android distribuind aplicația prietenilor sau devenind membru pe Ko‑fi.</string>
-	<string name="main_join_kofi">Alătură-te pe Ko‑fi</string>
+    <string name="main_thank_you_title">Îți place GameNative?</string>
+    <string name="main_thank_you_message">Devino membru astăzi. Membrii primesc:\n\n• Acces anticipat la versiuni noi\n• Ajutor prioritar pentru a-ți face jocurile să funcționeze\n• Roluri premium și canale exclusive pe Discord\n• …și altele\n\nDe la 5 $/lună</string>
+    <string name="main_join_kofi">Devino membru</string>
+    <string name="pitch_session_title">Îți place %1$s?</string>
+    <string name="pitch_five_star_title">Ne bucurăm că %1$s a mers excelent!</string>
 	<string name="main_share">Distribuie</string>
 	<string name="main_share_text">Descoperă GameNative - joacă jocurile tale Steam pe PC pe Android, cu suport complet pentru salvări în cloud!\nhttps://gamenative.app\nAlătură-te comunității: https://discord.gg/2hKv4VfZfE</string>
 	<string name="main_discord_support_title">A funcționat jocul?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -728,7 +728,6 @@ Ubuntu RootFs - releases.ubuntu.com/focal</string>
     <string name="main_downloading_steam">Загрузка Steam...</string>
     <string name="main_installing_bionic">Установка компонентов Bionic...</string>
     <string name="main_installing_glibc">Установка компонентов glibc...</string>
-    <string name="main_join_kofi">Присоединиться на Ko-fi</string>
     <string name="main_keep_local">Сохранить локальное</string>
     <string name="main_keep_remote">Сохранить удалённое</string>
     <string name="main_later_button">Позже</string>
@@ -756,6 +755,11 @@ Ubuntu RootFs - releases.ubuntu.com/focal</string>
     <string name="main_save_conflict_title">Конфликт сохранений</string>
     <string name="main_save_conflict_upgrade_v1_title">Выберите версию сохранения</string>
     <string name="main_save_conflict_upgrade_v1_message">Мы исправили обработку путей облачных сохранений для этой игры и обнаружили различия между локальным и облачным сохранением.\n\nЛокальное сохранение:\n\t%1$s\nОблачное сохранение:\n\t%2$s</string>
+    <string name="main_thank_you_title">Нравится GameNative?</string>
+    <string name="main_thank_you_message">Станьте участником сегодня. Участники получают:\n\n• Ранний доступ к новым версиям\n• Приоритетную помощь с запуском игр\n• Премиум-роли и эксклюзивные каналы в Discord\n• …и не только\n\nОт $5/мес.</string>
+    <string name="main_join_kofi">Стать участником</string>
+    <string name="pitch_session_title">Нравится %1$s?</string>
+    <string name="pitch_five_star_title">Рады, что %1$s отлично работает!</string>
     <string name="main_share">Поделиться</string>
     <string name="main_share_text">Проверьте GameNative - играйте в ваши ПК игры Steam на Android, с полной поддержкой облачных сохранений!
 https://gamenative.app
@@ -764,8 +768,6 @@ https://gamenative.app
     <string name="main_sync_in_progress">Синхронизация в процессе. Пожалуйста, попробуйте снова через момент.</string>
     <string name="main_sync_in_progress_launch_anyway_message">Синхронизация облачного сохранения для этой игры уже запущена. Вы можете подождать и попробовать снова, или запустить в любом случае без синхронизации (может вызвать конфликты сохранений).</string>
     <string name="main_sync_in_progress_retry">Операция синхронизации занимает слишком много времени. Пожалуйста, попробуйте запустить игру снова через момент.</string>
-    <string name="main_thank_you_message">Поддержите игры с открытым исходным кодом на Android, поделившись приложением с вашими друзьями или став членом на Ko-fi.</string>
-    <string name="main_thank_you_title">Спасибо за использование GameNative!</string>
     <string name="main_update_available_message">Доступна новая версия (%1$s)!%2$s</string>
     <string name="main_update_available_title">Доступно обновление</string>
     <string name="main_update_button">Обновить</string>
@@ -1051,17 +1053,17 @@ https://gamenative.app
     <string name="settings_emulation_title">Эмуляция</string>
     <string name="settings_emulation_wine_proton_manager_subtitle">Импортировать пользовательские версии Wine/Proton (только Bionic)</string>
     <string name="settings_emulation_wine_proton_manager_title">Менеджер Wine/Proton</string>
-    <string name="settings_info_ask_tip_subtitle">Предотвращает появление сообщения совета</string>
-    <string name="settings_info_ask_tip_title">Спросить совет при запуске</string>
     <string name="settings_info_libraries_subtitle">Узнайте, какие технологии делают GameNative возможным</string>
     <string name="settings_info_libraries_title">Используемые библиотеки</string>
     <string name="settings_info_privacy_subtitle">Открывает ссылку на политику конфиденциальности GameNative</string>
     <string name="settings_info_privacy_title">Политика конфиденциальности</string>
     <string name="settings_info_usage_analytics_title">Аналитика использования</string>
     <string name="settings_info_usage_analytics_subtitle">Мы никогда не отслеживаем личную информацию. Отключение останавливает несущественную аналитику, однако основные данные о производительности игр по-прежнему собираются как законный интерес для улучшения совместимости.</string>
-    <string name="settings_info_send_tip_subtitle">Внесите вклад в продолжающуюся разработку</string>
-    <string name="settings_info_send_tip_title">Отправить чаевые</string>
     <string name="settings_info_source_subtitle">Просмотреть исходный код этого проекта</string>
+    <string name="settings_info_send_tip_title">Стать участником</string>
+    <string name="settings_info_send_tip_subtitle">Ранний доступ к версиям, приоритетная помощь и другое</string>
+    <string name="settings_info_ask_tip_title">Предложения о членстве</string>
+    <string name="settings_info_ask_tip_subtitle">Иногда показывать предложения стать участником GameNative</string>
     <string name="settings_info_source_title">Исходный код</string>
     <string name="settings_info_title">Информация</string>
     <string name="settings_interface_download_server_title">Сервер загрузки Steam</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -970,10 +970,10 @@
 
     <!-- Settings: Info Group -->
     <string name="settings_info_title">Інформація</string>
-    <string name="settings_info_send_tip_title">Підтримати розробників</string>
-    <string name="settings_info_send_tip_subtitle">Сприяйте подальшому розвитку</string>
-    <string name="settings_info_ask_tip_title">Пропонувати підтримку розробників при запуску</string>
-    <string name="settings_info_ask_tip_subtitle">(ВИМК) Приховує повідомлення з пропозицією підтримки</string>
+    <string name="settings_info_send_tip_title">Стати учасником</string>
+    <string name="settings_info_send_tip_subtitle">Ранній доступ до версій, пріоритетна допомога та інше</string>
+    <string name="settings_info_ask_tip_title">Пропозиції членства</string>
+    <string name="settings_info_ask_tip_subtitle">Час від часу показувати пропозиції стати учасником GameNative</string>
     <string name="settings_info_source_title">Вихідний код</string>
     <string name="settings_info_source_subtitle">Переглянути вихідний код застосунку</string>
     <string name="settings_info_libraries_title">Використані бібліотеки</string>
@@ -1089,9 +1089,11 @@
     <!-- PluviaMain: Crash & Support -->
     <string name="main_recent_crash_title">Нещодавній збій</string>
     <string name="main_recent_crash_message">Перепрошуємо!\nБуло б добре дізнатися про проблему, з якою Ви нещодавно зіткнулися.\nВи можете переглянути та експортувати останній журнал збою в налаштуваннях застосунку і додати його як проблему (issue) на GitHub у репозиторії проєкту.\nПосилання на репозиторій GitHub також знаходиться в налаштуваннях!</string>
-    <string name="main_thank_you_title">Дякуємо за користування GameNative!</string>
-    <string name="main_thank_you_message">Підтримайте open-source ПК-ігри на Android, поділившись застосунком із друзями або ставши учасником на Ko-fi.</string>
-    <string name="main_join_kofi">Стати учасником на Ko-fi</string>
+    <string name="main_thank_you_title">Подобається GameNative?</string>
+    <string name="main_thank_you_message">Станьте учасником сьогодні. Учасники отримують:\n\n• Ранній доступ до нових версій\n• Пріоритетну допомогу із запуском ігор\n• Преміум-ролі та ексклюзивні канали в Discord\n• …та інше\n\nВід $5/міс.</string>
+    <string name="main_join_kofi">Стати учасником</string>
+    <string name="pitch_session_title">Подобається %1$s?</string>
+    <string name="pitch_five_star_title">Раді, що %1$s чудово працює!</string>
     <string name="main_share">Поділитися</string>
     <string name="main_share_text">Спробуй GameNative — грай у свої Steam-ігри з ПК на Android з повною підтримкою хмарних збережень!\nhttps://gamenative.app\nПриєднуйся до спільноти: https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">Чи працювала гра?</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -960,10 +960,10 @@
 
     <!-- 设置：信息组 -->
     <string name="settings_info_title">信息</string>
-    <string name="settings_info_send_tip_title">捐款支持</string>
-    <string name="settings_info_send_tip_subtitle">为持续的应用程序开发贡献力量</string>
-    <string name="settings_info_ask_tip_title">启动时显示捐款信息</string>
-    <string name="settings_info_ask_tip_subtitle">停止显示捐款信息</string>
+    <string name="settings_info_send_tip_title">成为会员</string>
+    <string name="settings_info_send_tip_subtitle">版本抢先体验、优先支持等</string>
+    <string name="settings_info_ask_tip_title">会员优惠</string>
+    <string name="settings_info_ask_tip_subtitle">偶尔显示成为 GameNative 会员的优惠信息</string>
     <string name="settings_info_source_title">源代码</string>
     <string name="settings_info_source_subtitle">查看此项目的源代码</string>
     <string name="settings_info_libraries_title">使用的库</string>
@@ -1074,9 +1074,11 @@
     <!-- 主界面：崩溃与支持 -->
     <string name="main_recent_crash_title">最近应用程序崩溃</string>
     <string name="main_recent_crash_message">若能了解您最近遇到的问题，将有助于我们改善应用程序。\n您可在应用程序设置中查看并导出最近的崩溃日志，将其附加至项目源代码仓库的 Github Issue中\nGithub 源代码仓库的链接亦位于设置页面内</string>
-    <string name="main_thank_you_title">感谢您使用 GameNative！</string>
-    <string name="main_thank_you_message">通过与朋友分享应用程序或在 Ko-fi 成为会员，支持 Android 平台的开源 PC 游戏</string>
-    <string name="main_join_kofi">加入 Ko-fi</string>
+    <string name="main_thank_you_title">喜欢 GameNative 吗？</string>
+    <string name="main_thank_you_message">立即成为会员。会员可享受：\n\n• 新版本抢先体验\n• 游戏运行问题优先支持\n• Discord 高级身份组和专属频道\n• …以及更多\n\n每月 $5 起</string>
+    <string name="main_join_kofi">成为会员</string>
+    <string name="pitch_session_title">喜欢《%1$s》吗？</string>
+    <string name="pitch_five_star_title">很高兴《%1$s》运行顺畅！</string>
     <string name="main_share">分享</string>
     <string name="main_share_text">试试 GameNative - 在 Android 上畅玩您的 PC Steam 游戏，完整支持云存档！\nhttps://gamenative.app\n加入社区：https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">游戏运行正常吗？</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -962,10 +962,10 @@
 
     <!-- Settings: Info Group -->
     <string name="settings_info_title">資訊</string>
-    <string name="settings_info_send_tip_title">捐款支持</string>
-    <string name="settings_info_send_tip_subtitle">為持續的應用程式開發貢獻力量</string>
-    <string name="settings_info_ask_tip_title">啟動時顯示捐款訊息</string>
-    <string name="settings_info_ask_tip_subtitle">停止顯示捐款訊息</string>
+    <string name="settings_info_send_tip_title">成為會員</string>
+    <string name="settings_info_send_tip_subtitle">版本搶先體驗、優先支援等</string>
+    <string name="settings_info_ask_tip_title">會員優惠</string>
+    <string name="settings_info_ask_tip_subtitle">偶爾顯示成為 GameNative 會員的優惠資訊</string>
     <string name="settings_info_source_title">原始碼</string>
     <string name="settings_info_source_subtitle">檢視此專案的原始碼</string>
     <string name="settings_info_libraries_title">使用的函式庫</string>
@@ -1076,9 +1076,11 @@
     <!-- PluviaMain: Crash & Support -->
     <string name="main_recent_crash_title">最近應用程式當機</string>
     <string name="main_recent_crash_message">若能了解您最近遇到的問題, 將有助於我們改善應用程式.\n您可在應用程式設定中檢視並匯出最近的崩潰日誌, 將其附加至專案原始碼儲存庫的 Github Issue中\nGithub 原始碼儲存庫的連結亦位於設定頁面內</string>
-    <string name="main_thank_you_title">感謝您使用GameNative!</string>
-    <string name="main_thank_you_message">透過與朋友分享應用程式或在Ko-fi成為會員，支持Android平台的開源PC遊戲</string>
-    <string name="main_join_kofi">加入Ko-fi</string>
+    <string name="main_thank_you_title">喜歡 GameNative 嗎？</string>
+    <string name="main_thank_you_message">立即成為會員。會員可享有：\n\n• 新版本搶先體驗\n• 遊戲執行問題優先支援\n• Discord 進階身分組與專屬頻道\n• …還有更多\n\n每月 $5 起</string>
+    <string name="main_join_kofi">成為會員</string>
+    <string name="pitch_session_title">喜歡《%1$s》嗎？</string>
+    <string name="pitch_five_star_title">很高興《%1$s》執行順暢！</string>
     <string name="main_share">分享</string>
     <string name="main_share_text">試試 GameNative - 在 Android 上暢玩您的 PC Steam 遊戲，完整支援雲端存檔！\nhttps://gamenative.app\n加入社群：https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">遊戲運作正常嗎?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1066,10 +1066,10 @@
 
     <!-- Settings: Info Group -->
     <string name="settings_info_title">Info</string>
-    <string name="settings_info_send_tip_title">Send tip</string>
-    <string name="settings_info_send_tip_subtitle">Contribute to ongoing development</string>
-    <string name="settings_info_ask_tip_title">Ask for tip on startup</string>
-    <string name="settings_info_ask_tip_subtitle">Stops the tip message from appearing</string>
+    <string name="settings_info_send_tip_title">Become a member</string>
+    <string name="settings_info_send_tip_subtitle">Early access to releases, priority help, and more</string>
+    <string name="settings_info_ask_tip_title">Membership offers</string>
+    <string name="settings_info_ask_tip_subtitle">Show occasional offers to become a GameNative member</string>
     <string name="settings_info_source_title">Source code</string>
     <string name="settings_info_source_subtitle">View the source code of this project</string>
     <string name="settings_info_libraries_title">Libraries Used</string>
@@ -1242,9 +1242,11 @@
     <!-- PluviaMain: Crash & Support -->
     <string name="main_recent_crash_title">Recent Crash</string>
     <string name="main_recent_crash_message">Sorry about that!\nIt would be nice to know about the recent issue you\'ve had.\nYou can view and export the most recent crash log in the app\'s settings and attach it as a Github issue in the project\'s repository.\nLink to the Github repo is also in settings!</string>
-    <string name="main_thank_you_title">Thank you for using GameNative!</string>
-    <string name="main_thank_you_message">Support open-source PC gaming on Android by sharing the app with your friends or becoming a member on Ko-fi.</string>
-    <string name="main_join_kofi">Join on Ko-fi</string>
+    <string name="main_thank_you_title">Enjoying GameNative?</string>
+    <string name="main_thank_you_message">Become a member today. Members get:\n\n• Early access to new releases\n• Priority help getting your games running\n• Premium roles and exclusive channels on Discord\n• …and more\n\nFrom $5/month</string>
+    <string name="main_join_kofi">Become a member</string>
+    <string name="pitch_session_title">Enjoying %1$s?</string>
+    <string name="pitch_five_star_title">Glad %1$s ran great!</string>
     <string name="main_share">Share</string>
     <string name="main_share_text">Check out GameNative - play your PC Steam games on Android, with full support for cloud saves!\nhttps://gamenative.app\nJoin the community: https://discord.gg/2hKv4VfZfE</string>
     <string name="main_discord_support_title">Did the game work?</string>


### PR DESCRIPTION
## Description
Reduced frequency of membership popups to prevent annoyance to users, explained benefits of membership better.

## Recording


## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make membership prompts less frequent and more contextual to reduce annoyance and improve conversions. Previously we showed a generic tip/support dialog; now we show membership prompts only on defined triggers with cooldowns and updated copy.

- Launch pitch: show only if not `PrefManager.tipped` or `BuildConfig.GOLD`, user has attempted a game launch, no game played this session, and 5-day cooldown since `PrefManager.lastLaunchPitchTime`. Set `lastLaunchPitchTime` when shown.
- Warm pitch: after a session ≥7 minutes, trigger after a 5‑star rating (“five_star”) or when feedback is dismissed (“long_session”). Enforce a 3‑day cooldown via `PrefManager.lastWarmPitchTime`. Suppress if `tipped` or `GOLD`. Titles include the game name.
- Tracking: capture `membership_prompt_shown` and `membership_prompt_clicked` to `PostHog` with a `trigger` property. Respect `PrefManager.usageAnalyticsEnabled`.
- State: add `PrefManager.hasAttemptedGameLaunch`, `PrefManager.lastLaunchPitchTime`, and `PrefManager.lastWarmPitchTime`. Track `MainViewModel.gamePlayedThisSession`. Do not set `tipped` on membership clicks in the dialog or settings.
- UI and copy: remove the “Share” action from the support dialog; make message text scrollable; restructure the feedback dialog so content scrolls and buttons remain visible. Update settings labels to “Become a member” and “Membership offers.” Replace the generic “thank you” copy with membership benefits and add new `pitch_session_title`/`pitch_five_star_title` strings across locales.

<sup>Written for commit ef757d9f0e606a1f077a273df94b139ac10a2558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-aware membership prompts after game launches, extended sessions, and highly rated feedback.
  * Added cooldowns and eligibility checks to prevent repetitive prompts.
  * Added game-specific appreciation messaging and membership benefits information.
* **Bug Fixes**
  * Improved long-dialog usability with scrollable feedback and message content.
  * Corrected support and membership actions so preferences update only when explicitly changed.
* **Localization**
  * Updated membership and support messaging across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->