### PR TITLE
Improved personalized recommendations + disclosure

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -1178,10 +1178,24 @@ object PrefManager {
         }
 
     private val REC_DISCLOSURE_SHOWN = booleanPreferencesKey("rec_disclosure_shown")
+
+    // Cached in memory because the DataStore write is async: consumers read this back
+    // immediately after granting consent, before the write lands on disk.
+    @Volatile private var recDisclosureShownCache: Boolean? = null
     var recDisclosureShown: Boolean
-        get() = getPref(REC_DISCLOSURE_SHOWN, false)
+        get() = recDisclosureShownCache
+            ?: getPref(REC_DISCLOSURE_SHOWN, false).also { recDisclosureShownCache = it }
         set(value) {
+            recDisclosureShownCache = value
             setPref(REC_DISCLOSURE_SHOWN, value)
+        }
+
+    // Day seed when the user last dismissed the frosted rec teaser ("Not now")
+    private val REC_TEASER_DISMISSED_DAY = longPreferencesKey("rec_teaser_dismissed_day")
+    var recTeaserDismissedDay: Long
+        get() = getPref(REC_TEASER_DISMISSED_DAY, 0L)
+        set(value) {
+            setPref(REC_TEASER_DISMISSED_DAY, value)
         }
 
     // Show dialog when adding custom game folder

--- a/app/src/main/java/app/gamenative/data/LibraryItem.kt
+++ b/app/src/main/java/app/gamenative/data/LibraryItem.kt
@@ -46,6 +46,8 @@ data class LibraryItem(
     val recStoreCard: Boolean = false,
     val recSource: String = "",
     val isFeatured: Boolean = false,
+    val isRecTeaser: Boolean = false,
+    val isRecLoading: Boolean = false,
 ) {
     val clientIconUrl: String
         get() = when (gameSource) {

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -108,6 +108,12 @@ class LibraryViewModel @Inject constructor(
     }
 
     private val onRecommendationToggleChanged: (AndroidEvent.RecommendationToggleChanged) -> Unit = {
+        // Consent granted from the frosted teaser: show a loading spinner on the card
+        // until the refresh below swaps in the personalized pick.
+        if (cachedRecTeaser && PrefManager.recDisclosureShown) {
+            cachedRecLoading = true
+            onFilterApps(paginationCurrentPage)
+        }
         refreshRecommendationHero()
     }
 
@@ -130,6 +136,8 @@ class LibraryViewModel @Inject constructor(
     // Cached recommendation (fetched once at startup)
     @Volatile private var cachedRecommendation: RecommendedGame? = null
     @Volatile private var cachedFeatured: app.gamenative.data.FeaturedItem? = null
+    @Volatile private var cachedRecTeaser: Boolean = false
+    @Volatile private var cachedRecLoading: Boolean = false
 
     // Track debounce job for search
     private var searchDebounceJob: Job? = null
@@ -284,6 +292,7 @@ class LibraryViewModel @Inject constructor(
     private fun refreshRecommendationHero() {
         viewModelScope.launch(Dispatchers.IO) {
             val hero = RecommendationRepository.getHero(context)
+            val daySeed = System.currentTimeMillis() / (24L * 60 * 60 * 1000)
             cachedFeatured = hero.featured
             cachedRecommendation = when {
                 // A live featured takes the slot (still gated by the showRecommendations
@@ -298,11 +307,19 @@ class LibraryViewModel @Inject constructor(
                         amazonGameDao,
                     )
                     val userId = GOGAuthManager.getStoredCredentials(context).getOrNull()?.userId
-                    val daySeed = System.currentTimeMillis() / (24L * 60 * 60 * 1000)
                     GogRecommendationsRepository.getDailyHero(context, owned, userId, daySeed)
                 }.getOrNull() ?: hero.recommendation
                 else -> hero.recommendation
             }
+            // Frosted teaser: pre-consent only, never over a featured slot. Shows every day
+            // until the first "Not now", then one day in three. A frosted day stays frosted
+            // all day, dismissed or not.
+            val dismissedDay = PrefManager.recTeaserDismissedDay
+            cachedRecTeaser = hero.featured == null &&
+                PrefManager.showRecommendations &&
+                !PrefManager.recDisclosureShown &&
+                (dismissedDay == 0L || dismissedDay == daySeed || daySeed % 3 == 0L)
+            cachedRecLoading = false
             onFilterApps(paginationCurrentPage)
         }
     }
@@ -1035,6 +1052,8 @@ class LibraryViewModel @Inject constructor(
                         recommendedGameId = rec.id,
                         recSource = "hero",
                         gameSource = GameSource.STEAM,
+                        isRecTeaser = cachedRecTeaser || cachedRecLoading,
+                        isRecLoading = cachedRecLoading,
                     )
                     else -> null
                 }

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -117,6 +117,7 @@ import app.gamenative.service.gog.GOGService
 import app.gamenative.utils.CustomGameScanner
 import app.gamenative.utils.PlatformOAuthHandlers
 import app.gamenative.utils.SteamUtils
+import com.posthog.PostHog
 import kotlinx.coroutines.launch
 import android.os.SystemClock
 
@@ -325,6 +326,17 @@ private fun LibraryScreenContent(
     val isViewWide = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
     var currentPaneType by remember { mutableStateOf(PrefManager.libraryLayout) }
     var recDisclosureShown by remember { mutableStateOf(PrefManager.recDisclosureShown) }
+    var showRecTeaserDialog by remember { mutableStateOf(false) }
+    val onRecTeaserTapped = {
+        if (PrefManager.usageAnalyticsEnabled) PostHog.capture(event = "rec_teaser_tapped")
+        showRecTeaserDialog = true
+    }
+    val recTeaserVisible = state.appInfoList.firstOrNull()?.isRecTeaser == true
+    LaunchedEffect(recTeaserVisible) {
+        if (recTeaserVisible && PrefManager.usageAnalyticsEnabled) {
+            PostHog.capture(event = "rec_teaser_shown")
+        }
+    }
 
     // Initialize layout if undecided
     LaunchedEffect(Unit) {
@@ -938,6 +950,21 @@ private fun LibraryScreenContent(
         if (selectedAppId == null) {
             // Use Box to allow content to scroll behind the tab bar
             Box(modifier = Modifier.fillMaxSize()) {
+                if (showRecTeaserDialog) {
+                    RecommendationDisclosureDialog(
+                        onContinue = {
+                            PrefManager.recDisclosureShown = true
+                            recDisclosureShown = true
+                            showRecTeaserDialog = false
+                            PluviaApp.events.emit(AndroidEvent.RecommendationToggleChanged)
+                        },
+                        onDismiss = {
+                            PrefManager.recTeaserDismissedDay = System.currentTimeMillis() / (24L * 60 * 60 * 1000)
+                            showRecTeaserDialog = false
+                        },
+                        source = "hero",
+                    )
+                }
                 // When on Steam/GOG/Epic/Amazon tab and not logged in, or LOCAL tab with no custom games, show splash
                 if (state.currentTab == LibraryTab.RECOMMENDED) {
                     if (recDisclosureShown) {
@@ -1017,8 +1044,15 @@ private fun LibraryScreenContent(
                             listState = carouselListState,
                             onPageChange = onPageChange,
                             onNavigate = { appId ->
-                                selectedAppId = appId
-                                selectedLibraryItem = state.appInfoList.find { it.appId == appId }
+                                val item = state.appInfoList.find { it.appId == appId }
+                                if (item?.isRecTeaser == true) {
+                                    if (!item.isRecLoading && !recDisclosureShown) {
+                                        onRecTeaserTapped()
+                                    }
+                                } else {
+                                    selectedAppId = appId
+                                    selectedLibraryItem = item
+                                }
                             },
                             onRefresh = onRefresh,
                             modifier = Modifier.fillMaxSize(),
@@ -1035,8 +1069,15 @@ private fun LibraryScreenContent(
                             focusTargetListIndex = gridFocusTargetListIndex,
                             onPageChange = onPageChange,
                             onNavigate = { appId ->
-                                selectedAppId = appId
-                                selectedLibraryItem = state.appInfoList.find { it.appId == appId }
+                                val item = state.appInfoList.find { it.appId == appId }
+                                if (item?.isRecTeaser == true) {
+                                    if (!item.isRecLoading && !recDisclosureShown) {
+                                        onRecTeaserTapped()
+                                    }
+                                } else {
+                                    selectedAppId = appId
+                                    selectedLibraryItem = item
+                                }
                             },
                             onRefresh = onRefresh,
                             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryCarouselPane.kt
@@ -408,7 +408,10 @@ internal fun LibraryCarouselPane(
                     ) {
                         items(
                             count = state.appInfoList.size,
-                            key = { listIndex -> state.appInfoList[listIndex].appId },
+                            key = { listIndex ->
+                                val item = state.appInfoList[listIndex]
+                                if (item.recSource == "hero") "HERO_SLOT" else item.appId
+                            },
                         ) { listIndex ->
                             val item = state.appInfoList[listIndex]
 

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryGridCard.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryGridCard.kt
@@ -1,6 +1,8 @@
 package app.gamenative.ui.screen.library.components
 
 import android.content.Context
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -25,6 +27,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Face4
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -124,6 +127,12 @@ internal fun GridViewCard(
         Modifier
     }
     val cardShape = RoundedCornerShape(12.dp)
+    // 1f = frosted teaser, 0f = normal card; animates the reveal when consent is granted
+    val frost by animateFloatAsState(
+        targetValue = if (appInfo.isRecTeaser) 1f else 0f,
+        animationSpec = tween(durationMillis = 700),
+        label = "recTeaserFrost",
+    )
     val interactionSource = remember { MutableInteractionSource() }
     val isItemFocused by interactionSource.collectIsFocusedAsState()
 
@@ -210,7 +219,8 @@ internal fun GridViewCard(
                     imageModifier = Modifier
                         .fillMaxSize()
                         .alpha(imageAlpha)
-                        .then(gridHeroZoom),
+                        .then(gridHeroZoom)
+                        .then(if (frost > 0f) Modifier.blur(10.dp * frost) else Modifier),
                     contentScale = getGridContentScale(paneType),
                     image = { currentImageUrl },
                     onFailure = {
@@ -222,6 +232,47 @@ internal fun GridViewCard(
                     },
                 )
 
+                val displayName = if (appInfo.isRecTeaser) {
+                    stringResource(R.string.rec_teaser_title)
+                } else {
+                    appInfo.name
+                }
+
+                if (frost > 0f) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .alpha(frost)
+                            .background(Color.Black.copy(alpha = 0.35f))
+                            .padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        if (appInfo.isRecLoading) {
+                            CircularProgressIndicator(
+                                color = Color.White,
+                                modifier = Modifier.size(32.dp),
+                            )
+                        } else {
+                            Text(
+                                text = stringResource(R.string.rec_teaser_title),
+                                style = MaterialTheme.typography.titleMedium.copy(
+                                    fontWeight = FontWeight.Bold,
+                                ),
+                                color = Color.White,
+                                textAlign = TextAlign.Center,
+                            )
+                            Text(
+                                text = stringResource(R.string.rec_teaser_subtitle),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = Color.White.copy(alpha = 0.7f),
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.padding(top = 4.dp),
+                            )
+                        }
+                    }
+                }
+
                 // Fallback text when image fails to load (drawn before overlays so badges/icons stay visible)
                 if (!hideText) {
                     Box(
@@ -231,7 +282,7 @@ internal fun GridViewCard(
                         contentAlignment = Alignment.Center,
                     ) {
                         Text(
-                            text = appInfo.name,
+                            text = displayName,
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -242,11 +293,13 @@ internal fun GridViewCard(
                 }
 
                 // Gradient overlay at bottom for title
+                if (frost < 1f) {
                 Box(
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .fillMaxWidth()
                         .height(bottomGradientHeight)
+                        .alpha(1f - frost)
                         .background(
                             Brush.verticalGradient(
                                 colors = listOf(
@@ -262,6 +315,7 @@ internal fun GridViewCard(
                     modifier = Modifier
                         .align(Alignment.BottomStart)
                         .fillMaxWidth()
+                        .alpha(1f - frost)
                         .padding(horizontal = 10.dp, vertical = cardContentBottomPadding),
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
@@ -307,6 +361,7 @@ internal fun GridViewCard(
                             animate = animateStats,
                         )
                     }
+                }
                 }
 
                 // Top-left: Featured badge, GOG rating (store rec), or Recommended/compat badge

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListCard.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Face4
+import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -131,12 +132,22 @@ internal fun ListViewCard(
                     .size(52.dp)
                     .clip(RoundedCornerShape(10.dp))
                     .background(MaterialTheme.colorScheme.surfaceVariant),
+                contentAlignment = Alignment.Center,
             ) {
-                ListItemImage(
-                    modifier = Modifier.fillMaxSize(),
-                    imageModifier = Modifier.clip(RoundedCornerShape(10.dp)),
-                    image = { iconUrl },
-                )
+                if (appInfo.isRecTeaser) {
+                    Icon(
+                        imageVector = Icons.Rounded.AutoAwesome,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                } else {
+                    ListItemImage(
+                        modifier = Modifier.fillMaxSize(),
+                        imageModifier = Modifier.clip(RoundedCornerShape(10.dp)),
+                        image = { iconUrl },
+                    )
+                }
             }
 
             // Game info
@@ -145,7 +156,11 @@ internal fun ListViewCard(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 Text(
-                    text = appInfo.name,
+                    text = if (appInfo.isRecTeaser) {
+                        stringResource(R.string.rec_teaser_title)
+                    } else {
+                        appInfo.name
+                    },
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.SemiBold,
                     color = MaterialTheme.colorScheme.onSurface,
@@ -154,7 +169,7 @@ internal fun ListViewCard(
                 )
 
                 // Status row with compact badges
-                Row(
+                if (!appInfo.isRecTeaser) Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -254,7 +254,10 @@ internal fun LibraryListPane(
                         ) {
                             items(
                                 count = state.appInfoList.size,
-                                key = { listIndex -> state.appInfoList[listIndex].appId },
+                                key = { listIndex ->
+                                    val item = state.appInfoList[listIndex]
+                                    if (item.recSource == "hero") "HERO_SLOT" else item.appId
+                                },
                             ) { listIndex ->
                                 val item = state.appInfoList[listIndex]
                                 val animateFade = remember(item.index) { !listState.isScrollInProgress }

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/RecommendationDisclosure.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/RecommendationDisclosure.kt
@@ -14,28 +14,36 @@ import com.posthog.PostHog
 fun RecommendationDisclosureDialog(
     onContinue: () -> Unit,
     onDismiss: () -> Unit,
+    source: String = "tab",
 ) {
+    fun capture(event: String) {
+        if (PrefManager.usageAnalyticsEnabled) {
+            PostHog.capture(event = event, properties = mapOf("source" to source))
+        }
+    }
     LaunchedEffect(Unit) {
-        if (PrefManager.usageAnalyticsEnabled) PostHog.capture(event = "rec_disclosure_shown")
+        capture("rec_disclosure_shown")
     }
     AlertDialog(
         onDismissRequest = {
-            if (PrefManager.usageAnalyticsEnabled) PostHog.capture(event = "rec_disclosure_declined")
+            capture("rec_disclosure_declined")
             onDismiss()
         },
         title = { Text(text = stringResource(R.string.rec_disclosure_title)) },
         text = { Text(text = stringResource(R.string.rec_disclosure_body)) },
         confirmButton = {
-            TextButton(onClick = {
-                if (PrefManager.usageAnalyticsEnabled) PostHog.capture(event = "rec_disclosure_allowed")
-                onContinue()
-            }) {
+            TextButton(
+                onClick = {
+                    capture("rec_disclosure_allowed")
+                    onContinue()
+                },
+            ) {
                 Text(text = stringResource(R.string.rec_disclosure_allow))
             }
         },
         dismissButton = {
             TextButton(onClick = {
-                if (PrefManager.usageAnalyticsEnabled) PostHog.capture(event = "rec_disclosure_declined")
+                capture("rec_disclosure_declined")
                 onDismiss()
             }) {
                 Text(text = stringResource(R.string.rec_disclosure_not_now))

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1946,6 +1946,8 @@
     <string name="rec_disclosure_body">For personlige anbefalinger deler vi de spil, du spiller, med GOG. Slå fra når som helst i Indstillinger.</string>
     <string name="rec_disclosure_allow">Tillad</string>
     <string name="rec_disclosure_not_now">Ikke nu</string>
+    <string name="rec_teaser_title">Opdag spil til din enhed</string>
+    <string name="rec_teaser_subtitle">Tryk for at kigge</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">Sponsoreret</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2016,6 +2016,8 @@
     <string name="rec_disclosure_body">Für personalisierte Empfehlungen teilen wir die von dir gespielten Spiele mit GOG. Jederzeit in den Einstellungen deaktivierbar.</string>
     <string name="rec_disclosure_allow">Zulassen</string>
     <string name="rec_disclosure_not_now">Nicht jetzt</string>
+    <string name="rec_teaser_title">Entdecke Spiele für dein Gerät</string>
+    <string name="rec_teaser_subtitle">Zum Ansehen tippen</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">Gesponsert</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2074,6 +2074,8 @@
     <string name="rec_disclosure_body">Para ofrecerte recomendaciones personalizadas, compartimos los juegos que juegas con GOG. Puedes desactivarlo cuando quieras en Ajustes.</string>
     <string name="rec_disclosure_allow">Permitir</string>
     <string name="rec_disclosure_not_now">Ahora no</string>
+    <string name="rec_teaser_title">Descubre juegos para tu dispositivo</string>
+    <string name="rec_teaser_subtitle">Toca para echar un vistazo</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">Patrocinado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2076,6 +2076,8 @@
     <string name="rec_disclosure_body">Pour des recommandations personnalisées, nous partageons les jeux auxquels vous jouez avec GOG. Désactivable à tout moment dans les Paramètres.</string>
     <string name="rec_disclosure_allow">Autoriser</string>
     <string name="rec_disclosure_not_now">Pas maintenant</string>
+    <string name="rec_teaser_title">Découvrez des jeux pour votre appareil</string>
+    <string name="rec_teaser_subtitle">Appuyez pour jeter un œil</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">Sponsorisé</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -2067,6 +2067,8 @@
     <string name="rec_disclosure_body">Per consigli personalizzati, condividiamo i giochi a cui giochi con GOG. Puoi disattivarlo in qualsiasi momento nelle Impostazioni.</string>
     <string name="rec_disclosure_allow">Consenti</string>
     <string name="rec_disclosure_not_now">Non ora</string>
+    <string name="rec_teaser_title">Scopri giochi per il tuo dispositivo</string>
+    <string name="rec_teaser_subtitle">Tocca per dare un\'occhiata</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">Sponsorizzato</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2033,6 +2033,8 @@
     <string name="rec_disclosure_body">パーソナライズされたおすすめのため、プレイしたゲームを GOG と共有します。設定でいつでもオフにできます。</string>
     <string name="rec_disclosure_allow">許可</string>
     <string name="rec_disclosure_not_now">後で</string>
+    <string name="rec_teaser_title">あなたのデバイスに合うゲームを発見</string>
+    <string name="rec_teaser_subtitle">タップしてチェック</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">スポンサー</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2074,6 +2074,8 @@
     <string name="rec_disclosure_body">맞춤 추천을 위해 플레이한 게임을 GOG와 공유합니다. 설정에서 언제든지 끌 수 있습니다.</string>
     <string name="rec_disclosure_allow">허용</string>
     <string name="rec_disclosure_not_now">나중에</string>
+    <string name="rec_teaser_title">내 기기에 맞는 게임 찾기</string>
+    <string name="rec_teaser_subtitle">탭하여 살펴보기</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">스폰서</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -2074,6 +2074,8 @@
     <string name="rec_disclosure_body">Aby zapewnić spersonalizowane rekomendacje, udostępniamy ograne przez Ciebie gry serwisowi GOG. Możesz to wyłączyć w Ustawieniach.</string>
     <string name="rec_disclosure_allow">Zezwól</string>
     <string name="rec_disclosure_not_now">Nie teraz</string>
+    <string name="rec_teaser_title">Odkryj gry dla swojego urządzenia</string>
+    <string name="rec_teaser_subtitle">Dotknij, aby zobaczyć</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">Sponsorowane</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1946,6 +1946,8 @@
     <string name="rec_disclosure_body">Para recomendações personalizadas, compartilhamos os jogos que você joga com a GOG. Desative quando quiser nas Configurações.</string>
     <string name="rec_disclosure_allow">Permitir</string>
     <string name="rec_disclosure_not_now">Agora não</string>
+    <string name="rec_teaser_title">Descubra jogos para o seu dispositivo</string>
+    <string name="rec_teaser_subtitle">Toque para dar uma olhada</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">Patrocinado</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -2077,6 +2077,8 @@
     <string name="rec_disclosure_body">Pentru recomandări personalizate, partajăm jocurile pe care le joci cu GOG. Poți dezactiva oricând din Setări.</string>
     <string name="rec_disclosure_allow">Permite</string>
     <string name="rec_disclosure_not_now">Nu acum</string>
+    <string name="rec_teaser_title">Descoperă jocuri pentru dispozitivul tău</string>
+    <string name="rec_teaser_subtitle">Atinge pentru a arunca o privire</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">Sponsorizat</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2002,6 +2002,8 @@ https://gamenative.app
     <string name="rec_disclosure_body">Для персональных рекомендаций мы передаём игры, в которые вы играете, сервису GOG. Отключить можно в любой момент в Настройках.</string>
     <string name="rec_disclosure_allow">Разрешить</string>
     <string name="rec_disclosure_not_now">Не сейчас</string>
+    <string name="rec_teaser_title">Откройте игры для вашего устройства</string>
+    <string name="rec_teaser_subtitle">Нажмите, чтобы посмотреть</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">Спонсировано</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -2070,6 +2070,8 @@
     <string name="rec_disclosure_body">Для персональних рекомендацій ми надаємо ігри, у які ви граєте, сервісу GOG. Вимкнути можна будь-коли в Налаштуваннях.</string>
     <string name="rec_disclosure_allow">Дозволити</string>
     <string name="rec_disclosure_not_now">Не зараз</string>
+    <string name="rec_teaser_title">Відкрийте ігри для вашого пристрою</string>
+    <string name="rec_teaser_subtitle">Торкніться, щоб переглянути</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">Спонсовано</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2094,6 +2094,8 @@
     <string name="rec_disclosure_body">为提供个性化推荐，我们会将你玩过的游戏分享给 GOG。可随时在设置中关闭。</string>
     <string name="rec_disclosure_allow">允许</string>
     <string name="rec_disclosure_not_now">暂不</string>
+    <string name="rec_teaser_title">发现适合你设备的游戏</string>
+    <string name="rec_teaser_subtitle">点按查看</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">赞助</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2085,6 +2085,8 @@
     <string name="rec_disclosure_body">為提供個人化推薦，我們會將你玩過的遊戲分享給 GOG。可隨時在設定中關閉。</string>
     <string name="rec_disclosure_allow">允許</string>
     <string name="rec_disclosure_not_now">暫不</string>
+    <string name="rec_teaser_title">探索適合你裝置的遊戲</string>
+    <string name="rec_teaser_subtitle">點按查看</string>
 
     <!-- Sponsorship (featured slot) -->
     <string name="featured_badge">贊助</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2061,6 +2061,8 @@
     <string name="rec_disclosure_body">For personalized recommendations, we share the games you play with GOG. Turn off anytime in Settings.</string>
     <string name="rec_disclosure_allow">Allow</string>
     <string name="rec_disclosure_not_now">Not now</string>
+    <string name="rec_teaser_title">Discover games for your device</string>
+    <string name="rec_teaser_subtitle">Tap to take a look</string>
     <string name="settings_interface_show_recommendations_title">Show game recommendations</string>
     <string name="settings_interface_show_recommendations_subtitle">Show personalized recommendations. Keeping this on helps support GameNative.</string>
 


### PR DESCRIPTION
## Description
Show disclosure over static recommendations and improved disclosure

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a consent-gated hero recommendation teaser with improved disclosure and analytics. Previously, recommendations appeared with a tab-level disclosure; now the hero slot shows a frosted teaser that blocks navigation until consent. Tapping opens the disclosure; Allow shows a loading spinner and then swaps in a personalized pick; Not now snoozes the teaser (daily until first dismiss, then one day in three). Featured slots are never replaced by the teaser.

- Caches `PrefManager.recDisclosureShown` in memory to avoid stale reads after consent, and adds `rec_teaser_dismissed_day` for snooze scheduling.
- Flags hero items with `isRecTeaser` and `isRecLoading`; UI gates navigation and animates a frosted overlay with blur and strings for all locales.
- Stabilizes Compose list keys for the hero card (`"HERO_SLOT"`) to prevent recompositions when switching teaser/loading/personalized.
- Captures teaser and disclosure events via `PostHog` with a `source` property (`"hero"` or `"tab"`).

**Rollout**
- No migrations required; new DataStore key initializes to 0.
- Ensure `usageAnalyticsEnabled` is respected; events only fire when enabled.

<sup>Written for commit bbd354a12a1ab9bac17f8e64a39b7f01b8526251. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a daily recommendations teaser to the library, with localized titles and subtitles.
  * Teasers now display polished loading, blurred, and darkened visual states across carousel, grid, and list views.
  * Selecting a teaser opens a disclosure dialog before recommendations are enabled.
  * Users can dismiss the teaser for the day or continue to enable recommendations.

* **Bug Fixes**
  * Improved teaser loading behavior and refreshed recommendations after consent.
  * Enhanced library item handling to prevent display inconsistencies during updates.

* **Localization**
  * Added teaser translations across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->