### PR TITLE
Gog epic improvements + controller mapping fix

### DIFF
--- a/app/src/main/java/app/gamenative/data/DownloadInfo.kt
+++ b/app/src/main/java/app/gamenative/data/DownloadInfo.kt
@@ -1,7 +1,10 @@
 package app.gamenative.data
 
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -44,14 +47,19 @@ data class DownloadInfo(
     }
 
     fun cancel(message: String) {
-        // Persist the most recent progress so a resume can pick up where it left off.
-        persistProgressSnapshot()
         // Mark as inactive and clear speed tracking so a future resume
         // does not use stale samples.
         setActive(false)
         setPostInstallSyncing(false)
         resetSpeedTracking()
-        downloadJob?.cancel(CancellationException(message))
+        // The snapshot write hits the (possibly saturated) install volume and the
+        // job cancel cascades through many continuations; callers include UI click
+        // handlers on the main thread, so both must run off it (ANR otherwise).
+        CoroutineScope(Dispatchers.IO).launch {
+            // Persist the most recent progress so a resume can pick up where it left off.
+            persistProgressSnapshot()
+            downloadJob?.cancel(CancellationException(message))
+        }
     }
 
     fun setDownloadJob(job: Job) {

--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import app.gamenative.PrefManager
 import app.gamenative.data.DownloadInfo
+import app.gamenative.data.GameSource
 import app.gamenative.enums.Marker
 import app.gamenative.utils.CdnRankingUtils
 import app.gamenative.utils.MarkerUtils
@@ -13,8 +14,11 @@ import app.gamenative.service.epic.manifest.ChunkPart
 import app.gamenative.service.epic.manifest.EpicManifest
 import app.gamenative.service.epic.manifest.ManifestUtils
 import app.gamenative.service.gog.HttpStatusException
+import app.gamenative.utils.ContainerStorageManager
 import app.gamenative.utils.DownloadSpeedConfig
 import app.gamenative.utils.Net
+import app.gamenative.utils.StorageUtils
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -60,6 +64,7 @@ import java.util.concurrent.atomic.AtomicInteger
 @Singleton
 class EpicDownloadManager @Inject constructor(
     private val epicManager: EpicManager,
+    @ApplicationContext private val context: Context,
 ) {
     companion object {
         private const val CHUNK_BUFFER_SIZE = 1024 * 1024 // 1MB buffer for decompression
@@ -224,8 +229,11 @@ class EpicDownloadManager @Inject constructor(
             downloadInfo.setTotalExpectedBytes(totalDownloadSize)
             downloadInfo.updateStatusMessage("Downloading base game...")
 
-            // Download chunks in parallel
-            val chunkCacheDir = File(installPath, ".chunks")
+            // Download chunks in parallel.
+            // Cache lives on internal storage: on exFAT SD cards (dirsync mount) every
+            // create/rename/delete in the cache dir is a synchronous directory flush,
+            // which dominates download time for small chunks.
+            val chunkCacheDir = File(context.cacheDir, "epic_chunks/${File(installPath).name}")
             chunkCacheDir.mkdirs()
 
             Timber.tag("Epic").d(
@@ -240,17 +248,24 @@ class EpicDownloadManager @Inject constructor(
             )
 
             // Build file-ordered chunk queue and run streaming download + assembly
-            val fileChunkIds = files.map { f -> f.chunkParts.map { it.guidStr } }
-            val chunkQueue = buildFileOrderedChunkQueue(manifest, fileChunkIds)
             val installDir = File(installPath)
             installDir.mkdirs()
+
+            // Incremental download: skip files already on disk with matching size and SHA-1
+            val pendingFiles = files.filter { file ->
+                !fileExistsWithCorrectHash(File(installDir, file.filename), file.fileSize, file.hash)
+            }
+            Timber.tag("Epic").d("Skipping ${files.size - pendingFiles.size} existing file(s), downloading ${pendingFiles.size}")
+
+            val fileChunkIds = pendingFiles.map { f -> f.chunkParts.map { it.guidStr } }
+            val chunkQueue = buildFileOrderedChunkQueue(manifest, fileChunkIds)
 
             val downloadResult = downloadAndAssembleEpicChunks(
                 manifest = manifest,
                 cdnUrls = cdnUrls,
                 chunkCacheDir = chunkCacheDir,
                 installDir = installDir,
-                files = files,
+                files = pendingFiles,
                 downloadInfo = downloadInfo,
                 chunkQueue = chunkQueue,
                 chunkDir = chunkDir,
@@ -383,20 +398,26 @@ class EpicDownloadManager @Inject constructor(
             val files = fileManifestList.elements
             val chunkDir = manifest.getChunkDir()
 
-            val fileChunkIds = files.map { f -> f.chunkParts.map { it.guidStr } }
-            val chunkQueue = buildFileOrderedChunkQueue(manifest, fileChunkIds)
-
-            val chunkCacheDir = File(installPath, ".chunks")
+            val chunkCacheDir = File(context.cacheDir, "epic_chunks/${File(installPath).name}")
             chunkCacheDir.mkdirs()
             val installDir = File(installPath)
             installDir.mkdirs()
+
+            // Incremental download: skip files already on disk with matching size and SHA-1
+            val pendingFiles = files.filter { file ->
+                !fileExistsWithCorrectHash(File(installDir, file.filename), file.fileSize, file.hash)
+            }
+            Timber.tag("Epic").d("Skipping ${files.size - pendingFiles.size} existing file(s), downloading ${pendingFiles.size}")
+
+            val fileChunkIds = pendingFiles.map { f -> f.chunkParts.map { it.guidStr } }
+            val chunkQueue = buildFileOrderedChunkQueue(manifest, fileChunkIds)
 
             val dlcDownloadResult = downloadAndAssembleEpicChunks(
                 manifest = manifest,
                 cdnUrls = cdnUrls,
                 chunkCacheDir = chunkCacheDir,
                 installDir = installDir,
-                files = files,
+                files = pendingFiles,
                 downloadInfo = downloadInfo,
                 chunkQueue = chunkQueue,
                 chunkDir = chunkDir,
@@ -449,7 +470,7 @@ class EpicDownloadManager @Inject constructor(
             val chunkDir = manifest.getChunkDir()
 
             val installDir = File(installPath).also { it.mkdirs() }
-            val chunkCacheDir = File(installDir, ".chunks").also { it.mkdirs() }
+            val chunkCacheDir = File(context.cacheDir, "epic_chunks/${installDir.name}").also { it.mkdirs() }
 
             // Dummy DownloadInfo – overlay downloads are small and need no UI progress events
             val dummyDownloadInfo = DownloadInfo(
@@ -844,6 +865,31 @@ class EpicDownloadManager @Inject constructor(
         }
     }
 
+    /**
+     * True when the file on disk matches the manifest's size and full-file SHA-1,
+     * so it can be skipped on resume. An all-zero manifest hash is treated as
+     * unverifiable and the file is re-downloaded.
+     */
+    private fun fileExistsWithCorrectHash(outputFile: File, expectedSize: Long, expectedHash: ByteArray): Boolean {
+        if (!outputFile.exists()) return false
+        if (outputFile.length() != expectedSize) return false
+        if (expectedHash.all { it == 0.toByte() }) return false
+        return try {
+            val digest = MessageDigest.getInstance("SHA-1")
+            outputFile.inputStream().use { input ->
+                val buffer = ByteArray(64 * 1024)
+                var bytesRead: Int
+                while (input.read(buffer).also { bytesRead = it } != -1) {
+                    digest.update(buffer, 0, bytesRead)
+                }
+            }
+            digest.digest().contentEquals(expectedHash)
+        } catch (e: Exception) {
+            Timber.tag("Epic").w(e, "Could not verify existing file ${outputFile.path}, re-downloading")
+            false
+        }
+    }
+
     private fun buildFileOrderedChunkQueue(
         manifest: EpicManifest,
         fileChunkIds: List<List<String>>,
@@ -882,6 +928,25 @@ class EpicDownloadManager @Inject constructor(
 
             // Calculate total expected installed size once (sum of all file sizes)
             val totalExpectedSize = files.sumOf { it.fileSize }
+
+            val onExternalStorage = runCatching {
+                ContainerStorageManager.getStorageLocation(context, GameSource.EPIC, installDir.absolutePath) ==
+                    ContainerStorageManager.StorageLocation.EXTERNAL
+            }.getOrDefault(false)
+            if (onExternalStorage) {
+                val remainingBytes = files.sumOf { file ->
+                    (file.fileSize - File(installDir, file.filename).length()).coerceAtLeast(0L)
+                }
+                val availableBytes = StorageUtils.getAvailableSpaceForUncreatedPath(installDir.absolutePath)
+                if (availableBytes < remainingBytes) {
+                    return@withContext Result.failure(
+                        IOException(
+                            "Not enough free space: need ${StorageUtils.formatBinarySize(remainingBytes)}, " +
+                                "available ${StorageUtils.formatBinarySize(availableBytes)}",
+                        ),
+                    )
+                }
+            }
 
             chunkQueue.forEach { chunkInfo ->
                 chunkUsageCounts[chunkInfo.guidStr] = AtomicInteger(
@@ -1053,8 +1118,14 @@ class EpicDownloadManager @Inject constructor(
 
                     try {
                         // okio resize can OOM for large files on android.
+                        // External volumes are exFAT: no sparse files, so setLength physically
+                        // zero-fills the whole file there. Skip and let offset writes grow it.
                         RandomAccessFile(outputFile.path, "rw").use {
-                            it.setLength(totalSize)
+                            if (!onExternalStorage) {
+                                it.setLength(totalSize)
+                            } else if (it.length() > totalSize) {
+                                it.setLength(totalSize)
+                            }
                         }
                     } catch (e: IOException) {
                         throw IOException("Failed to allocate file ${outputFile.path}: ${e.message}")

--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -262,10 +262,15 @@ class EpicDownloadManager @Inject constructor(
             val installDir = File(installPath)
             installDir.mkdirs()
 
-            // Incremental download: skip files already on disk with matching size and SHA-1
+            // Incremental download: skip files already on disk with matching size and SHA-1.
+            // On a resume this hashes every completed file, which can take minutes for a
+            // large install — surface it in the UI and honor cancellation between files.
+            downloadInfo.updateStatusMessage("Verifying existing files...")
             val pendingFiles = files.filter { file ->
+                if (!downloadInfo.isActive()) return@withContext Result.failure(Exception("Download cancelled"))
                 !fileExistsWithCorrectHash(File(installDir, file.filename), file.fileSize, file.hash)
             }
+            downloadInfo.updateStatusMessage(null)
             Timber.tag("Epic").d("Skipping ${files.size - pendingFiles.size} existing file(s), downloading ${pendingFiles.size}")
 
             val fileChunkIds = pendingFiles.map { f -> f.chunkParts.map { it.guidStr } }
@@ -414,10 +419,15 @@ class EpicDownloadManager @Inject constructor(
             val installDir = File(installPath)
             installDir.mkdirs()
 
-            // Incremental download: skip files already on disk with matching size and SHA-1
+            // Incremental download: skip files already on disk with matching size and SHA-1.
+            // On a resume this hashes every completed file, which can take minutes for a
+            // large install — surface it in the UI and honor cancellation between files.
+            downloadInfo.updateStatusMessage("Verifying existing files...")
             val pendingFiles = files.filter { file ->
+                if (!downloadInfo.isActive()) return@withContext Result.failure(Exception("Download cancelled"))
                 !fileExistsWithCorrectHash(File(installDir, file.filename), file.fileSize, file.hash)
             }
+            downloadInfo.updateStatusMessage(null)
             Timber.tag("Epic").d("Skipping ${files.size - pendingFiles.size} existing file(s), downloading ${pendingFiles.size}")
 
             val fileChunkIds = pendingFiles.map { f -> f.chunkParts.map { it.guidStr } }

--- a/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicDownloadManager.kt
@@ -67,6 +67,17 @@ class EpicDownloadManager @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
     companion object {
+        /**
+         * Internal chunk-cache dir for a download target. Keyed by the full install
+         * path (not just the directory name) so two containers installing the EOS
+         * overlay — whose install dirs are all named "Overlay" — never share a cache.
+         */
+        fun chunkCacheDirFor(context: Context, installPath: String): File {
+            val dir = File(installPath)
+            val key = Integer.toHexString(dir.absolutePath.hashCode())
+            return File(context.cacheDir, "epic_chunks/$key-${dir.name}")
+        }
+
         private const val CHUNK_BUFFER_SIZE = 1024 * 1024 // 1MB buffer for decompression
         private const val MAX_CHUNK_RETRIES = 3 // Maximum retries per chunk
         private const val RETRY_DELAY_MS = 1000L // Initial retry delay in milliseconds
@@ -233,7 +244,7 @@ class EpicDownloadManager @Inject constructor(
             // Cache lives on internal storage: on exFAT SD cards (dirsync mount) every
             // create/rename/delete in the cache dir is a synchronous directory flush,
             // which dominates download time for small chunks.
-            val chunkCacheDir = File(context.cacheDir, "epic_chunks/${File(installPath).name}")
+            val chunkCacheDir = chunkCacheDirFor(context, installPath)
             chunkCacheDir.mkdirs()
 
             Timber.tag("Epic").d(
@@ -398,7 +409,7 @@ class EpicDownloadManager @Inject constructor(
             val files = fileManifestList.elements
             val chunkDir = manifest.getChunkDir()
 
-            val chunkCacheDir = File(context.cacheDir, "epic_chunks/${File(installPath).name}")
+            val chunkCacheDir = chunkCacheDirFor(context, installPath)
             chunkCacheDir.mkdirs()
             val installDir = File(installPath)
             installDir.mkdirs()
@@ -470,7 +481,7 @@ class EpicDownloadManager @Inject constructor(
             val chunkDir = manifest.getChunkDir()
 
             val installDir = File(installPath).also { it.mkdirs() }
-            val chunkCacheDir = File(context.cacheDir, "epic_chunks/${installDir.name}").also { it.mkdirs() }
+            val chunkCacheDir = chunkCacheDirFor(context, installDir.absolutePath).also { it.mkdirs() }
 
             // Dummy DownloadInfo – overlay downloads are small and need no UI progress events
             val dummyDownloadInfo = DownloadInfo(
@@ -929,22 +940,13 @@ class EpicDownloadManager @Inject constructor(
             // Calculate total expected installed size once (sum of all file sizes)
             val totalExpectedSize = files.sumOf { it.fileSize }
 
-            val onExternalStorage = runCatching {
-                ContainerStorageManager.getStorageLocation(context, GameSource.EPIC, installDir.absolutePath) ==
-                    ContainerStorageManager.StorageLocation.EXTERNAL
-            }.getOrDefault(false)
+            val onExternalStorage = ContainerStorageManager.isOnExternalStorage(context, GameSource.EPIC, installDir.absolutePath)
             if (onExternalStorage) {
                 val remainingBytes = files.sumOf { file ->
                     (file.fileSize - File(installDir, file.filename).length()).coerceAtLeast(0L)
                 }
-                val availableBytes = StorageUtils.getAvailableSpaceForUncreatedPath(installDir.absolutePath)
-                if (availableBytes < remainingBytes) {
-                    return@withContext Result.failure(
-                        IOException(
-                            "Not enough free space: need ${StorageUtils.formatBinarySize(remainingBytes)}, " +
-                                "available ${StorageUtils.formatBinarySize(availableBytes)}",
-                        ),
-                    )
+                StorageUtils.downloadSpaceShortfall(installDir, remainingBytes, chunkCacheDir)?.let {
+                    return@withContext Result.failure(IOException(it))
                 }
             }
 

--- a/app/src/main/java/app/gamenative/service/epic/EpicOverlayManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicOverlayManager.kt
@@ -54,15 +54,10 @@ class EpicOverlayManager @Inject constructor(
         // Mirrors legendary/core.py Core.is_overlay_install().
         const val OVERLAY_MARKER_FILE = "EOSOVH-Win64-Shipping.dll"
 
-        // The overlay's CEF browser cannot create a D3D device under Wine; route it
-        // to builtin wined3d with renderer=no3d (per-exe) so CEF falls back to
-        // software rendering while the game keeps DXVK. Same recipe as the Forza
-        // Horizon 4 ForzaWebHelper fix.
-        private val RENDERER_EXES = listOf(
-            "EOSOverlayRenderer-Win64-Shipping.exe",
-            "EOSOverlayRenderer-Win32-Shipping.exe",
-        )
-        private val RENDERER_BUILTIN_DLLS = listOf("d3d11", "d3d9", "dxgi")
+        // Unlike FH4's windowed ForzaWebHelper (which needs the no3d software-rendering
+        // recipe), the EOS overlay renders OFF-SCREEN into shared D3D11 textures that
+        // EOSOVH composites over the game. Forcing no3d breaks that handoff (grey
+        // overlay), so the renderer must use the container's normal D3D (DXVK).
     }
 
     // ─────────────────────────────────────────────────────────────────────────────
@@ -154,10 +149,7 @@ class EpicOverlayManager @Inject constructor(
         val userRegFile = File(container.rootDir, ".wine/user.reg")
         if (!userRegFile.isFile) return false
         return WineRegistryEditor(userRegFile).use { editor ->
-            editor.getStringValue(EOS_OVERLAY_REG_KEY, EOS_OVERLAY_REG_VALUE, null) == OVERLAY_WIN_PATH &&
-                RENDERER_EXES.all { exe ->
-                    editor.getStringValue("Software\\Wine\\AppDefaults\\$exe\\Direct3D", "renderer", null) == "no3d"
-                }
+            editor.getStringValue(EOS_OVERLAY_REG_KEY, EOS_OVERLAY_REG_VALUE, null) == OVERLAY_WIN_PATH
         }
     }
 
@@ -205,8 +197,7 @@ class EpicOverlayManager @Inject constructor(
 
     /**
      * Write the EOS overlay path to HKCU\SOFTWARE\Epic Games\EOS\OverlayPath in
-     * [container]'s Wine user.reg, plus the per-exe software-rendering keys for
-     * the overlay's CEF browser.
+     * [container]'s Wine user.reg.
      *
      * Mirrors `add_registry_entries` in legendary/lfs/eos.py for the Wine/prefix
      * code path (HKCU only; Vulkan implicit layers are not set because they do
@@ -217,15 +208,9 @@ class EpicOverlayManager @Inject constructor(
         WineRegistryEditor(userRegFile).use { editor ->
             editor.setCreateKeyIfNotExist(true)
             editor.setStringValue(EOS_OVERLAY_REG_KEY, EOS_OVERLAY_REG_VALUE, OVERLAY_WIN_PATH)
-            for (exe in RENDERER_EXES) {
-                for (dll in RENDERER_BUILTIN_DLLS) {
-                    editor.setStringValue("Software\\Wine\\AppDefaults\\$exe\\DllOverrides", dll, "builtin")
-                }
-                editor.setStringValue("Software\\Wine\\AppDefaults\\$exe\\Direct3D", "renderer", "no3d")
-            }
         }
         Timber.tag("EOSOverlay").d(
-            "Registry updated: HKCU\\$EOS_OVERLAY_REG_KEY\\$EOS_OVERLAY_REG_VALUE = $OVERLAY_WIN_PATH + CEF no3d overrides",
+            "Registry updated: HKCU\\$EOS_OVERLAY_REG_KEY\\$EOS_OVERLAY_REG_VALUE = $OVERLAY_WIN_PATH",
         )
     }
 

--- a/app/src/main/java/app/gamenative/service/epic/EpicOverlayManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicOverlayManager.kt
@@ -53,6 +53,16 @@ class EpicOverlayManager @Inject constructor(
         // Presence of this file signals that the overlay is installed.
         // Mirrors legendary/core.py Core.is_overlay_install().
         const val OVERLAY_MARKER_FILE = "EOSOVH-Win64-Shipping.dll"
+
+        // The overlay's CEF browser cannot create a D3D device under Wine; route it
+        // to builtin wined3d with renderer=no3d (per-exe) so CEF falls back to
+        // software rendering while the game keeps DXVK. Same recipe as the Forza
+        // Horizon 4 ForzaWebHelper fix.
+        private val RENDERER_EXES = listOf(
+            "EOSOverlayRenderer-Win64-Shipping.exe",
+            "EOSOverlayRenderer-Win32-Shipping.exe",
+        )
+        private val RENDERER_BUILTIN_DLLS = listOf("d3d11", "d3d9", "dxgi")
     }
 
     // ─────────────────────────────────────────────────────────────────────────────
@@ -75,7 +85,10 @@ class EpicOverlayManager @Inject constructor(
             val overlayDir = overlayDir(container)
 
             if (!forceReinstall && isOverlayInstalled(container)) {
-                Timber.tag("EOSOverlay").i("Overlay already installed at ${overlayDir.absolutePath}, skipping")
+                // Wine's shutdown flush can drop registry keys written mid-session,
+                // so repair them even when the overlay files are already on disk.
+                writeRegistryEntries(container)
+                Timber.tag("EOSOverlay").i("Overlay already installed at ${overlayDir.absolutePath}, skipping download")
                 return@withContext Result.success(Unit)
             }
 
@@ -116,7 +129,7 @@ class EpicOverlayManager @Inject constructor(
             // The EOS SDK in games reads this to locate the overlay; if the
             // overlay DLLs fail to load under Wine the SDK degrades gracefully
             // (no HUD) while keeping auth/online features working.
-            writeRegistryPath(container, OVERLAY_WIN_PATH)
+            writeRegistryEntries(container)
 
             Timber.tag("EOSOverlay").i("EOS overlay installation complete")
             Result.success(Unit)
@@ -131,6 +144,22 @@ class EpicOverlayManager @Inject constructor(
      */
     fun isOverlayInstalled(container: Container): Boolean =
         File(overlayDir(container), OVERLAY_MARKER_FILE).exists()
+
+    /**
+     * Returns true only when the overlay files exist AND the registry entries the
+     * EOS SDK needs to find and render it are present in user.reg.
+     */
+    fun isOverlayConfigured(container: Container): Boolean {
+        if (!isOverlayInstalled(container)) return false
+        val userRegFile = File(container.rootDir, ".wine/user.reg")
+        if (!userRegFile.isFile) return false
+        return WineRegistryEditor(userRegFile).use { editor ->
+            editor.getStringValue(EOS_OVERLAY_REG_KEY, EOS_OVERLAY_REG_VALUE, null) == OVERLAY_WIN_PATH &&
+                RENDERER_EXES.all { exe ->
+                    editor.getStringValue("Software\\Wine\\AppDefaults\\$exe\\Direct3D", "renderer", null) == "no3d"
+                }
+        }
+    }
 
     /**
      * Remove all overlay files from [container] and clear the registry path.
@@ -163,20 +192,27 @@ class EpicOverlayManager @Inject constructor(
 
     /**
      * Write the EOS overlay path to HKCU\SOFTWARE\Epic Games\EOS\OverlayPath in
-     * [container]'s Wine user.reg.
+     * [container]'s Wine user.reg, plus the per-exe software-rendering keys for
+     * the overlay's CEF browser.
      *
      * Mirrors `add_registry_entries` in legendary/lfs/eos.py for the Wine/prefix
      * code path (HKCU only; Vulkan implicit layers are not set because they do
      * not work in Wine).
      */
-    private fun writeRegistryPath(container: Container, winPath: String) {
+    private fun writeRegistryEntries(container: Container) {
         val userRegFile = File(container.rootDir, ".wine/user.reg")
         WineRegistryEditor(userRegFile).use { editor ->
             editor.setCreateKeyIfNotExist(true)
-            editor.setStringValue(EOS_OVERLAY_REG_KEY, EOS_OVERLAY_REG_VALUE, winPath)
+            editor.setStringValue(EOS_OVERLAY_REG_KEY, EOS_OVERLAY_REG_VALUE, OVERLAY_WIN_PATH)
+            for (exe in RENDERER_EXES) {
+                for (dll in RENDERER_BUILTIN_DLLS) {
+                    editor.setStringValue("Software\\Wine\\AppDefaults\\$exe\\DllOverrides", dll, "builtin")
+                }
+                editor.setStringValue("Software\\Wine\\AppDefaults\\$exe\\Direct3D", "renderer", "no3d")
+            }
         }
         Timber.tag("EOSOverlay").d(
-            "Registry updated: HKCU\\$EOS_OVERLAY_REG_KEY\\$EOS_OVERLAY_REG_VALUE = $winPath",
+            "Registry updated: HKCU\\$EOS_OVERLAY_REG_KEY\\$EOS_OVERLAY_REG_VALUE = $OVERLAY_WIN_PATH + CEF no3d overrides",
         )
     }
 

--- a/app/src/main/java/app/gamenative/service/epic/EpicOverlayManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicOverlayManager.kt
@@ -58,6 +58,60 @@ class EpicOverlayManager @Inject constructor(
         // recipe), the EOS overlay renders OFF-SCREEN into shared D3D11 textures that
         // EOSOVH composites over the game. Forcing no3d breaks that handoff (grey
         // overlay), so the renderer must use the container's normal D3D (DXVK).
+
+        // The checks and registry writes below are static so boot-path callers
+        // (XServerScreen, launch dependencies) don't depend on EpicService being
+        // alive — routing them through a service instance silently no-ops when
+        // the service is stopped.
+
+        fun overlayDir(container: Container): File =
+            File(container.rootDir, ".wine/$OVERLAY_WINE_RELATIVE_PATH")
+
+        /** True if the overlay marker file exists in the container's Wine prefix. */
+        fun isOverlayInstalled(container: Container): Boolean =
+            File(overlayDir(container), OVERLAY_MARKER_FILE).exists()
+
+        /** True only when the overlay files exist AND OverlayPath is present in user.reg. */
+        fun isOverlayConfigured(container: Container): Boolean {
+            if (!isOverlayInstalled(container)) return false
+            val userRegFile = File(container.rootDir, ".wine/user.reg")
+            if (!userRegFile.isFile) return false
+            return WineRegistryEditor(userRegFile).use { editor ->
+                editor.getStringValue(EOS_OVERLAY_REG_KEY, EOS_OVERLAY_REG_VALUE, null) == OVERLAY_WIN_PATH
+            }
+        }
+
+        /**
+         * Re-write the overlay registry entries if the overlay files are installed but
+         * the keys are missing. Called from the container boot path AFTER prefix
+         * provisioning, because a wine/proton version change re-extracts the prefix
+         * template and replaces user.reg, wiping keys written earlier in the launch.
+         */
+        fun ensureRegistryEntries(container: Container) {
+            if (!isOverlayInstalled(container)) return
+            if (isOverlayConfigured(container)) return
+            Timber.tag("EOSOverlay").i("Overlay registry entries missing (prefix re-provisioned?) — re-writing")
+            writeRegistryEntries(container)
+        }
+
+        /**
+         * Write the EOS overlay path to HKCU\SOFTWARE\Epic Games\EOS\OverlayPath in
+         * [container]'s Wine user.reg.
+         *
+         * Mirrors `add_registry_entries` in legendary/lfs/eos.py for the Wine/prefix
+         * code path (HKCU only; Vulkan implicit layers are not set because they do
+         * not work in Wine).
+         */
+        internal fun writeRegistryEntries(container: Container) {
+            val userRegFile = File(container.rootDir, ".wine/user.reg")
+            WineRegistryEditor(userRegFile).use { editor ->
+                editor.setCreateKeyIfNotExist(true)
+                editor.setStringValue(EOS_OVERLAY_REG_KEY, EOS_OVERLAY_REG_VALUE, OVERLAY_WIN_PATH)
+            }
+            Timber.tag("EOSOverlay").d(
+                "Registry updated: HKCU\\$EOS_OVERLAY_REG_KEY\\$EOS_OVERLAY_REG_VALUE = $OVERLAY_WIN_PATH",
+            )
+        }
     }
 
     // ─────────────────────────────────────────────────────────────────────────────
@@ -135,38 +189,6 @@ class EpicOverlayManager @Inject constructor(
     }
 
     /**
-     * Returns true if the overlay marker file exists in the container's Wine prefix.
-     */
-    fun isOverlayInstalled(container: Container): Boolean =
-        File(overlayDir(container), OVERLAY_MARKER_FILE).exists()
-
-    /**
-     * Returns true only when the overlay files exist AND the registry entries the
-     * EOS SDK needs to find and render it are present in user.reg.
-     */
-    fun isOverlayConfigured(container: Container): Boolean {
-        if (!isOverlayInstalled(container)) return false
-        val userRegFile = File(container.rootDir, ".wine/user.reg")
-        if (!userRegFile.isFile) return false
-        return WineRegistryEditor(userRegFile).use { editor ->
-            editor.getStringValue(EOS_OVERLAY_REG_KEY, EOS_OVERLAY_REG_VALUE, null) == OVERLAY_WIN_PATH
-        }
-    }
-
-    /**
-     * Re-write the overlay registry entries if the overlay files are installed but
-     * the keys are missing. Called from the container boot path AFTER prefix
-     * provisioning, because a wine/proton version change re-extracts the prefix
-     * template and replaces user.reg, wiping keys written earlier in the launch.
-     */
-    fun ensureRegistryEntries(container: Container) {
-        if (!isOverlayInstalled(container)) return
-        if (isOverlayConfigured(container)) return
-        Timber.tag("EOSOverlay").i("Overlay registry entries missing (prefix re-provisioned?) — re-writing")
-        writeRegistryEntries(container)
-    }
-
-    /**
      * Remove all overlay files from [container] and clear the registry path.
      */
     suspend fun removeOverlay(context: Context, container: Container): Result<Unit> =
@@ -188,31 +210,6 @@ class EpicOverlayManager @Inject constructor(
     // ─────────────────────────────────────────────────────────────────────────────
     // Internal helpers
     // ─────────────────────────────────────────────────────────────────────────────
-
-    /**
-     * Returns the overlay install directory inside [container]'s Wine prefix.
-     */
-    private fun overlayDir(container: Container): File =
-        File(container.rootDir, ".wine/$OVERLAY_WINE_RELATIVE_PATH")
-
-    /**
-     * Write the EOS overlay path to HKCU\SOFTWARE\Epic Games\EOS\OverlayPath in
-     * [container]'s Wine user.reg.
-     *
-     * Mirrors `add_registry_entries` in legendary/lfs/eos.py for the Wine/prefix
-     * code path (HKCU only; Vulkan implicit layers are not set because they do
-     * not work in Wine).
-     */
-    private fun writeRegistryEntries(container: Container) {
-        val userRegFile = File(container.rootDir, ".wine/user.reg")
-        WineRegistryEditor(userRegFile).use { editor ->
-            editor.setCreateKeyIfNotExist(true)
-            editor.setStringValue(EOS_OVERLAY_REG_KEY, EOS_OVERLAY_REG_VALUE, OVERLAY_WIN_PATH)
-        }
-        Timber.tag("EOSOverlay").d(
-            "Registry updated: HKCU\\$EOS_OVERLAY_REG_KEY\\$EOS_OVERLAY_REG_VALUE = $OVERLAY_WIN_PATH",
-        )
-    }
 
     /**
      * Clear the EOS overlay path from the Wine user.reg.

--- a/app/src/main/java/app/gamenative/service/epic/EpicOverlayManager.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicOverlayManager.kt
@@ -162,6 +162,19 @@ class EpicOverlayManager @Inject constructor(
     }
 
     /**
+     * Re-write the overlay registry entries if the overlay files are installed but
+     * the keys are missing. Called from the container boot path AFTER prefix
+     * provisioning, because a wine/proton version change re-extracts the prefix
+     * template and replaces user.reg, wiping keys written earlier in the launch.
+     */
+    fun ensureRegistryEntries(container: Container) {
+        if (!isOverlayInstalled(container)) return
+        if (isOverlayConfigured(container)) return
+        Timber.tag("EOSOverlay").i("Overlay registry entries missing (prefix re-provisioned?) — re-writing")
+        writeRegistryEntries(container)
+    }
+
+    /**
      * Remove all overlay files from [container] and clear the registry path.
      */
     suspend fun removeOverlay(context: Context, container: Container): Result<Unit> =

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -587,6 +587,9 @@ class EpicService : Service() {
         fun isOverlayInstalled(container: Container): Boolean =
             getInstance()?.epicOverlayManager?.isOverlayInstalled(container) ?: false
 
+        fun isOverlayConfigured(container: Container): Boolean =
+            getInstance()?.epicOverlayManager?.isOverlayConfigured(container) ?: false
+
         /**
          * Remove the EOS overlay from [container] and clear its registry entry.
          */

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -590,6 +590,10 @@ class EpicService : Service() {
         fun isOverlayConfigured(container: Container): Boolean =
             getInstance()?.epicOverlayManager?.isOverlayConfigured(container) ?: false
 
+        fun ensureOverlayRegistryEntries(container: Container) {
+            getInstance()?.epicOverlayManager?.ensureRegistryEntries(container)
+        }
+
         /**
          * Remove the EOS overlay from [container] and clear its registry entry.
          */

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -250,6 +250,9 @@ class EpicService : Service() {
                     MarkerUtils.removeMarker(path, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
                 }
 
+                // Drop any leftover chunk cache (kept on failed downloads for resume)
+                EpicDownloadManager.chunkCacheDirFor(context, path).deleteRecursively()
+
                 // Uninstall from database (keeps the entry but marks as not installed)
                 instance.epicManager.uninstall(appId)
 
@@ -579,19 +582,6 @@ class EpicService : Service() {
             return instance.epicOverlayManager.installOverlay(
                 context, container, forceReinstall, onProgress,
             )
-        }
-
-        /**
-         * Returns true if the EOS overlay is installed in [container].
-         */
-        fun isOverlayInstalled(container: Container): Boolean =
-            getInstance()?.epicOverlayManager?.isOverlayInstalled(container) ?: false
-
-        fun isOverlayConfigured(container: Container): Boolean =
-            getInstance()?.epicOverlayManager?.isOverlayConfigured(container) ?: false
-
-        fun ensureOverlayRegistryEntries(container: Container) {
-            getInstance()?.epicOverlayManager?.ensureRegistryEntries(container)
         }
 
         /**

--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -278,10 +278,14 @@ class GOGDownloadManager @Inject constructor(
             val filesToDownload = if (withDlcs) baseFiles + dlcFiles else baseFiles
             var (gameFiles, supportFiles) = parser.separateSupportFiles(filesToDownload)
 
-            // Filter out files that already exist with correct size (incremental download)
+            // Filter out files that already exist with correct size (incremental download).
+            // On a resume this MD5-reads every completed file, which can take minutes for
+            // a large install — surface it in the UI and honor cancellation between files.
             val gameInstallDir = installPath
+            downloadInfo.updateStatusMessage("Verifying existing files...")
             val beforeCount = gameFiles.size
             gameFiles = gameFiles.filter { file ->
+                if (!downloadInfo.isActive()) return@withContext Result.failure(Exception("Download cancelled"))
                 val outputFile = File(gameInstallDir, file.path)
                 val expectedSize = file.chunks.sumOf { it.size }
                 !fileExistsWithCorrectSize(outputFile, expectedSize, file.md5)
@@ -290,11 +294,13 @@ class GOGDownloadManager @Inject constructor(
 
             val beforeSupportCount = supportFiles.size
             supportFiles = supportFiles.filter { file ->
+                if (!downloadInfo.isActive()) return@withContext Result.failure(Exception("Download cancelled"))
                 val installRelativePath = getSupportInstallPath(file.path)
                 val outputFile = File(gameInstallDir, installRelativePath)
                 val expectedSize = file.chunks.sumOf { it.size }
                 !fileExistsWithCorrectSize(outputFile, expectedSize, file.md5)
             }
+            downloadInfo.updateStatusMessage(null)
             val supportFilesForGameDirAssemble = supportFiles.map { file ->
                 val installRelativePath = getSupportInstallPath(file.path)
                 if (installRelativePath != file.path) file.copy(path = installRelativePath) else file

--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -2,6 +2,7 @@ package app.gamenative.service.gog
 
 import android.content.Context
 import app.gamenative.data.DownloadInfo
+import app.gamenative.data.GameSource
 import app.gamenative.service.gog.api.DepotDirectory
 import app.gamenative.service.gog.api.DepotFile
 import app.gamenative.service.gog.api.DepotLink
@@ -12,7 +13,9 @@ import app.gamenative.service.gog.api.GOGManifestParser
 import app.gamenative.service.gog.api.V1DepotFile
 import app.gamenative.enums.Marker
 import app.gamenative.utils.CdnRankingUtils
+import app.gamenative.utils.ContainerStorageManager
 import app.gamenative.utils.DownloadSpeedConfig
+import app.gamenative.utils.StorageUtils
 import app.gamenative.utils.MarkerUtils
 import app.gamenative.utils.Net
 import org.json.JSONArray
@@ -429,7 +432,10 @@ class GOGDownloadManager @Inject constructor(
 
             downloadInfo.updateStatusMessage("Downloading...")
 
-            val chunkCacheDir = File(installPath, ".gog_chunks")
+            // Cache lives on internal storage: on exFAT SD cards (dirsync mount) every
+            // create/rename/delete in the cache dir is a synchronous directory flush,
+            // which dominates download time for small chunks.
+            val chunkCacheDir = File(context.cacheDir, "gog_chunks/$gameId")
             chunkCacheDir.mkdirs()
             gameInstallDir.mkdirs()
 
@@ -445,9 +451,12 @@ class GOGDownloadManager @Inject constructor(
             )
 
             if (downloadAndAssembleResult.isFailure) {
+                // Keep the chunk cache so an interrupted download can resume from it
                 MarkerUtils.removeMarker(installPath.absolutePath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
                 return@withContext downloadAndAssembleResult
             }
+
+            chunkCacheDir.deleteRecursively()
 
             // Create declared directories and symlinks (no chunks, so not handled by the assemble path).
             // Gate by base/DLC ownership the same way files are: only the base product unless DLCs are included.
@@ -819,6 +828,25 @@ class GOGDownloadManager @Inject constructor(
             // Calculate total expected installed size once (sum of all file sizes)
             val totalExpectedSize = files.sumOf { file -> file.chunks.sumOf { it.size } }
 
+            val onExternalStorage = runCatching {
+                ContainerStorageManager.getStorageLocation(context, GameSource.GOG, installDir.absolutePath) ==
+                    ContainerStorageManager.StorageLocation.EXTERNAL
+            }.getOrDefault(false)
+            if (onExternalStorage) {
+                val remainingBytes = files.sumOf { file ->
+                    (file.chunks.sumOf { it.size } - File(installDir, file.path).length()).coerceAtLeast(0L)
+                }
+                val availableBytes = StorageUtils.getAvailableSpaceForUncreatedPath(installDir.absolutePath)
+                if (availableBytes < remainingBytes) {
+                    return@withContext Result.failure(
+                        IOException(
+                            "Not enough free space: need ${StorageUtils.formatBinarySize(remainingBytes)}, " +
+                                "available ${StorageUtils.formatBinarySize(availableBytes)}",
+                        ),
+                    )
+                }
+            }
+
             chunkHashes.forEach { chunkMd5 ->
                 chunkUsageCounts[chunkMd5] = AtomicInteger(
                     files.sumOf { file -> file.chunks.count { chunk -> chunk.compressedMd5 == chunkMd5 } }
@@ -829,6 +857,10 @@ class GOGDownloadManager @Inject constructor(
             val assembleFlow = MutableSharedFlow<Pair<String, Result<File>>>(extraBufferCapacity = Int.MAX_VALUE)
 
             var assemblyFailure: Throwable? = null
+
+            // Remaining chunk positions per file; the full-file MD5 runs once, when this hits zero.
+            val filePendingPositions = ConcurrentHashMap<String, AtomicInteger>()
+            files.forEach { file -> filePendingPositions[file.path] = AtomicInteger(file.chunks.size) }
 
             // assemble every file whose chunks have all arrived (or that has zero chunks)
             suspend fun assembleReady(chunkMd5: String): Result<Unit> {
@@ -844,6 +876,7 @@ class GOGDownloadManager @Inject constructor(
                 // 2. For each file found, write this chunk into its position
                 var expectedCount = 0
                 var assemblySuccessCount = 0
+                val assembledPerFile = mutableMapOf<DepotFile, Int>()
 
                 matchedFiles.forEach { file ->
                     file.chunks.withIndex()
@@ -853,6 +886,7 @@ class GOGDownloadManager @Inject constructor(
                             val result = assembleFile(file, chunk, chunkIndex, chunkCacheDir, installDir)
                             if (result.isSuccess) {
                                 assemblySuccessCount++
+                                assembledPerFile[file] = (assembledPerFile[file] ?: 0) + 1
                             } else {
                                 Timber.tag("GOG").d(result.exceptionOrNull()?.message ?: "Failed to assemble ${file.path}")
                             }
@@ -861,10 +895,19 @@ class GOGDownloadManager @Inject constructor(
 
                 // 3. Only finalize once every position using this chunk has been written; a partial
                 // result is reported as failure so the caller can re-fetch and retry the chunk.
+                // Position counters are only decremented below, on the fully-successful attempt,
+                // so a retried chunk cannot decrement the same position twice.
                 if (assemblySuccessCount < expectedCount) {
                     return Result.failure(
                         Exception("Assembled $assemblySuccessCount/$expectedCount position(s) for chunk $chunkMd5"),
                     )
+                }
+
+                assembledPerFile.forEach { (file, count) ->
+                    val remaining = filePendingPositions[file.path]?.addAndGet(-count)
+                    if (remaining == 0) {
+                        verifyAssembledFile(file, installDir)
+                    }
                 }
 
                 // 4. Free the cached chunk once it has been placed into all of its positions
@@ -1010,8 +1053,14 @@ class GOGDownloadManager @Inject constructor(
 
                     try {
                         // okio resize can OOM for large files on android.
+                        // External volumes are exFAT: no sparse files, so setLength physically
+                        // zero-fills the whole file there. Skip and let offset writes grow it.
                         RandomAccessFile(outputFile.path, "rw").use {
-                            it.setLength(totalSize)
+                            if (!onExternalStorage) {
+                                it.setLength(totalSize)
+                            } else if (it.length() > totalSize) {
+                                it.setLength(totalSize)
+                            }
                         }
 
                         file.chunks.forEach { chunk ->
@@ -1544,27 +1593,28 @@ class GOGDownloadManager @Inject constructor(
                 )
             }
 
-            // Verify final file hash if provided
-            if (file.md5 != null) {
-                val fileMd5 = calculateMd5File(outputFile)
-                if (fileMd5 != file.md5) {
-                    // Timber.tag("GOG").w("File MD5 mismatch: ${file.path}, expected ${file.md5}, got $fileMd5")
-                    // Don't fail - some games have incorrect MD5 in manifest
-                    // And as it is changed to use RandomAccessFile, it happens when not all chunks are completed download
-                } else {
-                    // Move the log here for files finally assembled
-                    Timber.tag("GOG").v("Assembled: ${file.path} (${outputFile.length()} bytes)")
-                }
-            } else {
-                // For md5 is null, likely it does not need to decompress, need to show log here
-                Timber.tag("GOG").v("Assembled: ${file.path} (${outputFile.length()} bytes)")
-            }
-
             Result.success(outputFile)
         } catch (e: Exception) {
             Timber.tag("GOG").e(e, "Failed to assemble file ${file.path}")
             Result.failure(e)
         }
+    }
+
+    /**
+     * Full-file verification, run exactly once per file when its last chunk position lands.
+     * Per-chunk MD5s are already verified in-stream during download.
+     */
+    private fun verifyAssembledFile(file: DepotFile, installDir: File) {
+        val outputFile = File(installDir, file.path)
+        if (file.md5 != null) {
+            val fileMd5 = calculateMd5File(outputFile)
+            if (!fileMd5.equals(file.md5, ignoreCase = true)) {
+                // Don't fail - some games have incorrect MD5 in manifest
+                Timber.tag("GOG").w("File MD5 mismatch: ${file.path}, expected ${file.md5}, got $fileMd5")
+                return
+            }
+        }
+        Timber.tag("GOG").v("Assembled: ${file.path} (${outputFile.length()} bytes)")
     }
 
     /**

--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -828,22 +828,13 @@ class GOGDownloadManager @Inject constructor(
             // Calculate total expected installed size once (sum of all file sizes)
             val totalExpectedSize = files.sumOf { file -> file.chunks.sumOf { it.size } }
 
-            val onExternalStorage = runCatching {
-                ContainerStorageManager.getStorageLocation(context, GameSource.GOG, installDir.absolutePath) ==
-                    ContainerStorageManager.StorageLocation.EXTERNAL
-            }.getOrDefault(false)
+            val onExternalStorage = ContainerStorageManager.isOnExternalStorage(context, GameSource.GOG, installDir.absolutePath)
             if (onExternalStorage) {
                 val remainingBytes = files.sumOf { file ->
                     (file.chunks.sumOf { it.size } - File(installDir, file.path).length()).coerceAtLeast(0L)
                 }
-                val availableBytes = StorageUtils.getAvailableSpaceForUncreatedPath(installDir.absolutePath)
-                if (availableBytes < remainingBytes) {
-                    return@withContext Result.failure(
-                        IOException(
-                            "Not enough free space: need ${StorageUtils.formatBinarySize(remainingBytes)}, " +
-                                "available ${StorageUtils.formatBinarySize(availableBytes)}",
-                        ),
-                    )
+                StorageUtils.downloadSpaceShortfall(installDir, remainingBytes, chunkCacheDir)?.let {
+                    return@withContext Result.failure(IOException(it))
                 }
             }
 
@@ -1268,8 +1259,9 @@ class GOGDownloadManager @Inject constructor(
                 )
                 val chunkUrlCandidates = buildChunkUrlCandidates(depotChunkHashes, rankedDependencyUrls)
 
-                // Create cache directory for this dependency
-                val depotCacheDir = File(installBaseDir, ".gog_dep_${depot.dependencyId}")
+                // Dependency chunk cache also lives on internal storage (same exFAT
+                // dirsync cost as the game chunk cache when installing to SD)
+                val depotCacheDir = File(context.cacheDir, "gog_chunks/dep_${depot.dependencyId}")
                 depotCacheDir.mkdirs()
 
                 val depotInstallDir = installBaseDir

--- a/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
@@ -512,6 +512,9 @@ class GOGManager @Inject constructor(
                     MarkerUtils.removeMarker(path, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
                 }
 
+                // Drop any leftover chunk cache (kept on failed downloads for resume)
+                File(context.cacheDir, "gog_chunks/$gameId").deleteRecursively()
+
                 if (game != null) {
                     val updatedGame = game.copy(isInstalled = false, installPath = "")
                     gogGameDao.update(updatedGame)

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -5007,6 +5007,11 @@ private suspend fun setupWineSystemFiles(
         ContainerStorageManager.normalizeContainerId(container.id),
     ) == GameSource.EPIC
     val needsOverlayServices = isEpicContainer && EpicService.isOverlayInstalled(container)
+    if (needsOverlayServices) {
+        // Prefix re-provisioning above (wine/proton version change) replaces user.reg,
+        // so the overlay registry entries must be repaired here, not just at install time.
+        EpicService.ensureOverlayRegistryEntries(container)
+    }
     val effectiveStartupSelection = if (needsOverlayServices) Container.STARTUP_SELECTION_NORMAL else container.startupSelection
     val startupSelection = effectiveStartupSelection.toString()
     if (startupSelection != container.getExtra("startupSelection")) {

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -104,6 +104,7 @@ import app.gamenative.externaldisplay.SwapInputOverlayView
 import app.gamenative.powercontrol.PowerManager
 import app.gamenative.service.AchievementWatcher
 import app.gamenative.service.SteamService
+import app.gamenative.service.epic.EpicOverlayManager
 import app.gamenative.service.epic.EpicService
 import app.gamenative.service.gog.GOGService
 import app.gamenative.ui.component.QuickMenu
@@ -116,7 +117,6 @@ import app.gamenative.ui.data.PerformanceHudSize
 import app.gamenative.ui.data.XServerState
 import app.gamenative.ui.widget.PerformanceHudView
 import app.gamenative.utils.AssetUtils
-import app.gamenative.utils.ContainerStorageManager
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.downloader.CoreDriverDownloader
 import app.gamenative.utils.CustomGameScanner
@@ -3695,6 +3695,10 @@ private fun setupXEnvironment(
                 container.startupSelection = Container.STARTUP_SELECTION_ESSENTIAL
                 container.putExtra("startupSelection", java.lang.String.valueOf(Container.STARTUP_SELECTION_ESSENTIAL))
                 container.saveData()
+            } else if (EpicOverlayManager.isOverlayInstalled(container)) {
+                // The EOS overlay needs RpcSs/BITS; services were forced to normal
+                // in setupWineSystemFiles, so don't kill services.exe here.
+                Timber.d("Keeping services.exe alive for EOS overlay despite aggressive startup selection")
             } else {
                 xServer.winHandler.killProcess("services.exe");
             }
@@ -5002,15 +5006,12 @@ private suspend fun setupWineSystemFiles(
 
     // The EOS overlay's CEF browser needs RpcSs and BITS: without them it
     // crash-loops and EOS login fails. Force normal services only for containers
-    // that actually have the overlay installed, not every Epic container.
-    val isEpicContainer = ContainerStorageManager.detectGameSource(
-        ContainerStorageManager.normalizeContainerId(container.id),
-    ) == GameSource.EPIC
-    val needsOverlayServices = isEpicContainer && EpicService.isOverlayInstalled(container)
+    // that actually have the overlay installed.
+    val needsOverlayServices = EpicOverlayManager.isOverlayInstalled(container)
     if (needsOverlayServices) {
         // Prefix re-provisioning above (wine/proton version change) replaces user.reg,
         // so the overlay registry entries must be repaired here, not just at install time.
-        EpicService.ensureOverlayRegistryEntries(container)
+        EpicOverlayManager.ensureRegistryEntries(container)
     }
     val effectiveStartupSelection = if (needsOverlayServices) Container.STARTUP_SELECTION_NORMAL else container.startupSelection
     val startupSelection = effectiveStartupSelection.toString()

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -116,6 +116,7 @@ import app.gamenative.ui.data.PerformanceHudSize
 import app.gamenative.ui.data.XServerState
 import app.gamenative.ui.widget.PerformanceHudView
 import app.gamenative.utils.AssetUtils
+import app.gamenative.utils.ContainerStorageManager
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.downloader.CoreDriverDownloader
 import app.gamenative.utils.CustomGameScanner
@@ -4999,9 +5000,17 @@ private suspend fun setupWineSystemFiles(
     WineStartMenuCreator.create(context, container)
     WineUtils.createDosdevicesSymlinks(context, container)
 
-    val startupSelection = container.startupSelection.toString()
+    // The EOS overlay's CEF browser needs RpcSs and BITS: without them it
+    // crash-loops and EOS login fails. Force normal services only for containers
+    // that actually have the overlay installed, not every Epic container.
+    val isEpicContainer = ContainerStorageManager.detectGameSource(
+        ContainerStorageManager.normalizeContainerId(container.id),
+    ) == GameSource.EPIC
+    val needsOverlayServices = isEpicContainer && EpicService.isOverlayInstalled(container)
+    val effectiveStartupSelection = if (needsOverlayServices) Container.STARTUP_SELECTION_NORMAL else container.startupSelection
+    val startupSelection = effectiveStartupSelection.toString()
     if (startupSelection != container.getExtra("startupSelection")) {
-        WineUtils.changeServicesStatus(container, container.startupSelection != Container.STARTUP_SELECTION_NORMAL)
+        WineUtils.changeServicesStatus(container, effectiveStartupSelection != Container.STARTUP_SELECTION_NORMAL)
         container.putExtra("startupSelection", startupSelection)
         containerDataChanged = true
     }

--- a/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
@@ -779,7 +779,7 @@ object ContainerStorageManager {
         }
     }
 
-    private fun getStorageLocation(context: Context, gameSource: GameSource, installPath: String): StorageLocation {
+    fun getStorageLocation(context: Context, gameSource: GameSource, installPath: String): StorageLocation {
         val normalizedPath = normalizePath(installPath)
 
         val internalRoots = when (gameSource) {

--- a/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerStorageManager.kt
@@ -779,6 +779,14 @@ object ContainerStorageManager {
         }
     }
 
+    /**
+     * True when [installPath] resolves to a removable/external volume. Defaults to
+     * false on any resolution failure so callers fall back to internal-storage behavior.
+     */
+    fun isOnExternalStorage(context: Context, gameSource: GameSource, installPath: String): Boolean =
+        runCatching { getStorageLocation(context, gameSource, installPath) == StorageLocation.EXTERNAL }
+            .getOrDefault(false)
+
     fun getStorageLocation(context: Context, gameSource: GameSource, installPath: String): StorageLocation {
         val normalizedPath = normalizePath(installPath)
 

--- a/app/src/main/java/app/gamenative/utils/StorageUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/StorageUtils.kt
@@ -51,6 +51,31 @@ object StorageUtils {
         return stat.blockSizeLong * stat.availableBlocksLong
     }
 
+    // Minimum internal free space required to host a transient download chunk cache.
+    // The cache normally stays MB-sized (chunks are deleted as they are assembled),
+    // so this only guards against starting a download on a nearly-full data partition.
+    private const val MIN_INTERNAL_CACHE_BYTES = 512L * 1024 * 1024
+
+    /**
+     * Pre-download disk space check shared by the GOG and Epic download managers.
+     * Returns a human-readable error when there is not enough space, or null when
+     * the download can proceed. [requiredBytes] is checked against the install
+     * volume; the internal volume hosting [internalCacheDir] only needs modest
+     * headroom for the transient chunk cache.
+     */
+    fun downloadSpaceShortfall(installDir: File, requiredBytes: Long, internalCacheDir: File): String? {
+        val available = getAvailableSpaceForUncreatedPath(installDir.absolutePath)
+        if (available < requiredBytes) {
+            return "Not enough free space: need ${formatBinarySize(requiredBytes)}, available ${formatBinarySize(available)}"
+        }
+        val internalAvailable = getAvailableSpaceForUncreatedPath(internalCacheDir.absolutePath)
+        if (internalAvailable < MIN_INTERNAL_CACHE_BYTES) {
+            return "Not enough internal storage for the download cache: " +
+                "${formatBinarySize(internalAvailable)} free, need at least ${formatBinarySize(MIN_INTERNAL_CACHE_BYTES)}"
+        }
+        return null
+    }
+
     fun getTotalSpace(path: String): Long {
         val file = File(path)
         if (!file.exists()) {

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/EpicOverlayDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/EpicOverlayDependency.kt
@@ -2,6 +2,7 @@ package app.gamenative.utils.launchdependencies
 
 import android.content.Context
 import app.gamenative.data.GameSource
+import app.gamenative.service.epic.EpicOverlayManager
 import app.gamenative.service.epic.EpicService
 import app.gamenative.utils.LOADING_PROGRESS_UNKNOWN
 import com.winlator.container.Container
@@ -24,7 +25,7 @@ object EpicOverlayDependency : LaunchDependency {
         gameSource == GameSource.EPIC
 
     override fun isSatisfied(context: Context, container: Container, gameSource: GameSource, gameId: Int): Boolean =
-        EpicService.isOverlayConfigured(container)
+        EpicOverlayManager.isOverlayConfigured(container)
 
     override fun getLoadingMessage(context: Context, container: Container, gameSource: GameSource, gameId: Int): String =
         "Downloading EOS overlay"

--- a/app/src/main/java/app/gamenative/utils/launchdependencies/EpicOverlayDependency.kt
+++ b/app/src/main/java/app/gamenative/utils/launchdependencies/EpicOverlayDependency.kt
@@ -24,7 +24,7 @@ object EpicOverlayDependency : LaunchDependency {
         gameSource == GameSource.EPIC
 
     override fun isSatisfied(context: Context, container: Container, gameSource: GameSource, gameId: Int): Boolean =
-        EpicService.isOverlayInstalled(container)
+        EpicService.isOverlayConfigured(container)
 
     override fun getLoadingMessage(context: Context, container: Container, gameSource: GameSource, gameId: Int): String =
         "Downloading EOS overlay"

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -1025,6 +1025,7 @@ public class WinHandler {
                 controller = getControllerFromSlot(slot);
             }
             if (controller != null && controller.getDeviceId() == event.getDeviceId()) {
+                if (event.getRepeatCount() > 0) return true;
                 handled = controller.updateStateFromKeyEvent(event); // or motion variant
                 Log.d(TAG, "Key routed deviceId=" + event.getDeviceId()
                         + " keyCode=" + event.getKeyCode()


### PR DESCRIPTION
## Description
Fixed double-presses when controllers were mapped.
Also improved downloading on external storage for GOG and Epic - cache on internal instead of external and don't preallocate space beforehand on SD which can take a while.
Also fixes for EOS overlay for Epic games.

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double presses from mapped controllers and improves Epic/GOG installs to external SD by moving chunk caches to internal storage, adding space checks, safer resume, and more reliable EOS overlay setup.

- Controller input: `WinHandler` now ignores key repeats in the controller-slot path (old: repeats caused double presses; new: repeats are swallowed).
- Epic/GOG downloads:
  - Chunk caches now live in `context.cacheDir` and are keyed per install; kept on failure for resume and deleted on successful install and on uninstall.
  - External installs skip full-file preallocation and only shrink oversized files; internal installs still preallocate.
  - Pre-start checks verify external-target free space and require ~512 MB internal headroom for the transient cache; fail fast with a clear message.
  - Resume flow surfaces “Verifying existing files…” and honors cancellation between files; Epic skips files matching size+SHA‑1, GOG verifies chunks in-stream and runs one full-file MD5 when the last chunk lands.
  - Pausing on SD no longer ANRs: `DownloadInfo.cancel` now cancels and snapshots off the main thread; resume snapshots are generation‑guarded to avoid recreating files after completion.
- EOS overlay:
  - Writes and repairs registry keys after prefix provisioning and exposes `isOverlayConfigured`/`ensureRegistryEntries`; `EpicOverlayDependency` now checks configured state.
  - Removes forced CEF “no3d” so the overlay renders via normal D3D/DXVK. RpcSs/BITS are kept and `services.exe` is not killed only for containers with the overlay installed.

<sup>Written for commit 4aaa699ad811116590cac914935802d2bf3b5440. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer downloads with storage checks, resumable caches, and file integrity validation.
  * Improved support for external-storage installations, including optimized file preparation on exFAT volumes.
  * Improved Epic overlay startup integration and automatic configuration repair.

* **Bug Fixes**
  * Prevented redundant downloads when valid files already exist.
  * Improved download resumption and cleanup after successful or deleted installations.
  * Prevented repeated controller key events from causing duplicate state updates.
  * Improved download cancellation and progress-state handling.
  * Added final verification for completed GOG downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->