### PR TITLE
Fix container_config handling on external launch intents, add a folder-registration intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,6 +81,10 @@
                 <action android:name="app.gamenative.LAUNCH_GAME" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="app.gamenative.ADD_CUSTOM_GAME_FOLDER" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
 
             <!--Allows app window to be resized on Oculus Quest VR headsets-->
             <meta-data

--- a/app/src/main/java/app/gamenative/MainActivity.kt
+++ b/app/src/main/java/app/gamenative/MainActivity.kt
@@ -60,6 +60,7 @@ import com.skydoves.landscapist.coil.LocalCoilImageLoader
 import com.winlator.core.AppUtils
 import com.winlator.inputcontrols.ControllerManager
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.util.EnumSet
 import kotlin.math.abs
@@ -333,6 +334,17 @@ class MainActivity : ComponentActivity() {
         }
         Timber.d("[IntentLaunch]: handleLaunchIntent called with action=${intent.action}, isNewIntent=$isNewIntent")
         try {
+            if (intent.action == IntentLaunchManager.ACTION_ADD_CUSTOM_GAME_FOLDER) {
+                // scanning the folder touches the filesystem, so keep it off the main thread
+                lifecycleScope.launch(Dispatchers.IO) {
+                    val added = IntentLaunchManager.addCustomGameFolder(this@MainActivity, intent)
+                    SnackbarManager.show(
+                        getString(if (added) R.string.custom_game_import_success else R.string.custom_game_import_failed),
+                    )
+                }
+                return
+            }
+
             val launchRequest = IntentLaunchManager.parseLaunchIntent(intent)
             if (launchRequest != null) {
                 Timber.d("[IntentLaunch]: Received external launch intent for app ${launchRequest.appId}")

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -59,7 +59,6 @@ import app.gamenative.utils.unaccent
 import com.winlator.core.GPUInformation
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.io.File
 import java.util.EnumSet
 import javax.inject.Inject
 import kotlin.math.max
@@ -559,20 +558,10 @@ class LibraryViewModel @Inject constructor(
 
     fun addCustomGameFolder(path: String) {
         viewModelScope.launch(Dispatchers.IO) {
-            val normalizedPath = File(path).absolutePath
-            val libraryItem = CustomGameScanner.createLibraryItemFromFolder(normalizedPath)
-            if (libraryItem == null) {
-                Timber.tag("LibraryViewModel").w("Selected folder is not a valid custom game: $normalizedPath")
+            if (!CustomGameScanner.registerManualFolder(path)) {
                 return@launch
             }
 
-            val manualFolders = PrefManager.customGameManualFolders.toMutableSet()
-            if (!manualFolders.contains(normalizedPath)) {
-                manualFolders.add(normalizedPath)
-                PrefManager.customGameManualFolders = manualFolders
-            }
-
-            CustomGameScanner.invalidateCache()
             onFilterApps(paginationCurrentPage)
         }
     }

--- a/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
+++ b/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
@@ -692,6 +692,27 @@ object CustomGameScanner {
     }
 
     /**
+     * Registers [folderPath] as a manually added custom game folder.
+     * Returns false if the folder is not a valid custom game; a folder that is already
+     * registered succeeds without changing anything.
+     */
+    fun registerManualFolder(folderPath: String): Boolean {
+        val normalizedPath = File(folderPath).absolutePath
+        if (createLibraryItemFromFolder(normalizedPath) == null) {
+            Timber.tag("CustomGameScanner").w("Folder is not a valid custom game: $normalizedPath")
+            return false
+        }
+
+        val manualFolders = PrefManager.customGameManualFolders.toMutableSet()
+        if (manualFolders.add(normalizedPath)) {
+            PrefManager.customGameManualFolders = manualFolders
+        }
+
+        invalidateCache()
+        return true
+    }
+
+    /**
      * Reads the game ID from the .gamenative file in the given folder.
      * Returns null if the file doesn't exist or doesn't contain a valid ID.
      */

--- a/app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt
+++ b/app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt
@@ -257,7 +257,10 @@ object IntentLaunchManager {
         // Quick return if no actual overrides
         if (override == base) return base
 
-        return ContainerData(
+        // Copy the container's own configuration so every field the intent does not carry
+        // (wine version, container variant, emulator, ...) keeps its stored value instead of
+        // silently falling back to the ContainerData defaults.
+        return base.copy(
             name = override.name.ifEmpty { base.name },
             screenSize = if (override.screenSize != Container.DEFAULT_SCREEN_SIZE) {
                 override.screenSize
@@ -323,7 +326,6 @@ object IntentLaunchManager {
             enableDInput = if (override.enableDInput != true) override.enableDInput else base.enableDInput,
             dinputMapperType = if (override.dinputMapperType != 1.toByte()) override.dinputMapperType else base.dinputMapperType,
             disableMouseInput = if (override.disableMouseInput != false) override.disableMouseInput else base.disableMouseInput,
-            suspendPolicy = base.suspendPolicy,
             shaderBackend = if (override.shaderBackend != "glsl") override.shaderBackend else base.shaderBackend,
             useGLSL = if (override.useGLSL != "enabled") override.useGLSL else base.useGLSL,
         )

--- a/app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt
+++ b/app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt
@@ -4,9 +4,12 @@ import android.content.Context
 import android.content.Intent
 import app.gamenative.PrefManager
 import app.gamenative.data.GameSource
+import com.winlator.box86_64.Box86_64Preset
 import com.winlator.container.Container
 import com.winlator.container.ContainerData
 import com.winlator.core.DXVKHelper
+import com.winlator.core.DefaultVersion
+import com.winlator.core.WineThemeManager
 import org.json.JSONObject
 import timber.log.Timber
 
@@ -216,11 +219,11 @@ object IntentLaunchManager {
             } else {
                 Container.STARTUP_SELECTION_ESSENTIAL.toInt().toByte()
             },
-            box86Version = if (json.has("box86Version")) json.getString("box86Version") else "",
-            box64Version = if (json.has("box64Version")) json.getString("box64Version") else "",
-            box86Preset = if (json.has("box86Preset")) json.getString("box86Preset") else "",
-            box64Preset = if (json.has("box64Preset")) json.getString("box64Preset") else "",
-            desktopTheme = if (json.has("desktopTheme")) json.getString("desktopTheme") else "",
+            box86Version = if (json.has("box86Version")) json.getString("box86Version") else DefaultVersion.BOX86,
+            box64Version = if (json.has("box64Version")) json.getString("box64Version") else DefaultVersion.BOX64,
+            box86Preset = if (json.has("box86Preset")) json.getString("box86Preset") else Box86_64Preset.COMPATIBILITY,
+            box64Preset = if (json.has("box64Preset")) json.getString("box64Preset") else Box86_64Preset.COMPATIBILITY,
+            desktopTheme = if (json.has("desktopTheme")) json.getString("desktopTheme") else WineThemeManager.DEFAULT_DESKTOP_THEME,
             csmt = if (json.has("csmt")) json.getBoolean("csmt") else true,
             videoPciDeviceID = if (json.has("videoPciDeviceID")) json.getInt("videoPciDeviceID") else 1728,
             offScreenRenderingMode = if (json.has("offScreenRenderingMode")) json.getString("offScreenRenderingMode") else "fbo",
@@ -306,11 +309,15 @@ object IntentLaunchManager {
             } else {
                 base.startupSelection
             },
-            box86Version = override.box86Version.ifEmpty { base.box86Version },
-            box64Version = override.box64Version.ifEmpty { base.box64Version },
-            box86Preset = override.box86Preset.ifEmpty { base.box86Preset },
-            box64Preset = override.box64Preset.ifEmpty { base.box64Preset },
-            desktopTheme = override.desktopTheme.ifEmpty { base.desktopTheme },
+            box86Version = if (override.box86Version != DefaultVersion.BOX86) override.box86Version else base.box86Version,
+            box64Version = if (override.box64Version != DefaultVersion.BOX64) override.box64Version else base.box64Version,
+            box86Preset = if (override.box86Preset != Box86_64Preset.COMPATIBILITY) override.box86Preset else base.box86Preset,
+            box64Preset = if (override.box64Preset != Box86_64Preset.COMPATIBILITY) override.box64Preset else base.box64Preset,
+            desktopTheme = if (override.desktopTheme != WineThemeManager.DEFAULT_DESKTOP_THEME) {
+                override.desktopTheme
+            } else {
+                base.desktopTheme
+            },
             csmt = if (override.csmt != true) override.csmt else base.csmt,
             videoPciDeviceID = if (override.videoPciDeviceID != 1728) override.videoPciDeviceID else base.videoPciDeviceID,
             offScreenRenderingMode = if (override.offScreenRenderingMode != "fbo") {

--- a/app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt
+++ b/app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt
@@ -14,7 +14,8 @@ import org.json.JSONObject
 import timber.log.Timber
 
 /**
- * Handles external game launch intents with container configuration overrides.
+ * Handles external game launch intents with container configuration overrides, and the external
+ * intent that registers a custom game folder.
  */
 object IntentLaunchManager {
 
@@ -23,6 +24,8 @@ object IntentLaunchManager {
     private const val EXTRA_GAME_SOURCE = "game_source"
     private const val EXTRA_CONTAINER_CONFIG = "container_config"
     private const val ACTION_LAUNCH_GAME = "app.gamenative.LAUNCH_GAME"
+    private const val EXTRA_FOLDER = "folder"
+    const val ACTION_ADD_CUSTOM_GAME_FOLDER = "app.gamenative.ADD_CUSTOM_GAME_FOLDER"
     private const val MAX_CONFIG_JSON_SIZE = 50000 // 50KB limit to prevent memory exhaustion
 
     data class LaunchRequest(
@@ -69,6 +72,31 @@ object IntentLaunchManager {
         }
 
         return LaunchRequest(appId, containerConfig)
+    }
+
+    /**
+     * Registers the custom game folder named by the [EXTRA_FOLDER] extra, so a launcher that
+     * installs games into its own directories does not need the folder picker. Returns whether
+     * the folder is registered; a folder that is already registered reports success.
+     */
+    fun addCustomGameFolder(context: Context, intent: Intent): Boolean {
+        val folder = intent.getStringExtra(EXTRA_FOLDER)?.trim()
+        if (folder.isNullOrEmpty()) {
+            Timber.w("[IntentLaunchManager]: Missing '$EXTRA_FOLDER' extra in $ACTION_ADD_CUSTOM_GAME_FOLDER intent")
+            return false
+        }
+
+        if (!CustomGameScanner.hasStoragePermission(context, folder)) {
+            Timber.w("[IntentLaunchManager]: Missing storage permission to read custom game folder $folder")
+            return false
+        }
+
+        return try {
+            CustomGameScanner.registerManualFolder(folder)
+        } catch (e: Exception) {
+            Timber.e(e, "[IntentLaunchManager]: Failed to register custom game folder $folder")
+            false
+        }
     }
 
     fun applyTemporaryConfigOverride(context: Context, appId: String, configOverride: ContainerData) {


### PR DESCRIPTION
Found while driving GameNative from another launcher over `app.gamenative.LAUNCH_GAME` with a `container_config` extra. All three items measured on an AYN handheld (Snapdragon 8 Gen 2 / Adreno 740, Android 13) against the published v1.1.1 APK.

### 1. Any `container_config` resets the container's wine build

`mergeConfigurations` (`app/src/main/java/app/gamenative/utils/IntentLaunchManager.kt:256`) returns a fresh `ContainerData(...)` listing about half the fields. Everything it does not list — `wineVersion`, `containerVariant`, `emulator`, `fexcore*`, `graphicsDriverConfig`, `displayRenderer`, `language`, `gestureConfig`, … — falls back to the data class default, and `ContainerUtils.applyToContainer` then writes `container.wineVersion = containerData.wineVersion` unconditionally (`ContainerUtils.kt:524`).

With the container configured `bionic` + `proton-10.0-arm64ec-2`, the class default `wine-9.2-x86_64` is not installed, so the launch dies:

```
[BOX64] Error: File is not found. (wine)
Guest program terminated with status: 255
```

The user sees a black screen and then a return to the library. The container's stored value is untouched, so its own editor still shows the right wine build — it looks like a launcher problem rather than an overwritten config. Every intent launch that carries a config is affected; launches without one merge nothing and work.

### 2. A container created from a `container_config` inherits the parser's empty strings

When no container exists yet, `ContainerUtils.createNewContainer` uses the parsed `ContainerData` wholesale (`ContainerUtils.kt:860-866`) and consults no preferences. `parseContainerConfig` defaults `desktopTheme` to `""` (`IntentLaunchManager.kt:223`), and `WineThemeManager.ThemeInfo` runs `Theme.valueOf("")`:

```
java.lang.IllegalArgumentException: No enum constant com.winlator.core.WineThemeManager.Theme.
```

That kills wine setup outright. Same shape, non-fatal: `box64Version`/`box86Version` default to `""` instead of `DefaultVersion.BOX64`/`.BOX86`, and `box64Preset`/`box86Preset` to `""` instead of `Box86_64Preset.COMPATIBILITY` — `Box86_64PresetManager.getEnvVars` matches no branch for `""` and returns empty `EnvVars`, so the container runs with no `BOX64_DYNAREC_*` tuning at all.

### 3. Registering a custom game folder needs the folder picker

`PrefManager.customGameManualFolders` is private SharedPreferences and its only writer was `LibraryViewModel.addCustomGameFolder`, reachable only from `OpenDocumentTree`. A launcher that installs games into its own directories cannot register them, so the user taps through the picker once per game. This is the one new feature in the PR; happy to split it out if you would rather discuss it first, per CONTRIBUTING.

### Commits

1. **fix: keep container settings the launch intent does not override** — build the merge result with `base.copy(...)` instead of a fresh `ContainerData(...)`, so a field the intent does not carry keeps the container's value. Every existing "differs from the parse-time default wins" rule is unchanged; the now-redundant `suspendPolicy = base.suspendPolicy` line is dropped.
2. **fix: use the real defaults when parsing an intent container config** — the five defaults above become `DefaultVersion.BOX86`/`BOX64`, `Box86_64Preset.COMPATIBILITY` and `WineThemeManager.DEFAULT_DESKTOP_THEME`, with the matching comparisons in `mergeConfigurations` so a config that omits those fields still leaves an existing container's values alone.
3. **feat: add an intent to register a custom game folder** — `app.gamenative.ADD_CUSTOM_GAME_FOLDER` with an absolute path in the `folder` string extra, dispatched from `MainActivity.handleLaunchIntent` like `LAUNCH_GAME`, gated on the same `CustomGameScanner.hasStoragePermission` check the picker uses, idempotent, and reporting through the existing import snackbars. The picker path now goes through the same `CustomGameScanner.registerManualFolder`, so there is still one writer. `LAUNCH_GAME` semantics are untouched.

### Verification

`./gradlew :app:compileLegacyDebugKotlin` succeeds (Linux, JDK 17, compileSdk 36).

I also checked the two fixes with a throwaway Robolectric test around `parseContainerConfig`/`mergeConfigurations`. Before commits 1–2, merging `{"screenSize":"1280x720"}` onto a container with `wineVersion = proton-10.0-arm64ec-2` produced `wine-9.2-x86_64` and `box64Version = ""`; after them the container's values survive, `desktopTheme` parses into a valid `ThemeInfo`, and an explicit `"box64Version":"0.4.0"` still wins over the container. Glad to add that test as a fourth commit if you want it in the tree. No recording attached: the broken case is a black screen and the fixed case is the game booting normally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes external `app.gamenative.LAUNCH_GAME` intent handling to preserve container settings and use real defaults, and adds `app.gamenative.ADD_CUSTOM_GAME_FOLDER` to register a game folder without the picker. Previously, any `container_config` reset unspecified fields (e.g., `wineVersion`) to defaults and intent-created containers used empty strings that crashed theme parsing and dropped Box86/64 tuning; now, unspecified fields keep the container’s values and defaults match in-app behavior. `LAUNCH_GAME` semantics are unchanged.

- Merge behavior: builds from the base container so fields not present in `container_config` keep their stored values.
- Parsing defaults: `box86Version`/`box64Version` use `DefaultVersion.BOX86`/`BOX64`, presets use `Box86_64Preset.COMPATIBILITY`, and `desktopTheme` uses `WineThemeManager.DEFAULT_DESKTOP_THEME`.
- New intent: `app.gamenative.ADD_CUSTOM_GAME_FOLDER` with a `folder` absolute path extra; permission-checked, idempotent, and reports via existing import snackbars.
- The folder picker path now calls the same registration method for a single writer across both paths.

<sup>Written for commit d8a1b8158a5f4822c9353a849d291f86ae3d2a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for importing custom game folders through external actions.
  - Custom folders are validated, saved, and incorporated into the game library automatically.
  - Added success and failure feedback during folder imports.

- **Bug Fixes**
  - Improved container configuration handling to preserve existing settings and apply current defaults correctly.
  - Prevented invalid or unsuccessful folder registrations from triggering unnecessary library refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->