### PR TITLE
bumped version for prerelease

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,7 +65,7 @@ android {
         buildConfigField("boolean", "MODERN_XR", "false")
 
         versionCode = 21
-        versionName = "1.1.1"
+        versionName = "1.2.0"
 
         buildConfigField("boolean", "GOLD", "false")
         fun secret(name: String) =


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [ ] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 1.2.0 prerelease by bumping Android versionName from 1.1.1 to 1.2.0. This updates the user-visible version and release tagging only; no runtime changes.

**Review and rollout**
- Verify CI/distribution publish artifacts labeled 1.2.0 to the prerelease track.
- Confirm versionCode remains 21 and update release notes accordingly.

<sup>Written for commit 7a15d0911f4eee316da39e0b5a1aefecd45cf2e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

