### PR TITLE
Allow .bat files in container executable path dropdown

### DIFF
--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -1266,7 +1266,7 @@ object ContainerUtils {
     }
 
     /**
-     * Scans the container's A: drive for all .exe files
+     * Scans the container's A: drive for all .exe and .bat files
      */
     fun scanExecutablesInADrive(drives: String): List<String> {
         val executables = mutableListOf<String>()
@@ -1287,7 +1287,7 @@ object ContainerUtils {
 
             Timber.d("Scanning for executables in A: drive: $aDrivePath")
 
-            // Recursively scan for .exe files using listFiles with depth limit.
+            // Recursively scan for .exe/.bat files using listFiles with depth limit.
             // Symlinked directories are skipped to avoid cycles (e.g. GOG ISI rootdir -> game root).
             fun scanRecursive(dir: File, baseDir: File, depth: Int = 0, maxDepth: Int = 10) {
                 if (depth > maxDepth) return
@@ -1296,7 +1296,7 @@ object ContainerUtils {
                     if (file.isDirectory) {
                         if (FileUtils.isSymlink(file)) return@forEach
                         scanRecursive(file, baseDir, depth + 1, maxDepth)
-                    } else if (file.isFile && file.name.lowercase().endsWith(".exe")) {
+                    } else if (file.isFile && (file.name.lowercase().endsWith(".exe") || file.name.lowercase().endsWith(".bat"))) {
                         // Convert to relative Windows path format
                         val relativePath = baseDir.toURI().relativize(file.toURI()).path
                         executables.add(relativePath)
@@ -1332,7 +1332,7 @@ object ContainerUtils {
      */
     fun filterExesForUnpacking(exePaths: List<String>): List<String> = exePaths.filter { path ->
         val fileName = path.substringAfterLast('/').substringAfterLast('\\').lowercase()
-        !isSystemExecutable(fileName)
+        fileName.endsWith(".exe") && !isSystemExecutable(fileName)
     }
 
     /**


### PR DESCRIPTION
## Description
The Edit Container -> Executable Path dropdown only listed .exe files from the A: drive scan. This change also includes .bat files, so users can pick a batch launcher as the game executable.

The launch path already handles .bat selections: everything launches through winhandler.exe, and CreateProcess under Wine starts .bat files through cmd.exe, same as Windows. Custom-game validation only checks that the configured file exists, so no changes were needed there.

filterExesForUnpacking now keeps only .exe files, since the same scan feeds Steamless when unpack files is enabled and Steamless cannot process batch files.

## Recording
N/A

## Type of Change
- [x] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows selecting .bat files in Edit Container → Executable Path by scanning A: for both .exe and .bat. Keeps the Steamless unpack list .exe-only to avoid handing batch files to Steamless.

- A: drive scan now includes .bat files; dropdown shows them alongside .exe.
- Launch flow already supports .bat (winhandler.exe/Wine uses cmd.exe), so runtime behavior is unchanged.
- `filterExesForUnpacking` now returns only .exe and skips system executables.
- Validation remains “file exists”; no migration needed.

<sup>Written for commit 0979e333f424308dabf47f6a4defd84fac306c08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Executable scanning now detects both `.exe` and `.bat` files.
  * Unpacking continues to include only `.exe` files while excluding system executables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->