### PR TITLE
feat: add PrefManager option to enable / disable Power Control

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -1501,4 +1501,11 @@ object PrefManager {
             }
         }
 
+    private val POWER_CONTROL_ENABLED = booleanPreferencesKey("power_control_enabled")
+    var powerControlEnabled: Boolean
+        get() = getPref(POWER_CONTROL_ENABLED, true)
+        set(value) {
+            // Written synchronously: PowerManager.initialize() checks isEnabled() right after the toggle.
+            runBlocking { dataStore.edit { pref -> pref[POWER_CONTROL_ENABLED] = value } }
+        }
 }

--- a/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
@@ -7,6 +7,7 @@ import android.os.Looper
 import android.util.AtomicFile
 import app.gamenative.BuildConfig
 import app.gamenative.PluviaApp
+import app.gamenative.PrefManager
 import app.gamenative.powercontrol.autotuning.ClusterTuner
 import app.gamenative.powercontrol.autotuning.PerformanceAutoTuner
 import app.gamenative.powercontrol.drivers.NoOpPerformanceDriver
@@ -145,6 +146,8 @@ object PowerManager {
      * Should be called once during application startup.
      */
     fun initialize(context: Context) {
+        if (!isEnabled()) return
+
         appContext = context.applicationContext
         if (driver != null) return
 
@@ -177,6 +180,11 @@ object PowerManager {
             }
         }
         driver?.reset()
+    }
+
+    fun deinitialize() {
+        Timber.tag("PowerManager").w("PowerManager deinitialized")
+        driver = null
     }
 
     private fun getDriver(): PerformanceDriver {
@@ -219,6 +227,7 @@ object PowerManager {
      * @param containerDir The container directory for saving/restoring per-container profiles
      */
     fun start(containerDir: File? = null) {
+        if (!isEnabled()) return
         this.containerDir = containerDir
         resolveGameAffinityOwnership()
         getDriver().start()
@@ -244,6 +253,7 @@ object PowerManager {
      * Stop the performance driver and save current profile
      */
     fun stop() {
+        if (!isEnabled()) return
         // Save the current profile if available, otherwise read from driver
         saveProfile()
         stopAutoTuning()
@@ -265,6 +275,7 @@ object PowerManager {
      * Pause the performance driver and auto-tuning when app goes to background
      */
     fun pause() {
+        if (!isEnabled()) return
         if (!isGameStarted) return
         saveProfile()
         stopAutoTuning()
@@ -278,6 +289,7 @@ object PowerManager {
      * Resume the performance driver and auto-tuning when app comes to foreground
      */
     fun resume() {
+        if (!isEnabled()) return
         if (!isGameStarted) return
         getDriver().start()
         restoreSavedProfile()
@@ -689,6 +701,11 @@ object PowerManager {
      * Check if driver is supported
      */
     fun isDriverSupported(): Boolean = getDriver().isDriverSupported()
+
+    /**
+     * True when the user has power control enabled in preferences.
+     */
+    fun isEnabled(): Boolean = PrefManager.powerControlEnabled
 
     /**
      * Get display unit preference for frequency values
@@ -1148,6 +1165,8 @@ object PowerManager {
         maxRetries: Int = GAME_PIN_MAX_RETRIES,
         retryDelayMs: Long = GAME_PIN_RETRY_DELAY_MS
     ) {
+        if (!isEnabled()) return
+
         pinnedGameProcessName = processName
         startGamePin(processName, "game start", maxRetries, retryDelayMs)
     }

--- a/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
@@ -973,19 +973,6 @@ object PowerManager {
     }
 
     // ========================================
-    // File I/O
-    // ========================================
-
-    /**
-     * Read a file using the driver's file reading capabilities.
-     * For PServerDriver, this uses root access with fallback to direct file read.
-     * For other drivers, returns null.
-     * @param path The absolute path to the file to read
-     * @return The file contents as a trimmed string, or null if the file cannot be read
-     */
-    fun readFile(path: String): String? = getDriver().readFile(path)
-
-    // ========================================
     // Profile Persistence
     // ========================================
 

--- a/app/src/main/java/app/gamenative/powercontrol/drivers/PServerDriver.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/drivers/PServerDriver.kt
@@ -401,19 +401,6 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
     fun executeRootCommand(command: String): Result<String?> = executeAsRoot(command)
 
     /**
-     * Read a file using PServer root access with fallback to direct file read.
-     * @param path The absolute path to the file to read
-     * @return The file contents as a trimmed string, or null if the file cannot be read
-     */
-    override fun readFile(path: String): String? {
-        return if (pserverExecutor != null) {
-            readSysfsFile(path)
-        } else {
-            null
-        }
-    }
-
-    /**
      * Attach (or clear) the command that hands the fan back to the vendor controller and
      * rewrite the on-disk artifacts, so the babysitter and any dirty-session recovery
      * carry it too.

--- a/app/src/main/java/app/gamenative/powercontrol/drivers/PerformanceDriver.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/drivers/PerformanceDriver.kt
@@ -224,13 +224,4 @@ abstract class PerformanceDriver {
      * Set maximum RAM bus performance level
      */
     open fun setMaxBusLevel(level: Int): Boolean = false
-
-    // ========================================
-    // Utility functions
-    // ========================================
-
-    /**
-     * Read File using driver
-     */
-    open fun readFile(path: String): String? = null
 }

--- a/app/src/main/java/app/gamenative/powercontrol/metrics/SystemMetricsReader.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/metrics/SystemMetricsReader.kt
@@ -1,7 +1,6 @@
 package app.gamenative.powercontrol.metrics
 
 import android.os.SystemClock
-import app.gamenative.powercontrol.PowerManager
 import java.io.File
 import java.util.Locale
 import timber.log.Timber
@@ -48,7 +47,7 @@ object SystemMetricsSources {
 
         val candidates = linkedSetOf<String>()
         fun add(path: String) {
-            if (File(path).exists()) {
+            if (File(path).canRead()) {
                 candidates += path
             }
         }
@@ -87,7 +86,7 @@ object SystemMetricsSources {
                 )
                 for (fileName in usageFiles) {
                     val file = File(nodeDir, fileName)
-                    if (!file.exists()) continue
+                    if (!file.canRead()) continue
                     if (looksLikeGpuNode || fileName == "gpu_busy_percentage" || fileName == "gpuinfo") {
                         candidates += file.path
                     }
@@ -202,8 +201,7 @@ object SystemMetricsSources {
 
     fun readFirstLine(path: String): String? {
         return try {
-            PowerManager.readFile(path)?.lines()?.firstOrNull()
-                ?: File(path).bufferedReader().use { it.readLine() }
+            File(path).bufferedReader().use { it.readLine() }
         } catch (_: Exception) {
             null
         }
@@ -211,10 +209,9 @@ object SystemMetricsSources {
 
     fun readNthLine(path: String, lineIndex: Int): String? {
         return try {
-            PowerManager.readFile(path)?.lines()?.drop(lineIndex)?.firstOrNull()
-                ?: File(path).bufferedReader().useLines { lines ->
-                    lines.drop(lineIndex).firstOrNull()
-                }
+            File(path).bufferedReader().useLines { lines ->
+                lines.drop(lineIndex).firstOrNull()
+            }
         } catch (_: Exception) {
             null
         }

--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -470,6 +470,7 @@ fun QuickMenu(
     // trip a VerifyError at class load (dex methods over 255 registers hit a
     // broken D8 codegen path).
     val inviteMenu = remember(container?.id) { SteamInviteState.createIfAvailable(container) }
+    val isPowerControlEnabled = remember { PowerManager.isEnabled() }
     // Owned here, not plumbed through XServerScreen (register limit; see inviteMenu).
     var lsfgPresentMode by remember(container?.id) {
         mutableStateOf(container?.let { app.gamenative.utils.LsfgQuickMenuHelper.presentMode(it) } ?: "mailbox")
@@ -480,7 +481,7 @@ fun QuickMenu(
             when {
                 PrefManager.quickMenuLastTab == QuickMenuTab.LSFG && !isLsfgAvailable -> QuickMenuTab.HUD
                 PrefManager.quickMenuLastTab == QuickMenuTab.INVITE && inviteMenu == null -> QuickMenuTab.HUD
-                PrefManager.quickMenuLastTab == QuickMenuTab.POWER -> QuickMenuTab.HUD
+                PrefManager.quickMenuLastTab == QuickMenuTab.POWER && !isPowerControlEnabled -> QuickMenuTab.HUD
                 PrefManager.quickMenuLastTab == QuickMenuTab.IMMERSIVE && immersiveControls == null -> QuickMenuTab.HUD
                 else -> PrefManager.quickMenuLastTab
             }
@@ -551,10 +552,10 @@ fun QuickMenu(
 
     // Only the tabs actually shown in the rail, in on-screen order — mirrors the conditions each
     // QuickMenuTabButton below is gated on (isLsfgAvailable, a renderer being available, etc).
-    val availableTabs = remember(isLsfgAvailable, renderer, glRenderer, immersiveControls, inviteMenu)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           {
+    val availableTabs = remember(isLsfgAvailable, renderer, glRenderer, immersiveControls, inviteMenu, isPowerControlEnabled) {
         buildList {
             add(QuickMenuTab.HUD)
-            add(QuickMenuTab.POWER)
+            if (isPowerControlEnabled) add(QuickMenuTab.POWER)
             if (isLsfgAvailable) add(QuickMenuTab.LSFG)
             if (inviteMenu != null) add(QuickMenuTab.INVITE)
             if (renderer != null || glRenderer != null) add(QuickMenuTab.EFFECTS)
@@ -749,18 +750,20 @@ fun QuickMenu(
                                     modifier = Modifier.width(56.dp),
                                     focusRequester = hudTabFocusRequester,
                                 )
-                                QuickMenuTabButton(
-                                    icon = Icons.Default.BatteryChargingFull,
-                                    contentDescriptionResId = R.string.power_control,
-                                    selected = selectedTab == QuickMenuTab.POWER,
-                                    accentColor = PluviaTheme.colors.accentPurple,
-                                    onSelected = {
-                                        selectedTab = QuickMenuTab.POWER
-                                        PrefManager.quickMenuLastTab = selectedTab
-                                    },
-                                    modifier = Modifier.width(56.dp),
-                                    focusRequester = powerTabFocusRequester,
-                                )
+                                if (isPowerControlEnabled) {
+                                    QuickMenuTabButton(
+                                        icon = Icons.Default.BatteryChargingFull,
+                                        contentDescriptionResId = R.string.power_control,
+                                        selected = selectedTab == QuickMenuTab.POWER,
+                                        accentColor = PluviaTheme.colors.accentPurple,
+                                        onSelected = {
+                                            selectedTab = QuickMenuTab.POWER
+                                            PrefManager.quickMenuLastTab = selectedTab
+                                        },
+                                        modifier = Modifier.width(56.dp),
+                                        focusRequester = powerTabFocusRequester,
+                                    )
+                                }
                                 if (isLsfgAvailable) {
                                     QuickMenuTabButton(
                                         icon = Icons.Default.Speed,

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupPerformance.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupPerformance.kt
@@ -1,0 +1,39 @@
+package app.gamenative.ui.screen.settings
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import app.gamenative.PrefManager
+import app.gamenative.R
+import app.gamenative.powercontrol.PowerManager
+import app.gamenative.ui.theme.settingsTileColorsAlt
+import com.alorma.compose.settings.ui.SettingsGroup
+import com.alorma.compose.settings.ui.SettingsSwitch
+
+@Composable
+fun SettingsGroupPerformance() {
+    SettingsGroup {
+        val context = LocalContext.current
+        var powerControlEnabled by rememberSaveable { mutableStateOf(PrefManager.powerControlEnabled) }
+        SettingsSwitch(
+            colors = settingsTileColorsAlt(),
+            state = powerControlEnabled,
+            title = { Text(stringResource(R.string.settings_performance_power_control_title)) },
+            subtitle = { Text(stringResource(R.string.settings_performance_power_control_subtitle)) },
+            onCheckedChange = {
+                powerControlEnabled = it
+                PrefManager.powerControlEnabled = it
+                if (powerControlEnabled) {
+                    PowerManager.initialize(context)
+                } else {
+                    PowerManager.deinitialize()
+                }
+            },
+        )
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.Gamepad
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -128,6 +129,15 @@ private fun SettingsScreenContent(
                     iconTint = PluviaTheme.colors.accentCyan,
                 ) {
                     SettingsGroupEmulation()
+                }
+
+                // Performance section
+                SettingsSection(
+                    title = stringResource(R.string.settings_performance_title),
+                    icon = Icons.Default.Speed,
+                    iconTint = PluviaTheme.colors.accentWarning,
+                ) {
+                    SettingsGroupPerformance()
                 }
 
                 // Interface section

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -752,6 +752,11 @@
     <string name="settings_language_restart_confirm">Genstart</string>
     <string name="settings_language_changing">Ændrer sprog og genstarter...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Ydeevne</string>
+    <string name="settings_performance_power_control_title">Strømstyring</string>
+    <string name="settings_performance_power_control_subtitle">Aktivér CPU/GPU-strømstyring og vis fanen Strøm i hurtigmenuen i spillet</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulering</string>
     <string name="settings_emulation_orientations_title">Tilladte orienteringer</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -901,6 +901,11 @@
     <string name="settings_language_restart_message">Die Änderung der Sprache erfordert einen Neustart der App. Möchtest du fortfahren?</string>
     <string name="settings_language_restart_confirm">Neustart</string>
     <string name="settings_language_changing">Sprache wird geändert und Neustart durchgeführt…</string>
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Leistung</string>
+    <string name="settings_performance_power_control_title">Energieverwaltung</string>
+    <string name="settings_performance_power_control_subtitle">CPU/GPU-Energieverwaltung aktivieren und den Tab „Energie“ im Schnellmenü im Spiel anzeigen</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulation</string>
     <string name="settings_emulation_orientations_title">Erlaubte Ausrichtungen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -942,6 +942,11 @@
     <string name="settings_language_restart_confirm">Reiniciar</string>
     <string name="settings_language_changing">Cambiando idioma y reiniciando…</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Rendimiento</string>
+    <string name="settings_performance_power_control_title">Control de energía</string>
+    <string name="settings_performance_power_control_subtitle">Activa la gestión de energía de CPU/GPU y muestra la pestaña Energía en el menú rápido del juego</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulación</string>
     <string name="settings_emulation_orientations_title">Orientaciones de pantalla permitidas</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -952,6 +952,11 @@
     <string name="settings_language_restart_confirm">Redémarrer</string>
     <string name="settings_language_changing">Changement de langue et redémarrage…</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Performances</string>
+    <string name="settings_performance_power_control_title">Gestion de l\'alimentation</string>
+    <string name="settings_performance_power_control_subtitle">Activer la gestion de l\'alimentation CPU/GPU et afficher l\'onglet Alimentation dans le menu rapide en jeu</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Émulation</string>
     <string name="settings_emulation_orientations_title">Orientations autorisées</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -926,6 +926,11 @@
     <string name="settings_language_restart_confirm">Riavvia</string>
     <string name="settings_language_changing">Cambio lingua e riavvio...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Prestazioni</string>
+    <string name="settings_performance_power_control_title">Gestione energetica</string>
+    <string name="settings_performance_power_control_subtitle">Abilita la gestione energetica di CPU/GPU e mostra la scheda Energia nel menu rapido di gioco</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulazione</string>
     <string name="settings_emulation_orientations_title">Orientamenti Consentiti</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -904,6 +904,11 @@
     <string name="settings_language_restart_confirm">再起動</string>
     <string name="settings_language_changing">言語を変更して再起動しています…</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">パフォーマンス</string>
+    <string name="settings_performance_power_control_title">電力コントロール</string>
+    <string name="settings_performance_power_control_subtitle">CPU/GPUの電力管理を有効にし、ゲーム内クイックメニューに「電力」タブを表示します</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">エミュレーション</string>
     <string name="settings_emulation_orientations_title">許可される向き</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -935,6 +935,11 @@
     <string name="settings_language_restart_confirm">재시작</string>
     <string name="settings_language_changing">언어 변경 및 재시작 중...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">성능</string>
+    <string name="settings_performance_power_control_title">전원 제어</string>
+    <string name="settings_performance_power_control_subtitle">CPU/GPU 전원 관리를 활성화하고 게임 내 퀵 메뉴에 전원 탭을 표시합니다</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">에뮬레이션</string>
     <string name="settings_emulation_orientations_title">허용된 방향</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -943,6 +943,11 @@
     <string name="settings_language_restart_confirm">Uruchom ponownie</string>
     <string name="settings_language_changing">Zmiana języka i ponowne uruchamianie...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Wydajność</string>
+    <string name="settings_performance_power_control_title">Zarządzanie energią</string>
+    <string name="settings_performance_power_control_subtitle">Włącz zarządzanie energią CPU/GPU i pokaż kartę Zasilanie w menu szybkim w grze</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulacja</string>
     <string name="settings_emulation_orientations_title">Dozwolone orientacje</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -752,6 +752,11 @@
     <string name="settings_language_restart_confirm">Reiniciar</string>
     <string name="settings_language_changing">Alterando idioma e reiniciando...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Desempenho</string>
+    <string name="settings_performance_power_control_title">Controle de energia</string>
+    <string name="settings_performance_power_control_subtitle">Ativa o gerenciamento de energia de CPU/GPU e exibe a aba Energia no menu rápido do jogo</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulação</string>
     <string name="settings_emulation_orientations_title">Orientações permitidas</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -935,6 +935,11 @@
 	<string name="settings_language_restart_confirm">Repornește</string>
 	<string name="settings_language_changing">Se schimbă limba și se repornește...</string>
 
+	<!-- Settings: Performance Group -->
+	<string name="settings_performance_title">Performanță</string>
+	<string name="settings_performance_power_control_title">Control alimentare</string>
+	<string name="settings_performance_power_control_subtitle">Activează gestionarea energiei CPU/GPU și afișează fila Alimentare în meniul rapid din joc</string>
+
 	<!-- Settings: Emulation Group -->
 	<string name="settings_emulation_title">Emulare</string>
 	<string name="settings_emulation_orientations_title">Orientări permise</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1107,6 +1107,11 @@ https://gamenative.app
     <string name="settings_emulation_default_config_subtitle">Начальные настройки контейнера для каждой игры (не влияет на уже установленные игры)</string>
     <string name="settings_emulation_default_config_title">Изменить конфигурацию по умолчанию</string>
     <string name="settings_emulation_driver_manager_subtitle">Установить или удалить пользовательские пакеты графических драйверов</string>
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Производительность</string>
+    <string name="settings_performance_power_control_title">Управление питанием</string>
+    <string name="settings_performance_power_control_subtitle">Включает управление питанием CPU/GPU и показывает вкладку «Питание» в быстром меню в игре</string>
+
     <string name="settings_emulation_driver_manager_title">Менеджер драйверов</string>
     <string name="settings_emulation_orientations_subtitle">Выберите, какие ориентации можно повернуть во время игры</string>
     <string name="settings_emulation_orientations_title">Разрешённые ориентации</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -929,6 +929,11 @@
     <string name="settings_language_restart_confirm">Перезапустити</string>
     <string name="settings_language_changing">Зміна мови та перезапуск...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Продуктивність</string>
+    <string name="settings_performance_power_control_title">Керування живленням</string>
+    <string name="settings_performance_power_control_subtitle">Вмикає керування живленням CPU/GPU та показує вкладку «Живлення» у швидкому меню в грі</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Емуляція</string>
     <string name="settings_emulation_orientations_title">Дозволені орієнтації екрану</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -919,6 +919,11 @@
     <string name="settings_language_restart_confirm">重新启动</string>
     <string name="settings_language_changing">切换语言并重新启动中...</string>
 
+    <!-- 设置：性能组 -->
+    <string name="settings_performance_title">性能</string>
+    <string name="settings_performance_power_control_title">功耗控制</string>
+    <string name="settings_performance_power_control_subtitle">启用 CPU/GPU 功耗管理，并在游戏内快捷菜单中显示“功耗”标签页</string>
+
     <!-- 设置：模拟组 -->
     <string name="settings_emulation_title">模拟设置</string>
     <string name="settings_emulation_orientations_title">允许的屏幕方向</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -921,6 +921,11 @@
     <string name="settings_language_restart_confirm">重新啟動</string>
     <string name="settings_language_changing">切換語言並重新啟動中...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">效能</string>
+    <string name="settings_performance_power_control_title">功耗控制</string>
+    <string name="settings_performance_power_control_subtitle">啟用 CPU/GPU 功耗管理，並在遊戲內快捷選單中顯示「功耗」分頁</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">模擬設定</string>
     <string name="settings_emulation_orientations_title">允許的螢幕方向</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1049,6 +1049,11 @@
     <string name="settings_language_restart_confirm">Restart</string>
     <string name="settings_language_changing">Changing language and restarting...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Performance</string>
+    <string name="settings_performance_power_control_title">Power Control</string>
+    <string name="settings_performance_power_control_subtitle">Enable CPU/GPU power management and show the Power tab in the in-game quick menu</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulation</string>
     <string name="settings_emulation_orientations_title">Allowed Orientations</string>


### PR DESCRIPTION
## Description
add PrefManager option to enable / disable Power Control, revert changes to SystemMetricsReader for plain file read.

## Recording
N/A

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a user setting to enable or disable Power Control. Previously always on with the Power tab visible; now it defaults to on, and when off `PowerManager` no-ops and the Power tab is hidden.

- Introduces `PrefManager.powerControlEnabled` (default true) with synchronous writes so `PowerManager.initialize()` reads the updated value immediately.
- Gates `PowerManager` entry points (`initialize`, `start`, `stop`, `pause`, `resume`, game pin) behind `isEnabled()`. Adds `isEnabled()` and `deinitialize()`.
- Adds a Performance section in Settings with a toggle; toggling initializes or deinitializes `PowerManager`. Includes localized strings.
- Updates `QuickMenu` to hide the Power tab when disabled and fall back to HUD if the last tab was Power.
- Simplifies metrics: `SystemMetricsReader` reads directly from readable files (`canRead()`); removes driver-assisted file reads and deletes `readFile` from `PerformanceDriver`, `PServerDriver`, and `PowerManager` (metrics may be unavailable on nodes requiring elevated access).

- Migration:
  - Check `PowerManager.isEnabled()` before invoking any power-control behavior.
  - Remove any usage of `PowerManager.readFile`/`PerformanceDriver.readFile`; they no longer exist.

<sup>Written for commit 3c263e0b0f3e3ebceb1bbc2d96d8afdf85649533. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Performance section in Settings with a toggle for CPU/GPU power management.
  - Power management preferences persist across sessions and apply immediately when changed.
  - The in-game Power tab is shown or hidden based on the setting.
  - Quick-menu navigation automatically falls back to the HUD tab when Power is unavailable.

- **Localization**
  - Added translations for the Performance and power-management settings across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->