### PR TITLE
Don't treat composite HID keyboards as game controllers

### DIFF
--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -188,9 +188,13 @@ public class ControllerManager {
         boolean isGamepad = device.supportsSource(InputDevice.SOURCE_GAMEPAD);
         boolean isJoystick = device.supportsSource(InputDevice.SOURCE_JOYSTICK);
 
+        // Only consider axes reported under the JOYSTICK source class.
+        // Composite HID devices (e.g. keyboards with built-in touchpads) expose
+        // AXIS_X/AXIS_Y through SOURCE_MOUSE and may wrongly claim SOURCE_JOYSTICK
+        // in their source mask, which caused them to be treated as gamepads.
         boolean hasAxes =
-                device.getMotionRange(android.view.MotionEvent.AXIS_X) != null ||
-                        device.getMotionRange(android.view.MotionEvent.AXIS_Y) != null;
+                device.getMotionRange(android.view.MotionEvent.AXIS_X, InputDevice.SOURCE_JOYSTICK) != null ||
+                        device.getMotionRange(android.view.MotionEvent.AXIS_Y, InputDevice.SOURCE_JOYSTICK) != null;
 
         boolean[] hasGamepadKeysArray = device.hasKeys(
                 KeyEvent.KEYCODE_BUTTON_A,

--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -188,13 +188,14 @@ public class ControllerManager {
         boolean isGamepad = device.supportsSource(InputDevice.SOURCE_GAMEPAD);
         boolean isJoystick = device.supportsSource(InputDevice.SOURCE_JOYSTICK);
 
-        // Only consider axes reported under the JOYSTICK source class.
-        // Composite HID devices (e.g. keyboards with built-in touchpads) expose
-        // AXIS_X/AXIS_Y through SOURCE_MOUSE and may wrongly claim SOURCE_JOYSTICK
-        // in their source mask, which caused them to be treated as gamepads.
+        // Only consider axes reported under a controller source class. Composite HID
+        // devices (e.g. keyboards with built-in touchpads) expose AXIS_X/AXIS_Y through
+        // SOURCE_MOUSE and may wrongly claim SOURCE_JOYSTICK in their source mask, which
+        // caused them to be treated as gamepads. SOURCE_GAMEPAD is queried as well, for
+        // drivers that attach the sticks to the gamepad source instead.
         boolean hasAxes =
-                device.getMotionRange(android.view.MotionEvent.AXIS_X, InputDevice.SOURCE_JOYSTICK) != null ||
-                        device.getMotionRange(android.view.MotionEvent.AXIS_Y, InputDevice.SOURCE_JOYSTICK) != null;
+                hasControllerAxis(device, android.view.MotionEvent.AXIS_X) ||
+                        hasControllerAxis(device, android.view.MotionEvent.AXIS_Y);
 
         boolean[] hasGamepadKeysArray = device.hasKeys(
                 KeyEvent.KEYCODE_BUTTON_A,
@@ -213,6 +214,11 @@ public class ControllerManager {
 
         return (isGamepad && hasGamepadKeys) ||
                 (isJoystick && hasAxes);
+    }
+
+    private static boolean hasControllerAxis(InputDevice device, int axis) {
+        return device.getMotionRange(axis, InputDevice.SOURCE_JOYSTICK) != null ||
+                device.getMotionRange(axis, InputDevice.SOURCE_GAMEPAD) != null;
     }
 
     /**

--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -194,8 +194,8 @@ public class ControllerManager {
         // caused them to be treated as gamepads. SOURCE_GAMEPAD is queried as well, for
         // drivers that attach the sticks to the gamepad source instead.
         boolean hasAxes =
-                hasControllerAxis(device, android.view.MotionEvent.AXIS_X) ||
-                        hasControllerAxis(device, android.view.MotionEvent.AXIS_Y);
+                ExternalController.hasControllerAxis(device, android.view.MotionEvent.AXIS_X) ||
+                        ExternalController.hasControllerAxis(device, android.view.MotionEvent.AXIS_Y);
 
         boolean[] hasGamepadKeysArray = device.hasKeys(
                 KeyEvent.KEYCODE_BUTTON_A,
@@ -214,11 +214,6 @@ public class ControllerManager {
 
         return (isGamepad && hasGamepadKeys) ||
                 (isJoystick && hasAxes);
-    }
-
-    private static boolean hasControllerAxis(InputDevice device, int axis) {
-        return device.getMotionRange(axis, InputDevice.SOURCE_JOYSTICK) != null ||
-                device.getMotionRange(axis, InputDevice.SOURCE_GAMEPAD) != null;
     }
 
     /**

--- a/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
@@ -367,13 +367,14 @@ public class ExternalController {
         boolean isGamepad = device.supportsSource(InputDevice.SOURCE_GAMEPAD);
         boolean isJoystick = device.supportsSource(InputDevice.SOURCE_JOYSTICK);
 
-        // Only consider axes reported under the JOYSTICK source class.
-        // Composite HID devices (e.g. keyboards with built-in touchpads) expose
-        // AXIS_X/AXIS_Y through SOURCE_MOUSE and may wrongly claim SOURCE_JOYSTICK
-        // in their source mask, which caused them to be treated as gamepads.
+        // Only consider axes reported under a controller source class. Composite HID
+        // devices (e.g. keyboards with built-in touchpads) expose AXIS_X/AXIS_Y through
+        // SOURCE_MOUSE and may wrongly claim SOURCE_JOYSTICK in their source mask, which
+        // caused them to be treated as gamepads. SOURCE_GAMEPAD is queried as well, for
+        // drivers that attach the sticks to the gamepad source instead.
         boolean hasAxes =
-                device.getMotionRange(android.view.MotionEvent.AXIS_X, InputDevice.SOURCE_JOYSTICK) != null ||
-                        device.getMotionRange(android.view.MotionEvent.AXIS_Y, InputDevice.SOURCE_JOYSTICK) != null;
+                hasControllerAxis(device, android.view.MotionEvent.AXIS_X) ||
+                        hasControllerAxis(device, android.view.MotionEvent.AXIS_Y);
 
         boolean[] hasGamepadKeysArray = device.hasKeys(
                 KeyEvent.KEYCODE_BUTTON_A,
@@ -392,6 +393,11 @@ public class ExternalController {
 
         return (isGamepad && hasGamepadKeys) ||
                 (isJoystick && hasAxes);
+    }
+
+    private static boolean hasControllerAxis(InputDevice device, int axis) {
+        return device.getMotionRange(axis, InputDevice.SOURCE_JOYSTICK) != null ||
+                device.getMotionRange(axis, InputDevice.SOURCE_GAMEPAD) != null;
     }
 
     public static float getCenteredAxis(MotionEvent event, int axis, int historyPos) {

--- a/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
@@ -395,7 +395,8 @@ public class ExternalController {
                 (isJoystick && hasAxes);
     }
 
-    private static boolean hasControllerAxis(InputDevice device, int axis) {
+    /** Shared with {@link ControllerManager#isGameController(InputDevice)}. */
+    static boolean hasControllerAxis(InputDevice device, int axis) {
         return device.getMotionRange(axis, InputDevice.SOURCE_JOYSTICK) != null ||
                 device.getMotionRange(axis, InputDevice.SOURCE_GAMEPAD) != null;
     }

--- a/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
@@ -367,9 +367,13 @@ public class ExternalController {
         boolean isGamepad = device.supportsSource(InputDevice.SOURCE_GAMEPAD);
         boolean isJoystick = device.supportsSource(InputDevice.SOURCE_JOYSTICK);
 
+        // Only consider axes reported under the JOYSTICK source class.
+        // Composite HID devices (e.g. keyboards with built-in touchpads) expose
+        // AXIS_X/AXIS_Y through SOURCE_MOUSE and may wrongly claim SOURCE_JOYSTICK
+        // in their source mask, which caused them to be treated as gamepads.
         boolean hasAxes =
-                device.getMotionRange(android.view.MotionEvent.AXIS_X) != null ||
-                        device.getMotionRange(android.view.MotionEvent.AXIS_Y) != null;
+                device.getMotionRange(android.view.MotionEvent.AXIS_X, InputDevice.SOURCE_JOYSTICK) != null ||
+                        device.getMotionRange(android.view.MotionEvent.AXIS_Y, InputDevice.SOURCE_JOYSTICK) != null;
 
         boolean[] hasGamepadKeysArray = device.hasKeys(
                 KeyEvent.KEYCODE_BUTTON_A,


### PR DESCRIPTION
`isGameController()` calls `getMotionRange()` without a source class, so a device that claims `SOURCE_JOYSTICK` in its source mask is treated as a controller as soon as it reports `AXIS_X`/`AXIS_Y` through *any* source:

```java
boolean hasAxes =
        device.getMotionRange(android.view.MotionEvent.AXIS_X) != null ||
                device.getMotionRange(android.view.MotionEvent.AXIS_Y) != null;
...
return (isGamepad && hasGamepadKeys) || (isJoystick && hasAxes);
```

Bluetooth keyboards with a built-in touchpad hit exactly that. The touchpad reports those axes under `SOURCE_MOUSE`, while the composite HID descriptor also advertises `SOURCE_JOYSTICK`, so `isJoystick && hasAxes` is true. The keyboard gets bound as a virtual XInput pad, which takes over library navigation and leaves keyboard+mouse unusable in game. There is no UI option to exclude an input device, and `SDL_GAMECONTROLLER_IGNORE_DEVICES` does not help, because the binding happens in the Android layer, before the container.

This queries the motion ranges under `SOURCE_JOYSTICK` explicitly, in both copies of the check — `ExternalController.java` and `ControllerManager.java` carry the same logic duplicated.

`PhysicalControllerHandler.kt` already queries axes by source, in its `hasMotionRange` helper:

```kotlin
device.getMotionRange(axis, InputDevice.SOURCE_JOYSTICK) != null ||
    device.getMotionRange(axis, InputDevice.SOURCE_GAMEPAD) != null ||
    device.getMotionRange(axis) != null
```

This PR matches the first two arms and deliberately omits the third. The source-agnostic overload is what matches a touchpad's `SOURCE_MOUSE` axes — the very misclassification being fixed here. It is harmless in `hasMotionRange` because that helper is only reachable from `deviceHasTriggerAxis` (`PhysicalControllerHandler.kt:127`, guarded by `controllerBinding != null`), i.e. for a device that already has a controller profile bound; it asks "does this controller have an analog trigger?", not "is this a controller?".

Real controllers should be unaffected: they either report their joystick axes under `SOURCE_JOYSTICK`, or match on the `isGamepad && hasGamepadKeys` branch, which this PR does not touch. The devices whose classification changes are those reporting axes only under a non-joystick source *and* exposing no gamepad buttons — which are not controllers. That is reasoning from the code, not a measurement — see the caveat below.

### Device this was found on

- ProtoArc XK01 TP (foldable Bluetooth keyboard with integrated touchpad), vendor `0x3554` / product `0xF605`
- Samsung Galaxy S25 Ultra, unrooted
- Android classifies it as `KEYBOARD | GAMEPAD`; confirmed with a gamepad tester app and Device Info HW
- Affects 1.1.1 and master

### Verification

Built the `legacy` debug flavor with this patch and installed it on the S25 Ultra:

- Before: the keyboard occupied controller slot P1 and the library switched to gamepad navigation as soon as it connected.
- After: slot P1 stays at `Waiting — No controller assigned` with the keyboard connected, and keyboard + touchpad work as keyboard and mouse in game.

**Not tested with a real game controller.** I have no physical gamepad to hand, so the no-regression side of this change is unverified on hardware; the argument that controllers still bind is the code reasoning above, nothing more. If someone with a controller can confirm it still gets picked up, that would close the gap — and I am happy to run any check you want on the keyboard side.

## Recording

Screenshot of the in-game quick menu with the keyboard connected, after the patch: controller slot P1 reads `Waiting — No controller assigned` instead of binding the keyboard, and keyboard + touchpad drive the game as keyboard and mouse.

<img width="2340" height="1080" alt="Screenshot_20260819_230624_GameNative Fork" src="https://github.com/user-attachments/assets/0c97cb99-ca8d-4966-b42f-6bc6d6c9bf06" />


## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops composite HID keyboards with touchpads from being detected as game controllers by counting axes only under controller sources, and de-duplicates the axis check into a shared helper.

- `ExternalController.isGameController()` and `ControllerManager.isGameController()` now use `hasControllerAxis()` (in `ExternalController`) to query `getMotionRange(axis, SOURCE_JOYSTICK|SOURCE_GAMEPAD)`.
- Excludes the source-agnostic overload to avoid matching `SOURCE_MOUSE` axes; aligns with the intent of `PhysicalControllerHandler`.
- Intentional non-change: the two `isGameController()` methods remain separate due to different virtual-device handling; unifying them would be a behavior change and is out of scope.
- Expected impact: real controllers still match; composite HID keyboards no longer bind as virtual controllers. Verified on ProtoArc XK01 TP + Galaxy S25 Ultra; please confirm with a hardware controller. No config or migration required.

<sup>Written for commit aea2dcc4815cd3b01a6d9ea9838718037c0beb86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved detection of external game controllers across devices reporting joystick or gamepad axis inputs.
- Reduced incorrect identification of unrelated input devices, including mouse-like controls and keyboards with touchpads.
- Expanded compatibility with a wider range of external controllers while preserving existing gamepad button detection.
- Improved controller recognition consistency when devices report movement through different input sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->