### PR TITLE
fix: revert changes to SystemMetricsReader to use plain file read directly

### DIFF
--- a/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
@@ -956,19 +956,6 @@ object PowerManager {
     }
 
     // ========================================
-    // File I/O
-    // ========================================
-
-    /**
-     * Read a file using the driver's file reading capabilities.
-     * For PServerDriver, this uses root access with fallback to direct file read.
-     * For other drivers, returns null.
-     * @param path The absolute path to the file to read
-     * @return The file contents as a trimmed string, or null if the file cannot be read
-     */
-    fun readFile(path: String): String? = getDriver().readFile(path)
-
-    // ========================================
     // Profile Persistence
     // ========================================
 

--- a/app/src/main/java/app/gamenative/powercontrol/drivers/PServerDriver.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/drivers/PServerDriver.kt
@@ -401,19 +401,6 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
     fun executeRootCommand(command: String): Result<String?> = executeAsRoot(command)
 
     /**
-     * Read a file using PServer root access with fallback to direct file read.
-     * @param path The absolute path to the file to read
-     * @return The file contents as a trimmed string, or null if the file cannot be read
-     */
-    override fun readFile(path: String): String? {
-        return if (pserverExecutor != null) {
-            readSysfsFile(path)
-        } else {
-            null
-        }
-    }
-
-    /**
      * Attach (or clear) the command that hands the fan back to the vendor controller and
      * rewrite the on-disk artifacts, so the babysitter and any dirty-session recovery
      * carry it too.

--- a/app/src/main/java/app/gamenative/powercontrol/drivers/PerformanceDriver.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/drivers/PerformanceDriver.kt
@@ -224,13 +224,4 @@ abstract class PerformanceDriver {
      * Set maximum RAM bus performance level
      */
     open fun setMaxBusLevel(level: Int): Boolean = false
-
-    // ========================================
-    // Utility functions
-    // ========================================
-
-    /**
-     * Read File using driver
-     */
-    open fun readFile(path: String): String? = null
 }

--- a/app/src/main/java/app/gamenative/powercontrol/metrics/SystemMetricsReader.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/metrics/SystemMetricsReader.kt
@@ -1,7 +1,6 @@
 package app.gamenative.powercontrol.metrics
 
 import android.os.SystemClock
-import app.gamenative.powercontrol.PowerManager
 import java.io.File
 import java.util.Locale
 import timber.log.Timber
@@ -48,7 +47,7 @@ object SystemMetricsSources {
 
         val candidates = linkedSetOf<String>()
         fun add(path: String) {
-            if (File(path).exists()) {
+            if (File(path).canRead()) {
                 candidates += path
             }
         }
@@ -87,7 +86,7 @@ object SystemMetricsSources {
                 )
                 for (fileName in usageFiles) {
                     val file = File(nodeDir, fileName)
-                    if (!file.exists()) continue
+                    if (!file.canRead()) continue
                     if (looksLikeGpuNode || fileName == "gpu_busy_percentage" || fileName == "gpuinfo") {
                         candidates += file.path
                     }
@@ -202,8 +201,7 @@ object SystemMetricsSources {
 
     fun readFirstLine(path: String): String? {
         return try {
-            PowerManager.readFile(path)?.lines()?.firstOrNull()
-                ?: File(path).bufferedReader().use { it.readLine() }
+            File(path).bufferedReader().use { it.readLine() }
         } catch (_: Exception) {
             null
         }
@@ -211,10 +209,9 @@ object SystemMetricsSources {
 
     fun readNthLine(path: String, lineIndex: Int): String? {
         return try {
-            PowerManager.readFile(path)?.lines()?.drop(lineIndex)?.firstOrNull()
-                ?: File(path).bufferedReader().useLines { lines ->
-                    lines.drop(lineIndex).firstOrNull()
-                }
+            File(path).bufferedReader().useLines { lines ->
+                lines.drop(lineIndex).firstOrNull()
+            }
         } catch (_: Exception) {
             null
         }


### PR DESCRIPTION
## Description
fix: revert changes to SystemMetricsReader to use plain file read directly

## Recording
N/A

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts metrics file I/O to direct filesystem reads and removes driver-backed helpers. Previously `SystemMetricsReader` tried driver/root reads via `PowerManager.readFile`; now it reads with plain `File` and filters to readable files, reducing dependency on PServer and avoiding unreadable path access.

- Uses `canRead()` instead of `exists()` when collecting metric file candidates.
- Simplifies `readFirstLine`/`readNthLine` to use `File.bufferedReader` only.
- Deletes `PowerManager.readFile`, `PerformanceDriver.readFile`, and the `PServerDriver` override; replace any usages with direct `File` I/O.
- Side effect: metrics that required root-only sysfs access will be skipped rather than read via PServer.

<sup>Written for commit 13aec309d3eb814ee279d6104125a97914bba3bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system metrics collection by discovering only files that can be read.
  * Increased reliability when reading system performance and power information.
  * Removed fallback behavior that could return unavailable or incomplete file data.
* **Refactor**
  * Streamlined power-control and metrics handling to use more direct, consistent file access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->