### PR TITLE
Restrict FFP fastpath shim to external storage volumes

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3839,7 +3839,9 @@ private fun setupXEnvironment(
             Container.drivesIterator(container.drives).asSequence()
                 .firstOrNull { it[0] == "A" }?.let { File(it[1]).canonicalFile.path }
         }.getOrNull() ?: ""
-        if (ffpGameDir.startsWith("/storage/") && ffpGameDir.contains("/Android/data/")) {
+        if (ffpGameDir.startsWith("/storage/") &&
+            !(gameSource == GameSource.CUSTOM_GAME && ffpGameDir.startsWith("/storage/emulated/"))
+        ) {
             envVars.put("FFP_ENABLE", "1")
             envVars.put("FFP_MARKERS", "/steamapps/common/;/dosdevices/a:")
         }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3839,7 +3839,7 @@ private fun setupXEnvironment(
             Container.drivesIterator(container.drives).asSequence()
                 .firstOrNull { it[0] == "A" }?.let { File(it[1]).canonicalFile.path }
         }.getOrNull() ?: ""
-        if (ffpGameDir.startsWith("/storage/") && gameSource != GameSource.CUSTOM_GAME) {
+        if (ffpGameDir.startsWith("/storage/") && ffpGameDir.contains("/Android/data/")) {
             envVars.put("FFP_ENABLE", "1")
             envVars.put("FFP_MARKERS", "/steamapps/common/;/dosdevices/a:")
         }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3839,7 +3839,7 @@ private fun setupXEnvironment(
             Container.drivesIterator(container.drives).asSequence()
                 .firstOrNull { it[0] == "A" }?.let { File(it[1]).canonicalFile.path }
         }.getOrNull() ?: ""
-        if (ffpGameDir.startsWith("/storage/")) {
+        if (ffpGameDir.startsWith("/storage/") && gameSource != GameSource.CUSTOM_GAME) {
             envVars.put("FFP_ENABLE", "1")
             envVars.put("FFP_MARKERS", "/steamapps/common/;/dosdevices/a:")
         }


### PR DESCRIPTION
## Description
1.2.0's store-agnostic FFP gate (bad4d393a) enables the fastpath shim for any game whose A: drive is under /storage/ — including internal shared storage (/storage/emulated/), where the shim's benefit was never measured. A user's game (custom game imported as a Steam game, installed under /storage/emulated/0/Download/Games/steamapps/common/) refused to boot on 1.2.0: the environment came up but the guest process died before wine printed a single line. Setting FFP_DISABLE=1 in the container env vars fixed it, confirming the shim kills the guest at process bootstrap on that combination (bionic container, proton-11.0-1-arm64ec, FEXCore 2604). The same gate is the prime suspect for the wider custom-game perf regression reports on internal storage.

This restores the original intent of the gate: FFP only activates when the game tree is on a non-emulated /storage volume (SD cards / USB), where its win is device-validated (BL2 6.5min → seconds). Internal-storage games — where metadata ops are already dcache-fast — no longer get the shim. Game source no longer matters, so custom games imported as Steam games are covered too. FFP_DISABLE=1 remains available as a per-container kill switch.

Follow-up (not this PR): reproduce and fix the shim's process-bootstrap crash with proton-11-arm64ec/FEX so external-storage installs of those containers don't hit it.

## Recording
Not applicable — env var gating change, no UI.

## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.