### PR TITLE
Restrict FFP fastpath shim to non-emulated storage volumes

### DIFF
--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3839,9 +3839,7 @@ private fun setupXEnvironment(
             Container.drivesIterator(container.drives).asSequence()
                 .firstOrNull { it[0] == "A" }?.let { File(it[1]).canonicalFile.path }
         }.getOrNull() ?: ""
-        if (ffpGameDir.startsWith("/storage/") &&
-            !(gameSource == GameSource.CUSTOM_GAME && ffpGameDir.startsWith("/storage/emulated/"))
-        ) {
+        if (ffpGameDir.startsWith("/storage/") && !ffpGameDir.startsWith("/storage/emulated/")) {
             envVars.put("FFP_ENABLE", "1")
             envVars.put("FFP_MARKERS", "/steamapps/common/;/dosdevices/a:")
         }


### PR DESCRIPTION
## Description
Remove the FFP fastpath for ALL games on emulated storage (only apply for external storage)

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [ ] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the FFP fastpath shim to non‑emulated storage to prevent it from activating on internal/emulated volumes. Previously it could activate on `/storage/emulated/*` unless the game was a custom game; now it never activates on emulated storage.

- Sets `FFP_ENABLE` and `FFP_MARKERS` only when `ffpGameDir` is under `/storage/` and not under `/storage/emulated/`.
- Change is in `setupXEnvironment` in `XServerScreen.kt`; removes the `GameSource.CUSTOM_GAME` special case.
- Verify: games on `/storage/emulated/*` no longer receive `FFP_ENABLE`; games on external `/storage/*` still do.

<sup>Written for commit f300620f2b198fc42e955a47ad589cdaadd1c521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FFP activation for storage-based game paths.
  * FFP is now enabled for supported storage locations regardless of the game’s source.
  * Excludes the `/storage/emulated/` path from this behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->