### PR TITLE
refactor: Add global toggle for in-game power control, fix issues

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -14,6 +14,7 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import app.gamenative.data.GameSource
+import app.gamenative.powercontrol.autotuning.DeviceGate
 import app.gamenative.enums.AppTheme
 import app.gamenative.ui.enums.AppFilter
 import app.gamenative.ui.enums.HomeDestination
@@ -23,7 +24,6 @@ import com.materialkolor.PaletteStyle
 import com.winlator.box86_64.Box86_64Preset
 import com.winlator.container.Container
 import com.winlator.core.DefaultVersion
-import com.winlator.xenvironment.components.PulseAudioComponent
 import `in`.dragonbra.javasteam.enums.EPersonaState
 import java.util.EnumSet
 import kotlinx.coroutines.CoroutineScope
@@ -1501,4 +1501,8 @@ object PrefManager {
             }
         }
 
+    private val POWER_CONTROL_DEFAULT_ENABLED = booleanPreferencesKey("power_control_default_enabled")
+    var powerControlDefaultEnabled: Boolean
+        get() = getPref(POWER_CONTROL_DEFAULT_ENABLED, DeviceGate.isDeviceSupported())
+        set(value) { setPref(POWER_CONTROL_DEFAULT_ENABLED, value) }
 }

--- a/app/src/main/java/app/gamenative/powercontrol/PowerControlUiState.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerControlUiState.kt
@@ -3,11 +3,11 @@ package app.gamenative.powercontrol
 sealed class PowerControlUiState {
     object Loading : PowerControlUiState()
     data class Success(
-        val cpuInfo: CpuDisplayInfo,
+        val selectedProfile: PowerProfile,
+        val availableProfiles: List<PowerProfile>,
+        val cpuInfo: CpuDisplayInfo?,
         val gpuInfo: GpuDisplayInfo?,
         val ramInfo: RamDisplayInfo?,
-        val selectedProfile: PowerProfile,
-        val availableProfiles: List<PowerProfile>
     ) : PowerControlUiState()
 }
 

--- a/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
@@ -261,6 +261,7 @@ object PowerManager {
     fun stopPowerControl() {
         stopAutoTuning()
         FanController.stop()
+        driver.stop()
     }
 
     /**

--- a/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
@@ -166,8 +166,16 @@ object PowerManager {
         resolveGameAffinityOwnership()
         loadCurrentProfile()
         if (isProfilePowerControlEnabled()) {
-            start()
+            startPowerControl()
         }
+
+        if (currentProfile.enableAdaptiveFpsCap) {
+            AdaptiveFpsCapController.start(containerDir, tunerLogDirectory())
+        }
+
+        appContext.let { PerformanceMetricsCollector.start(it) }
+
+        isGameStarted = true
     }
 
     /**
@@ -218,9 +226,9 @@ object PowerManager {
         currentProfile = currentProfile.copy(enablePowerControl = enabled)
 
         if (enabled) {
-            start()
+            startPowerControl()
         } else {
-            stop()
+            stopPowerControl()
         }
     }
 
@@ -233,20 +241,12 @@ object PowerManager {
      * Start the performance driver and restore saved profile if available
      */
     @Synchronized
-    private fun start() {
+    private fun startPowerControl() {
         driver.start()
-
         applyCurrentProfile()
 
         // Pin PulseAudio to dedicated performance cores if PServer is available
         pinPulseAudioToDedicatedCores()
-        isGameStarted = true
-
-        if (currentProfile.enableAdaptiveFpsCap) {
-            AdaptiveFpsCapController.start(containerDir, tunerLogDirectory())
-        }
-
-        appContext.let { PerformanceMetricsCollector.start(it) }
 
         // Reset the driver on initialize. For PServer this also restores the recorded
         // baseline of a session that died without restoring it.
@@ -255,10 +255,12 @@ object PowerManager {
                 Timber.tag("PowerControl").i("Power baseline from a previous session found on disk, restoring it")
             }
         }
+    }
 
-        if (currentProfile.enableFanControl) {
-            FanController.start(driver)
-        }
+    @Synchronized
+    fun stopPowerControl() {
+        stopAutoTuning()
+        FanController.stop()
     }
 
     /**
@@ -268,10 +270,9 @@ object PowerManager {
     fun stop() {
         // Save the current profile if available, otherwise read from driver
         saveProfile()
-        stopAutoTuning()
         AdaptiveFpsCapController.stop()
         PerformanceMetricsCollector.stop()
-        FanController.stop()
+        stopPowerControl()
         driver.stop()
         isGameStarted = false
         fpsCapApplier = null
@@ -290,10 +291,9 @@ object PowerManager {
     fun pause() {
         if (!isGameStarted) return
         saveProfile()
-        stopAutoTuning()
         AdaptiveFpsCapController.pause()
         PerformanceMetricsCollector.pause()
-        FanController.pause()
+        stopPowerControl()
         driver.stop()
     }
 
@@ -308,9 +308,6 @@ object PowerManager {
             AdaptiveFpsCapController.start(containerDir, tunerLogDirectory())
         }
         PerformanceMetricsCollector.resume()
-        if (currentProfile.enableFanControl) {
-            FanController.start(driver)
-        }
     }
 
     /**
@@ -553,13 +550,15 @@ object PowerManager {
             stopAutoTuning()
         }
 
-        if (isGameStarted) {
+        if (previousProfile.enableAdaptiveFpsCap != profile.enableAdaptiveFpsCap) {
             if (profile.enableAdaptiveFpsCap) {
                 AdaptiveFpsCapController.start(containerDir, tunerLogDirectory())
             } else {
                 AdaptiveFpsCapController.stop()
             }
+        }
 
+        if (isGameStarted) {
             if (profile.enableFanControl) {
                 FanController.start(driver)
             } else {
@@ -1510,6 +1509,10 @@ object PowerManager {
 
                 if (currentProfile.enableAutoTuning) {
                     startAutoTuning()
+                }
+
+                if (currentProfile.enableFanControl) {
+                    FanController.start(driver)
                 }
             } catch (e: Exception) {
                 Timber.tag("PowerManager").e(e, "Failed to apply current profile")

--- a/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
@@ -30,6 +30,25 @@ import org.json.JSONObject
 import timber.log.Timber
 import java.io.File
 
+data class CpuInfo(
+    val currentGovernor: String,
+    val currentMinValue: Long,
+    val currentMaxValue: Long
+)
+
+data class GpuInfo(
+    val currentGpuValue: Long,
+    val minGpuPowerLevel: Int,
+    val maxGpuPowerLevel: Int,
+    val numGpuPowerLevels: Int
+)
+
+data class BusInfo(
+    val minBusLevel: Int,
+    val maxBusLevel: Int,
+    val numBusLevels: Int
+)
+
 /**
  * Manager for CPU and GPU performance control.
  * Provides a unified interface for CPU frequency, governor, and GPU power management.
@@ -45,11 +64,11 @@ object PowerManager {
         ignoreUnknownKeys = true
     }
 
-    private var driver: PerformanceDriver? = null
+    private lateinit var appContext: Context
+    private var containerDir: File? = null
+    private lateinit var driver: PerformanceDriver
     private var autoTuner: PerformanceAutoTuner? = null
     private var clusterTuner: ClusterTuner? = null
-    private var containerDir: File? = null
-    private var appContext: Context? = null
 
     /**
      * Flag to track if a game has been started.
@@ -62,8 +81,7 @@ object PowerManager {
      * The currently active power profile.
      * Updated when settings change, used for saving on stop.
      */
-    var currentProfile: PowerProfile? = null
-        private set
+    lateinit var currentProfile: PowerProfile
 
     /**
      * Observable UI state for the power control quick menu.
@@ -141,16 +159,32 @@ object PowerManager {
     private var gamePinGeneration: Int = 0
 
     /**
+     * Start thread to run in start()
+     */
+    @Volatile
+    private var startThread: Thread? = null
+
+    /**
+     * Autostart with contain dir and application context
+     */
+    fun autoStart(rootDir: File) {
+        containerDir = rootDir
+        resolveGameAffinityOwnership()
+        loadCurrentProfile()
+        if (isProfilePowerControlEnabled()) {
+            start()
+        }
+    }
+
+    /**
      * Initialize PowerManager with application context.
      * Should be called once during application startup.
      */
     fun initialize(context: Context) {
         appContext = context.applicationContext
-        if (driver != null) return
-
         driver = when {
             SamsungPerformanceDriver.isSamsungDevice() -> {
-                val samsungDriver = SamsungPerformanceDriver(context.applicationContext)
+                val samsungDriver = SamsungPerformanceDriver(appContext)
                 if (samsungDriver.isDriverSupported()) {
                     Timber.tag("PowerManager").i("Using Samsung Performance Driver")
                     samsungDriver
@@ -159,56 +193,43 @@ object PowerManager {
                     NoOpPerformanceDriver()
                 }
             }
-            PServerDriver(context.applicationContext).isDriverSupported() -> {
+            PServerDriver.checkPServerAvailability() -> {
                 Timber.tag("PowerManager").i("Using PServer Driver")
-                PServerDriver(context.applicationContext)
+                PServerDriver(appContext)
             }
             else -> {
                 Timber.tag("PowerManager").w("No performance driver available")
                 NoOpPerformanceDriver()
             }
         }
-
-        // Reset the driver on initialize. For PServer this also restores the recorded
-        // baseline of a session that died without restoring it.
-        (driver as? PServerDriver)?.let {
-            if (it.hasPendingBaseline()) {
-                Timber.tag("PowerControl").i("Power baseline from a previous session found on disk, restoring it")
-            }
-        }
-        driver?.reset()
-    }
-
-    private fun getDriver(): PerformanceDriver {
-        return driver ?: NoOpPerformanceDriver().also {
-            Timber.tag("PowerManager").w("PowerManager not initialized, using NoOpPerformanceDriver as fallback")
-            driver = it
-        }
     }
 
     /**
      * Get Driver Default Profile
      */
-    fun getDriverDefaultProfile(): PowerProfile = getDriver().getDefaultProfile()
+    fun getDriverDefaultProfile(): PowerProfile = driver.getDefaultProfile()
 
-    data class CpuInfo(
-        val currentGovernor: String,
-        val currentMinValue: Long,
-        val currentMaxValue: Long
-    )
+    /**
+     * True when the active profile has in-game power control enabled.
+     */
+    fun isProfilePowerControlEnabled(): Boolean = currentProfile.enablePowerControl
 
-    data class GpuInfo(
-        val currentGpuValue: Long,
-        val minGpuPowerLevel: Int,
-        val maxGpuPowerLevel: Int,
-        val numGpuPowerLevels: Int
-    )
+    /**
+     * Enable or disable in-game power control at runtime. Disabling stops the
+     * driver and hands clock control back to the OS; enabling re-initializes
+     * and restarts it when a game is running.
+     */
+    fun setPowerControlEnabled(enabled: Boolean) {
+        // Always save the profile
+        currentProfile = currentProfile.copy(enablePowerControl = enabled)
 
-    data class BusInfo(
-        val minBusLevel: Int,
-        val maxBusLevel: Int,
-        val numBusLevels: Int
-    )
+        if (enabled) {
+            start()
+        } else {
+            stop()
+        }
+    }
+
 
     // ========================================
     // General Settings
@@ -216,41 +237,58 @@ object PowerManager {
 
     /**
      * Start the performance driver and restore saved profile if available
-     * @param containerDir The container directory for saving/restoring per-container profiles
      */
-    fun start(containerDir: File? = null) {
-        this.containerDir = containerDir
-        resolveGameAffinityOwnership()
-        getDriver().start()
-        restoreSavedProfile()
+    @Synchronized
+    private fun start() {
+        if (startThread?.isAlive == true) return
 
-        // Pin PulseAudio to dedicated performance cores if PServer is available
-        pinPulseAudioToDedicatedCores()
-        isGameStarted = true
+        driver.start()
 
-        if (currentProfile?.enableAdaptiveFpsCap != false) {
-            AdaptiveFpsCapController.start(containerDir, tunerLogDirectory())
-        }
+        startThread = Thread {
+            if (Thread.currentThread().isInterrupted) return@Thread
+            applyCurrentProfile()
 
-        appContext?.let { PerformanceMetricsCollector.start(it) }
-            ?: Timber.tag("PowerManager").w("No application context, metrics collector not started")
+            // Pin PulseAudio to dedicated performance cores if PServer is available
+            pinPulseAudioToDedicatedCores()
+            if (Thread.currentThread().isInterrupted) return@Thread
+            isGameStarted = true
 
-        if (currentProfile?.enableFanControl != false) {
-            FanController.start(getDriver())
-        }
+            if (currentProfile.enableAdaptiveFpsCap) {
+                AdaptiveFpsCapController.start(containerDir, tunerLogDirectory())
+            }
+
+            if (Thread.currentThread().isInterrupted) return@Thread
+            appContext.let { PerformanceMetricsCollector.start(it) }
+
+            // Reset the driver on initialize. For PServer this also restores the recorded
+            // baseline of a session that died without restoring it.
+            (driver as? PServerDriver)?.let {
+                if (it.hasPendingBaseline()) {
+                    Timber.tag("PowerControl").i("Power baseline from a previous session found on disk, restoring it")
+                }
+            }
+
+            if (Thread.currentThread().isInterrupted) return@Thread
+            if (currentProfile.enableFanControl) {
+                FanController.start(driver)
+            }
+        }.also { it.start() }
     }
 
     /**
      * Stop the performance driver and save current profile
      */
+    @Synchronized
     fun stop() {
+        startThread?.interrupt()
+        startThread = null
         // Save the current profile if available, otherwise read from driver
         saveProfile()
         stopAutoTuning()
         AdaptiveFpsCapController.stop()
         PerformanceMetricsCollector.stop()
         FanController.stop()
-        getDriver().stop()
+        driver.stop()
         isGameStarted = false
         fpsCapApplier = null
         frameSampleStride = 1
@@ -264,14 +302,17 @@ object PowerManager {
     /**
      * Pause the performance driver and auto-tuning when app goes to background
      */
+    @Synchronized
     fun pause() {
+        startThread?.interrupt()
+        startThread = null
         if (!isGameStarted) return
         saveProfile()
         stopAutoTuning()
         AdaptiveFpsCapController.pause()
         PerformanceMetricsCollector.pause()
         FanController.pause()
-        getDriver().stop()
+        driver.stop()
     }
 
     /**
@@ -279,14 +320,14 @@ object PowerManager {
      */
     fun resume() {
         if (!isGameStarted) return
-        getDriver().start()
-        restoreSavedProfile()
-        if (currentProfile?.enableAdaptiveFpsCap != false) {
+        driver.start()
+        applyCurrentProfile()
+        if (currentProfile.enableAdaptiveFpsCap) {
             AdaptiveFpsCapController.start(containerDir, tunerLogDirectory())
         }
         PerformanceMetricsCollector.resume()
-        if (currentProfile?.enableFanControl != false) {
-            FanController.start(getDriver())
+        if (currentProfile.enableFanControl) {
+            FanController.start(driver)
         }
     }
 
@@ -296,14 +337,14 @@ object PowerManager {
      * Works with any driver that supports CPU frequency and GPU power level control.
      */
     fun startAutoTuning() {
-        val driver = getDriver()
+        val driver = driver
 
         if (autoTuner?.isRunning() == true || clusterTuner?.isRunning() == true) {
             Timber.tag("PowerManager").w("Auto-tuning already running")
             return
         }
 
-        val perClusterTuning = currentProfile?.enablePerClusterTuning ?: true
+        val perClusterTuning = currentProfile.enablePerClusterTuning
         val clusterTuningSupported = driver.isPerClusterSupported()
         val pserver = driver as? PServerDriver
         if (perClusterTuning && clusterTuningSupported && pserver != null) {
@@ -330,31 +371,31 @@ object PowerManager {
             availableCpuFreqs = availableCpuFreqs,
             numGpuLevels = numGpuLevels,
             numBusLevels = numBusLevels,
-            onCpuFrequencyChange = { freq ->
-                if (currentProfile?.minCpuFreq != freq || currentProfile?.maxCpuFreq != freq) {
+            onCpuFrequencyChange = { minFreq, maxFreq ->
+                if (currentProfile.minCpuFreq != minFreq || currentProfile.maxCpuFreq != maxFreq) {
                     update {
-                        setMinCpuValue(freq)
-                        setMaxCpuValue(freq)
+                        setMinCpuValue(minFreq)
+                        setMaxCpuValue(maxFreq)
                     }
                 }
             },
-            onGpuLevelChange = { level ->
-                if (currentProfile?.minGpuPowerLevel != level || currentProfile?.maxGpuPowerLevel != level) {
+            onGpuLevelChange = { minLevel, maxLevel ->
+                if (currentProfile.minGpuPowerLevel != minLevel || currentProfile.maxGpuPowerLevel != maxLevel) {
                     update {
-                        setMinGpuPowerLevel(level)
-                        setMaxGpuPowerLevel(level)
+                        setMinGpuPowerLevel(minLevel)
+                        setMaxGpuPowerLevel(maxLevel)
                     }
                 }
             },
-            onBusLevelChange = { level ->
-                if (currentProfile?.minBusLevel != level || currentProfile?.maxBusLevel != level) {
+            onBusLevelChange = { minLevel, maxLevel ->
+                if (currentProfile.minBusLevel != minLevel || currentProfile.maxBusLevel != maxLevel) {
                     update {
-                        setMinBusLevel(level)
-                        setMaxBusLevel(level)
+                        setMinBusLevel(minLevel)
+                        setMaxBusLevel(maxLevel)
                     }
                 }
             },
-            getTuningStrategy = { currentProfile?.tuningStrategy ?: AutoTuningStrategy.BALANCED },
+            getTuningStrategy = { currentProfile.tuningStrategy },
             enableLogging = BuildConfig.DEBUG,
             skipWarmupCycles = isGameStarted
         )
@@ -398,7 +439,7 @@ object PowerManager {
             metricsProvider = { latestMetrics },
             targetFpsProvider = { targetFps },
             fanSampleProvider = { FanController.latestSample },
-            strategyProvider = { currentProfile?.tuningStrategy ?: AutoTuningStrategy.BALANCED },
+            strategyProvider = { currentProfile.tuningStrategy },
             fpsCapProvider = { AdaptiveFpsCapController.snapshot() },
             stateFile = ClusterTuner.stateFileFor(containerDir),
             logDirectory = tunerLogDirectory(),
@@ -412,8 +453,8 @@ object PowerManager {
         return true
     }
 
-    private fun tunerLogDirectory(): File? {
-        return appContext?.let { context ->
+    private fun tunerLogDirectory(): File {
+        return appContext.let { context ->
             File(
                 context.getExternalFilesDir(null) ?: context.filesDir,
                 PowerBaselineScripts.DIRECTORY_NAME
@@ -509,19 +550,23 @@ object PowerManager {
      * Update the current profile reference.
      * Should be called when the UI changes the active profile.
      */
-    fun setCurrentProfile(profile: PowerProfile) {
+    fun setPowerProfile(profile: PowerProfile) {
         val previousProfile = currentProfile
         currentProfile = profile
 
         // Handle auto-tuning based on profile setting
-        if (profile.enableAutoTuning) {
-            if (previousProfile != null && previousProfile.enablePerClusterTuning != profile.enablePerClusterTuning) {
-                Timber.tag("PowerManager").i(
-                    "Per-cluster tuning changed to ${profile.enablePerClusterTuning}, restarting the tuner"
-                )
+        if (profile.enablePowerControl) {
+            if (profile.enableAutoTuning) {
+                if (previousProfile.enablePerClusterTuning != profile.enablePerClusterTuning) {
+                    Timber.tag("PowerManager").i(
+                        "Per-cluster tuning changed to ${profile.enablePerClusterTuning}, restarting the tuner"
+                    )
+                    stopAutoTuning()
+                }
+                startAutoTuning()
+            } else {
                 stopAutoTuning()
             }
-            startAutoTuning()
         } else {
             stopAutoTuning()
         }
@@ -534,12 +579,12 @@ object PowerManager {
             }
 
             if (profile.enableFanControl) {
-                FanController.start(getDriver())
+                FanController.start(driver)
             } else {
                 FanController.stop()
             }
 
-            if (previousProfile != null && previousProfile.enableGamePinning != profile.enableGamePinning) {
+            if (previousProfile.enableGamePinning != profile.enableGamePinning) {
                 val processName = pinnedGameProcessName
                 if (profile.enableGamePinning) {
                     if (processName != null) {
@@ -560,6 +605,17 @@ object PowerManager {
      * Performs blocking sysfs/driver reads, so call it from a background thread.
      */
     fun refreshUiState() {
+        if (!isProfilePowerControlEnabled()) {
+            _uiState.value = PowerControlUiState.Success(
+                selectedProfile = currentProfile,
+                availableProfiles = emptyList(),
+                cpuInfo = null,
+                gpuInfo = null,
+                ramInfo = null,
+            )
+            return
+        }
+
         try {
             val cpuInfo = getCpuInfo() ?: return
 
@@ -620,7 +676,7 @@ object PowerManager {
             // Try to match current settings against available profiles
             // Match by PowerManager's current profile name
             val matchingProfile = profiles.find { profile ->
-                profile.name == (currentProfile?.name ?: PerformancePreset.CUSTOM.displayName)
+                profile.name == (currentProfile.name)
             }
 
             val selectedProfile = (matchingProfile ?: PowerProfile(
@@ -634,15 +690,18 @@ object PowerManager {
                 maxBusLevel = ramDisplayInfo?.maxBusLevel ?: 0
             )).copy(
                 // Preserve enableAutoTuning and tuningStrategy from PowerManager's current profile
-                enableAutoTuning = currentProfile?.enableAutoTuning ?: true,
-                enablePerClusterTuning = currentProfile?.enablePerClusterTuning ?: true,
-                enableAdaptiveFpsCap = currentProfile?.enableAdaptiveFpsCap ?: true,
-                enableFanControl = currentProfile?.enableFanControl ?: true,
-                enableGamePinning = currentProfile?.enableGamePinning ?: false,
-                tuningStrategy = currentProfile?.tuningStrategy ?: AutoTuningStrategy.POWER_EFFICIENT
+                enablePowerControl = currentProfile.enablePowerControl,
+                enableAutoTuning = currentProfile.enableAutoTuning,
+                enablePerClusterTuning = currentProfile.enablePerClusterTuning,
+                enableAdaptiveFpsCap = currentProfile.enableAdaptiveFpsCap,
+                enableFanControl = currentProfile.enableFanControl,
+                enableGamePinning = currentProfile.enableGamePinning,
+                tuningStrategy = currentProfile.tuningStrategy
             )
 
             _uiState.value = PowerControlUiState.Success(
+                selectedProfile = selectedProfile,
+                availableProfiles = profiles,
                 cpuInfo = CpuDisplayInfo(
                     currentGovernor = cpuInfo.currentGovernor,
                     availableGovernors = availableGovernors,
@@ -653,8 +712,6 @@ object PowerManager {
                     selectedMaxFreqIndex = selectedMaxFreqIndex
                 ),
                 gpuInfo = gpuDisplayInfo,
-                selectedProfile = selectedProfile,
-                availableProfiles = profiles,
                 ramInfo = ramDisplayInfo,
             )
         } catch (e: Exception) {
@@ -671,29 +728,29 @@ object PowerManager {
      * True when driver support fan control and the FanController is usable
      */
     fun isFanControlAvailable(): Boolean {
-        val driver = getDriver()
-        return getDriver().isFanSupported() && FanController.isAvailable(driver)
+        val driver = driver
+        return driver.isFanSupported() && FanController.isAvailable(driver)
     }
 
     /**
      * True when this session can hold the game on the fast CPU cores.
      */
-    fun isGamePinningAvailable(): Boolean = getDriver().isCpuPinningSupported()
+    fun isGamePinningAvailable(): Boolean = driver.isCpuPinningSupported()
 
     /**
      * True when auto-tuning caps each CPU cluster separately via [ClusterTuner].
      */
-    fun isClusterTuningAvailable(): Boolean = getDriver().isPerClusterSupported()
+    fun isClusterTuningAvailable(): Boolean = driver.isPerClusterSupported()
 
     /**
      * Check if driver is supported
      */
-    fun isDriverSupported(): Boolean = getDriver().isDriverSupported()
+    fun isDriverSupported(): Boolean = driver.isDriverSupported()
 
     /**
      * Get display unit preference for frequency values
      */
-    fun getDisplayUnit(): PerformanceDriver.DisplayUnit = getDriver().getDisplayUnit()
+    fun getDisplayUnit(): PerformanceDriver.DisplayUnit = driver.getDisplayUnit()
 
     /**
      * Begin a batch update session.
@@ -701,7 +758,7 @@ object PowerManager {
      * For SamsungDriver, this is a no-op as CustomParams already handles batching.
      */
     fun beginUpdate() {
-        getDriver().beginUpdate()
+        driver.beginUpdate()
     }
 
     /**
@@ -710,7 +767,7 @@ object PowerManager {
      * For SamsungDriver, this is a no-op as each setter already calls start(params).
      */
     fun commit(): Boolean {
-        return getDriver().commit()
+        return driver.commit()
     }
 
     /**
@@ -790,9 +847,9 @@ object PowerManager {
     fun getCpuInfo(): CpuInfo? {
         return try {
             CpuInfo(
-                currentGovernor = getDriver().getCurrentGovernor(),
-                currentMinValue = getDriver().getCurrentMinCpuValue(),
-                currentMaxValue = getDriver().getCurrentMaxCpuValue()
+                currentGovernor = driver.getCurrentGovernor(),
+                currentMinValue = driver.getCurrentMinCpuValue(),
+                currentMaxValue = driver.getCurrentMaxCpuValue()
             )
         } catch (e: Exception) {
             Timber.tag("PowerManager").e(e, "Failed to get CPU info")
@@ -804,29 +861,29 @@ object PowerManager {
      * Get list of available CPU governors
      */
     fun getAvailableGovernors(): List<String> {
-        return getDriver().getAvailableGovernors()
+        return driver.getAvailableGovernors()
     }
 
     /**
      * Get list of available CPU frequencies in KHz
      */
     fun getAvailableCpuFrequencies(): List<Long> {
-        return getDriver().getAvailableCpuFrequencies()
+        return driver.getAvailableCpuFrequencies()
     }
 
     fun setProfileName(name: String) {
-        currentProfile?.name = name
+        currentProfile.name = name
     }
 
     /**
      * Set CPU governor
      */
     fun setGovernor(governor: String): Boolean {
-        val result = getDriver().setGovernor(governor)
+        val result = driver.setGovernor(governor)
         if (result) {
             val cpuGovernor = CpuGovernor.fromString(governor)
             if (cpuGovernor != null) {
-                currentProfile?.governor = cpuGovernor
+                currentProfile.governor = cpuGovernor
             }
         }
         return result
@@ -836,9 +893,9 @@ object PowerManager {
      * Set minimum CPU Value in KHz / Integer
      */
     fun setMinCpuValue(frequency: Long): Boolean {
-        val result = getDriver().setMinCpuValue(frequency)
+        val result = driver.setMinCpuValue(frequency)
         if (result) {
-            currentProfile?.minCpuFreq = frequency
+            currentProfile.minCpuFreq = frequency
         }
         return result
     }
@@ -847,9 +904,9 @@ object PowerManager {
      * Set maximum CPU Value in KHz / Integer
      */
     fun setMaxCpuValue(frequency: Long): Boolean {
-        val result = getDriver().setMaxCpuValue(frequency)
+        val result = driver.setMaxCpuValue(frequency)
         if (result) {
-            currentProfile?.maxCpuFreq = frequency
+            currentProfile.maxCpuFreq = frequency
         }
         return result
     }
@@ -862,7 +919,7 @@ object PowerManager {
      * Check if GPU control is supported
      */
     fun isGpuSupported(): Boolean {
-        return getDriver().isGpuSupported()
+        return driver.isGpuSupported()
     }
 
     /**
@@ -870,12 +927,21 @@ object PowerManager {
      */
     fun getGpuInfo(): GpuInfo? {
         return try {
-            if (!getDriver().isGpuSupported()) return null
+            if (!driver.isGpuSupported()) return null
+            // Batched single-round-trip read when the driver supports it
+            (driver as? PServerDriver)?.readGpuState()?.let { state ->
+                return GpuInfo(
+                    currentGpuValue = state.currentFreqKHz,
+                    minGpuPowerLevel = state.minPowerLevel,
+                    maxGpuPowerLevel = state.maxPowerLevel,
+                    numGpuPowerLevels = state.numPowerLevels
+                )
+            }
             GpuInfo(
-                currentGpuValue = getDriver().getCurrentGpuValue(),
-                minGpuPowerLevel = getDriver().getCurrentMinGpuPowerLevel(),
-                maxGpuPowerLevel = getDriver().getCurrentMaxGpuPowerLevel(),
-                numGpuPowerLevels = getDriver().getNumGpuPowerLevels()
+                currentGpuValue = driver.getCurrentGpuValue(),
+                minGpuPowerLevel = driver.getCurrentMinGpuPowerLevel(),
+                maxGpuPowerLevel = driver.getCurrentMaxGpuPowerLevel(),
+                numGpuPowerLevels = driver.getNumGpuPowerLevels()
             )
         } catch (e: Exception) {
             Timber.tag("PowerManager").e(e, "Failed to get GPU info")
@@ -887,16 +953,16 @@ object PowerManager {
      * Get list of available GPU frequencies in KHz
      */
     fun getAvailableGpuFrequencies(): List<Long> {
-        return getDriver().getAvailableGpuFrequencies()
+        return driver.getAvailableGpuFrequencies()
     }
 
     /**
      * Set minimum GPU power level (0 = fastest, higher = slower)
      */
     fun setMinGpuPowerLevel(level: Int): Boolean {
-        val result = getDriver().setMinGpuPowerLevel(level)
+        val result = driver.setMinGpuPowerLevel(level)
         if (result) {
-            currentProfile?.minGpuPowerLevel = level
+            currentProfile.minGpuPowerLevel = level
         }
         return result
     }
@@ -905,9 +971,9 @@ object PowerManager {
      * Set maximum GPU power level (0 = fastest, higher = slower)
      */
     fun setMaxGpuPowerLevel(level: Int): Boolean {
-        val result = getDriver().setMaxGpuPowerLevel(level)
+        val result = driver.setMaxGpuPowerLevel(level)
         if (result) {
-            currentProfile?.maxGpuPowerLevel = level
+            currentProfile.maxGpuPowerLevel = level
         }
         return result
     }
@@ -917,17 +983,17 @@ object PowerManager {
     // ========================================
 
     fun isBusSupported(): Boolean {
-        return getDriver().isBusSupported()
+        return driver.isBusSupported()
     }
 
     fun getBusInfo(): BusInfo? {
         return try {
-            if (!getDriver().isBusSupported()) return null
+            if (!driver.isBusSupported()) return null
 
             BusInfo(
-                minBusLevel = getDriver().getCurrentMinBusLevel(),
-                maxBusLevel = getDriver().getCurrentMaxBusLevel(),
-                numBusLevels = getDriver().getNumBusLevels()
+                minBusLevel = driver.getCurrentMinBusLevel(),
+                maxBusLevel = driver.getCurrentMaxBusLevel(),
+                numBusLevels = driver.getNumBusLevels()
             )
         } catch (e: Exception) {
             Timber.tag("PowerManager").e(e, "Failed to get RAM bus info")
@@ -936,37 +1002,24 @@ object PowerManager {
     }
 
     fun setMinBusLevel(level: Int): Boolean {
-        val result = getDriver().setMinBusLevel(level)
+        val result = driver.setMinBusLevel(level)
 
         if (result) {
-            currentProfile?.minBusLevel = level
+            currentProfile.minBusLevel = level
         }
 
         return result
     }
 
     fun setMaxBusLevel(level: Int): Boolean {
-        val result = getDriver().setMaxBusLevel(level)
+        val result = driver.setMaxBusLevel(level)
 
         if (result) {
-            currentProfile?.maxBusLevel = level
+            currentProfile.maxBusLevel = level
         }
 
         return result
     }
-
-    // ========================================
-    // File I/O
-    // ========================================
-
-    /**
-     * Read a file using the driver's file reading capabilities.
-     * For PServerDriver, this uses root access with fallback to direct file read.
-     * For other drivers, returns null.
-     * @param path The absolute path to the file to read
-     * @return The file contents as a trimmed string, or null if the file cannot be read
-     */
-    fun readFile(path: String): String? = getDriver().readFile(path)
 
     // ========================================
     // Profile Persistence
@@ -978,10 +1031,7 @@ object PowerManager {
      */
     fun saveProfile() {
         try {
-            val jsonString = if (currentProfile != null) {
-                json.encodeToString(currentProfile)
-            } else ""
-
+            val jsonString = json.encodeToString(currentProfile)
             val profileFile = getProfileFile()
             if (profileFile != null) {
                 profileFile.parentFile?.mkdirs()
@@ -1041,7 +1091,7 @@ object PowerManager {
      * a CPU with the game.
      */
     private fun pinPulseAudioToDedicatedCores() {
-        val driver = getDriver()
+        val driver = driver
         if (driver !is PServerDriver) return
 
         Thread {
@@ -1074,7 +1124,8 @@ object PowerManager {
      * share a CPU with the game.
      */
     fun pinBackgroundProcesses() {
-        val driver = getDriver()
+        if (!isProfilePowerControlEnabled()) return
+        val driver = driver
         if (driver !is PServerDriver) return
 
         Thread {
@@ -1148,6 +1199,7 @@ object PowerManager {
         maxRetries: Int = GAME_PIN_MAX_RETRIES,
         retryDelayMs: Long = GAME_PIN_RETRY_DELAY_MS
     ) {
+        if (!isProfilePowerControlEnabled()) return
         pinnedGameProcessName = processName
         startGamePin(processName, "game start", maxRetries, retryDelayMs)
     }
@@ -1167,12 +1219,12 @@ object PowerManager {
         val pserver = driver as? PServerDriver
         if (pserver == null) {
             Timber.tag("PowerManager").i(
-                "Game pinning inactive (driver=${driver?.let { it::class.simpleName }}), not pinning $processName"
+                "Game pinning inactive (driver=${driver.let { it::class.simpleName }}), not pinning $processName"
             )
             return
         }
 
-        if (currentProfile?.enableGamePinning != true) {
+        if (!currentProfile.enableGamePinning) {
             Timber.tag("PowerManager").i("Game pinning switched off in the profile, not pinning $processName")
             return
         }
@@ -1433,65 +1485,53 @@ object PowerManager {
         return containerDir?.let { File(it, ".config/.power-profile") }
     }
 
-    private fun applyDefaultProfile(logMessage: String?) {
-        currentProfile = getDriverDefaultProfile()
-        logMessage?.let { Timber.tag("PowerManager").d(it) }
-        if (currentProfile?.enableAutoTuning == true) {
-            startAutoTuning()
+    /**
+     * Load Current Profile
+     */
+    private fun loadCurrentProfile() {
+        val profileFile = getProfileFile()
+
+        currentProfile = if (profileFile == null || !profileFile.exists()) {
+            getDriverDefaultProfile()
+        } else {
+            val jsonString = profileFile.readText()
+            Timber.tag("PowerManager").d("Restoring power profile from ${profileFile.absolutePath}: $jsonString")
+            json.decodeFromString<PowerProfile>(jsonString)
         }
     }
 
     /**
      * Restore the saved power profile from container-specific file
      */
-    private fun restoreSavedProfile() {
-        try {
-            val profileFile = getProfileFile()
-            if (profileFile == null) {
-                applyDefaultProfile("No container directory set, using default profile")
-                return
-            }
-
-            if (!profileFile.exists()) {
-                applyDefaultProfile("No saved profile found at ${profileFile.absolutePath}, using default profile")
-                return
-            }
-
-            val jsonString = profileFile.readText()
-            if (jsonString.isEmpty()) {
-                applyDefaultProfile("Empty profile file, using default profile")
-                return
-            }
-
-            currentProfile = json.decodeFromString<PowerProfile>(jsonString)
-            Timber.tag("PowerManager").d("Restoring power profile from ${profileFile.absolutePath}: $jsonString")
-
-            val success = update {
-                governor(currentProfile!!.governor.governorName)
-                minCpuValue(currentProfile!!.minCpuFreq)
-                maxCpuValue(currentProfile!!.maxCpuFreq)
-                if (isGpuSupported()) {
-                    minGpuPowerLevel(currentProfile!!.minGpuPowerLevel)
-                    maxGpuPowerLevel(currentProfile!!.maxGpuPowerLevel)
+    private fun applyCurrentProfile() {
+        if (currentProfile.enablePowerControl) {
+            try {
+                val success = update {
+                    governor(currentProfile.governor.governorName)
+                    minCpuValue(currentProfile.minCpuFreq)
+                    maxCpuValue(currentProfile.maxCpuFreq)
+                    if (isGpuSupported()) {
+                        minGpuPowerLevel(currentProfile.minGpuPowerLevel)
+                        maxGpuPowerLevel(currentProfile.maxGpuPowerLevel)
+                    }
+                    if (isBusSupported()) {
+                        minBusLevel(currentProfile.minBusLevel)
+                        maxBusLevel(currentProfile.maxBusLevel)
+                    }
                 }
-                if (isBusSupported()) {
-                    minBusLevel(currentProfile!!.minBusLevel)
-                    maxBusLevel(currentProfile!!.maxBusLevel)
+
+                if (success) {
+                    Timber.tag("PowerManager").i("Successfully restored power profile")
+                } else {
+                    Timber.tag("PowerManager").w("Failed to restore power profile")
                 }
-            }
 
-            if (success) {
-                Timber.tag("PowerManager").i("Successfully restored power profile")
-            } else {
-                Timber.tag("PowerManager").w("Failed to restore power profile")
+                if (currentProfile.enableAutoTuning) {
+                    startAutoTuning()
+                }
+            } catch (e: Exception) {
+                Timber.tag("PowerManager").e(e, "Failed to apply current profile")
             }
-
-            if (currentProfile?.enableAutoTuning == true) {
-                startAutoTuning()
-            }
-        } catch (e: Exception) {
-            Timber.tag("PowerManager").e(e, "Failed to restore power profile, falling back to default")
-            applyDefaultProfile(null)
         }
     }
 }

--- a/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
@@ -159,12 +159,6 @@ object PowerManager {
     private var gamePinGeneration: Int = 0
 
     /**
-     * Start thread to run in start()
-     */
-    @Volatile
-    private var startThread: Thread? = null
-
-    /**
      * Autostart with contain dir and application context
      */
     fun autoStart(rootDir: File) {
@@ -240,39 +234,31 @@ object PowerManager {
      */
     @Synchronized
     private fun start() {
-        if (startThread?.isAlive == true) return
-
         driver.start()
 
-        startThread = Thread {
-            if (Thread.currentThread().isInterrupted) return@Thread
-            applyCurrentProfile()
+        applyCurrentProfile()
 
-            // Pin PulseAudio to dedicated performance cores if PServer is available
-            pinPulseAudioToDedicatedCores()
-            if (Thread.currentThread().isInterrupted) return@Thread
-            isGameStarted = true
+        // Pin PulseAudio to dedicated performance cores if PServer is available
+        pinPulseAudioToDedicatedCores()
+        isGameStarted = true
 
-            if (currentProfile.enableAdaptiveFpsCap) {
-                AdaptiveFpsCapController.start(containerDir, tunerLogDirectory())
+        if (currentProfile.enableAdaptiveFpsCap) {
+            AdaptiveFpsCapController.start(containerDir, tunerLogDirectory())
+        }
+
+        appContext.let { PerformanceMetricsCollector.start(it) }
+
+        // Reset the driver on initialize. For PServer this also restores the recorded
+        // baseline of a session that died without restoring it.
+        (driver as? PServerDriver)?.let {
+            if (it.hasPendingBaseline()) {
+                Timber.tag("PowerControl").i("Power baseline from a previous session found on disk, restoring it")
             }
+        }
 
-            if (Thread.currentThread().isInterrupted) return@Thread
-            appContext.let { PerformanceMetricsCollector.start(it) }
-
-            // Reset the driver on initialize. For PServer this also restores the recorded
-            // baseline of a session that died without restoring it.
-            (driver as? PServerDriver)?.let {
-                if (it.hasPendingBaseline()) {
-                    Timber.tag("PowerControl").i("Power baseline from a previous session found on disk, restoring it")
-                }
-            }
-
-            if (Thread.currentThread().isInterrupted) return@Thread
-            if (currentProfile.enableFanControl) {
-                FanController.start(driver)
-            }
-        }.also { it.start() }
+        if (currentProfile.enableFanControl) {
+            FanController.start(driver)
+        }
     }
 
     /**
@@ -280,8 +266,6 @@ object PowerManager {
      */
     @Synchronized
     fun stop() {
-        startThread?.interrupt()
-        startThread = null
         // Save the current profile if available, otherwise read from driver
         saveProfile()
         stopAutoTuning()
@@ -304,8 +288,6 @@ object PowerManager {
      */
     @Synchronized
     fun pause() {
-        startThread?.interrupt()
-        startThread = null
         if (!isGameStarted) return
         saveProfile()
         stopAutoTuning()

--- a/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
@@ -534,22 +534,20 @@ object PowerManager {
         currentProfile = profile
 
         // Handle auto-tuning based on profile setting
-        if (previousProfile.enablePowerControl != profile.enablePowerControl) {
-            if (profile.enablePowerControl) {
-                if (profile.enableAutoTuning) {
-                    if (previousProfile.enablePerClusterTuning != profile.enablePerClusterTuning) {
-                        Timber.tag("PowerManager").i(
-                            "Per-cluster tuning changed to ${profile.enablePerClusterTuning}, restarting the tuner"
-                        )
-                        stopAutoTuning()
-                    }
-                    startAutoTuning()
-                } else {
+        if (profile.enablePowerControl) {
+            if (profile.enableAutoTuning) {
+                if (previousProfile.enablePerClusterTuning != profile.enablePerClusterTuning) {
+                    Timber.tag("PowerManager").i(
+                        "Per-cluster tuning changed to ${profile.enablePerClusterTuning}, restarting the tuner"
+                    )
                     stopAutoTuning()
                 }
+                startAutoTuning()
             } else {
                 stopAutoTuning()
             }
+        } else {
+            stopAutoTuning()
         }
 
         if (previousProfile.enableAdaptiveFpsCap != profile.enableAdaptiveFpsCap) {

--- a/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
@@ -534,20 +534,22 @@ object PowerManager {
         currentProfile = profile
 
         // Handle auto-tuning based on profile setting
-        if (profile.enablePowerControl) {
-            if (profile.enableAutoTuning) {
-                if (previousProfile.enablePerClusterTuning != profile.enablePerClusterTuning) {
-                    Timber.tag("PowerManager").i(
-                        "Per-cluster tuning changed to ${profile.enablePerClusterTuning}, restarting the tuner"
-                    )
+        if (previousProfile.enablePowerControl != profile.enablePowerControl) {
+            if (profile.enablePowerControl) {
+                if (profile.enableAutoTuning) {
+                    if (previousProfile.enablePerClusterTuning != profile.enablePerClusterTuning) {
+                        Timber.tag("PowerManager").i(
+                            "Per-cluster tuning changed to ${profile.enablePerClusterTuning}, restarting the tuner"
+                        )
+                        stopAutoTuning()
+                    }
+                    startAutoTuning()
+                } else {
                     stopAutoTuning()
                 }
-                startAutoTuning()
             } else {
                 stopAutoTuning()
             }
-        } else {
-            stopAutoTuning()
         }
 
         if (previousProfile.enableAdaptiveFpsCap != profile.enableAdaptiveFpsCap) {
@@ -559,10 +561,12 @@ object PowerManager {
         }
 
         if (isGameStarted) {
-            if (profile.enableFanControl) {
-                FanController.start(driver)
-            } else {
-                FanController.stop()
+            if (previousProfile.enableFanControl != profile.enableFanControl) {
+                if (profile.enableFanControl) {
+                    FanController.start(driver)
+                } else {
+                    FanController.stop()
+                }
             }
 
             if (previousProfile.enableGamePinning != profile.enableGamePinning) {

--- a/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
@@ -274,7 +274,6 @@ object PowerManager {
         AdaptiveFpsCapController.stop()
         PerformanceMetricsCollector.stop()
         stopPowerControl()
-        driver.stop()
         isGameStarted = false
         fpsCapApplier = null
         frameSampleStride = 1
@@ -295,7 +294,6 @@ object PowerManager {
         AdaptiveFpsCapController.pause()
         PerformanceMetricsCollector.pause()
         stopPowerControl()
-        driver.stop()
     }
 
     /**

--- a/app/src/main/java/app/gamenative/powercontrol/PowerProfile.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerProfile.kt
@@ -1,8 +1,8 @@
 package app.gamenative.powercontrol
 
+import app.gamenative.PrefManager
 import androidx.annotation.StringRes
 import app.gamenative.R
-import app.gamenative.powercontrol.autotuning.DeviceGate
 import app.gamenative.powercontrol.profiles.CpuGovernor
 import app.gamenative.powercontrol.profiles.PerformancePreset
 import kotlinx.serialization.Serializable
@@ -16,6 +16,7 @@ enum class AutoTuningStrategy(@param:StringRes val displayNameRes: Int, @param:S
 
 @Serializable
 data class PowerProfile(
+    var enablePowerControl: Boolean = PrefManager.powerControlDefaultEnabled,
     var enableAdaptiveFpsCap: Boolean = true,
     var enableAutoTuning: Boolean = false,
     var enablePerClusterTuning: Boolean = false,

--- a/app/src/main/java/app/gamenative/powercontrol/autotuning/PerformanceAutoTuner.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/autotuning/PerformanceAutoTuner.kt
@@ -12,18 +12,18 @@ import kotlin.math.abs
  * @param availableCpuFreqs List of available CPU frequencies
  * @param numGpuLevels Number of GPU power levels
  * @param numBusLevels Number of RAM bus levels
- * @param onCpuFrequencyChange Callback when CPU frequency changes
- * @param onGpuLevelChange Callback when GPU level changes
- * @param onBusLevelChange Callback when RAM bus level changes
+ * @param onCpuFrequencyChange Callback when CPU frequency changes (minFreq, maxFreq)
+ * @param onGpuLevelChange Callback when GPU level changes (minLevel, maxLevel)
+ * @param onBusLevelChange Callback when RAM bus level changes (minLevel, maxLevel)
  * @param enableLogging Enable verbose logging of tuning operations
  */
 class PerformanceAutoTuner(
     private val availableCpuFreqs: List<Long>,
     private val numGpuLevels: Int,
     private val numBusLevels: Int,
-    private val onCpuFrequencyChange: (Long) -> Unit,
-    private val onGpuLevelChange: (Int) -> Unit,
-    private val onBusLevelChange: (Int) -> Unit,
+    private val onCpuFrequencyChange: (minFreq: Long, maxFreq: Long) -> Unit,
+    private val onGpuLevelChange: (minLevel: Int, maxLevel: Int) -> Unit,
+    private val onBusLevelChange: (minLevel: Int, maxLevel: Int) -> Unit,
     private val getTuningStrategy: () -> AutoTuningStrategy,
     private val enableLogging: Boolean = false,
     private val skipWarmupCycles: Boolean = false,
@@ -276,8 +276,10 @@ class PerformanceAutoTuner(
             val targetCpuFreq = minCpuFreq + ((maxCpuFreq - minCpuFreq) * currentCpuPerformance / 100.0)
             val closestFreq = findClosestFrequency(availableCpuFreqs, targetCpuFreq.toLong())
 
-            // Apply frequency change
-            onCpuFrequencyChange(closestFreq)
+            // Apply frequency change: max is the target frequency, min is 2 steps below
+            val closestIndex = availableCpuFreqs.indexOf(closestFreq).coerceAtLeast(0)
+            val minFreq = availableCpuFreqs[(closestIndex - 2).coerceAtLeast(0)]
+            onCpuFrequencyChange(minFreq, closestFreq)
 
             if (enableLogging) {
                 Timber.tag(TAG).d(
@@ -335,8 +337,9 @@ class PerformanceAutoTuner(
             val targetLevel = (currentGpuPerformance * (numGpuLevels - 1) / 100.0).toInt()
             val gpuLevel = targetLevel.coerceIn(0, numGpuLevels - 1)
 
-            // Apply GPU level change
-            onGpuLevelChange(gpuLevel)
+            // Apply GPU level change: max is the target level, min is 1 step below
+            val minGpuLevel = (gpuLevel - 1).coerceAtLeast(0)
+            onGpuLevelChange(minGpuLevel, gpuLevel)
 
             if (enableLogging) {
                 Timber.tag(TAG).d(
@@ -385,8 +388,9 @@ class PerformanceAutoTuner(
             val targetLevel = (currentBusPerformance * (numBusLevels - 1) / 100.0).toInt()
             val busLevel = targetLevel.coerceIn(0, numBusLevels - 1)
 
-            // Apply bus level change
-            onBusLevelChange(busLevel)
+            // Apply bus level change: max is the target level, min is 1 step below
+            val minBusLevel = (busLevel - 1).coerceAtLeast(0)
+            onBusLevelChange(minBusLevel, busLevel)
 
             if (enableLogging) {
                 Timber.tag(TAG).d(

--- a/app/src/main/java/app/gamenative/powercontrol/drivers/PServerDriver.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/drivers/PServerDriver.kt
@@ -42,10 +42,10 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
         private const val GPU_DEVFREQ_PATH = "$GPU_BASE_PATH/devfreq"
 
         // CPU policies discovered at initialization (reduces redundant IPC calls)
-        private lateinit var cpuPolicies: List<CpuPolicy>
+        private var cpuPolicies: List<CpuPolicy> = emptyList()
 
         // CPU cluster mapping for affinity control
-        private lateinit var cpuClusters: Map<CpuCluster, List<Int>>
+        private var cpuClusters: Map<CpuCluster, List<Int>> = emptyMap()
 
         /**
          * Check if PServer service is available without maintaining connection

--- a/app/src/main/java/app/gamenative/powercontrol/drivers/PServerDriver.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/drivers/PServerDriver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.DeadObjectException
 import android.os.IBinder
 import android.os.Parcel
+import app.gamenative.PrefManager
 import app.gamenative.powercontrol.PowerBaseline
 import app.gamenative.powercontrol.PowerBaselineEntry
 import app.gamenative.powercontrol.PowerBaselineScripts
@@ -39,6 +40,34 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
         // GPU sysfs paths (Adreno)
         private const val GPU_BASE_PATH = "/sys/class/kgsl/kgsl-3d0"
         private const val GPU_DEVFREQ_PATH = "$GPU_BASE_PATH/devfreq"
+
+        // CPU policies discovered at initialization (reduces redundant IPC calls)
+        private lateinit var cpuPolicies: List<CpuPolicy>
+
+        // CPU cluster mapping for affinity control
+        private lateinit var cpuClusters: Map<CpuCluster, List<Int>>
+
+        /**
+         * Check if PServer service is available without maintaining connection
+         */
+        fun checkPServerAvailability(): Boolean {
+            return runCatching {
+                val serviceManager = Class.forName("android.os.ServiceManager")
+                val getService = serviceManager.getDeclaredMethod("getService", String::class.java)
+                val rawBinder = getService.invoke(serviceManager, "PServerBinder") as IBinder?
+
+                if (rawBinder != null && rawBinder.isBinderAlive) {
+                    Timber.tag(TAG).i("PServer service is available")
+                    true
+                } else {
+                    Timber.tag(TAG).w("PServer service not found or not alive")
+                    false
+                }
+            }.getOrElse {
+                Timber.tag(TAG).w("Failed to check PServer availability: ${it.message}")
+                false
+            }
+        }
     }
 
     // CPU policy information for optimized control
@@ -77,12 +106,6 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
     private var batchFilePaths = mutableSetOf<String>()
     private var isBatchMode = false
 
-    // CPU policies discovered at initialization (reduces redundant IPC calls)
-    private var cpuPolicies: List<CpuPolicy> = emptyList()
-
-    // CPU cluster mapping for affinity control
-    private var cpuClusters: Map<CpuCluster, List<Int>> = emptyMap()
-
     // Taskset mask format (cached after first detection)
     private var tasksetMaskFormat: TasksetMaskFormat? = null
 
@@ -103,11 +126,11 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
     private var currentMinCpuFreq: Long = 0L
     private var currentMaxCpuFreq: Long = 0L
     private var currentGovernor: String = ""
+    private var allAvailableGovernors: List<String> = emptyList()
+    private var allAvailableCpuFrequencies: List<Long> = emptyList()
+    private var allAvailableGpuFrequencies: List<Long> = emptyList()
 
     init {
-        // Check if PServer is available without maintaining connection
-        isPServerAvailable = checkPServerAvailability()
-
         // Check GPU support once during initialization
         isGpuAvailable = try {
             val maxPwrLevelFile = File("$GPU_BASE_PATH/max_pwrlevel")
@@ -115,6 +138,32 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
             maxPwrLevelFile.exists() && availableFreqsFile.exists()
         } catch (e: Exception) {
             false
+        }
+
+        // Check if PServer is available and discover CPU policies
+        isPServerAvailable = checkPServerAvailability() && validateCpuFreqSupport()
+        if (isPServerAvailable) {
+            // Create executor for PServer operations
+            if (pserverExecutor == null) {
+                pserverExecutor = Executors.newSingleThreadExecutor { r ->
+                    Thread(r, "PServerDriver-Worker")
+                }
+                Timber.tag(TAG).d("Created PServer executor")
+            }
+
+            // Start a thread to get all system values
+            Thread {
+                cpuPolicies = discoverCpuPolicies()
+                cpuClusters = identifyCpuClusters()
+                currentGovernor = getCurrentGovernor()
+                currentMinCpuFreq = getCurrentMinCpuValue()
+                currentMaxCpuFreq = getCurrentMaxCpuValue()
+                allAvailableGovernors = getAvailableGovernors()
+                allAvailableCpuFrequencies = getAvailableCpuFrequencies()
+                allAvailableGpuFrequencies = getAvailableGpuFrequencies()
+                getNumGpuPowerLevels()
+                detectTasksetMaskFormat()
+            }.start()
         }
     }
 
@@ -286,20 +335,6 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
     override fun commit(): Boolean = commitInternal()
 
     /**
-     * Reset the performance driver.
-     */
-    override fun reset() {
-        Thread {
-            try {
-                start()
-            } catch (e: Exception) {
-                Timber.tag(TAG).e(e, "Failed to start PServerDriver during reset")
-            }
-            stop()
-        }.start()
-    }
-
-    /**
      * Start the performance driver.
      * Validates CPU frequency scaling support and discovers CPU policies.
      */
@@ -321,16 +356,9 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
             Timber.tag(TAG).d("Created PServer executor")
         }
 
-        // Discover CPU policies if not already done
-        if (cpuPolicies.isEmpty()) {
-            validateCpuFreqSupport()
-            cpuPolicies = discoverCpuPolicies()
-            cpuClusters = identifyCpuClusters()
-        }
-
-        if (isPServerAvailable) {
+        Thread {
             armSessionBaseline()
-        }
+        }.start()
     }
 
     /**
@@ -339,11 +367,6 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
      * Runs asynchronously on a background thread
      */
     override fun stop() {
-        if (!isPServerAvailable) {
-            Timber.tag(TAG).w("PServer not available to restore settings")
-            return
-        }
-
         // Run restoration on background thread to avoid blocking
         val cleanupThread = Thread {
             try {
@@ -362,10 +385,6 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
                     rootRestoreScriptPath = ""
                     modifiedSysfsFiles.clear()
                 }
-
-                // Clear CPU policies and clusters to force re-discovery on next start()
-                cpuPolicies = emptyList()
-                cpuClusters = emptyMap()
 
                 // Shutdown executor only if not interrupted by start()
                 if (!Thread.currentThread().isInterrupted) {
@@ -399,19 +418,6 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
      * Run a command as root on the driver's executor.
      */
     fun executeRootCommand(command: String): Result<String?> = executeAsRoot(command)
-
-    /**
-     * Read a file using PServer root access with fallback to direct file read.
-     * @param path The absolute path to the file to read
-     * @return The file contents as a trimmed string, or null if the file cannot be read
-     */
-    override fun readFile(path: String): String? {
-        return if (pserverExecutor != null) {
-            readSysfsFile(path)
-        } else {
-            null
-        }
-    }
 
     /**
      * Attach (or clear) the command that hands the fan back to the vendor controller and
@@ -743,13 +749,16 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
      * Get list of available CPU governors
      */
     override fun getAvailableGovernors(): List<String> {
-        return try {
-            val governors = readSysfsFile("$POLICY0_PATH/scaling_available_governors")
-            governors?.split("\\s+".toRegex())?.filter { it.isNotBlank() } ?: emptyList()
-        } catch (e: Exception) {
-            Timber.tag(TAG).e(e, "Failed to get available governors")
-            emptyList()
+        if (allAvailableGovernors.isEmpty()) {
+            allAvailableGovernors = try {
+                val governors = readSysfsFile("$POLICY0_PATH/scaling_available_governors")
+                governors?.split("\\s+".toRegex())?.filter { it.isNotBlank() } ?: emptyList()
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Failed to get available governors")
+                emptyList()
+            }
         }
+        return allAvailableGovernors
     }
 
     /**
@@ -757,31 +766,34 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
      * Collects frequencies from all CPU policies to include all clusters
      */
     override fun getAvailableCpuFrequencies(): List<Long> {
-        return try {
-            val allFrequencies = mutableSetOf<Long>()
+        if (allAvailableCpuFrequencies.isEmpty()) {
+            allAvailableCpuFrequencies = try {
+                val allFrequencies = mutableSetOf<Long>()
 
-            // If policies are discovered, read from each policy
-            if (cpuPolicies.isNotEmpty()) {
-                for (policy in cpuPolicies) {
-                    val policyDir = policy.governorPath.substringBeforeLast("/")
-                    val freqs = readSysfsFile("$policyDir/scaling_available_frequencies")
+                // If policies are discovered, read from each policy
+                if (cpuPolicies.isNotEmpty()) {
+                    for (policy in cpuPolicies) {
+                        val policyDir = policy.governorPath.substringBeforeLast("/")
+                        val freqs = readSysfsFile("$policyDir/scaling_available_frequencies")
+                        freqs?.split("\\s+".toRegex())
+                            ?.mapNotNull { it.toLongOrNull() }
+                            ?.let { allFrequencies.addAll(it) }
+                    }
+                } else {
+                    // Fallback: read from policy0 only
+                    val freqs = readSysfsFile("$POLICY0_PATH/scaling_available_frequencies")
                     freqs?.split("\\s+".toRegex())
                         ?.mapNotNull { it.toLongOrNull() }
                         ?.let { allFrequencies.addAll(it) }
                 }
-            } else {
-                // Fallback: read from policy0 only
-                val freqs = readSysfsFile("$POLICY0_PATH/scaling_available_frequencies")
-                freqs?.split("\\s+".toRegex())
-                    ?.mapNotNull { it.toLongOrNull() }
-                    ?.let { allFrequencies.addAll(it) }
-            }
 
-            allFrequencies.sorted()
-        } catch (e: Exception) {
-            Timber.tag(TAG).e(e, "Failed to get available frequencies")
-            emptyList()
+                allFrequencies.sorted()
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Failed to get available frequencies")
+                emptyList()
+            }
         }
+        return allAvailableCpuFrequencies
     }
 
     // ========================================
@@ -1106,17 +1118,60 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
      * Get list of available GPU frequencies in KHz (sorted)
      */
     override fun getAvailableGpuFrequencies(): List<Long> {
-        return try {
-            val freqs = readSysfsFile("$GPU_DEVFREQ_PATH/available_frequencies")
-            freqs?.split("\\s+".toRegex())
-                ?.mapNotNull { it.toLongOrNull() }
-                ?.map { it / 1000 }
-                ?.sorted()
-                ?: emptyList()
-        } catch (e: Exception) {
-            Timber.tag(TAG).e(e, "Failed to get available GPU frequencies")
-            emptyList()
+        if (allAvailableGpuFrequencies.isEmpty()) {
+            allAvailableGpuFrequencies = try {
+                val freqs = readSysfsFile("$GPU_DEVFREQ_PATH/available_frequencies")
+                freqs?.split("\\s+".toRegex())
+                    ?.mapNotNull { it.toLongOrNull() }
+                    ?.map { it / 1000 }
+                    ?.sorted()
+                    ?: emptyList()
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Failed to get available GPU frequencies")
+                emptyList()
+            }
         }
+        return allAvailableGpuFrequencies
+    }
+
+    /**
+     * GPU display state captured in a single binder round trip.
+     * Power levels are already converted to UI semantics (higher = faster).
+     */
+    data class GpuSysfsState(
+        val currentFreqKHz: Long,
+        val minPowerLevel: Int,
+        val maxPowerLevel: Int,
+        val numPowerLevels: Int
+    )
+
+    /**
+     * Read all GPU display values with one root command instead of one
+     * binder transaction per file. Returns null if any value is unreadable.
+     */
+    fun readGpuState(): GpuSysfsState? {
+        if (!isGpuSupported()) return null
+        val paths = listOf(
+            "$GPU_DEVFREQ_PATH/cur_freq",
+            "$GPU_BASE_PATH/min_pwrlevel",
+            "$GPU_BASE_PATH/max_pwrlevel",
+            "$GPU_BASE_PATH/num_pwrlevels"
+        )
+        val output = executeAsRoot(PowerBaselineScripts.buildReadCommand(paths)).getOrNull()
+        val values = PowerBaselineScripts.parseReadOutput(output, paths)
+            .associate { it.path to it.value }
+
+        val freqHz = values[paths[0]]?.toLongOrNull() ?: return null
+        val sysfsMin = values[paths[1]]?.toIntOrNull() ?: return null
+        val sysfsMax = values[paths[2]]?.toIntOrNull() ?: return null
+        val numLevels = values[paths[3]]?.toIntOrNull() ?: return null
+
+        return GpuSysfsState(
+            currentFreqKHz = freqHz / 1000,
+            minPowerLevel = if (numLevels > 0) numLevels - 1 - sysfsMin else 0,
+            maxPowerLevel = if (numLevels > 0) numLevels - 1 - sysfsMax else 0,
+            numPowerLevels = numLevels
+        )
     }
 
     /**
@@ -1166,16 +1221,23 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
         }
     }
 
+    @Volatile
+    private var cachedNumGpuPowerLevels: Int = -1
+
     /**
-     * Get total number of GPU power levels available
+     * Get total number of GPU power levels available.
+     * Static per device, so it is read once and cached.
      */
     override fun getNumGpuPowerLevels(): Int {
-        return try {
+        if (cachedNumGpuPowerLevels >= 0) return cachedNumGpuPowerLevels
+        val levels = try {
             readSysfsFile("$GPU_BASE_PATH/num_pwrlevels")?.toIntOrNull() ?: 0
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Failed to get number of GPU power levels")
             0
         }
+        if (levels > 0) cachedNumGpuPowerLevels = levels
+        return levels
     }
 
     // ========================================
@@ -1227,6 +1289,7 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
         val isTestedDevice = DeviceGate.isDeviceSupported()
 
         val defaultProfile = PowerProfile(
+            enablePowerControl = PrefManager.powerControlDefaultEnabled,
             enableAdaptiveFpsCap = isTestedDevice,
             enableAutoTuning = isTestedDevice,
             enablePerClusterTuning = isTestedDevice,
@@ -1279,11 +1342,6 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
      * @param level Power level value in sysfs semantics (0 = fastest for Adreno)
      */
     private fun writeGpuPowerLevel(path: String, level: Int): Boolean {
-        if (!isPServerAvailable) {
-            Timber.tag(TAG).w("PServer not available to write GPU power level")
-            return false
-        }
-
         return try {
             // Concatenate chmod -> echo -> chmod into a single command
             val command = "chmod 644 '$path'; echo $level > $path; chmod 444 '$path'"
@@ -1509,11 +1567,6 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
      * @return true if successful
      */
     fun setCpuAffinity(pid: Int, cpuMask: String): Boolean {
-        if (!isPServerAvailable) {
-            Timber.tag(TAG).w("PServer not available for CPU affinity")
-            return false
-        }
-
         return try {
             val command = "taskset -p $cpuMask $pid"
             val result = executeAsRoot(command)
@@ -1560,14 +1613,20 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
      * @return Formatted mask string (e.g., "f8" or "0xf8")
      */
     fun getTasksetMask(mask: Int): String {
-        // Return cached format if already detected
-        if (tasksetMaskFormat != null) {
-            return when (tasksetMaskFormat) {
-                TasksetMaskFormat.PLAIN_HEX -> mask.toString(16)
-                TasksetMaskFormat.HEX_PREFIX -> "0x${mask.toString(16)}"
-                else -> mask.toString(16)
-            }
+        detectTasksetMaskFormat()
+        return when (tasksetMaskFormat) {
+            TasksetMaskFormat.PLAIN_HEX -> mask.toString(16)
+            TasksetMaskFormat.HEX_PREFIX -> "0x${mask.toString(16)}"
+            else -> mask.toString(16)
         }
+    }
+
+    /**
+     * Detect and cache the taskset mask format. Safe to call during init to
+     * pre-cache the result so the first real pin doesn't spawn a subprocess.
+     */
+    fun detectTasksetMaskFormat() {
+        if (tasksetMaskFormat != null) return
 
         // Detect format by testing with a simple command
         try {
@@ -1589,13 +1648,6 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
         } catch (e: Exception) {
             Timber.tag(TAG).w(e, "Failed to detect taskset format, defaulting to plain hex")
             tasksetMaskFormat = TasksetMaskFormat.PLAIN_HEX
-        }
-
-        // Return formatted mask
-        return when (tasksetMaskFormat) {
-            TasksetMaskFormat.PLAIN_HEX -> mask.toString(16)
-            TasksetMaskFormat.HEX_PREFIX -> "0x${mask.toString(16)}"
-            else -> mask.toString(16)
         }
     }
 
@@ -1713,37 +1765,22 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
         }
     }
 
-    /**
-     * Check if PServer service is available without maintaining connection
-     */
-    private fun checkPServerAvailability(): Boolean {
-        return runCatching {
-            val serviceManager = Class.forName("android.os.ServiceManager")
-            val getService = serviceManager.getDeclaredMethod("getService", String::class.java)
-            val rawBinder = getService.invoke(serviceManager, "PServerBinder") as IBinder?
-
-            if (rawBinder != null && rawBinder.isBinderAlive) {
-                Timber.tag(TAG).i("PServer service is available")
-                true
-            } else {
-                Timber.tag(TAG).w("PServer service not found or not alive")
-                false
-            }
-        }.getOrElse {
-            Timber.tag(TAG).w("Failed to check PServer availability: ${it.message}")
-            false
-        }
-    }
+    @Volatile
+    private var cachedBinder: IBinder? = null
 
     /**
-     * Get a fresh binder connection to PServer
+     * Get a binder connection to PServer, caching it between calls.
+     * The cache is dropped when a transaction fails with [DeadObjectException].
      */
     private fun getPServerBinder(): IBinder? {
-        return runCatching {
+        cachedBinder?.let { if (it.isBinderAlive) return it }
+        val binder = runCatching {
             val serviceManager = Class.forName("android.os.ServiceManager")
             val getService = serviceManager.getDeclaredMethod("getService", String::class.java)
             getService.invoke(serviceManager, "PServerBinder") as IBinder
         }.getOrNull()
+        cachedBinder = binder
+        return binder
     }
 
     /**
@@ -1775,10 +1812,6 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
      * Internal implementation of executeAsRoot that runs on the executor thread
      */
     private fun executeAsRootInternal(cmd: String): Result<String?> {
-        if (!isPServerAvailable) {
-            return Result.failure(IllegalStateException("PServer not available"))
-        }
-
         // Get fresh binder for each operation
         val binder = getPServerBinder()
             ?: return Result.failure(IllegalStateException("Failed to get PServer binder"))
@@ -1793,6 +1826,7 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
             Timber.tag(TAG).e(e, "PServer binder died during transaction, retrying once")
 
             // Retry once with fresh binder
+            cachedBinder = null
             val retryBinder = getPServerBinder()
             if (retryBinder != null) {
                 try {
@@ -1824,25 +1858,20 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
 
     private fun readSysfsFile(path: String): String? {
         // Try using PServer cat command first (works with root permissions)
-        if (isPServerAvailable) {
-            return try {
-                val result = executeAsRoot("cat '$path'")
-                if (result.isSuccess) {
-                    result.getOrNull()?.trim()
-                } else {
-                    Timber.tag(TAG).e("Failed to read $path via PServer: ${result.exceptionOrNull()?.message}")
-                    // Fallback: try direct file read
-                    tryDirectFileRead(path)
-                }
-            } catch (e: Exception) {
-                Timber.tag(TAG).e(e, "Failed to read $path via PServer")
+        return try {
+            val result = executeAsRoot("cat '$path'")
+            if (result.isSuccess) {
+                result.getOrNull()?.trim()
+            } else {
+                Timber.tag(TAG).e("Failed to read $path via PServer: ${result.exceptionOrNull()?.message}")
                 // Fallback: try direct file read
                 tryDirectFileRead(path)
             }
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Failed to read $path via PServer")
+            // Fallback: try direct file read
+            tryDirectFileRead(path)
         }
-
-        // Fallback: try direct file read if PServer not available
-        return tryDirectFileRead(path)
     }
 
     private fun tryDirectFileRead(path: String): String? {
@@ -1860,11 +1889,6 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
     }
 
     private fun writeSysfsFile(path: String, value: String): Boolean {
-        if (!isPServerAvailable) {
-            Timber.tag(TAG).w("PServer not available to write to $path")
-            return false
-        }
-
         return try {
             // Concatenate chmod -> echo -> chmod into a single command
             val command = "chmod 644 '$path'; echo '$value' > '$path'; chmod 444 '$path'"

--- a/app/src/main/java/app/gamenative/powercontrol/drivers/PServerDriver.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/drivers/PServerDriver.kt
@@ -356,9 +356,7 @@ class PServerDriver(private val context: Context? = null) : PerformanceDriver() 
             Timber.tag(TAG).d("Created PServer executor")
         }
 
-        Thread {
-            armSessionBaseline()
-        }.start()
+        armSessionBaseline()
     }
 
     /**

--- a/app/src/main/java/app/gamenative/powercontrol/drivers/PerformanceDriver.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/drivers/PerformanceDriver.kt
@@ -77,11 +77,6 @@ abstract class PerformanceDriver {
     open fun stop() {}
 
     /**
-     * Reset the performance driver
-     */
-    open fun reset() {}
-
-    /**
      * Begin a batch update session.
      * For PServerDriver, this starts collecting commands to execute in a single call.
      * For SamsungDriver, this is a no-op as CustomParams already handles batching.
@@ -224,13 +219,4 @@ abstract class PerformanceDriver {
      * Set maximum RAM bus performance level
      */
     open fun setMaxBusLevel(level: Int): Boolean = false
-
-    // ========================================
-    // Utility functions
-    // ========================================
-
-    /**
-     * Read File using driver
-     */
-    open fun readFile(path: String): String? = null
 }

--- a/app/src/main/java/app/gamenative/powercontrol/drivers/SamsungPerformanceDriver.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/drivers/SamsungPerformanceDriver.kt
@@ -1,6 +1,7 @@
 package app.gamenative.powercontrol.drivers
 
 import android.content.Context
+import app.gamenative.PrefManager
 import app.gamenative.powercontrol.PowerProfile
 import app.gamenative.powercontrol.autotuning.DeviceGate
 import app.gamenative.powercontrol.profiles.CpuGovernor
@@ -260,8 +261,9 @@ class SamsungPerformanceDriver(private val context: Context) : PerformanceDriver
         // Default: Balanced profile (full range)
 
         return PowerProfile(
+            enablePowerControl = PrefManager.powerControlDefaultEnabled,
             enableAdaptiveFpsCap = true,
-            enableAutoTuning = true,
+            enableAutoTuning = false,
             enablePerClusterTuning = false,
             enableGamePinning = false,
             name = PerformancePreset.BALANCED.displayName,

--- a/app/src/main/java/app/gamenative/powercontrol/fan/FanController.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/fan/FanController.kt
@@ -67,6 +67,8 @@ object FanController {
         if (running) return
 
         val pserver = candidate as? PServerDriver ?: return
+        driver = pserver
+
         val period = readPeriodTicks(pserver)
         if (period == null) {
             Timber.tag(TAG).d("Fan PWM nodes not readable, fan control disabled")
@@ -80,7 +82,6 @@ object FanController {
         }
         Timber.tag(TAG).i("Captured fan_mode=%s (period=%d ticks)", mode?.toString() ?: "unreadable", period)
 
-        driver = pserver
         capturedMode = mode
         periodTicks = period
         controller.reset()

--- a/app/src/main/java/app/gamenative/powercontrol/metrics/SystemMetricsReader.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/metrics/SystemMetricsReader.kt
@@ -1,7 +1,6 @@
 package app.gamenative.powercontrol.metrics
 
 import android.os.SystemClock
-import app.gamenative.powercontrol.PowerManager
 import java.io.File
 import java.util.Locale
 import timber.log.Timber
@@ -48,7 +47,7 @@ object SystemMetricsSources {
 
         val candidates = linkedSetOf<String>()
         fun add(path: String) {
-            if (File(path).exists()) {
+            if (File(path).canRead()) {
                 candidates += path
             }
         }
@@ -87,7 +86,7 @@ object SystemMetricsSources {
                 )
                 for (fileName in usageFiles) {
                     val file = File(nodeDir, fileName)
-                    if (!file.exists()) continue
+                    if (!file.canRead()) continue
                     if (looksLikeGpuNode || fileName == "gpu_busy_percentage" || fileName == "gpuinfo") {
                         candidates += file.path
                     }
@@ -202,8 +201,7 @@ object SystemMetricsSources {
 
     fun readFirstLine(path: String): String? {
         return try {
-            PowerManager.readFile(path)?.lines()?.firstOrNull()
-                ?: File(path).bufferedReader().use { it.readLine() }
+            File(path).bufferedReader().use { it.readLine() }
         } catch (_: Exception) {
             null
         }
@@ -211,10 +209,9 @@ object SystemMetricsSources {
 
     fun readNthLine(path: String, lineIndex: Int): String? {
         return try {
-            PowerManager.readFile(path)?.lines()?.drop(lineIndex)?.firstOrNull()
-                ?: File(path).bufferedReader().useLines { lines ->
-                    lines.drop(lineIndex).firstOrNull()
-                }
+            File(path).bufferedReader().useLines { lines ->
+                lines.drop(lineIndex).firstOrNull()
+            }
         } catch (_: Exception) {
             null
         }

--- a/app/src/main/java/app/gamenative/ui/component/quickMenus/PowerControlQuickMenuContent.kt
+++ b/app/src/main/java/app/gamenative/ui/component/quickMenus/PowerControlQuickMenuContent.kt
@@ -64,24 +64,25 @@ import kotlinx.coroutines.delay
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun PowerControlQuickMenuContent(
+    modifier: Modifier = Modifier,
     uiState: PowerControlUiState,
     isDriverSupported: Boolean,
-    onAutoTuningToggled: (Boolean) -> Unit,
-    onTuningStrategySelected: (AutoTuningStrategy) -> Unit,
-    onProfileSelected: (PowerProfile) -> Unit,
-    onGovernorSelected: (String) -> Unit,
-    onMinCpuValueChanged: (Int) -> Unit,
-    onMaxCpuValueChanged: (Int) -> Unit,
-    onMinGpuPowerChanged: (Int) -> Unit,
-    onMaxGpuPowerChanged: (Int) -> Unit,
-    onMinRamValueChanged: (Int) -> Unit,
-    onMaxRamValueChanged: (Int) -> Unit,
-    modifier: Modifier = Modifier,
+    firstItemFocusRequester: FocusRequester? = null,
+    onAdaptiveFpsCapToggled: (Boolean) -> Unit = {},
+    onPowerControlToggled: (Boolean) -> Unit = {},
     onFanControlToggled: (Boolean) -> Unit = {},
     onGamePinningToggled: (Boolean) -> Unit = {},
+    onAutoTuningToggled: (Boolean) -> Unit = {},
     onTuningModeSelected: (Boolean) -> Unit = {},
-    onAdaptiveFpsCapToggled: (Boolean) -> Unit = {},
-    firstItemFocusRequester: FocusRequester? = null,
+    onTuningStrategySelected: (AutoTuningStrategy) -> Unit = {},
+    onProfileSelected: (PowerProfile) -> Unit = {},
+    onGovernorSelected: (String) -> Unit = {},
+    onMinCpuValueChanged: (Int) -> Unit = {},
+    onMaxCpuValueChanged: (Int) -> Unit = {},
+    onMinGpuPowerChanged: (Int) -> Unit = {},
+    onMaxGpuPowerChanged: (Int) -> Unit = {},
+    onMinRamValueChanged: (Int) -> Unit = {},
+    onMaxRamValueChanged: (Int) -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
 
@@ -104,11 +105,13 @@ fun PowerControlQuickMenuContent(
                     SuccessView(
                         state = uiState,
                         isDriverSupported = isDriverSupported,
-                        onAutoTuningToggled = onAutoTuningToggled,
+                        firstItemFocusRequester = firstItemFocusRequester,
+                        onAdaptiveFpsCapToggled = onAdaptiveFpsCapToggled,
+                        onPowerControlToggled = onPowerControlToggled,
                         onFanControlToggled = onFanControlToggled,
                         onGamePinningToggled = onGamePinningToggled,
+                        onAutoTuningToggled = onAutoTuningToggled,
                         onTuningModeSelected = onTuningModeSelected,
-                        onAdaptiveFpsCapToggled = onAdaptiveFpsCapToggled,
                         onTuningStrategySelected = onTuningStrategySelected,
                         onProfileSelected = onProfileSelected,
                         onGovernorSelected = onGovernorSelected,
@@ -118,7 +121,6 @@ fun PowerControlQuickMenuContent(
                         onMaxGpuPowerChanged = onMaxGpuPowerChanged,
                         onMinRamValueChanged = onMinRamValueChanged,
                         onMaxRamValueChanged = onMaxRamValueChanged,
-                        firstItemFocusRequester = firstItemFocusRequester,
                     )
                 }
             }
@@ -178,11 +180,13 @@ private fun LoadingView() {
 private fun FlowRowScope.SuccessView(
     state: PowerControlUiState.Success,
     isDriverSupported: Boolean,
-    onAutoTuningToggled: (Boolean) -> Unit,
+    firstItemFocusRequester: FocusRequester? = null,
+    onAdaptiveFpsCapToggled: (Boolean) -> Unit,
+    onPowerControlToggled: (Boolean) -> Unit,
     onFanControlToggled: (Boolean) -> Unit,
     onGamePinningToggled: (Boolean) -> Unit,
+    onAutoTuningToggled: (Boolean) -> Unit,
     onTuningModeSelected: (Boolean) -> Unit,
-    onAdaptiveFpsCapToggled: (Boolean) -> Unit,
     onTuningStrategySelected: (AutoTuningStrategy) -> Unit,
     onProfileSelected: (PowerProfile) -> Unit,
     onGovernorSelected: (String) -> Unit,
@@ -192,23 +196,22 @@ private fun FlowRowScope.SuccessView(
     onMaxGpuPowerChanged: (Int) -> Unit,
     onMinRamValueChanged: (Int) -> Unit,
     onMaxRamValueChanged: (Int) -> Unit,
-    firstItemFocusRequester: FocusRequester? = null,
 ) {
     val accentColor = PluviaTheme.colors.accentPurple
     var isProfileDropdownExpanded by remember { mutableStateOf(false) }
     var isGovernorDropdownExpanded by remember { mutableStateOf(false) }
     var isTuningStrategyDropdownExpanded by remember { mutableStateOf(false) }
     var isTuningModeDropdownExpanded by remember { mutableStateOf(false) }
-    var selectedMinFreqIndex by remember { mutableIntStateOf(state.cpuInfo.selectedMinFreqIndex) }
-    var selectedMaxFreqIndex by remember { mutableIntStateOf(state.cpuInfo.selectedMaxFreqIndex) }
+    var selectedMinFreqIndex by remember { mutableIntStateOf(state.cpuInfo?.selectedMinFreqIndex ?: 0) }
+    var selectedMaxFreqIndex by remember { mutableIntStateOf(state.cpuInfo?.selectedMaxFreqIndex ?: 0) }
     var selectedMinGpuPowerLevel by remember { mutableIntStateOf(state.gpuInfo?.minPowerLevel ?: 0) }
     var selectedMaxGpuPowerLevel by remember { mutableIntStateOf(state.gpuInfo?.maxPowerLevel ?: 0) }
     var selectedMinRamValue by remember { mutableIntStateOf(state.ramInfo?.minBusLevel ?: 0) }
     var selectedMaxRamValue by remember { mutableIntStateOf(state.ramInfo?.maxBusLevel ?: 0) }
 
-    LaunchedEffect(state.cpuInfo.selectedMinFreqIndex, state.cpuInfo.selectedMaxFreqIndex) {
-        selectedMinFreqIndex = state.cpuInfo.selectedMinFreqIndex
-        selectedMaxFreqIndex = state.cpuInfo.selectedMaxFreqIndex
+    LaunchedEffect(state.cpuInfo?.selectedMinFreqIndex, state.cpuInfo?.selectedMaxFreqIndex) {
+        selectedMinFreqIndex = state.cpuInfo?.selectedMinFreqIndex ?: 0
+        selectedMaxFreqIndex = state.cpuInfo?.selectedMaxFreqIndex ?: 0
     }
 
     LaunchedEffect(state.gpuInfo?.minPowerLevel, state.gpuInfo?.maxPowerLevel) {
@@ -248,78 +251,114 @@ private fun FlowRowScope.SuccessView(
     )
 
     QuickMenuToggleRow(
-        title = stringResource(R.string.power_control_auto_tuning),
-        subtitle = stringResource(R.string.power_control_auto_tuning_desc),
-        enabled = state.selectedProfile.enableAutoTuning,
-        selectable = isDriverSupported,
-        onToggle = {
-            onAutoTuningToggled(!state.selectedProfile.enableAutoTuning)
-        },
+        title = stringResource(R.string.power_control_enable),
+        subtitle = stringResource(R.string.power_control_enable_desc),
+        enabled = state.selectedProfile.enablePowerControl,
+        onToggle = { onPowerControlToggled(!state.selectedProfile.enablePowerControl) },
         accentColor = accentColor,
         modifier = Modifier.weight(1f),
     )
 
-    // Tuning Mode Dropdown (only shown when auto-tuning is enabled)
-    val isClusterTuningAvailable = PowerManager.isClusterTuningAvailable()
-    if (state.selectedProfile.enableAutoTuning) {
-        val isPerClusterSelected = isClusterTuningAvailable && state.selectedProfile.enablePerClusterTuning
-
-        Column(
+    // All controls below only make sense while power control is active
+    if (state.selectedProfile.enablePowerControl) {
+        val isFanControlAvailable = PowerManager.isFanControlAvailable()
+        QuickMenuToggleRow(
+            title = stringResource(R.string.power_control_fan_control),
+            subtitle = stringResource(R.string.power_control_fan_control_desc),
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.power_control_tuning_mode),
-                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
-                color = MaterialTheme.colorScheme.onSurface,
-            )
+            selectable = isDriverSupported && isFanControlAvailable,
+            enabled = state.selectedProfile.enableFanControl,
+            onToggle = {
+                if (isFanControlAvailable) {
+                    onFanControlToggled(!state.selectedProfile.enableFanControl)
+                }
+            },
+            accentColor = accentColor,
+        )
 
-            SelectorRow(
-                valueText = if (isPerClusterSelected) {
-                    stringResource(R.string.power_control_tuning_mode_per_cluster)
-                } else {
-                    stringResource(R.string.power_control_tuning_mode_whole_cpu)
-                },
-                accentColor = accentColor,
-                expanded = isTuningModeDropdownExpanded,
-                onExpandedChange = { isTuningModeDropdownExpanded = it },
-            ) { menuFocusRequester ->
-                SelectorMenuItem(
-                    accentColor = accentColor,
-                    enabled = isClusterTuningAvailable,
-                    focusRequester = if (isClusterTuningAvailable) menuFocusRequester else null,
-                    onClick = {
-                        isTuningModeDropdownExpanded = false
-                        onTuningModeSelected(true)
-                    },
-                    text = {
-                        Text(
-                            text = stringResource(R.string.power_control_tuning_mode_per_cluster),
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                    },
-                )
-                SelectorMenuItem(
-                    accentColor = accentColor,
-                    focusRequester = if (isClusterTuningAvailable) null else menuFocusRequester,
-                    onClick = {
-                        isTuningModeDropdownExpanded = false
-                        onTuningModeSelected(false)
-                    },
-                    text = {
-                        Text(
-                            text = stringResource(R.string.power_control_tuning_mode_whole_cpu),
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                    },
-                )
-            }
-        }
-    }
+        val isGamePinningAvailable = PowerManager.isGamePinningAvailable()
+        QuickMenuToggleRow(
+            title = stringResource(R.string.power_control_game_pinning),
+            subtitle = stringResource(R.string.power_control_game_pinning_desc),
+            modifier = Modifier.weight(1f),
+            selectable = isDriverSupported && isGamePinningAvailable,
+            enabled = state.selectedProfile.enableGamePinning,
+            onToggle = {
+                if (isGamePinningAvailable) {
+                    onGamePinningToggled(!state.selectedProfile.enableGamePinning)
+                }
+            },
+            accentColor = accentColor,
+        )
 
-    if (isDriverSupported) {
-        // Tuning Strategy Dropdown (only shown when auto-tuning is enabled)
+        QuickMenuToggleRow(
+            title = stringResource(R.string.power_control_auto_tuning),
+            subtitle = stringResource(R.string.power_control_auto_tuning_desc),
+            enabled = state.selectedProfile.enableAutoTuning,
+            selectable = isDriverSupported,
+            onToggle = {
+                onAutoTuningToggled(!state.selectedProfile.enableAutoTuning)
+            },
+            accentColor = accentColor,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        // Tuning Mode Dropdown (only shown when auto-tuning is enabled)
+        val isClusterTuningAvailable = PowerManager.isClusterTuningAvailable()
         if (state.selectedProfile.enableAutoTuning) {
+            val isPerClusterSelected = isClusterTuningAvailable && state.selectedProfile.enablePerClusterTuning
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.power_control_tuning_mode),
+                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                SelectorRow(
+                    valueText = if (isPerClusterSelected) {
+                        stringResource(R.string.power_control_tuning_mode_per_cluster)
+                    } else {
+                        stringResource(R.string.power_control_tuning_mode_whole_cpu)
+                    },
+                    accentColor = accentColor,
+                    expanded = isTuningModeDropdownExpanded,
+                    onExpandedChange = { isTuningModeDropdownExpanded = it },
+                ) { menuFocusRequester ->
+                    SelectorMenuItem(
+                        accentColor = accentColor,
+                        enabled = isClusterTuningAvailable,
+                        focusRequester = if (isClusterTuningAvailable) menuFocusRequester else null,
+                        onClick = {
+                            isTuningModeDropdownExpanded = false
+                            onTuningModeSelected(true)
+                        },
+                        text = {
+                            Text(
+                                text = stringResource(R.string.power_control_tuning_mode_per_cluster),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        },
+                    )
+                    SelectorMenuItem(
+                        accentColor = accentColor,
+                        focusRequester = if (isClusterTuningAvailable) null else menuFocusRequester,
+                        onClick = {
+                            isTuningModeDropdownExpanded = false
+                            onTuningModeSelected(false)
+                        },
+                        text = {
+                            Text(
+                                text = stringResource(R.string.power_control_tuning_mode_whole_cpu),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        },
+                    )
+                }
+            }
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -365,40 +404,7 @@ private fun FlowRowScope.SuccessView(
                 }
             }
         }
-    }
 
-    val isFanControlAvailable = PowerManager.isFanControlAvailable()
-    QuickMenuToggleRow(
-        title = stringResource(R.string.power_control_fan_control),
-        subtitle = stringResource(R.string.power_control_fan_control_desc),
-        modifier = Modifier.weight(1f),
-        selectable = isDriverSupported && isFanControlAvailable,
-        enabled = state.selectedProfile.enableFanControl,
-        onToggle = {
-            if (isFanControlAvailable) {
-                onFanControlToggled(!state.selectedProfile.enableFanControl)
-            }
-        },
-        accentColor = accentColor,
-    )
-
-    val isGamePinningAvailable = PowerManager.isGamePinningAvailable()
-    QuickMenuToggleRow(
-        title = stringResource(R.string.power_control_game_pinning),
-        subtitle = stringResource(R.string.power_control_game_pinning_desc),
-        modifier = Modifier.weight(1f),
-        selectable = isDriverSupported && isGamePinningAvailable,
-        enabled = state.selectedProfile.enableGamePinning,
-        onToggle = {
-            if (isGamePinningAvailable) {
-                onGamePinningToggled(!state.selectedProfile.enableGamePinning)
-            }
-        },
-        accentColor = accentColor,
-    )
-
-    if (isDriverSupported) {
-        // Only show manual controls when auto-tuning is disabled
         if (!state.selectedProfile.enableAutoTuning) {
             SectionHeader(title = "Profile")
 
@@ -445,247 +451,253 @@ private fun FlowRowScope.SuccessView(
             }
         }
 
-        SectionHeader(title = "CPU")
+        state.cpuInfo?.let { cpuInfo ->
+            SectionHeader(title = "CPU")
 
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.power_control_governor),
-                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
-                color = MaterialTheme.colorScheme.onSurface,
-            )
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.power_control_governor),
+                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
 
-            SelectorRow(
-                valueText = state.cpuInfo.currentGovernor.replaceFirstChar { it.uppercase() },
-                accentColor = accentColor,
-                expanded = isGovernorDropdownExpanded,
-                onExpandedChange = { isGovernorDropdownExpanded = it },
-            ) { menuFocusRequester ->
-                state.cpuInfo.availableGovernors.forEachIndexed { index, governor ->
-                    SelectorMenuItem(
-                        accentColor = accentColor,
-                        focusRequester = if (index == 0) menuFocusRequester else null,
-                        onClick = {
-                            isGovernorDropdownExpanded = false
-                            onGovernorSelected(governor)
-                        },
-                        text = {
-                            Text(
-                                text = governor.replaceFirstChar { it.uppercase() },
-                                style = MaterialTheme.typography.bodyMedium
-                            )
-                        },
-                    )
+                SelectorRow(
+                    valueText = cpuInfo.currentGovernor.replaceFirstChar { it.uppercase() },
+                    accentColor = accentColor,
+                    expanded = isGovernorDropdownExpanded,
+                    onExpandedChange = { isGovernorDropdownExpanded = it },
+                ) { menuFocusRequester ->
+                    cpuInfo.availableGovernors.forEachIndexed { index, governor ->
+                        SelectorMenuItem(
+                            accentColor = accentColor,
+                            focusRequester = if (index == 0) menuFocusRequester else null,
+                            onClick = {
+                                isGovernorDropdownExpanded = false
+                                onGovernorSelected(governor)
+                            },
+                            text = {
+                                Text(
+                                    text = governor.replaceFirstChar { it.uppercase() },
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            },
+                        )
+                    }
                 }
             }
         }
 
-        // Only show manual controls when auto-tuning is disabled
-        if (!state.selectedProfile.enableAutoTuning) {
-            if (state.cpuInfo.availableFrequencies.isNotEmpty()) {
-                val maxFreqIndex = state.cpuInfo.availableFrequencies.size - 1
+        if (isDriverSupported) {
+            // Only show manual controls when auto-tuning is disabled
+            if (!state.selectedProfile.enableAutoTuning) {
+                state.cpuInfo?.let { cpuInfo ->
+                    if (cpuInfo.availableFrequencies.isNotEmpty()) {
+                        val maxFreqIndex = cpuInfo.availableFrequencies.size - 1
 
-                QuickMenuAdjustmentRow(
-                    title = stringResource(R.string.power_control_cpu_min_freq),
-                    modifier = Modifier.weight(1f),
-                    valueText = formatFrequency(
-                        state.cpuInfo.availableFrequencies[selectedMinFreqIndex.coerceIn(0, maxFreqIndex)],
-                    ),
-                    progress = normalizedProgress(selectedMinFreqIndex.toFloat(), 0f, maxFreqIndex.toFloat()),
-                    onDecrease = {
-                        val newIndex = (selectedMinFreqIndex - 1).coerceAtLeast(0)
-                        if (newIndex != selectedMinFreqIndex) {
-                            selectedMinFreqIndex = newIndex
-                            onMinCpuValueChanged(newIndex)
-                        }
-                    },
-                    onIncrease = {
-                        val newIndex = (selectedMinFreqIndex + 1).coerceAtMost(selectedMaxFreqIndex)
-                        if (newIndex != selectedMinFreqIndex) {
-                            selectedMinFreqIndex = newIndex
-                            onMinCpuValueChanged(newIndex)
-                        }
-                    },
-                    accentColor = accentColor,
-                )
-
-                QuickMenuAdjustmentRow(
-                    title = stringResource(R.string.power_control_cpu_max_freq),
-                    modifier = Modifier.weight(1f),
-                    valueText = formatFrequency(
-                        state.cpuInfo.availableFrequencies[selectedMaxFreqIndex.coerceIn(0, maxFreqIndex)],
-                    ),
-                    progress = normalizedProgress(selectedMaxFreqIndex.toFloat(), 0f, maxFreqIndex.toFloat()),
-                    onDecrease = {
-                        val newIndex = (selectedMaxFreqIndex - 1).coerceAtLeast(selectedMinFreqIndex)
-                        if (newIndex != selectedMaxFreqIndex) {
-                            selectedMaxFreqIndex = newIndex
-                            onMaxCpuValueChanged(newIndex)
-                        }
-                    },
-                    onIncrease = {
-                        val newIndex = (selectedMaxFreqIndex + 1).coerceAtMost(maxFreqIndex)
-                        if (newIndex != selectedMaxFreqIndex) {
-                            selectedMaxFreqIndex = newIndex
-                            onMaxCpuValueChanged(newIndex)
-                        }
-                    },
-                    accentColor = accentColor,
-                )
-            }
-
-            state.gpuInfo?.let { gpuInfo ->
-                SectionHeader(title = "GPU")
-
-                if (gpuInfo.availableFrequencies.isNotEmpty()) {
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        Text(
-                            text = stringResource(R.string.power_control_gpu_freq),
-                            style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        QuickMenuAdjustmentRow(
+                            title = stringResource(R.string.power_control_cpu_min_freq),
+                            modifier = Modifier.weight(1f),
+                            valueText = formatFrequency(
+                                cpuInfo.availableFrequencies[selectedMinFreqIndex.coerceIn(0, maxFreqIndex)],
+                            ),
+                            progress = normalizedProgress(selectedMinFreqIndex.toFloat(), 0f, maxFreqIndex.toFloat()),
+                            onDecrease = {
+                                val newIndex = (selectedMinFreqIndex - 1).coerceAtLeast(0)
+                                if (newIndex != selectedMinFreqIndex) {
+                                    selectedMinFreqIndex = newIndex
+                                    onMinCpuValueChanged(newIndex)
+                                }
+                            },
+                            onIncrease = {
+                                val newIndex = (selectedMinFreqIndex + 1).coerceAtMost(selectedMaxFreqIndex)
+                                if (newIndex != selectedMinFreqIndex) {
+                                    selectedMinFreqIndex = newIndex
+                                    onMinCpuValueChanged(newIndex)
+                                }
+                            },
+                            accentColor = accentColor,
                         )
 
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Slider(
-                                value = gpuInfo.currentFreqIndex.toFloat(),
-                                onValueChange = { },
-                                enabled = false,
-                                valueRange = 0f..(gpuInfo.availableFrequencies.size - 1).toFloat(),
-                                steps = gpuInfo.availableFrequencies.size - 2,
-                                modifier = Modifier.weight(1f)
-                            )
-                            Text(
-                                text = formatFrequency(gpuInfo.availableFrequencies[gpuInfo.currentFreqIndex]),
-                                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.width(80.dp)
-                            )
-                        }
+                        QuickMenuAdjustmentRow(
+                            title = stringResource(R.string.power_control_cpu_max_freq),
+                            modifier = Modifier.weight(1f),
+                            valueText = formatFrequency(
+                                state.cpuInfo.availableFrequencies[selectedMaxFreqIndex.coerceIn(0, maxFreqIndex)],
+                            ),
+                            progress = normalizedProgress(selectedMaxFreqIndex.toFloat(), 0f, maxFreqIndex.toFloat()),
+                            onDecrease = {
+                                val newIndex = (selectedMaxFreqIndex - 1).coerceAtLeast(selectedMinFreqIndex)
+                                if (newIndex != selectedMaxFreqIndex) {
+                                    selectedMaxFreqIndex = newIndex
+                                    onMaxCpuValueChanged(newIndex)
+                                }
+                            },
+                            onIncrease = {
+                                val newIndex = (selectedMaxFreqIndex + 1).coerceAtMost(maxFreqIndex)
+                                if (newIndex != selectedMaxFreqIndex) {
+                                    selectedMaxFreqIndex = newIndex
+                                    onMaxCpuValueChanged(newIndex)
+                                }
+                            },
+                            accentColor = accentColor,
+                        )
                     }
                 }
 
-                if (gpuInfo.maxAvailablePowerLevel > 0) {
-                    QuickMenuAdjustmentRow(
-                        title = stringResource(R.string.power_control_gpu_min_power),
-                        modifier = Modifier.weight(1f),
-                        valueText = selectedMinGpuPowerLevel.toString(),
-                        progress = normalizedProgress(
-                            selectedMinGpuPowerLevel.toFloat(),
-                            0f,
-                            gpuInfo.maxAvailablePowerLevel.toFloat(),
-                        ),
-                        onDecrease = {
-                            val newLevel = (selectedMinGpuPowerLevel - 1).coerceAtLeast(0)
-                            if (newLevel != selectedMinGpuPowerLevel) {
-                                selectedMinGpuPowerLevel = newLevel
-                                onMinGpuPowerChanged(newLevel)
-                            }
-                        },
-                        onIncrease = {
-                            val newLevel = (selectedMinGpuPowerLevel + 1).coerceAtMost(selectedMaxGpuPowerLevel)
-                            if (newLevel != selectedMinGpuPowerLevel) {
-                                selectedMinGpuPowerLevel = newLevel
-                                onMinGpuPowerChanged(newLevel)
-                            }
-                        },
-                        accentColor = accentColor,
-                    )
+                state.gpuInfo?.let { gpuInfo ->
+                    SectionHeader(title = "GPU")
 
-                    QuickMenuAdjustmentRow(
-                        title = stringResource(R.string.power_control_gpu_max_power),
-                        modifier = Modifier.weight(1f),
-                        valueText = selectedMaxGpuPowerLevel.toString(),
-                        progress = normalizedProgress(
-                            selectedMaxGpuPowerLevel.toFloat(),
-                            0f,
-                            gpuInfo.maxAvailablePowerLevel.toFloat(),
-                        ),
-                        onDecrease = {
-                            val newLevel = (selectedMaxGpuPowerLevel - 1).coerceAtLeast(selectedMinGpuPowerLevel)
-                            if (newLevel != selectedMaxGpuPowerLevel) {
-                                selectedMaxGpuPowerLevel = newLevel
-                                onMaxGpuPowerChanged(newLevel)
+                    if (gpuInfo.availableFrequencies.isNotEmpty()) {
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Text(
+                                text = stringResource(R.string.power_control_gpu_freq),
+                                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Slider(
+                                    value = gpuInfo.currentFreqIndex.toFloat(),
+                                    onValueChange = { },
+                                    enabled = false,
+                                    valueRange = 0f..(gpuInfo.availableFrequencies.size - 1).toFloat(),
+                                    steps = gpuInfo.availableFrequencies.size - 2,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                Text(
+                                    text = formatFrequency(gpuInfo.availableFrequencies[gpuInfo.currentFreqIndex]),
+                                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.width(80.dp)
+                                )
                             }
-                        },
-                        onIncrease = {
-                            val newLevel = (selectedMaxGpuPowerLevel + 1).coerceAtMost(gpuInfo.maxAvailablePowerLevel)
-                            if (newLevel != selectedMaxGpuPowerLevel) {
-                                selectedMaxGpuPowerLevel = newLevel
-                                onMaxGpuPowerChanged(newLevel)
-                            }
-                        },
-                        accentColor = accentColor,
-                    )
+                        }
+                    }
+
+                    if (gpuInfo.maxAvailablePowerLevel > 0) {
+                        QuickMenuAdjustmentRow(
+                            title = stringResource(R.string.power_control_gpu_min_power),
+                            modifier = Modifier.weight(1f),
+                            valueText = selectedMinGpuPowerLevel.toString(),
+                            progress = normalizedProgress(
+                                selectedMinGpuPowerLevel.toFloat(),
+                                0f,
+                                gpuInfo.maxAvailablePowerLevel.toFloat(),
+                            ),
+                            onDecrease = {
+                                val newLevel = (selectedMinGpuPowerLevel - 1).coerceAtLeast(0)
+                                if (newLevel != selectedMinGpuPowerLevel) {
+                                    selectedMinGpuPowerLevel = newLevel
+                                    onMinGpuPowerChanged(newLevel)
+                                }
+                            },
+                            onIncrease = {
+                                val newLevel = (selectedMinGpuPowerLevel + 1).coerceAtMost(selectedMaxGpuPowerLevel)
+                                if (newLevel != selectedMinGpuPowerLevel) {
+                                    selectedMinGpuPowerLevel = newLevel
+                                    onMinGpuPowerChanged(newLevel)
+                                }
+                            },
+                            accentColor = accentColor,
+                        )
+
+                        QuickMenuAdjustmentRow(
+                            title = stringResource(R.string.power_control_gpu_max_power),
+                            modifier = Modifier.weight(1f),
+                            valueText = selectedMaxGpuPowerLevel.toString(),
+                            progress = normalizedProgress(
+                                selectedMaxGpuPowerLevel.toFloat(),
+                                0f,
+                                gpuInfo.maxAvailablePowerLevel.toFloat(),
+                            ),
+                            onDecrease = {
+                                val newLevel = (selectedMaxGpuPowerLevel - 1).coerceAtLeast(selectedMinGpuPowerLevel)
+                                if (newLevel != selectedMaxGpuPowerLevel) {
+                                    selectedMaxGpuPowerLevel = newLevel
+                                    onMaxGpuPowerChanged(newLevel)
+                                }
+                            },
+                            onIncrease = {
+                                val newLevel = (selectedMaxGpuPowerLevel + 1).coerceAtMost(gpuInfo.maxAvailablePowerLevel)
+                                if (newLevel != selectedMaxGpuPowerLevel) {
+                                    selectedMaxGpuPowerLevel = newLevel
+                                    onMaxGpuPowerChanged(newLevel)
+                                }
+                            },
+                            accentColor = accentColor,
+                        )
+                    }
                 }
-            }
 
-            state.ramInfo?.let { ramInfo ->
-                if (ramInfo.maxAvailableBusLevel > 0) {
-                    SectionHeader(title = "RAM")
+                state.ramInfo?.let { ramInfo ->
+                    if (ramInfo.maxAvailableBusLevel > 0) {
+                        SectionHeader(title = "RAM")
 
-                    QuickMenuAdjustmentRow(
-                        title = stringResource(R.string.power_control_ram_min_power),
-                        modifier = Modifier.weight(1f),
-                        valueText = selectedMinRamValue.toString(),
-                        progress = normalizedProgress(
-                            selectedMinRamValue.toFloat(),
-                            0f,
-                            ramInfo.maxAvailableBusLevel.toFloat(),
-                        ),
-                        onDecrease = {
-                            val newLevel = (selectedMinRamValue - 1).coerceAtLeast(0)
-                            if (newLevel != selectedMinRamValue) {
-                                selectedMinRamValue = newLevel
-                                onMinRamValueChanged(newLevel)
-                            }
-                        },
-                        onIncrease = {
-                            val newLevel = (selectedMinRamValue + 1).coerceAtMost(selectedMaxRamValue)
-                            if (newLevel != selectedMinRamValue) {
-                                selectedMinRamValue = newLevel
-                                onMinRamValueChanged(newLevel)
-                            }
-                        },
-                        accentColor = accentColor,
-                    )
+                        QuickMenuAdjustmentRow(
+                            title = stringResource(R.string.power_control_ram_min_power),
+                            modifier = Modifier.weight(1f),
+                            valueText = selectedMinRamValue.toString(),
+                            progress = normalizedProgress(
+                                selectedMinRamValue.toFloat(),
+                                0f,
+                                ramInfo.maxAvailableBusLevel.toFloat(),
+                            ),
+                            onDecrease = {
+                                val newLevel = (selectedMinRamValue - 1).coerceAtLeast(0)
+                                if (newLevel != selectedMinRamValue) {
+                                    selectedMinRamValue = newLevel
+                                    onMinRamValueChanged(newLevel)
+                                }
+                            },
+                            onIncrease = {
+                                val newLevel = (selectedMinRamValue + 1).coerceAtMost(selectedMaxRamValue)
+                                if (newLevel != selectedMinRamValue) {
+                                    selectedMinRamValue = newLevel
+                                    onMinRamValueChanged(newLevel)
+                                }
+                            },
+                            accentColor = accentColor,
+                        )
 
-                    QuickMenuAdjustmentRow(
-                        title = stringResource(R.string.power_control_ram_max_power),
-                        modifier = Modifier.weight(1f),
-                        valueText = selectedMaxRamValue.toString(),
-                        progress = normalizedProgress(
-                            selectedMaxRamValue.toFloat(),
-                            0f,
-                            ramInfo.maxAvailableBusLevel.toFloat(),
-                        ),
-                        onDecrease = {
-                            val newLevel = (selectedMaxRamValue - 1).coerceAtLeast(selectedMinRamValue)
-                            if (newLevel != selectedMaxRamValue) {
-                                selectedMaxRamValue = newLevel
-                                onMaxRamValueChanged(newLevel)
-                            }
-                        },
-                        onIncrease = {
-                            val newLevel = (selectedMaxRamValue + 1).coerceAtMost(ramInfo.maxAvailableBusLevel)
-                            if (newLevel != selectedMaxRamValue) {
-                                selectedMaxRamValue = newLevel
-                                onMaxRamValueChanged(newLevel)
-                            }
-                        },
-                        accentColor = accentColor,
-                    )
+                        QuickMenuAdjustmentRow(
+                            title = stringResource(R.string.power_control_ram_max_power),
+                            modifier = Modifier.weight(1f),
+                            valueText = selectedMaxRamValue.toString(),
+                            progress = normalizedProgress(
+                                selectedMaxRamValue.toFloat(),
+                                0f,
+                                ramInfo.maxAvailableBusLevel.toFloat(),
+                            ),
+                            onDecrease = {
+                                val newLevel = (selectedMaxRamValue - 1).coerceAtLeast(selectedMinRamValue)
+                                if (newLevel != selectedMaxRamValue) {
+                                    selectedMaxRamValue = newLevel
+                                    onMaxRamValueChanged(newLevel)
+                                }
+                            },
+                            onIncrease = {
+                                val newLevel = (selectedMaxRamValue + 1).coerceAtMost(ramInfo.maxAvailableBusLevel)
+                                if (newLevel != selectedMaxRamValue) {
+                                    selectedMaxRamValue = newLevel
+                                    onMaxRamValueChanged(newLevel)
+                                }
+                            },
+                            accentColor = accentColor,
+                        )
+                    }
                 }
-            }
-        } // End of auto-tuning check
+            } // End of auto-tuning check
+        }
     }
 }
 

--- a/app/src/main/java/app/gamenative/ui/component/quickMenus/PowerControlQuickMenuContent.kt
+++ b/app/src/main/java/app/gamenative/ui/component/quickMenus/PowerControlQuickMenuContent.kt
@@ -451,46 +451,46 @@ private fun FlowRowScope.SuccessView(
             }
         }
 
-        state.cpuInfo?.let { cpuInfo ->
-            SectionHeader(title = "CPU")
+        if (isDriverSupported) {
+            state.cpuInfo?.let { cpuInfo ->
+                SectionHeader(title = "CPU")
 
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Text(
-                    text = stringResource(R.string.power_control_governor),
-                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.power_control_governor),
+                        style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
 
-                SelectorRow(
-                    valueText = cpuInfo.currentGovernor.replaceFirstChar { it.uppercase() },
-                    accentColor = accentColor,
-                    expanded = isGovernorDropdownExpanded,
-                    onExpandedChange = { isGovernorDropdownExpanded = it },
-                ) { menuFocusRequester ->
-                    cpuInfo.availableGovernors.forEachIndexed { index, governor ->
-                        SelectorMenuItem(
-                            accentColor = accentColor,
-                            focusRequester = if (index == 0) menuFocusRequester else null,
-                            onClick = {
-                                isGovernorDropdownExpanded = false
-                                onGovernorSelected(governor)
-                            },
-                            text = {
-                                Text(
-                                    text = governor.replaceFirstChar { it.uppercase() },
-                                    style = MaterialTheme.typography.bodyMedium
-                                )
-                            },
-                        )
+                    SelectorRow(
+                        valueText = cpuInfo.currentGovernor.replaceFirstChar { it.uppercase() },
+                        accentColor = accentColor,
+                        expanded = isGovernorDropdownExpanded,
+                        onExpandedChange = { isGovernorDropdownExpanded = it },
+                    ) { menuFocusRequester ->
+                        cpuInfo.availableGovernors.forEachIndexed { index, governor ->
+                            SelectorMenuItem(
+                                accentColor = accentColor,
+                                focusRequester = if (index == 0) menuFocusRequester else null,
+                                onClick = {
+                                    isGovernorDropdownExpanded = false
+                                    onGovernorSelected(governor)
+                                },
+                                text = {
+                                    Text(
+                                        text = governor.replaceFirstChar { it.uppercase() },
+                                        style = MaterialTheme.typography.bodyMedium
+                                    )
+                                },
+                            )
+                        }
                     }
                 }
             }
-        }
 
-        if (isDriverSupported) {
             // Only show manual controls when auto-tuning is disabled
             if (!state.selectedProfile.enableAutoTuning) {
                 state.cpuInfo?.let { cpuInfo ->

--- a/app/src/main/java/app/gamenative/ui/component/quickMenus/PowerControlQuickMenuTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/quickMenus/PowerControlQuickMenuTab.kt
@@ -40,36 +40,36 @@ fun PowerControlQuickMenuTab(
     }
 
     PowerControlQuickMenuContent(
+        modifier = modifier.focusGroup(),
         uiState = uiState,
         isDriverSupported = isDriverSupported,
+        firstItemFocusRequester = focusRequester,
+        onAdaptiveFpsCapToggled = { enabled ->
+            coroutineScope.launch(Dispatchers.IO) {
+                PowerManager.currentProfile.let { profile ->
+                    PowerManager.setPowerProfile(profile.copy(enableAdaptiveFpsCap = enabled))
+                }
+                PowerManager.refreshUiState()
+            }
+        },
+        onPowerControlToggled = { enabled ->
+            coroutineScope.launch(Dispatchers.IO) {
+                PowerManager.setPowerControlEnabled(enabled)
+                PowerManager.refreshUiState()
+            }
+        },
         onFanControlToggled = { enabled ->
             coroutineScope.launch(Dispatchers.IO) {
-                PowerManager.currentProfile?.let { profile ->
-                    PowerManager.setCurrentProfile(profile.copy(enableFanControl = enabled))
+                PowerManager.currentProfile.let { profile ->
+                    PowerManager.setPowerProfile(profile.copy(enableFanControl = enabled))
                 }
                 PowerManager.refreshUiState()
             }
         },
         onGamePinningToggled = { enabled ->
             coroutineScope.launch(Dispatchers.IO) {
-                PowerManager.currentProfile?.let { profile ->
-                    PowerManager.setCurrentProfile(profile.copy(enableGamePinning = enabled))
-                }
-                PowerManager.refreshUiState()
-            }
-        },
-        onTuningModeSelected = { perCluster ->
-            coroutineScope.launch(Dispatchers.IO) {
-                PowerManager.currentProfile?.let { profile ->
-                    PowerManager.setCurrentProfile(profile.copy(enablePerClusterTuning = perCluster))
-                }
-                PowerManager.refreshUiState()
-            }
-        },
-        onAdaptiveFpsCapToggled = { enabled ->
-            coroutineScope.launch(Dispatchers.IO) {
-                PowerManager.currentProfile?.let { profile ->
-                    PowerManager.setCurrentProfile(profile.copy(enableAdaptiveFpsCap = enabled))
+                PowerManager.currentProfile.let { profile ->
+                    PowerManager.setPowerProfile(profile.copy(enableGamePinning = enabled))
                 }
                 PowerManager.refreshUiState()
             }
@@ -77,26 +77,34 @@ fun PowerControlQuickMenuTab(
         onAutoTuningToggled = { enabled ->
             coroutineScope.launch(Dispatchers.IO) {
                 // Update current profile
-                PowerManager.currentProfile?.let { profile ->
+                PowerManager.currentProfile.let { profile ->
                     val updatedProfile = profile.copy(
                         enableAutoTuning = enabled,
                         name = PerformancePreset.CUSTOM.displayName
                     )
-                    PowerManager.setCurrentProfile(updatedProfile)
+                    PowerManager.setPowerProfile(updatedProfile)
                 }
 
+                PowerManager.refreshUiState()
+            }
+        },
+        onTuningModeSelected = { perCluster ->
+            coroutineScope.launch(Dispatchers.IO) {
+                PowerManager.currentProfile.let { profile ->
+                    PowerManager.setPowerProfile(profile.copy(enablePerClusterTuning = perCluster))
+                }
                 PowerManager.refreshUiState()
             }
         },
         onTuningStrategySelected = { strategy ->
             coroutineScope.launch(Dispatchers.IO) {
                 // Update current profile with new tuning strategy
-                PowerManager.currentProfile?.let { profile ->
+                PowerManager.currentProfile.let { profile ->
                     val updatedProfile = profile.copy(
                         tuningStrategy = strategy,
                         name = PerformancePreset.CUSTOM.displayName
                     )
-                    PowerManager.setCurrentProfile(updatedProfile)
+                    PowerManager.setPowerProfile(updatedProfile)
                 }
 
                 PowerManager.refreshUiState()
@@ -110,13 +118,13 @@ fun PowerControlQuickMenuTab(
                 // Preserve current enableFanControl and enableGamePinning settings
                 val currentProfile = PowerManager.currentProfile
                 val updatedProfile = profile.copy(
-                    enableAdaptiveFpsCap = currentProfile?.enableAdaptiveFpsCap ?: profile.enableAdaptiveFpsCap,
+                    enableAdaptiveFpsCap = currentProfile.enableAdaptiveFpsCap,
                     enableAutoTuning = false,
                     enablePerClusterTuning = false,
-                    enableFanControl = currentProfile?.enableFanControl ?: profile.enableFanControl,
-                    enableGamePinning = currentProfile?.enableGamePinning ?: profile.enableGamePinning,
+                    enableFanControl = currentProfile.enableFanControl,
+                    enableGamePinning = currentProfile.enableGamePinning,
                 )
-                PowerManager.setCurrentProfile(updatedProfile)
+                PowerManager.setPowerProfile(updatedProfile)
 
                 val success = PowerManager.update {
                     name(updatedProfile.name)
@@ -146,20 +154,20 @@ fun PowerControlQuickMenuTab(
         },
         onMinCpuValueChanged = { freqIndex ->
             if (uiState is PowerControlUiState.Success) {
-                val freq = (uiState as PowerControlUiState.Success).cpuInfo.availableFrequencies[freqIndex]
+                val freq = (uiState as PowerControlUiState.Success).cpuInfo?.availableFrequencies[freqIndex]
                 coroutineScope.launch(Dispatchers.IO) {
                     PowerManager.setProfileName(PerformancePreset.CUSTOM.displayName)
-                    PowerManager.setMinCpuValue(freq)
+                    PowerManager.setMinCpuValue(freq ?: 0L)
                     PowerManager.refreshUiState()
                 }
             }
         },
         onMaxCpuValueChanged = { freqIndex ->
             if (uiState is PowerControlUiState.Success) {
-                val freq = (uiState as PowerControlUiState.Success).cpuInfo.availableFrequencies[freqIndex]
+                val freq = (uiState as PowerControlUiState.Success).cpuInfo?.availableFrequencies[freqIndex]
                 coroutineScope.launch(Dispatchers.IO) {
                     PowerManager.setProfileName(PerformancePreset.CUSTOM.displayName)
-                    PowerManager.setMaxCpuValue(freq)
+                    PowerManager.setMaxCpuValue(freq ?: 0L)
                     PowerManager.refreshUiState()
                 }
             }
@@ -192,8 +200,6 @@ fun PowerControlQuickMenuTab(
                 PowerManager.refreshUiState()
             }
         },
-        firstItemFocusRequester = focusRequester,
-        modifier = modifier.focusGroup(),
     )
 }
 
@@ -204,16 +210,6 @@ fun PowerControlLoadingPreview() {
         PowerControlQuickMenuContent(
             uiState = PowerControlUiState.Loading,
             isDriverSupported = true,
-            onAutoTuningToggled = {},
-            onTuningStrategySelected = {},
-            onProfileSelected = {},
-            onGovernorSelected = {},
-            onMinCpuValueChanged = {},
-            onMaxCpuValueChanged = {},
-            onMinGpuPowerChanged = {},
-            onMaxGpuPowerChanged = {},
-            onMinRamValueChanged = {},
-            onMaxRamValueChanged = {},
         )
     }
 }
@@ -224,16 +220,6 @@ fun PowerControlSuccessCpuOnlyPreview() {
     MaterialTheme {
         PowerControlQuickMenuContent(
             uiState = PowerControlUiState.Success(
-                cpuInfo = CpuDisplayInfo(
-                    currentGovernor = "performance",
-                    availableGovernors = listOf("performance", "powersave", "ondemand", "schedutil"),
-                    availableFrequencies = listOf(300000, 825000, 1400000, 1800000, 2200000, 2800000),
-                    currentMinValue = 300000,
-                    currentMaxValue = 2800000,
-                    selectedMinFreqIndex = 0,
-                    selectedMaxFreqIndex = 5
-                ),
-                gpuInfo = null,
                 selectedProfile = PowerProfile(
                     name = PerformancePreset.PERFORMANCE.displayName,
                     governor = CpuGovernor.PERFORMANCE,
@@ -260,19 +246,19 @@ fun PowerControlSuccessCpuOnlyPreview() {
                         maxCpuFreq = 1400000
                     )
                 ),
+                cpuInfo = CpuDisplayInfo(
+                    currentGovernor = "performance",
+                    availableGovernors = listOf("performance", "powersave", "ondemand", "schedutil"),
+                    availableFrequencies = listOf(300000, 825000, 1400000, 1800000, 2200000, 2800000),
+                    currentMinValue = 300000,
+                    currentMaxValue = 2800000,
+                    selectedMinFreqIndex = 0,
+                    selectedMaxFreqIndex = 5
+                ),
+                gpuInfo = null,
                 ramInfo = null
             ),
             isDriverSupported = true,
-            onAutoTuningToggled = {},
-            onTuningStrategySelected = {},
-            onProfileSelected = {},
-            onGovernorSelected = {},
-            onMinCpuValueChanged = {},
-            onMaxCpuValueChanged = {},
-            onMinGpuPowerChanged = {},
-            onMaxGpuPowerChanged = {},
-            onMinRamValueChanged = {},
-            onMaxRamValueChanged = {},
         )
     }
 }
@@ -283,22 +269,6 @@ fun PowerControlSuccessWithGpuPreview() {
     MaterialTheme {
         PowerControlQuickMenuContent(
             uiState = PowerControlUiState.Success(
-                cpuInfo = CpuDisplayInfo(
-                    currentGovernor = "schedutil",
-                    availableGovernors = listOf("performance", "powersave", "ondemand", "schedutil"),
-                    availableFrequencies = listOf(300000, 825000, 1400000, 1800000, 2200000, 2800000),
-                    currentMinValue = 300000,
-                    currentMaxValue = 2200000,
-                    selectedMinFreqIndex = 0,
-                    selectedMaxFreqIndex = 4
-                ),
-                gpuInfo = GpuDisplayInfo(
-                    availableFrequencies = listOf(180000000, 305000000, 427000000, 587000000, 710000000),
-                    currentFreqIndex = 3,
-                    minPowerLevel = 0,
-                    maxPowerLevel = 4,
-                    maxAvailablePowerLevel = 4
-                ),
                 selectedProfile = PowerProfile(
                     name = PerformancePreset.BALANCED.displayName,
                     governor = CpuGovernor.SCHEDUTIL,
@@ -319,6 +289,22 @@ fun PowerControlSuccessWithGpuPreview() {
                         maxCpuFreq = 2200000
                     )
                 ),
+                cpuInfo = CpuDisplayInfo(
+                    currentGovernor = "schedutil",
+                    availableGovernors = listOf("performance", "powersave", "ondemand", "schedutil"),
+                    availableFrequencies = listOf(300000, 825000, 1400000, 1800000, 2200000, 2800000),
+                    currentMinValue = 300000,
+                    currentMaxValue = 2200000,
+                    selectedMinFreqIndex = 0,
+                    selectedMaxFreqIndex = 4
+                ),
+                gpuInfo = GpuDisplayInfo(
+                    availableFrequencies = listOf(180000000, 305000000, 427000000, 587000000, 710000000),
+                    currentFreqIndex = 3,
+                    minPowerLevel = 0,
+                    maxPowerLevel = 4,
+                    maxAvailablePowerLevel = 4
+                ),
                 ramInfo = RamDisplayInfo(
                     minBusLevel = 0,
                     maxBusLevel = 4,
@@ -326,16 +312,6 @@ fun PowerControlSuccessWithGpuPreview() {
                 ),
             ),
             isDriverSupported = true,
-            onAutoTuningToggled = {},
-            onTuningStrategySelected = {},
-            onProfileSelected = {},
-            onGovernorSelected = {},
-            onMinCpuValueChanged = {},
-            onMaxCpuValueChanged = {},
-            onMinGpuPowerChanged = {},
-            onMaxGpuPowerChanged = {},
-            onMinRamValueChanged = {},
-            onMaxRamValueChanged = {},
         )
     }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupPerformance.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupPerformance.kt
@@ -1,0 +1,31 @@
+package app.gamenative.ui.screen.settings
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import app.gamenative.PrefManager
+import app.gamenative.R
+import app.gamenative.ui.theme.settingsTileColorsAlt
+import com.alorma.compose.settings.ui.SettingsGroup
+import com.alorma.compose.settings.ui.SettingsSwitch
+
+@Composable
+fun SettingsGroupPerformance() {
+    SettingsGroup {
+        var powerControlDefaultEnabled by rememberSaveable { mutableStateOf(PrefManager.powerControlDefaultEnabled) }
+        SettingsSwitch(
+            colors = settingsTileColorsAlt(),
+            state = powerControlDefaultEnabled,
+            title = { Text(stringResource(R.string.settings_performance_power_control_title)) },
+            subtitle = { Text(stringResource(R.string.settings_performance_power_control_subtitle)) },
+            onCheckedChange = {
+                powerControlDefaultEnabled = it
+                PrefManager.powerControlDefaultEnabled = it
+            },
+        )
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.Gamepad
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -128,6 +129,15 @@ private fun SettingsScreenContent(
                     iconTint = PluviaTheme.colors.accentCyan,
                 ) {
                     SettingsGroupEmulation()
+                }
+
+                // Performance section
+                SettingsSection(
+                    title = stringResource(R.string.settings_performance_title),
+                    icon = Icons.Default.Speed,
+                    iconTint = PluviaTheme.colors.accentWarning,
+                ) {
+                    SettingsGroupPerformance()
                 }
 
                 // Interface section

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -2278,8 +2278,8 @@ fun XServerScreen(
                                 isOffline
                             )
 
-                            // Start performance driver after environment is set up
-                            PowerManager.start(container.rootDir)
+                            // Autostart performance driver after environment is set up
+                            PowerManager.autoStart(container.rootDir)
 
                             // Pin game process to performance cores (CPUs 4-7)
                             container.executablePath

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -752,6 +752,11 @@
     <string name="settings_language_restart_confirm">Genstart</string>
     <string name="settings_language_changing">Ændrer sprog og genstarter...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Ydeevne</string>
+    <string name="settings_performance_power_control_title">Strømstyring</string>
+    <string name="settings_performance_power_control_subtitle">Aktivér strømstyring i spil som standard (aktiveret på testede enheder: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulering</string>
     <string name="settings_emulation_orientations_title">Tilladte orienteringer</string>
@@ -2151,6 +2156,8 @@
     <string name="power_control_auto_tuning_desc">Mere stabil ydelse, længere batteritid, mindre varme: justerer automatisk CPU og GPU til dit spil. Verificeret på Retroid Pocket 6.</string>
     <string name="power_control_adaptive_fps">Automatisk FPS-reduktion</string>
     <string name="power_control_adaptive_fps_desc">Sænker FPS-grænsen, når spillet ikke kan nå den, for en stabil billedtakt. Verificeret på Retroid Pocket 6.</string>
+    <string name="power_control_enable">Strømstyring i spil</string>
+    <string name="power_control_enable_desc">Overtag CPU/GPU-klokstyring fra styresystemet</string>
     <string name="power_control_tuning_mode">Justeringstilstand</string>
     <string name="power_control_tuning_mode_per_cluster">Pr. klynge (verificeret på Retroid Pocket 6)</string>
     <string name="power_control_tuning_mode_whole_cpu">PID-regulator</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -901,6 +901,11 @@
     <string name="settings_language_restart_message">Die Änderung der Sprache erfordert einen Neustart der App. Möchtest du fortfahren?</string>
     <string name="settings_language_restart_confirm">Neustart</string>
     <string name="settings_language_changing">Sprache wird geändert und Neustart durchgeführt…</string>
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Leistung</string>
+    <string name="settings_performance_power_control_title">Energieverwaltung</string>
+    <string name="settings_performance_power_control_subtitle">Energieverwaltung im Spiel standardmäßig aktivieren (auf getesteten Geräten aktiviert: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulation</string>
     <string name="settings_emulation_orientations_title">Erlaubte Ausrichtungen</string>
@@ -2221,6 +2226,8 @@
     <string name="power_control_auto_tuning_desc">Stabilere Leistung, längere Akkulaufzeit, weniger Wärme: passt CPU und GPU automatisch an dein Spiel an. Auf dem Retroid Pocket 6 verifiziert.</string>
     <string name="power_control_adaptive_fps">Automatische FPS-Reduzierung</string>
     <string name="power_control_adaptive_fps_desc">Senkt die FPS-Grenze, wenn das Spiel sie nicht erreicht, für eine stabile Bildausgabe. Auf dem Retroid Pocket 6 verifiziert.</string>
+    <string name="power_control_enable">Energieverwaltung im Spiel</string>
+    <string name="power_control_enable_desc">Übernimmt die CPU/GPU-Taktsteuerung vom Betriebssystem</string>
     <string name="power_control_tuning_mode">Anpassungsmodus</string>
     <string name="power_control_tuning_mode_per_cluster">Pro Cluster (auf dem Retroid Pocket 6 verifiziert)</string>
     <string name="power_control_tuning_mode_whole_cpu">PID-Regler</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -942,6 +942,11 @@
     <string name="settings_language_restart_confirm">Reiniciar</string>
     <string name="settings_language_changing">Cambiando idioma y reiniciando…</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Rendimiento</string>
+    <string name="settings_performance_power_control_title">Control de energía</string>
+    <string name="settings_performance_power_control_subtitle">Activa el control de energía en el juego de forma predeterminada (activado en dispositivos probados: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulación</string>
     <string name="settings_emulation_orientations_title">Orientaciones de pantalla permitidas</string>
@@ -2279,6 +2284,8 @@
     <string name="power_control_auto_tuning_desc">Rendimiento más estable, mayor duración de batería, menos calor: ajusta automáticamente la CPU y la GPU para tu juego. Verificado en Retroid Pocket 6.</string>
     <string name="power_control_adaptive_fps">Reducción automática de FPS</string>
     <string name="power_control_adaptive_fps_desc">Reduce el límite de FPS cuando el juego no puede alcanzarlo, para un ritmo estable. Verificado en Retroid Pocket 6.</string>
+    <string name="power_control_enable">Control de energía en el juego</string>
+    <string name="power_control_enable_desc">Toma el control de las frecuencias de CPU/GPU desde el sistema</string>
     <string name="power_control_tuning_mode">Modo de ajuste</string>
     <string name="power_control_tuning_mode_per_cluster">Por clúster (verificado en Retroid Pocket 6)</string>
     <string name="power_control_tuning_mode_whole_cpu">Controlador PID</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -944,8 +944,8 @@
 
     <!-- Settings: Performance Group -->
     <string name="settings_performance_title">Rendimiento</string>
-    <string name="settings_performance_power_control_title">Control de energía</string>
-    <string name="settings_performance_power_control_subtitle">Activa el control de energía en el juego de forma predeterminada (activado en dispositivos probados: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+    <string name="settings_performance_power_control_title">Control de rendimiento</string>
+    <string name="settings_performance_power_control_subtitle">Activa el control de rendimiento en el juego de forma predeterminada (activado en dispositivos probados: AYN Odin 3, Retroid Pocket 6/Nova)</string>
 
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulación</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -955,7 +955,7 @@
     <!-- Settings: Performance Group -->
     <string name="settings_performance_title">Performances</string>
     <string name="settings_performance_power_control_title">Contrôle des performances</string>
-    <string name="settings_performance_power_control_subtitle">Activer la contrôle des performances en jeu par défaut (activée sur les appareils testés : AYN Odin 3, Retroid Pocket 6/Nova)</string>
+    <string name="settings_performance_power_control_subtitle">Activer le contrôle des performances en jeu par défaut (activé sur les appareils testés : AYN Odin 3, Retroid Pocket 6/Nova)</string>
 
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Émulation</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -952,6 +952,11 @@
     <string name="settings_language_restart_confirm">Redémarrer</string>
     <string name="settings_language_changing">Changement de langue et redémarrage…</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Performances</string>
+    <string name="settings_performance_power_control_title">Gestion de l\'alimentation</string>
+    <string name="settings_performance_power_control_subtitle">Activer la gestion de l\'alimentation en jeu par défaut (activée sur les appareils testés : AYN Odin 3, Retroid Pocket 6/Nova)</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Émulation</string>
     <string name="settings_emulation_orientations_title">Orientations autorisées</string>
@@ -2299,6 +2304,8 @@
     <string name="power_control_auto_tuning_desc">Des performances plus stables, une meilleure autonomie, moins de chaleur : ajuste automatiquement le CPU et le GPU pour votre jeu. Vérifié sur Retroid Pocket 6.</string>
     <string name="power_control_adaptive_fps">Réduction automatique des FPS</string>
     <string name="power_control_adaptive_fps_desc">Abaisse la limite de FPS lorsque le jeu ne parvient pas à l\'atteindre, pour une cadence stable. Vérifié sur Retroid Pocket 6.</string>
+    <string name="power_control_enable">Gestion de l\'alimentation en jeu</string>
+    <string name="power_control_enable_desc">Prend le contrôle des fréquences CPU/GPU à la place du système</string>
     <string name="power_control_tuning_mode">Mode de réglage</string>
     <string name="power_control_tuning_mode_per_cluster">Par cluster (vérifié sur Retroid Pocket 6)</string>
     <string name="power_control_tuning_mode_whole_cpu">Régulateur PID</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -954,8 +954,8 @@
 
     <!-- Settings: Performance Group -->
     <string name="settings_performance_title">Performances</string>
-    <string name="settings_performance_power_control_title">Gestion de l\'alimentation</string>
-    <string name="settings_performance_power_control_subtitle">Activer la gestion de l\'alimentation en jeu par défaut (activée sur les appareils testés : AYN Odin 3, Retroid Pocket 6/Nova)</string>
+    <string name="settings_performance_power_control_title">Contrôle des performances</string>
+    <string name="settings_performance_power_control_subtitle">Activer la contrôle des performances en jeu par défaut (activée sur les appareils testés : AYN Odin 3, Retroid Pocket 6/Nova)</string>
 
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Émulation</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -926,6 +926,11 @@
     <string name="settings_language_restart_confirm">Riavvia</string>
     <string name="settings_language_changing">Cambio lingua e riavvio...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Prestazioni</string>
+    <string name="settings_performance_power_control_title">Gestione energetica</string>
+    <string name="settings_performance_power_control_subtitle">Abilita la gestione energetica in gioco per impostazione predefinita (attiva sui dispositivi testati: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulazione</string>
     <string name="settings_emulation_orientations_title">Orientamenti Consentiti</string>
@@ -2272,6 +2277,8 @@
     <string name="power_control_auto_tuning_desc">Prestazioni più stabili, maggiore durata della batteria, meno calore: regola automaticamente CPU e GPU per il tuo gioco. Verificato su Retroid Pocket 6.</string>
     <string name="power_control_adaptive_fps">Riduzione automatica degli FPS</string>
     <string name="power_control_adaptive_fps_desc">Abbassa il limite di FPS quando il gioco non riesce a raggiungerlo, per un ritmo stabile. Verificato su Retroid Pocket 6.</string>
+    <string name="power_control_enable">Gestione energetica in gioco</string>
+    <string name="power_control_enable_desc">Assume il controllo delle frequenze CPU/GPU dal sistema operativo</string>
     <string name="power_control_tuning_mode">Modalità di regolazione</string>
     <string name="power_control_tuning_mode_per_cluster">Per cluster (verificato su Retroid Pocket 6)</string>
     <string name="power_control_tuning_mode_whole_cpu">Controller PID</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -906,8 +906,8 @@
 
     <!-- Settings: Performance Group -->
     <string name="settings_performance_title">パフォーマンス</string>
-    <string name="settings_performance_power_control_title">電力コントロール</string>
-    <string name="settings_performance_power_control_subtitle">ゲーム内電力コントロールをデフォルトで有効にする（テスト済みデバイスではオン: AYN Odin 3、Retroid Pocket 6/Nova）</string>
+    <string name="settings_performance_power_control_title">パフォーマンス制御</string>
+    <string name="settings_performance_power_control_subtitle">ゲーム内パフォーマンス制御をデフォルトで有効にする（テスト済みデバイスではオン: AYN Odin 3、Retroid Pocket 6/Nova）</string>
 
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">エミュレーション</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -904,6 +904,11 @@
     <string name="settings_language_restart_confirm">再起動</string>
     <string name="settings_language_changing">言語を変更して再起動しています…</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">パフォーマンス</string>
+    <string name="settings_performance_power_control_title">電力コントロール</string>
+    <string name="settings_performance_power_control_subtitle">ゲーム内電力コントロールをデフォルトで有効にする（テスト済みデバイスではオン: AYN Odin 3、Retroid Pocket 6/Nova）</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">エミュレーション</string>
     <string name="settings_emulation_orientations_title">許可される向き</string>
@@ -2235,6 +2240,8 @@
     <string name="power_control_auto_tuning_desc">より安定したパフォーマンス、より長いバッテリー駆動時間、発熱の低減：ゲームに合わせてCPUとGPUを自動調整します。Retroid Pocket 6で動作確認済みです。</string>
     <string name="power_control_adaptive_fps">FPSの自動低減</string>
     <string name="power_control_adaptive_fps_desc">ゲームがFPS上限に達しない場合は上限を下げ、フレーム間隔を安定させます。Retroid Pocket 6で動作確認済みです。</string>
+    <string name="power_control_enable">ゲーム内電力コントロール</string>
+    <string name="power_control_enable_desc">OSに代わってCPU/GPUのクロック制御を行います</string>
     <string name="power_control_tuning_mode">調整モード</string>
     <string name="power_control_tuning_mode_per_cluster">クラスターごと（Retroid Pocket 6で動作確認済み）</string>
     <string name="power_control_tuning_mode_whole_cpu">PID制御</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -937,8 +937,8 @@
 
     <!-- Settings: Performance Group -->
     <string name="settings_performance_title">성능</string>
-    <string name="settings_performance_power_control_title">전원 제어</string>
-    <string name="settings_performance_power_control_subtitle">게임 내 전원 제어를 기본적으로 활성화 (테스트된 기기에서 켜짐: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+    <string name="settings_performance_power_control_title">성능 제어</string>
+    <string name="settings_performance_power_control_subtitle">게임 내 성능 제어를 기본적으로 활성화 (테스트된 기기에서 켜짐: AYN Odin 3, Retroid Pocket 6/Nova)</string>
 
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">에뮬레이션</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -935,6 +935,11 @@
     <string name="settings_language_restart_confirm">재시작</string>
     <string name="settings_language_changing">언어 변경 및 재시작 중...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">성능</string>
+    <string name="settings_performance_power_control_title">전원 제어</string>
+    <string name="settings_performance_power_control_subtitle">게임 내 전원 제어를 기본적으로 활성화 (테스트된 기기에서 켜짐: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">에뮬레이션</string>
     <string name="settings_emulation_orientations_title">허용된 방향</string>
@@ -2276,6 +2281,8 @@
     <string name="power_control_auto_tuning_desc">더 안정적인 성능, 더 긴 배터리 사용 시간, 더 적은 발열: 게임에 맞춰 CPU와 GPU를 자동으로 조정합니다. Retroid Pocket 6에서 검증되었습니다.</string>
     <string name="power_control_adaptive_fps">FPS 자동 감소</string>
     <string name="power_control_adaptive_fps_desc">게임이 FPS 상한에 도달하지 못하면 상한을 낮춰 프레임 간격을 안정시킵니다. Retroid Pocket 6에서 검증되었습니다.</string>
+    <string name="power_control_enable">게임 내 전원 제어</string>
+    <string name="power_control_enable_desc">OS 대신 CPU/GPU 클럭을 제어합니다</string>
     <string name="power_control_tuning_mode">튜닝 모드</string>
     <string name="power_control_tuning_mode_per_cluster">클러스터별 (Retroid Pocket 6에서 검증됨)</string>
     <string name="power_control_tuning_mode_whole_cpu">PID 제어기</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -945,8 +945,8 @@
 
     <!-- Settings: Performance Group -->
     <string name="settings_performance_title">Wydajność</string>
-    <string name="settings_performance_power_control_title">Zarządzanie energią</string>
-    <string name="settings_performance_power_control_subtitle">Domyślnie włącz zarządzanie energią w grze (włączone na testowanych urządzeniach: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+    <string name="settings_performance_power_control_title">Kontrola wydajności</string>
+    <string name="settings_performance_power_control_subtitle">Domyślnie włącz kontrola wydajności w grze (włączone na testowanych urządzeniach: AYN Odin 3, Retroid Pocket 6/Nova)</string>
 
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulacja</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -946,7 +946,7 @@
     <!-- Settings: Performance Group -->
     <string name="settings_performance_title">Wydajność</string>
     <string name="settings_performance_power_control_title">Kontrola wydajności</string>
-    <string name="settings_performance_power_control_subtitle">Domyślnie włącz kontrola wydajności w grze (włączone na testowanych urządzeniach: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+    <string name="settings_performance_power_control_subtitle">Domyślnie włącz kontrolę wydajności w grze (włączone na testowanych urządzeniach: AYN Odin 3, Retroid Pocket 6/Nova)</string>
 
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulacja</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -943,6 +943,11 @@
     <string name="settings_language_restart_confirm">Uruchom ponownie</string>
     <string name="settings_language_changing">Zmiana języka i ponowne uruchamianie...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Wydajność</string>
+    <string name="settings_performance_power_control_title">Zarządzanie energią</string>
+    <string name="settings_performance_power_control_subtitle">Domyślnie włącz zarządzanie energią w grze (włączone na testowanych urządzeniach: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulacja</string>
     <string name="settings_emulation_orientations_title">Dozwolone orientacje</string>
@@ -2285,6 +2290,8 @@
     <string name="power_control_auto_tuning_desc">Stabilniejsza wydajność, dłuższy czas pracy baterii, mniej ciepła: automatycznie dostraja CPU i GPU do gry. Zweryfikowano na Retroid Pocket 6.</string>
     <string name="power_control_adaptive_fps">Automatyczna redukcja FPS</string>
     <string name="power_control_adaptive_fps_desc">Obniża limit FPS, gdy gra nie może go osiągnąć, aby zapewnić stabilne tempo klatek. Zweryfikowano na Retroid Pocket 6.</string>
+    <string name="power_control_enable">Zarządzanie energią w grze</string>
+    <string name="power_control_enable_desc">Przejmij kontrolę nad taktowaniem CPU/GPU od systemu</string>
     <string name="power_control_tuning_mode">Tryb dostrajania</string>
     <string name="power_control_tuning_mode_per_cluster">Na klaster (zweryfikowano na Retroid Pocket 6)</string>
     <string name="power_control_tuning_mode_whole_cpu">Regulator PID</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -754,8 +754,8 @@
 
     <!-- Settings: Performance Group -->
     <string name="settings_performance_title">Desempenho</string>
-    <string name="settings_performance_power_control_title">Controle de energia</string>
-    <string name="settings_performance_power_control_subtitle">Ativa o controle de energia no jogo por padrão (ativado em dispositivos testados: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+    <string name="settings_performance_power_control_title">Controle de desempenho</string>
+    <string name="settings_performance_power_control_subtitle">Ativa o controle de desempenho no jogo por padrão (ativado em dispositivos testados: AYN Odin 3, Retroid Pocket 6/Nova)</string>
 
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulação</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -752,6 +752,11 @@
     <string name="settings_language_restart_confirm">Reiniciar</string>
     <string name="settings_language_changing">Alterando idioma e reiniciando...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Desempenho</string>
+    <string name="settings_performance_power_control_title">Controle de energia</string>
+    <string name="settings_performance_power_control_subtitle">Ativa o controle de energia no jogo por padrão (ativado em dispositivos testados: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulação</string>
     <string name="settings_emulation_orientations_title">Orientações permitidas</string>
@@ -2151,6 +2156,8 @@
     <string name="power_control_auto_tuning_desc">Desempenho mais estável, maior duração da bateria, menos calor: ajusta automaticamente a CPU e a GPU para o seu jogo. Verificado no Retroid Pocket 6.</string>
     <string name="power_control_adaptive_fps">Redução automática de FPS</string>
     <string name="power_control_adaptive_fps_desc">Reduz o limite de FPS quando o jogo não consegue alcançá-lo, para um ritmo estável. Verificado no Retroid Pocket 6.</string>
+    <string name="power_control_enable">Controle de energia no jogo</string>
+    <string name="power_control_enable_desc">Assume o controle dos clocks de CPU/GPU no lugar do sistema</string>
     <string name="power_control_tuning_mode">Modo de ajuste</string>
     <string name="power_control_tuning_mode_per_cluster">Por cluster (verificado no Retroid Pocket 6)</string>
     <string name="power_control_tuning_mode_whole_cpu">Controlador PID</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -937,8 +937,8 @@
 
 	<!-- Settings: Performance Group -->
 	<string name="settings_performance_title">Performanță</string>
-	<string name="settings_performance_power_control_title">Control alimentare</string>
-	<string name="settings_performance_power_control_subtitle">Activează implicit controlul alimentării în joc (activat pe dispozitivele testate: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+	<string name="settings_performance_power_control_title">Control performanță</string>
+	<string name="settings_performance_power_control_subtitle">Activează implicit controlul performanță în joc (activat pe dispozitivele testate: AYN Odin 3, Retroid Pocket 6/Nova)</string>
 
 	<!-- Settings: Emulation Group -->
 	<string name="settings_emulation_title">Emulare</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -937,8 +937,8 @@
 
 	<!-- Settings: Performance Group -->
 	<string name="settings_performance_title">Performanță</string>
-	<string name="settings_performance_power_control_title">Control performanță</string>
-	<string name="settings_performance_power_control_subtitle">Activează implicit controlul performanță în joc (activat pe dispozitivele testate: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+	<string name="settings_performance_power_control_title">Control performanței</string>
+	<string name="settings_performance_power_control_subtitle">Activează implicit controlul performanței în joc (activat pe dispozitivele testate: AYN Odin 3, Retroid Pocket 6/Nova)</string>
 
 	<!-- Settings: Emulation Group -->
 	<string name="settings_emulation_title">Emulare</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -935,6 +935,11 @@
 	<string name="settings_language_restart_confirm">Repornește</string>
 	<string name="settings_language_changing">Se schimbă limba și se repornește...</string>
 
+	<!-- Settings: Performance Group -->
+	<string name="settings_performance_title">Performanță</string>
+	<string name="settings_performance_power_control_title">Control alimentare</string>
+	<string name="settings_performance_power_control_subtitle">Activează implicit controlul alimentării în joc (activat pe dispozitivele testate: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+
 	<!-- Settings: Emulation Group -->
 	<string name="settings_emulation_title">Emulare</string>
 	<string name="settings_emulation_orientations_title">Orientări permise</string>
@@ -2285,6 +2290,8 @@
     <string name="power_control_auto_tuning_desc">Performanță mai stabilă, autonomie mai mare a bateriei, mai puțină căldură: reglează automat CPU și GPU pentru jocul tău. Verificat pe Retroid Pocket 6.</string>
     <string name="power_control_adaptive_fps">Reducere automată a FPS</string>
     <string name="power_control_adaptive_fps_desc">Scade limita de FPS când jocul nu o poate atinge, pentru un ritm stabil. Verificat pe Retroid Pocket 6.</string>
+    <string name="power_control_enable">Control alimentare în joc</string>
+    <string name="power_control_enable_desc">Preia controlul frecvențelor CPU/GPU de la sistemul de operare</string>
     <string name="power_control_tuning_mode">Mod de reglare</string>
     <string name="power_control_tuning_mode_per_cluster">Pe cluster (verificat pe Retroid Pocket 6)</string>
     <string name="power_control_tuning_mode_whole_cpu">Regulator PID</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1109,8 +1109,8 @@ https://gamenative.app
     <string name="settings_emulation_driver_manager_subtitle">Установить или удалить пользовательские пакеты графических драйверов</string>
     <!-- Settings: Performance Group -->
     <string name="settings_performance_title">Производительность</string>
-    <string name="settings_performance_power_control_title">Управление питанием</string>
-    <string name="settings_performance_power_control_subtitle">Включать управление питанием в игре по умолчанию (включено на протестированных устройствах: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+    <string name="settings_performance_power_control_title">Управление производительностью</string>
+    <string name="settings_performance_power_control_subtitle">Включать управление производительностью в игре по умолчанию (включено на протестированных устройствах: AYN Odin 3, Retroid Pocket 6/Nova)</string>
 
     <string name="settings_emulation_driver_manager_title">Менеджер драйверов</string>
     <string name="settings_emulation_orientations_subtitle">Выберите, какие ориентации можно повернуть во время игры</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1107,6 +1107,11 @@ https://gamenative.app
     <string name="settings_emulation_default_config_subtitle">Начальные настройки контейнера для каждой игры (не влияет на уже установленные игры)</string>
     <string name="settings_emulation_default_config_title">Изменить конфигурацию по умолчанию</string>
     <string name="settings_emulation_driver_manager_subtitle">Установить или удалить пользовательские пакеты графических драйверов</string>
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Производительность</string>
+    <string name="settings_performance_power_control_title">Управление питанием</string>
+    <string name="settings_performance_power_control_subtitle">Включать управление питанием в игре по умолчанию (включено на протестированных устройствах: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+
     <string name="settings_emulation_driver_manager_title">Менеджер драйверов</string>
     <string name="settings_emulation_orientations_subtitle">Выберите, какие ориентации можно повернуть во время игры</string>
     <string name="settings_emulation_orientations_title">Разрешённые ориентации</string>
@@ -2213,6 +2218,8 @@ https://gamenative.app
     <string name="power_control_auto_tuning_desc">Более стабильная производительность, дольше работа от батареи, меньше нагрев: автоматически настраивает CPU и GPU под игру. Проверено на Retroid Pocket 6.</string>
     <string name="power_control_adaptive_fps">Автоматическое снижение FPS</string>
     <string name="power_control_adaptive_fps_desc">Снижает предел FPS, если игра не может его достичь, для стабильного темпа кадров. Проверено на Retroid Pocket 6.</string>
+    <string name="power_control_enable">Управление питанием в игре</string>
+    <string name="power_control_enable_desc">Перехватывает управление частотами CPU/GPU у ОС</string>
     <string name="power_control_tuning_mode">Режим настройки</string>
     <string name="power_control_tuning_mode_per_cluster">По кластерам (проверено на Retroid Pocket 6)</string>
     <string name="power_control_tuning_mode_whole_cpu">ПИД-регулятор</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -929,6 +929,11 @@
     <string name="settings_language_restart_confirm">Перезапустити</string>
     <string name="settings_language_changing">Зміна мови та перезапуск...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Продуктивність</string>
+    <string name="settings_performance_power_control_title">Керування живленням</string>
+    <string name="settings_performance_power_control_subtitle">Вмикати керування живленням у грі за замовчуванням (увімкнено на перевірених пристроях: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Емуляція</string>
     <string name="settings_emulation_orientations_title">Дозволені орієнтації екрану</string>
@@ -2281,6 +2286,8 @@
     <string name="power_control_auto_tuning_desc">Стабільніша продуктивність, довша робота від батареї, менше нагрівання: автоматично налаштовує CPU та GPU під гру. Перевірено на Retroid Pocket 6.</string>
     <string name="power_control_adaptive_fps">Автоматичне зниження FPS</string>
     <string name="power_control_adaptive_fps_desc">Знижує ліміт FPS, якщо гра не може його досягти, для стабільного темпу кадрів. Перевірено на Retroid Pocket 6.</string>
+    <string name="power_control_enable">Керування живленням у грі</string>
+    <string name="power_control_enable_desc">Перехоплює керування частотами CPU/GPU в ОС</string>
     <string name="power_control_tuning_mode">Режим налаштування</string>
     <string name="power_control_tuning_mode_per_cluster">За кластерами (перевірено на Retroid Pocket 6)</string>
     <string name="power_control_tuning_mode_whole_cpu">ПІД-регулятор</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -921,8 +921,8 @@
 
     <!-- 设置：性能组 -->
     <string name="settings_performance_title">性能</string>
-    <string name="settings_performance_power_control_title">功耗控制</string>
-    <string name="settings_performance_power_control_subtitle">默认启用游戏内功耗控制（已在测试设备上启用：AYN Odin 3、Retroid Pocket 6/Nova）</string>
+    <string name="settings_performance_power_control_title">性能控制</string>
+    <string name="settings_performance_power_control_subtitle">默认启用游戏内性能控制（已在测试设备上启用：AYN Odin 3、Retroid Pocket 6/Nova）</string>
 
     <!-- 设置：模拟组 -->
     <string name="settings_emulation_title">模拟设置</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -919,6 +919,11 @@
     <string name="settings_language_restart_confirm">重新启动</string>
     <string name="settings_language_changing">切换语言并重新启动中...</string>
 
+    <!-- 设置：性能组 -->
+    <string name="settings_performance_title">性能</string>
+    <string name="settings_performance_power_control_title">功耗控制</string>
+    <string name="settings_performance_power_control_subtitle">默认启用游戏内功耗控制（已在测试设备上启用：AYN Odin 3、Retroid Pocket 6/Nova）</string>
+
     <!-- 设置：模拟组 -->
     <string name="settings_emulation_title">模拟设置</string>
     <string name="settings_emulation_orientations_title">允许的屏幕方向</string>
@@ -2296,6 +2301,8 @@
     <string name="power_control_auto_tuning_desc">更稳定的性能、更长的续航、更少的发热：自动为游戏调节 CPU 和 GPU。已在 Retroid Pocket 6 上验证。</string>
     <string name="power_control_adaptive_fps">自动降低 FPS</string>
     <string name="power_control_adaptive_fps_desc">当游戏无法达到 FPS 上限时降低上限，以获得稳定的帧间隔。已在 Retroid Pocket 6 上验证。</string>
+    <string name="power_control_enable">游戏内功耗控制</string>
+    <string name="power_control_enable_desc">接管操作系统对 CPU/GPU 频率的控制</string>
     <string name="power_control_tuning_mode">调整模式</string>
     <string name="power_control_tuning_mode_per_cluster">分集群（已在 Retroid Pocket 6 上验证）</string>
     <string name="power_control_tuning_mode_whole_cpu">PID 控制器</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -921,6 +921,11 @@
     <string name="settings_language_restart_confirm">重新啟動</string>
     <string name="settings_language_changing">切換語言並重新啟動中...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">效能</string>
+    <string name="settings_performance_power_control_title">功耗控制</string>
+    <string name="settings_performance_power_control_subtitle">預設啟用遊戲內功耗控制（已在測試裝置上啟用：AYN Odin 3、Retroid Pocket 6/Nova）</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">模擬設定</string>
     <string name="settings_emulation_orientations_title">允許的螢幕方向</string>
@@ -2287,6 +2292,8 @@
     <string name="power_control_auto_tuning_desc">更穩定的效能、更長的續航、更少的發熱：自動為遊戲調節 CPU 和 GPU。已在 Retroid Pocket 6 上驗證。</string>
     <string name="power_control_adaptive_fps">自動降低 FPS</string>
     <string name="power_control_adaptive_fps_desc">當遊戲無法達到 FPS 上限時降低上限，以獲得穩定的影格間隔。已在 Retroid Pocket 6 上驗證。</string>
+    <string name="power_control_enable">遊戲內功耗控制</string>
+    <string name="power_control_enable_desc">接管作業系統對 CPU/GPU 頻率的控制</string>
     <string name="power_control_tuning_mode">調整模式</string>
     <string name="power_control_tuning_mode_per_cluster">分叢集（已在 Retroid Pocket 6 上驗證）</string>
     <string name="power_control_tuning_mode_whole_cpu">PID 控制器</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -923,8 +923,8 @@
 
     <!-- Settings: Performance Group -->
     <string name="settings_performance_title">效能</string>
-    <string name="settings_performance_power_control_title">功耗控制</string>
-    <string name="settings_performance_power_control_subtitle">預設啟用遊戲內功耗控制（已在測試裝置上啟用：AYN Odin 3、Retroid Pocket 6/Nova）</string>
+    <string name="settings_performance_power_control_title">效能控制</string>
+    <string name="settings_performance_power_control_subtitle">預設啟用遊戲內效能控制（已在測試裝置上啟用：AYN Odin 3、Retroid Pocket 6/Nova）</string>
 
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">模擬設定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1049,6 +1049,11 @@
     <string name="settings_language_restart_confirm">Restart</string>
     <string name="settings_language_changing">Changing language and restarting...</string>
 
+    <!-- Settings: Performance Group -->
+    <string name="settings_performance_title">Performance</string>
+    <string name="settings_performance_power_control_title">Power Control</string>
+    <string name="settings_performance_power_control_subtitle">Enable in-game power control by default (enabled on tested devices: AYN Odin 3, Retroid Pocket 6/Nova)</string>
+
     <!-- Settings: Emulation Group -->
     <string name="settings_emulation_title">Emulation</string>
     <string name="settings_emulation_orientations_title">Allowed Orientations</string>
@@ -2314,6 +2319,8 @@
     <string name="power_control_auto_tuning_desc">More stable performance, longer battery life, less heat: automatically tunes CPU and GPU for your game. Verified on Retroid Pocket 6.</string>
     <string name="power_control_adaptive_fps">Automatic FPS reduction</string>
     <string name="power_control_adaptive_fps_desc">Lowers the FPS cap when the game cannot reach it, for stable pacing. Verified on Retroid Pocket 6.</string>
+    <string name="power_control_enable">In-Game Power Control</string>
+    <string name="power_control_enable_desc">Take over CPU/GPU clock control from the OS</string>
     <string name="power_control_tuning_mode">Tuning Mode</string>
     <string name="power_control_tuning_mode_per_cluster">Per-cluster (verified on Retroid Pocket 6)</string>
     <string name="power_control_tuning_mode_whole_cpu">PID Controller</string>


### PR DESCRIPTION
## Description
Introduces a master switch to enable or disable all in-game power control features. This allows users to prevent the app from taking over CPU/GPU clock management from the OS.

- Adds a "Power Control" toggle to settings to set the default state.
- The `PowerManager` now conditionally activates its features based on this toggle, and the UI reflects this state by hiding/disabling sub-controls when power control is off.
- Refactors `PowerManager`'s lifecycle and `PServerDriver`'s initialization to streamline logic and simplify driver interactions.
- Update `PID Controller` implementation logic to give different min / max values
- Only tested devices (nova, rp6 and odin 3) will have power control enabled by default, all other devices will need to manually enable during game or using app setting.
- Fixed Metrics and Automatic FPS cap functions to work independently without enabling power control

## Recording
<img width="1920" height="1080" alt="Screenshot_20260821_020130" src="https://github.com/user-attachments/assets/3757d5af-4072-4516-80b8-99d16cf312e6" />

https://github.com/user-attachments/assets/8ebb8544-0869-43d7-966c-e0685700b461

## Type of Change
- [x] Bug fix
- [x] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x]  I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global toggle for in‑game power control so CPU/GPU management runs only when enabled. Previously power control always autostarted; now `autoStart(...)` respects the toggle, the quick menu exposes a master switch, controllers skip init when disabled, and the driver stops when power control is turned off.

- Settings: new Performance section with a “Power Control” default; profiles seed `enablePowerControl` from this; enabled by default only on tested devices (AYN Odin 3, Retroid Pocket 6/Nova).
- `PowerManager`: new `autoStart(containerDir)`, gates init/start/stop on the toggle; fixes `setPowerProfile`; stops the driver when disabling power control.
- `PServerDriver`: caches CPU policies and cluster mapping, adds availability checks, and reduces IPC.
- `PerformanceAutoTuner`: switches to min/max range updates and tightens PID bounds.
- Metrics/UI/hardening: use `canRead()` for sysfs; `PowerControlUiState.Success.cpuInfo` is nullable; fan controller correctly stops on toggle off; adaptive FPS cap and performance metrics loaders initialize correctly; quick menu adds Power Control and Adaptive FPS toggles.
- Defaults: `SamsungPerformanceDriver` disables auto‑tuning by default and seeds `enablePowerControl` from settings.

**Migration**
- Replace `PowerManager.start(...)` with `PowerManager.autoStart(containerDir)`.
- Update `PerformanceAutoTuner` callbacks to accept `(min, max)` for CPU/GPU/Bus.
- Remove any overrides/usages of `PerformanceDriver.reset()` and `readFile()`.
- Handle null for `PowerControlUiState.Success.cpuInfo`.

<sup>Written for commit 4a8255d8f3aa311b39476e3d5af353238b6d5b97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Performance settings section with a configurable default for in-game power control.
  * Added CPU/GPU tuning, fan control, game pinning, adaptive FPS, and profile-management options.
  * Added automatic tuning with separate minimum and maximum performance levels.
* **Bug Fixes**
  * Improved device support detection, hardware-state reporting, and unavailable CPU handling.
  * Enhanced GPU detection, driver startup, and power-control reliability.
  * Controls now appear only when supported by the device.
* **Localization**
  * Added translations for Performance and power-control settings across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->