### PR TITLE
Added new turnips, new fex, new box64, new wowbox64

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,24 @@
   "items": {
     "driver": [
       {
+        "id": "Turnip Gen8 V34",
+        "name": "Turnip_Gen8_V34",
+        "url": "https://downloads.gamenative.app/drivers/Turnip_Gen8_V34.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "Turnip v26.3.0-R3",
+        "name": "Turnip_v26.3.0-R3",
+        "url": "https://downloads.gamenative.app/drivers/Turnip_v26.3.0-R3.zip",
+        "variant": "bionic"
+      },
+      {
+        "id": "Turnip Adreno Driver T30 (@Mr_Purple_666)",
+        "name": "Turnip Adreno Driver T30 (@Mr_Purple_666)",
+        "url": "https://downloads.gamenative.app/drivers/turnip_mrpurple_T30-toasted.adpkg.zip",
+        "variant": "bionic"
+      },
+      {
         "id": "Turnip v26.1.0 A12 Fix",
         "name": "Turnip_v26.1.0_A12Fix",
         "url": "https://downloads.gamenative.app/drivers/Turnip_v26.1.0_A12Fix.zip",
@@ -832,13 +850,39 @@
     ],
     "fexcore": [
       {
+        "id": "2607-0",
+        "name": "FEX 2607",
+        "url": "https://downloads.gamenative.app/FEXCore-2607.wcp",
+        "variant": "bionic"
+      },
+      {
+        "id": "2608-0",
+        "name": "FEX 2608",
+        "url": "https://downloads.gamenative.app/FEXCore-2608.wcp",
+        "variant": "bionic"
+      },
+      {
         "id": "2601-217d039-0",
         "name": "FEX 2601-217d039",
         "url": "https://downloads.gamenative.app/FEXCore-2601-217d039.wcp",
         "variant": "bionic"
       }
     ],
+    "box64": [
+      {
+        "id": "0.4.4-1",
+        "name": "Box64 0.4.4",
+        "url": "https://downloads.gamenative.app/box64-0.4.4.wcp",
+        "variant": "bionic"
+      }
+    ],
     "wowbox64": [
+      {
+        "id": "0.4.4-1",
+        "name": "WOWBox64 0.4.4",
+        "url": "https://downloads.gamenative.app/Wowbox64-0.4.4.wcp",
+        "variant": "bionic"
+      },
       {
         "id": "0.3.6-0",
         "name": "WOWBox64 0.3.6",


### PR DESCRIPTION
## Description
Manifest changes with new contents

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new Turnip drivers, FEX builds, and `box64`/`wowbox64` entries to the manifest to expose newer GPU drivers and emulation layers. This is additive; existing entries remain unchanged.

**Changes**
- Drivers: Added Turnip Gen8 V34, Turnip v26.3.0-R3, and Turnip Adreno Driver T30 (`@Mr_Purple_666`) with `variant: bionic`.
- `fexcore`: Added FEX 2607 and 2608.
- `box64`: Introduced new section with Box64 0.4.4.
- `wowbox64`: Added WOWBox64 0.4.4.
- All assets served from downloads.gamenative.app.

**Rollout**
- No migration required. Refresh the manifest cache to surface new items.
- If clients hardcode manifest categories, add `box64` to the allowlist or ensure unknown sections are tolerated.

<sup>Written for commit 6408eec4db5b67df7a15027bbdb7fbfd39271b28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three Turnip drivers to the available driver manifest.
  * Added two FEXCore releases.
  * Added Box64 0.4.4 and WOWBox64 0.4.4 releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->