### PR TITLE
fix: handle lateinit exception in power manager

### DIFF
--- a/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
+++ b/app/src/main/java/app/gamenative/powercontrol/PowerManager.kt
@@ -204,6 +204,7 @@ object PowerManager {
                 NoOpPerformanceDriver()
             }
         }
+        currentProfile = driver.getDefaultProfile()
     }
 
     /**


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize `currentProfile` during `PowerManager` setup to prevent LateinitPropertyAccessException and startup crashes. Previously, reads before the first explicit assignment crashed; now we set `currentProfile` to `driver.getDefaultProfile()` immediately, so consumers always see a valid default.

- Verify `getDefaultProfile()` aligns with expected defaults for each driver (including `NoOpPerformanceDriver`).
- No migrations or configuration changes required.

<sup>Written for commit 9d69341296feffde43d7b3b32bcd20fa30a4c110. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Power management now reliably loads the driver’s default profile during initialization.
  * Prevented errors that could occur when accessing power settings before the profile was loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->