### PR TITLE
feat: explicit progress [QoL]

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -1455,6 +1455,11 @@ object PrefManager {
             setPref(CUSTOM_GAME_MANUAL_FOLDERS, Json.encodeToString(value))
         }
 
+    // Detailed per-step reporting on the boot splash; off means the plain indeterminate bar
+    private val VERBOSE_BOOT_PROGRESS = booleanPreferencesKey("verbose_boot_progress")
+    var verboseBootProgress: Boolean
+        get() = getPref(VERBOSE_BOOT_PROGRESS, false)
+        set(value) = setPref(VERBOSE_BOOT_PROGRESS, value)
     private val FAVORITE_APP_IDS = stringPreferencesKey("favorite_app_ids")
     var favoriteAppIds: Set<String>
         get() {

--- a/app/src/main/java/app/gamenative/events/AndroidEvent.kt
+++ b/app/src/main/java/app/gamenative/events/AndroidEvent.kt
@@ -20,7 +20,7 @@ interface AndroidEvent<T> : Event<T> {
     data class ShowGameFeedback(val appId: String) : AndroidEvent<Unit>
     data class ShowLaunchingOverlay(val appName: String) : AndroidEvent<Unit>
     data object HideLaunchingOverlay : AndroidEvent<Unit>
-    data class SetBootingSplashText(val text: String) : AndroidEvent<Unit>
+    data class SetBootingSplashText(val text: String, val progress: Float = -1f) : AndroidEvent<Unit>
     data object ClearBootingSplash : AndroidEvent<Unit>
     data class DownloadPausedDueToConnectivity(val appId: Int) : AndroidEvent<Unit>
     data class DownloadStatusChanged(val appId: Int, val isDownloading: Boolean) : AndroidEvent<Unit>

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1547,6 +1547,7 @@ fun PluviaMain(
                 BootingSplash(
                     visible = state.showBootingSplash,
                     text = state.bootingSplashText,
+                    progress = state.bootingSplashProgress,
                     heroImageUrl = state.bootingSplashHeroImageUrl,
                     bootAd = state.bootAd,
                 )

--- a/app/src/main/java/app/gamenative/ui/data/MainState.kt
+++ b/app/src/main/java/app/gamenative/ui/data/MainState.kt
@@ -25,6 +25,7 @@ data class MainState(
     val debugRun: Boolean = false,
     val showBootingSplash: Boolean = false,
     val bootingSplashText: String = "Booting...",
+    val bootingSplashProgress: Float = -1f,
     val bootingSplashHeroImageUrl: String = "",
     val bootAd: BootAdItem? = null,
 

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -340,6 +340,7 @@ class MainViewModel @Inject constructor(
         PluviaApp.events.off<SteamEvent.LoggedOut, Unit>(onLoggedOut)
         PluviaApp.events.off<AndroidEvent.ServiceReady, Unit>(onServiceReady)
         connectionTimeoutJob?.cancel()
+        BootProgress.stop()
     }
 
     fun setTheme(value: AppTheme) {
@@ -416,10 +417,26 @@ class MainViewModel @Inject constructor(
             }
             // bootAd stays in state so the exit fade keeps rendering it; the next show replaces it.
             PluviaApp.isBootingSplashShowing = false
-            _state.update { it.copy(showBootingSplash = false) }
+            _state.update {
+                it.copy(
+                    showBootingSplash = false,
+                    bootingSplashText = MainState().bootingSplashText,
+                    bootingSplashProgress = MainState().bootingSplashProgress,
+                )
+            }
         } else {
             PluviaApp.isBootingSplashShowing = value
-            _state.update { it.copy(showBootingSplash = value) }
+            _state.update {
+                if (value) {
+                    it.copy(showBootingSplash = true)
+                } else {
+                    it.copy(
+                        showBootingSplash = false,
+                        bootingSplashText = MainState().bootingSplashText,
+                        bootingSplashProgress = MainState().bootingSplashProgress,
+                    )
+                }
+            }
         }
     }
 

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -34,6 +34,7 @@ import app.gamenative.ui.data.MainState
 import app.gamenative.ui.enums.ConnectionState
 import app.gamenative.ui.screen.PluviaScreen
 import app.gamenative.ui.util.SnackbarManager
+import app.gamenative.utils.BootProgress
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.DebugReportUtils
 import app.gamenative.utils.IntentLaunchManager
@@ -259,6 +260,7 @@ class MainViewModel @Inject constructor(
 
     private val onSetBootingSplashText: (AndroidEvent.SetBootingSplashText) -> Unit = {
         setBootingSplashText(it.text)
+        _state.update { state -> state.copy(bootingSplashProgress = it.progress) }
         setShowBootingSplash(true)
     }
 
@@ -369,6 +371,8 @@ class MainViewModel @Inject constructor(
     }
 
     fun setShowBootingSplash(value: Boolean) {
+        // Single choke point for every dismissal path, so boot reporting can never outlive the splash.
+        if (!value) BootProgress.stop()
         val wasShowing = _state.value.showBootingSplash
         if (value && !wasShowing) {
             // The splash hides and re-shows between boot phases; a quick re-show is the same

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupDebug.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupDebug.kt
@@ -87,6 +87,9 @@ fun SettingsGroupDebug() {
     var enableBox86Logs by rememberSaveable { mutableStateOf(
         if (isPreview) false else WinlatorPrefManager.getBoolean("enable_box86_64_logs", false)
     ) }
+    var verboseBootProgress by rememberSaveable {
+        mutableStateOf(if (isPreview) false else PrefManager.verboseBootProgress)
+    }
     var latestCrashFile: File? by rememberSaveable { mutableStateOf(null) }
     LaunchedEffect(Unit) {
         val crashDir = File(context.getExternalFilesDir(null), "crash_logs")
@@ -219,6 +222,18 @@ fun SettingsGroupDebug() {
                 enableBox86Logs = it
                 if (!isPreview) {
                     WinlatorPrefManager.putBoolean("enable_box86_64_logs", it)
+                }
+            },
+        )
+        SettingsSwitch(
+            colors = settingsTileColorsAlt(),
+            state = verboseBootProgress,
+            title = { Text(text = stringResource(R.string.settings_debug_verbose_boot_title)) },
+            subtitle = { Text(text = stringResource(R.string.settings_debug_verbose_boot_subtitle)) },
+            onCheckedChange = {
+                verboseBootProgress = it
+                if (!isPreview) {
+                    PrefManager.verboseBootProgress = it
                 }
             },
         )

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XAudioUtils.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XAudioUtils.kt
@@ -1,13 +1,12 @@
 package app.gamenative.ui.screen.xserver
 
 import android.content.Context
-import app.gamenative.PluviaApp
 import app.gamenative.data.GameSource
-import app.gamenative.events.AndroidEvent
 import app.gamenative.service.SteamService
 import app.gamenative.service.amazon.AmazonService
 import app.gamenative.service.epic.EpicService
 import app.gamenative.service.gog.GOGService
+import app.gamenative.utils.BootProgress
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.CustomGameScanner
 import app.gamenative.utils.FileUtils
@@ -134,7 +133,7 @@ object XAudioUtils {
                 return
             }
 
-            PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Extracting XAudio DLLs..."))
+            BootProgress.detail("extracting XAudio DLLs")
 
             val batFile = File(tempDir, "extract_dx_audio_dlls.bat")
             val batContent = buildCabarcBatchScript(

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XAudioUtils.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XAudioUtils.kt
@@ -133,7 +133,7 @@ object XAudioUtils {
                 return
             }
 
-            BootProgress.detail("extracting XAudio DLLs")
+            BootProgress.detail("extracting XAudio DLLs", legacy = "Extracting XAudio DLLs...")
 
             val batFile = File(tempDir, "extract_dx_audio_dlls.bat")
             val batContent = buildCabarcBatchScript(

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -5012,6 +5012,7 @@ private fun unpackExecutableFile(
                     BootProgress.update(
                         index.toFloat() / exePaths.size,
                         "${index + 1}/${exePaths.size}: ${extractExecutableBasename(executablePath)}",
+                        legacy = "Handling DRM (${index + 1}/${exePaths.size})".takeIf { exePaths.size > 1 },
                     )
                     var batchFile: File? = null
                     try {

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -119,6 +119,7 @@ import app.gamenative.ui.component.QuickMenu
 import app.gamenative.ui.component.QuickMenuAction
 import app.gamenative.ui.component.SteamInviteState
 import app.gamenative.ui.component.parseBooleanExtra
+import app.gamenative.utils.BootProgress
 import app.gamenative.ui.component.parsePositiveFpsLimit
 import app.gamenative.ui.data.PerformanceHudConfig
 import app.gamenative.ui.data.PerformanceHudSize
@@ -2226,6 +2227,7 @@ fun XServerScreen(
 
                     setupExecutor.submit {
                         try {
+                            BootProgress.start()
                             val containerManager = ContainerManager(context)
                             // Configure WinHandler with container's input API settings
                             val handler = getxServer().winHandler
@@ -2308,6 +2310,7 @@ fun XServerScreen(
                             val envVars = EnvVars()
                             immersiveHooks?.windowsVr?.beforeWineSystemSetup(container)
 
+                            BootProgress.phase(BootProgress.Phase.WINE_FILES)
                             runBlocking {
                                 setupWineSystemFiles(
                                     context,
@@ -2324,6 +2327,7 @@ fun XServerScreen(
                             extractArm64ecInputDLLs(context, container) // REQUIRED: Uses updated xinput1_3 main.c from x86_64 build, prevents crashes with 3+ players, avoids need for input shim dlls.
                             extractx86_64InputDlls(context, container)
 
+                            BootProgress.phase(BootProgress.Phase.GRAPHICS)
                             runBlocking {
                                 extractGraphicsDriverFiles(
                                     context,
@@ -3830,6 +3834,7 @@ private fun setupXEnvironment(
     offline: Boolean = false,
     immersiveHooks: app.gamenative.ui.screen.xr.ImmersiveSessionHooks? = null,
 ): XEnvironment {
+    BootProgress.phase(BootProgress.Phase.ENVIRONMENT)
     ProcessHelper.hardKillStaleWineProcesses()
 
     val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
@@ -4017,9 +4022,9 @@ private fun setupXEnvironment(
                 onError = onGameLaunchError
             )
             if (preInstallCommands.isNotEmpty()) {
-                PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Installing prerequisites..."))
+                BootProgress.phase(BootProgress.Phase.PREREQS, "1/${preInstallCommands.size}")
             } else {
-                PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Launching game..."))
+                BootProgress.phase(BootProgress.Phase.LAUNCH)
             }
         }
 
@@ -4120,9 +4125,10 @@ private fun setupXEnvironment(
             }
             val nextRemaining = remaining.drop(1)
             if (nextRemaining.isEmpty()) {
-                PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Launching game..."))
+                BootProgress.phase(BootProgress.Phase.LAUNCH)
             } else {
-                PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Installing prerequisites..."))
+                val step = preInstallCommands.size - nextRemaining.size + 1
+                BootProgress.phase(BootProgress.Phase.PREREQS, "$step/${preInstallCommands.size}")
             }
             chainPreInstallSteps(nextRemaining)
             guestProgramLauncherComponent.start()
@@ -4905,7 +4911,9 @@ private fun unpackExecutableFile(
     var output = StringBuilder()
     if (needsUnpacking || containerVariantChanged){
         try {
-            PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Installing Mono..."))
+            BootProgress.phase(BootProgress.Phase.MONO)
+            // msiexec reports nothing back, so track the prefix directory it writes into instead.
+            BootProgress.watchOutput(File(imageFs.wineprefix, "drive_c/windows/mono"))
             val monoCmd = "wine msiexec /i Z:\\opt\\mono-gecko-offline\\wine-mono-11.0.0-x86.msi && wineserver -k"
             Timber.i("Install mono command $monoCmd")
             val monoOutput = guestProgramLauncherComponent.execShellCommand(monoCmd)
@@ -4935,7 +4943,7 @@ private fun unpackExecutableFile(
         val rootDir: File = imageFs.getRootDir()
 
         try {
-            PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Handling DRM..."))
+            BootProgress.phase(BootProgress.Phase.DRM, "reading interfaces")
             // a:/.../GameDir/orig_dll_path.txt  (same dir as the EXE inside A:)
             val origTxtFile  = File("${imageFs.wineprefix}/dosdevices/a:/orig_dll_path.txt")
 
@@ -4999,11 +5007,12 @@ private fun unpackExecutableFile(
             if (exePaths.isEmpty()) {
                 Timber.w("No executable path set, skipping Steamless")
             } else {
-                PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Handling DRM..."))
+                BootProgress.phase(BootProgress.Phase.DRM)
                 for ((index, executablePath) in exePaths.withIndex()) {
-                    if (exePaths.size > 1) {
-                        PluviaApp.events.emit(AndroidEvent.SetBootingSplashText("Handling DRM (${index + 1}/${exePaths.size})"))
-                    }
+                    BootProgress.update(
+                        index.toFloat() / exePaths.size,
+                        "${index + 1}/${exePaths.size}: ${extractExecutableBasename(executablePath)}",
+                    )
                     var batchFile: File? = null
                     try {
                         // Normalize path: use forward slashes for Unix format, backslashes for Windows
@@ -5209,7 +5218,7 @@ private suspend fun setupWineSystemFiles(
 
             // Download or use cached/bundled openal component
             val openalFile = WinComponentDownloader.ensureWinComponentAvailable(context, "openal") { progress ->
-                Timber.d("Downloading openal component: ${(progress * 100).toInt()}%")
+                BootProgress.download("OpenAL", progress)
             }
 
             if (openalFile == null) {
@@ -5351,7 +5360,7 @@ private suspend fun extractGraphicsDriverComponent(
     onExtractFileListener: OnExtractFileListener? = null
 ) {
     val componentFile = GraphicsDriverDownloader.ensureGraphicsDriverAvailable(context, componentId) { progress ->
-        Timber.d("Downloading graphics driver $componentId: ${(progress * 100).toInt()}%")
+        BootProgress.download("graphics driver $componentId", progress)
     }
 
     if (componentFile == null) {
@@ -5387,7 +5396,7 @@ private suspend fun extractDXWrapperComponent(
     onExtractFileListener: OnExtractFileListener?
 ) {
     val componentFile = DXWrapperDownloader.ensureDXWrapperAvailable(context, componentId) { progress ->
-        Timber.d("Downloading dxwrapper $componentId: ${(progress * 100).toInt()}%")
+        BootProgress.download("dxwrapper $componentId", progress)
     }
 
     if (componentFile == null) {
@@ -5624,7 +5633,7 @@ private suspend fun extractWinComponentFiles(
                 val componentFile = WinComponentDownloader.ensureWinComponentAvailable(
                     context, identifier
                 ) { progress ->
-                    Timber.d("Downloading wincomponent $identifier: ${(progress * 100).toInt()}%")
+                    BootProgress.download("component $identifier", progress)
                 }
 
                 if (componentFile == null) {
@@ -5782,7 +5791,7 @@ private suspend fun extractGraphicsDriverFiles(
 
             // Download or get cached core driver
             val driverFile = CoreDriverDownloader.ensureCoreDriverAvailable(context, assetZip) { progress ->
-                Timber.d("Downloading core driver $assetZip: ${(progress * 100).toInt()}%")
+                BootProgress.download("core driver $assetZip", progress)
             }
 
             // Read manifest name from zip to determine folder name

--- a/app/src/main/java/app/gamenative/utils/BootProgress.kt
+++ b/app/src/main/java/app/gamenative/utils/BootProgress.kt
@@ -1,0 +1,234 @@
+package app.gamenative.utils
+
+import app.gamenative.PluviaApp
+import app.gamenative.events.AndroidEvent
+import com.winlator.core.TarCompressorUtils
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * Weighted progress model behind the container boot splash.
+ *
+ * The splash used to be a single indeterminate bar with a handful of static labels, so a
+ * multi-minute first boot was indistinguishable from a stalled one. Each phase here reports a
+ * real fraction when the underlying work exposes one (download bytes, archive bytes) and a
+ * creeping estimate plus elapsed time when it does not (wine msiexec has no progress output).
+ *
+ * Phase weights are estimates, not measurements: which phases run at all depends on the
+ * container (first boot, changed variant, cached driver), so the bar moves unevenly by design.
+ *
+ * Nothing is emitted unless [start] has been called, so extractions and downloads that happen
+ * outside a boot (library installs) can share the same hooks without popping the splash up.
+ */
+object BootProgress {
+
+    enum class Phase(val label: String, val weight: Float) {
+        PREPARING("Preparing container", 0.05f),
+        WINE_FILES("Setting up Wine files", 0.25f),
+        GRAPHICS("Setting up graphics driver", 0.18f),
+        ENVIRONMENT("Starting Wine environment", 0.07f),
+        MONO("Installing Mono", 0.18f),
+        DRM("Handling DRM", 0.12f),
+        PREREQS("Installing prerequisites", 0.10f),
+        LAUNCH("Launching game", 0.05f),
+    }
+
+    /** Creep ceiling inside a phase with no measurable fraction. Never reaches the next phase. */
+    private const val CREEP_CEILING = 0.85f
+
+    /** How far creep may run past the last measured fraction, to cover gaps between reports. */
+    private const val CREEP_OVERSHOOT = 0.15f
+    private const val CREEP_RATE = 0.04f
+    private const val TICK_MS = 500L
+
+    /** Elapsed time is noise on a fast step; it only helps once a step visibly drags. */
+    private const val ELAPSED_AFTER_MS = 5000L
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var ticker: Job? = null
+
+    @Volatile private var active = false
+    private var phase: Phase = Phase.PREPARING
+    private var base = 0f
+    private var local = 0f
+    private var measured = false
+    private var measuredFloor = 0f
+    private var detail: String? = null
+    private var phaseStartedAt = 0L
+    private var watchedDir: File? = null
+    private var watchedBytes = 0L
+    private var segmentKey: String? = null
+    private var segmentStart = 0f
+    private var segmentSpan = 0f
+    private var ticks = 0
+
+    private var lastText = ""
+    private var lastProgress = 0f
+
+    /** Marks the beginning of a boot. Safe to call more than once. */
+    @Synchronized
+    fun start() {
+        TarCompressorUtils.extractProgressListener = TarCompressorUtils.ExtractProgressListener(::extracting)
+        active = true
+        base = 0f
+        local = 0f
+        measured = false
+        measuredFloor = 0f
+        detail = null
+        watchedDir = null
+        watchedBytes = 0L
+        segmentKey = null
+        lastText = ""
+        lastProgress = 0f
+        phase = Phase.PREPARING
+        phaseStartedAt = System.currentTimeMillis()
+        ticker?.cancel()
+        ticker = scope.launch {
+            while (isActive) {
+                delay(TICK_MS)
+                tick()
+            }
+        }
+        emit()
+    }
+
+    /** Boot is over (game window is up, or the splash was dismissed). Stops all emission. */
+    @Synchronized
+    fun stop() {
+        active = false
+        ticker?.cancel()
+        ticker = null
+        watchedDir = null
+    }
+
+    /**
+     * Enters [next]. Phases may be skipped entirely, so the base only ever moves forward.
+     */
+    @Synchronized
+    fun phase(next: Phase, detail: String? = null) {
+        if (!active) return
+        phase = next
+        base = maxOf(base, Phase.entries.takeWhile { it != next }.sumOf { it.weight.toDouble() }.toFloat())
+        local = 0f
+        measured = false
+        measuredFloor = 0f
+        this.detail = detail
+        watchedDir = null
+        watchedBytes = 0L
+        segmentKey = null
+        phaseStartedAt = System.currentTimeMillis()
+        emit()
+    }
+
+    /** Reports a real fraction (0..1) inside the current phase. */
+    @Synchronized
+    fun update(fraction: Float, detail: String? = null) {
+        if (!active) return
+        measured = true
+        measuredFloor = fraction.coerceIn(0f, 1f)
+        local = maxOf(local, measuredFloor)
+        if (detail != null) this.detail = detail
+        emit()
+    }
+
+    /** Replaces the sub-label without touching the fraction. */
+    @Synchronized
+    fun detail(text: String?) {
+        if (!active) return
+        detail = text
+        emit()
+    }
+
+    /**
+     * Watches a directory the current step writes into, so an opaque step (the Mono MSI) at
+     * least reports how much it has produced so far.
+     */
+    @Synchronized
+    fun watchOutput(dir: File?) {
+        if (!active) return
+        watchedDir = dir
+        watchedBytes = 0L
+    }
+
+    /**
+     * Maps one item's own fraction into the room left in the phase. A phase can hold any number
+     * of archives and downloads and none of them knows how many follow, so each takes half of
+     * what is left: the bar keeps advancing and never claims the phase is done early.
+     */
+    @Synchronized
+    private fun updateSegment(key: String, fraction: Float, detail: String) {
+        if (!active) return
+        if (key != segmentKey) {
+            segmentKey = key
+            segmentStart = local
+            segmentSpan = (1f - segmentStart) * 0.5f
+        }
+        update(segmentStart + segmentSpan * fraction.coerceIn(0f, 1f), detail)
+    }
+
+    /** Download progress hook for the component downloaders. */
+    fun download(what: String, fraction: Float) {
+        Timber.d("Downloading %s: %d%%", what, (fraction * 100).toInt())
+        updateSegment(what, fraction, "downloading $what ${(fraction * 100).toInt()}%")
+    }
+
+    /**
+     * Archive extraction hook, called from `TarCompressorUtils` for every archive in the app.
+     * [totalBytes] is -1 when the source size is unknown (streams, compressed assets).
+     */
+    fun extracting(sourceName: String?, bytesRead: Long, totalBytes: Long) {
+        if (!active) return
+        val name = sourceName?.substringAfterLast('/')?.substringBefore(".tzst")?.substringBefore(".tar")
+        if (totalBytes > 0 && name != null) {
+            updateSegment(name, bytesRead.toFloat() / totalBytes, "unpacking $name")
+        } else if (name != null) {
+            detail("unpacking $name")
+        }
+    }
+
+    private fun tick() = synchronized(this) {
+        if (!active) return@synchronized
+        // Creep runs in every phase: a measured step still goes quiet between reports (one
+        // Steamless pass per executable), and a frozen bar reads as a hang.
+        val ceiling = if (measured) minOf(measuredFloor + CREEP_OVERSHOOT, 1f) else CREEP_CEILING
+        if (local < ceiling) local += (ceiling - local) * CREEP_RATE
+        // Walking the tree is the expensive part of a tick, so sample it a quarter as often.
+        ticks++
+        watchedDir?.takeIf { ticks % 4 == 0 }?.let { dir ->
+            watchedBytes = runCatching { dirSize(dir) }.getOrDefault(watchedBytes)
+        }
+        emit()
+    }
+
+    private fun dirSize(dir: File): Long =
+        dir.walkTopDown().maxDepth(6).filter { it.isFile }.sumOf { it.length() }
+
+    private fun emit() {
+        if (!active) return
+        val progress = maxOf(lastProgress, (base + phase.weight * local).coerceIn(0f, 0.99f))
+        val text = buildString {
+            append(phase.label)
+            val parts = mutableListOf<String>()
+            detail?.let { parts.add(it) }
+            if (watchedBytes > 0) parts.add("${watchedBytes / (1024 * 1024)} MB")
+            val elapsed = System.currentTimeMillis() - phaseStartedAt
+            if (elapsed >= ELAPSED_AFTER_MS) {
+                val seconds = elapsed / 1000
+                parts.add("%d:%02d".format(seconds / 60, seconds % 60))
+            }
+            if (parts.isNotEmpty()) parts.joinTo(this, prefix = " (", postfix = ")")
+        }
+        // The extraction hook fires per tar entry; without this the splash would churn per file.
+        if (text == lastText && progress - lastProgress < 0.005f) return
+        lastText = text
+        lastProgress = progress
+        PluviaApp.events.emit(AndroidEvent.SetBootingSplashText(text, progress))
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/BootProgress.kt
+++ b/app/src/main/java/app/gamenative/utils/BootProgress.kt
@@ -86,6 +86,8 @@ object BootProgress {
         verbose = PrefManager.verboseBootProgress
         active = true
         lastText = ""
+        ticker?.cancel()
+        ticker = null
         if (!verbose) return
         TarCompressorUtils.extractProgressListener = TarCompressorUtils.ExtractProgressListener(::extracting)
         base = 0f
@@ -99,7 +101,6 @@ object BootProgress {
         lastProgress = 0f
         phase = Phase.PREPARING
         phaseStartedAt = System.currentTimeMillis()
-        ticker?.cancel()
         ticker = scope.launch {
             while (isActive) {
                 delay(TICK_MS)
@@ -116,6 +117,7 @@ object BootProgress {
         ticker?.cancel()
         ticker = null
         watchedDir = null
+        TarCompressorUtils.extractProgressListener = null
     }
 
     /**
@@ -123,11 +125,11 @@ object BootProgress {
      */
     @Synchronized
     fun phase(next: Phase, detail: String? = null) {
-        if (!active) return
         if (!verbose) {
             next.legacy?.let { emitLegacy(it) }
             return
         }
+        if (!active) return
         phase = next
         base = maxOf(base, Phase.entries.takeWhile { it != next }.sumOf { it.weight.toDouble() }.toFloat())
         local = 0f
@@ -147,11 +149,11 @@ object BootProgress {
      */
     @Synchronized
     fun update(fraction: Float, detail: String? = null, legacy: String? = null) {
-        if (!active) return
         if (!verbose) {
             legacy?.let { emitLegacy(it) }
             return
         }
+        if (!active) return
         measured = true
         measuredFloor = fraction.coerceIn(0f, 1f)
         local = maxOf(local, measuredFloor)
@@ -162,11 +164,11 @@ object BootProgress {
     /** Replaces the sub-label without touching the fraction. */
     @Synchronized
     fun detail(text: String?, legacy: String? = null) {
-        if (!active) return
         if (!verbose) {
             legacy?.let { emitLegacy(it) }
             return
         }
+        if (!active) return
         detail = text
         emit()
     }
@@ -218,18 +220,20 @@ object BootProgress {
         }
     }
 
-    private fun tick() = synchronized(this) {
-        if (!active) return@synchronized
-        // Creep runs in every phase: a measured step still goes quiet between reports (one
-        // Steamless pass per executable), and a frozen bar reads as a hang.
-        val ceiling = if (measured) minOf(measuredFloor + CREEP_OVERSHOOT, 1f) else CREEP_CEILING
-        if (local < ceiling) local += (ceiling - local) * CREEP_RATE
-        // Walking the tree is the expensive part of a tick, so sample it a quarter as often.
-        ticks++
-        watchedDir?.takeIf { ticks % 4 == 0 }?.let { dir ->
-            watchedBytes = runCatching { dirSize(dir) }.getOrDefault(watchedBytes)
+    private fun tick() {
+        val dir = synchronized(this) {
+            if (!active) return
+            ticks++
+            watchedDir?.takeIf { ticks % 4 == 0 }
         }
-        emit()
+        val bytes = dir?.let { runCatching { dirSize(it) }.getOrNull() }
+        synchronized(this) {
+            if (!active) return
+            if (bytes != null && watchedDir === dir) watchedBytes = bytes
+            val ceiling = if (measured) minOf(measuredFloor + CREEP_OVERSHOOT, 1f) else CREEP_CEILING
+            if (local < ceiling) local += (ceiling - local) * CREEP_RATE
+            emit()
+        }
     }
 
     private fun dirSize(dir: File): Long =

--- a/app/src/main/java/app/gamenative/utils/BootProgress.kt
+++ b/app/src/main/java/app/gamenative/utils/BootProgress.kt
@@ -1,6 +1,7 @@
 package app.gamenative.utils
 
 import app.gamenative.PluviaApp
+import app.gamenative.PrefManager
 import app.gamenative.events.AndroidEvent
 import com.winlator.core.TarCompressorUtils
 import java.io.File
@@ -26,18 +27,23 @@ import timber.log.Timber
  *
  * Nothing is emitted unless [start] has been called, so extractions and downloads that happen
  * outside a boot (library installs) can share the same hooks without popping the splash up.
+ *
+ * All of this sits behind PrefManager.verboseBootProgress and is off by default. With the setting
+ * off, only the phases that reported something before this existed emit, with their original text
+ * and an indeterminate bar, so the splash behaves exactly as it used to.
  */
 object BootProgress {
 
-    enum class Phase(val label: String, val weight: Float) {
+    /** [legacy] is what the phase put on the splash before this existed, null if it said nothing. */
+    enum class Phase(val label: String, val weight: Float, val legacy: String? = null) {
         PREPARING("Preparing container", 0.05f),
         WINE_FILES("Setting up Wine files", 0.25f),
         GRAPHICS("Setting up graphics driver", 0.18f),
         ENVIRONMENT("Starting Wine environment", 0.07f),
-        MONO("Installing Mono", 0.18f),
-        DRM("Handling DRM", 0.12f),
-        PREREQS("Installing prerequisites", 0.10f),
-        LAUNCH("Launching game", 0.05f),
+        MONO("Installing Mono", 0.18f, "Installing Mono..."),
+        DRM("Handling DRM", 0.12f, "Handling DRM..."),
+        PREREQS("Installing prerequisites", 0.10f, "Installing prerequisites..."),
+        LAUNCH("Launching game", 0.05f, "Launching game..."),
     }
 
     /** Creep ceiling inside a phase with no measurable fraction. Never reaches the next phase. */
@@ -55,6 +61,8 @@ object BootProgress {
     private var ticker: Job? = null
 
     @Volatile private var active = false
+
+    @Volatile private var verbose = false
     private var phase: Phase = Phase.PREPARING
     private var base = 0f
     private var local = 0f
@@ -75,8 +83,11 @@ object BootProgress {
     /** Marks the beginning of a boot. Safe to call more than once. */
     @Synchronized
     fun start() {
-        TarCompressorUtils.extractProgressListener = TarCompressorUtils.ExtractProgressListener(::extracting)
+        verbose = PrefManager.verboseBootProgress
         active = true
+        lastText = ""
+        if (!verbose) return
+        TarCompressorUtils.extractProgressListener = TarCompressorUtils.ExtractProgressListener(::extracting)
         base = 0f
         local = 0f
         measured = false
@@ -85,7 +96,6 @@ object BootProgress {
         watchedDir = null
         watchedBytes = 0L
         segmentKey = null
-        lastText = ""
         lastProgress = 0f
         phase = Phase.PREPARING
         phaseStartedAt = System.currentTimeMillis()
@@ -114,6 +124,10 @@ object BootProgress {
     @Synchronized
     fun phase(next: Phase, detail: String? = null) {
         if (!active) return
+        if (!verbose) {
+            next.legacy?.let { emitLegacy(it) }
+            return
+        }
         phase = next
         base = maxOf(base, Phase.entries.takeWhile { it != next }.sumOf { it.weight.toDouble() }.toFloat())
         local = 0f
@@ -127,10 +141,17 @@ object BootProgress {
         emit()
     }
 
-    /** Reports a real fraction (0..1) inside the current phase. */
+    /**
+     * Reports a real fraction (0..1) inside the current phase. [legacy] is what this call site
+     * used to put on the splash, emitted verbatim while detailed progress is off.
+     */
     @Synchronized
-    fun update(fraction: Float, detail: String? = null) {
+    fun update(fraction: Float, detail: String? = null, legacy: String? = null) {
         if (!active) return
+        if (!verbose) {
+            legacy?.let { emitLegacy(it) }
+            return
+        }
         measured = true
         measuredFloor = fraction.coerceIn(0f, 1f)
         local = maxOf(local, measuredFloor)
@@ -140,8 +161,12 @@ object BootProgress {
 
     /** Replaces the sub-label without touching the fraction. */
     @Synchronized
-    fun detail(text: String?) {
+    fun detail(text: String?, legacy: String? = null) {
         if (!active) return
+        if (!verbose) {
+            legacy?.let { emitLegacy(it) }
+            return
+        }
         detail = text
         emit()
     }
@@ -152,7 +177,7 @@ object BootProgress {
      */
     @Synchronized
     fun watchOutput(dir: File?) {
-        if (!active) return
+        if (!active || !verbose) return
         watchedDir = dir
         watchedBytes = 0L
     }
@@ -164,7 +189,7 @@ object BootProgress {
      */
     @Synchronized
     private fun updateSegment(key: String, fraction: Float, detail: String) {
-        if (!active) return
+        if (!active || !verbose) return
         if (key != segmentKey) {
             segmentKey = key
             segmentStart = local
@@ -184,7 +209,7 @@ object BootProgress {
      * [totalBytes] is -1 when the source size is unknown (streams, compressed assets).
      */
     fun extracting(sourceName: String?, bytesRead: Long, totalBytes: Long) {
-        if (!active) return
+        if (!active || !verbose) return
         val name = sourceName?.substringAfterLast('/')?.substringBefore(".tzst")?.substringBefore(".tar")
         if (totalBytes > 0 && name != null) {
             updateSegment(name, bytesRead.toFloat() / totalBytes, "unpacking $name")
@@ -209,6 +234,13 @@ object BootProgress {
 
     private fun dirSize(dir: File): Long =
         dir.walkTopDown().maxDepth(6).filter { it.isFile }.sumOf { it.length() }
+
+    /** Pre-existing behaviour: the original label, indeterminate bar, no sub-detail. */
+    private fun emitLegacy(text: String) {
+        if (text == lastText) return
+        lastText = text
+        PluviaApp.events.emit(AndroidEvent.SetBootingSplashText(text))
+    }
 
     private fun emit() {
         if (!active) return

--- a/app/src/main/java/com/winlator/core/TarCompressorUtils.java
+++ b/app/src/main/java/com/winlator/core/TarCompressorUtils.java
@@ -1,6 +1,7 @@
 package com.winlator.core;
 
 import android.content.Context;
+import android.content.res.AssetFileDescriptor;
 import android.content.res.AssetManager;
 import android.net.Uri;
 import android.util.Log;
@@ -22,12 +23,24 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
 public abstract class TarCompressorUtils {
     public enum Type {XZ, ZSTD}
+
+    /**
+     * Reports how far an extraction has consumed its source. Every extract() overload funnels
+     * through the same private method, so a single listener covers all of them.
+     */
+    public interface ExtractProgressListener {
+        //! totalBytes is -1 when the source size is unknown (raw streams, compressed assets)
+        void onExtractProgress(String sourceName, long bytesRead, long totalBytes);
+    }
+
+    public static volatile ExtractProgressListener extractProgressListener = null;
 
     private static void addFile(ArchiveOutputStream tar, File file, String entryName) {
         try {
@@ -108,10 +121,20 @@ public abstract class TarCompressorUtils {
 
     public static boolean extract(Type type, AssetManager assetManager, String assetFile, File destination, OnExtractFileListener onExtractFileListener) {
         try {
-            return extract(type, assetManager.open(assetFile), destination, onExtractFileListener);
+            return extract(type, assetManager.open(assetFile), destination, onExtractFileListener, assetFile, assetLength(assetManager, assetFile));
         }
         catch (IOException e) {
             return false;
+        }
+    }
+
+    //! Compressed assets have no file descriptor, so their size is only knowable after inflation
+    private static long assetLength(AssetManager assetManager, String assetFile) {
+        try (AssetFileDescriptor fd = assetManager.openFd(assetFile)) {
+            return fd.getLength();
+        }
+        catch (IOException e) {
+            return -1;
         }
     }
 
@@ -121,7 +144,7 @@ public abstract class TarCompressorUtils {
 
     public static boolean extract(Type type, Context context, String assetFile, File destination, OnExtractFileListener onExtractFileListener) {
         try {
-            return extract(type, context.getAssets().open(assetFile), destination, onExtractFileListener);
+            return extract(type, context.getAssets().open(assetFile), destination, onExtractFileListener, assetFile, assetLength(context.getAssets(), assetFile));
         }
         catch (IOException e) {
             return false;
@@ -136,9 +159,10 @@ public abstract class TarCompressorUtils {
         if (source == null) return false;
         try {
             if (source.toString().startsWith("/")) {
-                return extract(type, new FileInputStream(source.toString()), destination, onExtractFileListener);
+                File file = new File(source.toString());
+                return extract(type, new FileInputStream(file), destination, onExtractFileListener, file.getName(), file.length());
             } else {
-            return extract(type, context.getContentResolver().openInputStream(source), destination, onExtractFileListener);
+            return extract(type, context.getContentResolver().openInputStream(source), destination, onExtractFileListener, source.getLastPathSegment(), -1);
             }
         }
         catch (FileNotFoundException e) {
@@ -157,7 +181,7 @@ public abstract class TarCompressorUtils {
     public static boolean extract(Type type, File source, File destination, OnExtractFileListener onExtractFileListener) {
         if (source == null || !source.isFile()) return false;
         try {
-            return extract(type, new BufferedInputStream(new FileInputStream(source), StreamUtils.BUFFER_SIZE), destination, onExtractFileListener);
+            return extract(type, new BufferedInputStream(new FileInputStream(source), StreamUtils.BUFFER_SIZE), destination, onExtractFileListener, source.getName(), source.length());
         }
         catch (FileNotFoundException e) {
             return false;
@@ -165,8 +189,13 @@ public abstract class TarCompressorUtils {
     }
 
     private static boolean extract(Type type, InputStream source, File destination, OnExtractFileListener onExtractFileListener) {
+        return extract(type, source, destination, onExtractFileListener, null, -1);
+    }
+
+    private static boolean extract(Type type, InputStream source, File destination, OnExtractFileListener onExtractFileListener, String sourceName, long totalBytes) {
         if (source == null) return false;
-        try (InputStream inStream = getCompressorInputStream(type, source);
+        CountingInputStream countingSource = new CountingInputStream(source);
+        try (InputStream inStream = getCompressorInputStream(type, countingSource);
              ArchiveInputStream tar = new TarArchiveInputStream(inStream)) {
             TarArchiveEntry entry;
             while ((entry = (TarArchiveEntry)tar.getNextEntry()) != null) {
@@ -200,12 +229,49 @@ public abstract class TarCompressorUtils {
                 }
 
                 FileUtils.chmod(file, 0771);
+
+                ExtractProgressListener progressListener = extractProgressListener;
+                if (progressListener != null) progressListener.onExtractProgress(sourceName, countingSource.getCount(), totalBytes);
             }
             return true;
         }
         catch (IOException e) {
             e.printStackTrace();
             return false;
+        }
+    }
+
+    //! Counts the compressed bytes consumed, which is what the source size can be compared against
+    private static class CountingInputStream extends FilterInputStream {
+        private long count;
+
+        CountingInputStream(InputStream in) {
+            super(in);
+        }
+
+        long getCount() {
+            return count;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int value = super.read();
+            if (value != -1) count++;
+            return value;
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int length) throws IOException {
+            int read = super.read(buffer, offset, length);
+            if (read > 0) count += read;
+            return read;
+        }
+
+        @Override
+        public long skip(long n) throws IOException {
+            long skipped = super.skip(n);
+            if (skipped > 0) count += skipped;
+            return skipped;
         }
     }
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -780,6 +780,8 @@
     <string name="settings_debug_wine_logs_subtitle">Skriv Wine debug-output til fil</string>
     <string name="settings_debug_box_logs_title">Aktivér Box86/64-logs</string>
     <string name="settings_debug_box_logs_subtitle">Skriv Box86 &amp; Box64 debug-output til fil</string>
+    <string name="settings_debug_verbose_boot_title">Detaljeret opstartsforløb</string>
+    <string name="settings_debug_verbose_boot_subtitle">Vis det aktuelle trin og en reel forløbslinje, mens en container starter</string>
     <string name="settings_debug_view_crash_title">Vis seneste crash</string>
     <string name="settings_debug_view_crash_subtitle">Viser den seneste crash-rapport</string>
     <string name="settings_debug_no_crash_logs">Ingen nylige crash-rapporter fundet</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -930,6 +930,8 @@
     <string name="settings_debug_wine_logs_subtitle">Wine-Debug-Ausgaben in Datei schreiben</string>
     <string name="settings_debug_box_logs_title">Box86/64-Logs aktivieren</string>
     <string name="settings_debug_box_logs_subtitle">Box86 &amp; Box64-Debug-Ausgaben in Datei schreiben</string>
+    <string name="settings_debug_verbose_boot_title">Detaillierter Startfortschritt</string>
+    <string name="settings_debug_verbose_boot_subtitle">Aktuellen Schritt und einen echten Fortschrittsbalken anzeigen, während ein Container startet</string>
     <string name="settings_debug_view_crash_title">Letzten Absturz anzeigen</string>
     <string name="settings_debug_view_crash_subtitle">Zeigt das neueste Absturzprotokoll</string>
     <string name="settings_debug_no_crash_logs">Keine kürzlichen Absturzprotokolle gefunden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -972,6 +972,8 @@
     <string name="settings_debug_wine_logs_subtitle">Escribe la salida de depuración de Wine en un archivo.</string>
     <string name="settings_debug_box_logs_title">Activar registros de Box86/64</string>
     <string name="settings_debug_box_logs_subtitle">Escribe la salida de depuración de Box86 y Box64 en un archivo.</string>
+    <string name="settings_debug_verbose_boot_title">Progreso de inicio detallado</string>
+    <string name="settings_debug_verbose_boot_subtitle">Muestra el paso actual y una barra de progreso real mientras arranca un contenedor</string>
     <string name="settings_debug_view_crash_title">Ver último fallo</string>
     <string name="settings_debug_view_crash_subtitle">Muestra el registro de fallos más reciente.</string>
     <string name="settings_debug_no_crash_logs">No se encontraron registros de fallos recientes.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -982,6 +982,8 @@
     <string name="settings_debug_wine_logs_subtitle">Écrire la sortie de débogage Wine dans un fichier</string>
     <string name="settings_debug_box_logs_title">Activer les journaux Box86/64</string>
     <string name="settings_debug_box_logs_subtitle">Écrire la sortie de débogage Box86 &amp; Box64 dans un fichier</string>
+    <string name="settings_debug_verbose_boot_title">Progression de démarrage détaillée</string>
+    <string name="settings_debug_verbose_boot_subtitle">Afficher l\'étape en cours et une vraie barre de progression pendant le démarrage d\'un conteneur</string>
     <string name="settings_debug_view_crash_title">Voir le dernier plantage</string>
     <string name="settings_debug_view_crash_subtitle">Affiche le journal de plantage le plus récent</string>
     <string name="settings_debug_no_crash_logs">Aucun journal de plantage récent trouvé</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -956,6 +956,8 @@
     <string name="settings_debug_wine_logs_subtitle">Scrivi output debug Wine su file</string>
     <string name="settings_debug_box_logs_title">Abilita Log Box86/64</string>
     <string name="settings_debug_box_logs_subtitle">Scrivi output debug Box86 &amp; Box64 su file</string>
+    <string name="settings_debug_verbose_boot_title">Avanzamento avvio dettagliato</string>
+    <string name="settings_debug_verbose_boot_subtitle">Mostra il passaggio corrente e una barra di avanzamento reale durante l\'avvio di un container</string>
     <string name="settings_debug_view_crash_title">Visualizza ultimo crash</string>
     <string name="settings_debug_view_crash_subtitle">Mostra il log di crash più recente</string>
     <string name="settings_debug_no_crash_logs">Nessun log di crash recente trovato</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -934,6 +934,8 @@
     <string name="settings_debug_wine_logs_subtitle">Wine デバッグ出力をファイルに書き込む</string>
     <string name="settings_debug_box_logs_title">Box86/64 ログを有効にする</string>
     <string name="settings_debug_box_logs_subtitle">Box86 &amp; Box64 デバッグ出力をファイルに書き込む</string>
+    <string name="settings_debug_verbose_boot_title">詳細な起動進捗</string>
+    <string name="settings_debug_verbose_boot_subtitle">コンテナの起動中に現在のステップと実際の進捗バーを表示する</string>
     <string name="settings_debug_view_crash_title">最新のクラッシュを表示</string>
     <string name="settings_debug_view_crash_subtitle">最新のクラッシュログを表示します</string>
     <string name="settings_debug_no_crash_logs">最近のクラッシュ ログは見つかりませんでした</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -963,6 +963,8 @@
     <string name="settings_debug_wine_logs_subtitle">Wine 디버그 출력을 파일에 쓰기</string>
     <string name="settings_debug_box_logs_title">Box86/64 로그 활성화</string>
     <string name="settings_debug_box_logs_subtitle">Box86 &amp; Box64 디버그 출력을 파일에 쓰기</string>
+    <string name="settings_debug_verbose_boot_title">상세 실행 진행 상황</string>
+    <string name="settings_debug_verbose_boot_subtitle">컨테이너가 부팅되는 동안 현재 단계와 실제 진행 표시줄을 표시합니다</string>
     <string name="settings_debug_view_crash_title">최신 충돌 보기</string>
     <string name="settings_debug_view_crash_subtitle">가장 최근 충돌 로그 표시</string>
     <string name="settings_debug_no_crash_logs">최근 충돌 로그를 찾을 수 없음</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -973,6 +973,8 @@
     <string name="settings_debug_wine_logs_subtitle">Zapisz wyjście debugowania Wine do pliku</string>
     <string name="settings_debug_box_logs_title">Włącz logi Box86/64</string>
     <string name="settings_debug_box_logs_subtitle">Zapisz wyjście debugowania Box86 i Box64 do pliku</string>
+    <string name="settings_debug_verbose_boot_title">Szczegółowy postęp uruchamiania</string>
+    <string name="settings_debug_verbose_boot_subtitle">Pokazuj bieżący krok i rzeczywisty pasek postępu podczas uruchamiania kontenera</string>
     <string name="settings_debug_view_crash_title">Zobacz ostatni błąd</string>
     <string name="settings_debug_view_crash_subtitle">Pokazuje najnowszy log awarii</string>
     <string name="settings_debug_no_crash_logs">Nie znaleziono ostatnich logów awarii</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -780,6 +780,8 @@
     <string name="settings_debug_wine_logs_subtitle">Gravar saída de debug do Wine em arquivo</string>
     <string name="settings_debug_box_logs_title">Habilitar logs do Box86/64</string>
     <string name="settings_debug_box_logs_subtitle">Gravar saída de debug do Box86 &amp; Box64 em arquivo</string>
+    <string name="settings_debug_verbose_boot_title">Progresso detalhado da inicialização</string>
+    <string name="settings_debug_verbose_boot_subtitle">Mostrar a etapa atual e uma barra de progresso real enquanto um contêiner inicia</string>
     <string name="settings_debug_view_crash_title">Ver última falha</string>
     <string name="settings_debug_view_crash_subtitle">Mostra o log de falha mais recente</string>
     <string name="settings_debug_no_crash_logs">Nenhum log de falha recente encontrado</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -965,6 +965,8 @@
 	<string name="settings_debug_wine_logs_subtitle">Scrie ieșirea de debug Wine în fișier</string>
 	<string name="settings_debug_box_logs_title">Activează logurile Box86/64</string>
 	<string name="settings_debug_box_logs_subtitle">Scrie ieșirea de debug Box86 &amp; Box64 în fișier</string>
+	<string name="settings_debug_verbose_boot_title">Progres detaliat la pornire</string>
+	<string name="settings_debug_verbose_boot_subtitle">Afișează pasul curent și o bară de progres reală în timpul pornirii unui container</string>
 	<string name="settings_debug_view_crash_title">Vezi ultimul crash</string>
 	<string name="settings_debug_view_crash_subtitle">Afișează cel mai recent raport de crash</string>
 	<string name="settings_debug_no_crash_logs">Nu s-au găsit rapoarte de crash recente</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1073,6 +1073,8 @@ https://gamenative.app
     <string name="settings">Настройки</string>
     <string name="settings_debug_box_logs_subtitle">Записать вывод отладки Box86 &amp; Box64 в файл</string>
     <string name="settings_debug_box_logs_title">Включить логи Box86/64</string>
+    <string name="settings_debug_verbose_boot_title">Подробный прогресс</string>
+    <string name="settings_debug_verbose_boot_subtitle">Показывать текущий шаг и реальный прогресс при запуске контейнера</string>
     <string name="settings_debug_clear_cache_subtitle">Удалить все загруженные изображения.</string>
     <string name="settings_debug_clear_cache_title">Очистить кэш изображений</string>
     <string name="settings_debug_clear_db_subtitle">[Закрывает приложение] Может помочь исправить проблемы с элементами библиотеки или сообщениями.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -959,6 +959,8 @@
     <string name="settings_debug_wine_logs_subtitle">Записувати виведення налагодження Wine у файл</string>
     <string name="settings_debug_box_logs_title">Увімкнути журнали Box86/64</string>
     <string name="settings_debug_box_logs_subtitle">Записувати виведення налагодження Box86 та Box64 у файл</string>
+    <string name="settings_debug_verbose_boot_title">Докладний прогрес запуску</string>
+    <string name="settings_debug_verbose_boot_subtitle">Показувати поточний крок і реальний прогрес під час запуску контейнера</string>
     <string name="settings_debug_view_crash_title">Переглянути останній збій</string>
     <string name="settings_debug_view_crash_subtitle">Показує останній звіт про збій</string>
     <string name="settings_debug_no_crash_logs">Не знайдено нещодавніх звітів про збій</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -949,6 +949,8 @@
     <string name="settings_debug_wine_logs_subtitle">将 Wine 调试输出写入文件</string>
     <string name="settings_debug_box_logs_title">启用 Box86/64 日志</string>
     <string name="settings_debug_box_logs_subtitle">将 Box86 与 Box64 的调试输出写入文件</string>
+    <string name="settings_debug_verbose_boot_title">详细启动进度</string>
+    <string name="settings_debug_verbose_boot_subtitle">在容器启动时显示当前步骤和真实进度条</string>
     <string name="settings_debug_view_crash_title">查看最新崩溃日志</string>
     <string name="settings_debug_view_crash_subtitle">显示最新的崩溃报告</string>
     <string name="settings_debug_no_crash_logs">未找到最近的崩溃报告</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -951,6 +951,8 @@
     <string name="settings_debug_wine_logs_subtitle">將 Wine 除錯輸出寫入檔案</string>
     <string name="settings_debug_box_logs_title">啟用 Box86/64 日誌</string>
     <string name="settings_debug_box_logs_subtitle">將 Box86 與 Box64 的除錯輸出寫入檔案</string>
+    <string name="settings_debug_verbose_boot_title">詳細啟動進度</string>
+    <string name="settings_debug_verbose_boot_subtitle">在容器啟動時顯示目前步驟和實際進度列</string>
     <string name="settings_debug_view_crash_title">檢視最新崩潰日誌</string>
     <string name="settings_debug_view_crash_subtitle">顯示最新的崩潰報告</string>
     <string name="settings_debug_no_crash_logs">未找到最近的崩潰報告</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1099,6 +1099,8 @@
     <string name="settings_debug_wine_channels_title">Select Wine Debug Channels</string>
     <string name="settings_debug_wine_logs_title">Enable Wine Debug Logs</string>
     <string name="settings_debug_wine_logs_subtitle">Write Wine debug output to file</string>
+    <string name="settings_debug_verbose_boot_title">Detailed launch progress</string>
+    <string name="settings_debug_verbose_boot_subtitle">Show the current step and a real progress bar while a container boots</string>
     <string name="settings_debug_box_logs_title">Enable Box86/64 Logs</string>
     <string name="settings_debug_box_logs_subtitle">Write Box86 &amp; Box64 debug output to file</string>
     <string name="settings_debug_view_crash_title">View latest crash</string>


### PR DESCRIPTION
## Description
Detailed progress, which you can switch in debug menu. It's disabled by defautl, so it's not affect any default behaviour.
If you enable detailed progress, it would show detailed progress bar on each container start

## Recording
all the previews are in discord thread: https://discord.com/channels/1378308569287622737/1539669239512699001

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand. (p.s. not sure about this one, but we've discussed this pr on discord :D)
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional detailed boot progress for container launches behind a debug setting. Previously the splash used an indeterminate bar with static labels; when enabled, it shows weighted per-phase progress with real fractions, download/extraction updates, and elapsed time. Default remains off, so behavior is unchanged when disabled.

- Introduces `app.gamenative.utils.BootProgress` to track phases and emit progress; integrates download and extraction reporting via `com.winlator.core.TarCompressorUtils` and component downloaders.
- Extends `AndroidEvent.SetBootingSplashText` with a `progress` float and threads it through `MainState` to the `BootingSplash`; calls `BootProgress.start()` on launch and ensures `BootProgress.stop()` when the splash is dismissed.
- Adds a Debug setting `PrefManager.verboseBootProgress`, off by default, with the toggle and subtitle translated into every shipped locale.
- Replaces direct splash text in X server startup with `BootProgress` calls covering Wine files, graphics, environment, prerequisites, Mono, DRM, and launch; shows per-item counters where available.
- No migration required; legacy labels and an indeterminate bar remain when detailed progress is disabled.

<sup>Written for commit a72bc85f3dd6bba71e89f44e25fba6aeb865b00b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **Detailed launch progress** setting in Debug settings.
  * Boot screens now show startup steps and real progress for setup, graphics, downloads, extraction, installation, and launch.
  * Progress details now include download and extraction activity.
  * Added localized translations for the setting across supported languages.

* **Bug Fixes**
  * Boot progress stops correctly when startup is dismissed.
  * Progress indicators reset correctly between launches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->