### PR TITLE
Feat/discord rich presence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ app/src/main/cpp/steambootstrap/steam_bootstrap.c
 
 # Vendored SDL2 headers (fetched for evshim build, not pushed)
 app/src/main/cpp/third_party/SDL2/
+
+# Discord Social SDK (downloaded per-application from the Developer Portal, not redistributable)
+app/libs/*.aar

--- a/README.md
+++ b/README.md
@@ -1,3 +1,46 @@
+> ## About this fork
+>
+> This is a fork of [GameNative](https://github.com/utkarshdalal/GameNative) that adds **Discord
+> Rich Presence on Android**. Everything else (the Steam/Epic/GOG/Amazon libraries, Wine, cloud
+> saves, the compatibility database) is upstream GameNative and is documented below.
+>
+> When you launch a game, your Discord status becomes:
+>
+> ```
+> Playing  Grand Theft Auto V
+> 42 minutes elapsed
+> ```
+>
+> ...along with the game's cover art, pulled from whichever store it came from. The status clears
+> when you close the game.
+>
+> ### How it works
+>
+> It uses Discord's official [Social SDK](https://docs.discord.com/developers/discord-social-sdk/overview),
+> which since version 1.10 supports publishing presence on Android. GameNative talks to the SDK
+> through a small JNI bridge (`app/src/main/cpp/discordrpc`), and the SDK hands the activity to the
+> **Discord app already installed and signed in on your phone**.
+>
+> There is no Discord login inside GameNative, no OAuth, no account linking, no tokens stored
+> anywhere, and no PC or Discord Desktop involved. Nothing is read back from your account. The only
+> things that leave your device are the game name, its cover art URL and a start timestamp, handed
+> to the local Discord app. This is not a Gateway or self-bot workaround; those risk your account
+> and are not used here.
+>
+> It's **off by default**, since it makes what you play visible to your Discord friends. Turn it on
+> under **Settings > Discord**.
+>
+> ### Building it yourself
+>
+> The Discord Social SDK is distributed per-application from the Discord Developer Portal and
+> can't be redistributed, so it isn't checked into this repo. Without it the app builds and runs
+> exactly like upstream, and the Discord setting reports that it isn't available in your build.
+>
+> See [`app/libs/README-discord-social-sdk.md`](app/libs/README-discord-social-sdk.md) for the
+> steps to enable it.
+
+---
+
 <div align="center">
 
 # GameNative

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,12 @@ val posthogHost: String = project.findProperty("POSTHOG_HOST") as String? ?: Sys
 val metaAppId: String = project.findProperty("META_APP_ID") as String? ?: System.getenv("META_APP_ID") ?: ""
 val productSku: String = project.findProperty("PRODUCT_SKU") as String? ?: System.getenv("PRODUCT_SKU") ?: ""
 
+// The Discord Social SDK cannot be redistributed, so it is not checked in. When the AAR is
+// present we also build the JNI bridge in src/main/cpp/discordrpc; when absent the integration
+// reports "Discord unavailable" at runtime. See app/libs/README-discord-social-sdk.md.
+val discordSdkAar = file("libs/discord_partner_sdk.aar")
+val discordSdkBundled: Boolean = discordSdkAar.exists()
+
 room {
     schemaDirectory("$projectDir/schemas")
 }
@@ -75,6 +81,10 @@ android {
         buildConfigField("String", "POSTHOG_HOST",  "\"${secret("POSTHOG_HOST")}\"")
         buildConfigField("String", "STEAMGRIDDB_API_KEY", "\"${secret("STEAMGRIDDB_API_KEY")}\"")
         buildConfigField("String", "CLOUD_PROJECT_NUMBER", "\"${secret("CLOUD_PROJECT_NUMBER")}\"")
+
+        // Public identifier, broadcast with every presence update. Empty disables the feature.
+        buildConfigField("String", "DISCORD_APPLICATION_ID", "\"${secret("DISCORD_APPLICATION_ID")}\"")
+        buildConfigField("boolean", "DISCORD_SDK_BUNDLED", "$discordSdkBundled")
         val iconValue = "@mipmap/ic_launcher"
         val iconRoundValue = "@mipmap/ic_launcher_round"
         manifestPlaceholders.putAll(
@@ -238,6 +248,16 @@ android {
         // the release-only lintVital pass fails on 150+ ExtraTranslation errors.
         disable += "ExtraTranslation"
     }
+
+    if (discordSdkBundled) {
+        externalNativeBuild {
+            cmake {
+                path = file("src/main/cpp/discordrpc/CMakeLists.txt")
+                version = "3.22.1"
+            }
+        }
+    }
+
     dynamicFeatures += setOf(":ubuntufs")
 
     // Configure Assets to be used in different variants
@@ -434,6 +454,11 @@ dependencies {
 
     // Samsung Performance SDK
     implementation(files("src/main/lib/perfsdk-v1.0.0.jar"))
+
+    // Discord Social SDK, only when the AAR has been downloaded into app/libs.
+    if (discordSdkBundled) {
+        implementation(files("libs/discord_partner_sdk.aar"))
+    }
 
     "modernXrImplementation"("com.meta.horizon.platform.sdk:core-kotlin:0.2.2")
     "modernXrImplementation"("com.meta.horizon.platform.sdk:iap-kotlin:0.2.2")

--- a/app/libs/README-discord-social-sdk.md
+++ b/app/libs/README-discord-social-sdk.md
@@ -1,0 +1,91 @@
+# Discord Rich Presence: enabling the official Discord Social SDK
+
+GameNative can publish the running game as the user's Discord activity ("Playing GTA V", with an
+elapsed-time counter). It does this through Discord's official Discord Social SDK, using the SDK's
+unauthenticated RPC path, which since Social SDK 1.10 publishes presence through the Discord
+Android app when that app is installed and signed in.
+
+No Discord Desktop, no PC, no Gateway connection, no self-bot, no user token: GameNative never
+authenticates as the user and never reads anything back from their account.
+
+Reference: <https://docs.discord.com/developers/discord-social-sdk/development-guides/setting-rich-presence>
+and <https://docs.discord.com/developers/discord-social-sdk/core-concepts/mobile>.
+
+## Why the SDK is not checked in
+
+Discord distributes the Social SDK as a per-application download from the Developer Portal under a
+licence that does not allow redistribution. It is not published to Maven Central or Google's Maven,
+so it cannot be a normal Gradle coordinate.
+
+`app/build.gradle.kts` therefore probes for the file. Without it, everything below is skipped and
+GameNative builds and runs exactly as before: the Discord settings tile reports "Not available in
+this build of GameNative" and no Discord code ever executes.
+
+## Enabling it
+
+1. Create or choose a Discord application at <https://discord.com/developers/applications> and note
+   its Application ID (Settings > General Information). This is a public identifier, not a secret,
+   and is broadcast with every presence update. There is no client secret or bot token involved.
+
+2. Set the Rich Presence name. Discord shows the application's name as the activity title unless
+   the activity carries its own name; GameNative always sets the name explicitly to the game's
+   name, so the application name only matters as a fallback.
+
+3. Optionally upload one art asset, under Developer Portal > your app > Rich Presence > Art Assets.
+   Upload a GameNative logo keyed `gamenative` (`DiscordConfig.FALLBACK_IMAGE_ASSET_KEY`).
+
+   Per-game cover art does not go here. Discord's image fields accept an external image URL as well
+   as an uploaded key, and an application is capped at 300 uploaded assets, so GameNative sends
+   each game's art straight from the store CDN it already reads (Steam library capsule, GOG icon,
+   Epic square art, Amazon art). The `gamenative` asset is only used for custom games, whose art is
+   local files Discord cannot fetch. Presence publishes fine if it was never uploaded; that slot
+   just renders empty.
+
+4. Download the SDK from Developer Portal > your app > Discord Social SDK > Download. Take the
+   Android/mobile archive for 1.10 or newer; earlier versions have no Android support.
+
+5. Drop the AAR in place, exactly at:
+
+   ```
+   app/libs/discord_partner_sdk.aar
+   ```
+
+   (`app/libs/*.aar` is gitignored, do not commit it.)
+
+6. Build with the application ID, the same way this project passes its other build parameters:
+
+   ```bash
+   ./gradlew assembleModernDebug -PDISCORD_APPLICATION_ID=000000000000000000
+   # or
+   DISCORD_APPLICATION_ID=000000000000000000 ./gradlew assembleModernDebug
+   ```
+
+Gradle then also compiles `app/src/main/cpp/discordrpc` (the JNI bridge from Kotlin to the SDK's
+C++ `discordpp` API) via prefab, which is already enabled in this project. That step needs the NDK
+this project pins (`ndkVersion` in `app/build.gradle.kts`) installed. It is not required for builds
+without the AAR, since no native code is compiled then.
+
+Users still have to opt in per-device, under Settings > Discord > "Show game on Discord" (off by
+default, because it makes what someone plays visible to their Discord friends).
+
+## What the pieces are
+
+| Path | Role |
+| --- | --- |
+| `app/src/main/cpp/discordrpc/` | JNI bridge to `discordpp`; owns the SDK client and its `RunCallbacks()` pump |
+| `app/src/main/java/app/gamenative/discord/DiscordNative.kt` | `System.loadLibrary("discordbridge")` + `external fun`s; `isAvailable` is false when the bridge is absent |
+| `app/src/main/java/app/gamenative/discord/DiscordRichPresence.kt` | The integration itself: start/stop/clear, state, retry, failure reporting |
+| `app/src/main/java/app/gamenative/discord/DiscordConfig.kt` | Build-time application ID and art-asset keys |
+| `app/src/main/java/app/gamenative/discord/DiscordSocialSdkCompat.kt` | Reflective `DiscordSocialSdkInit.setEngineActivity(...)`, so `src/main/java` compiles with or without the AAR |
+| `app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupDiscord.kt` | The opt-in toggle and a plain-language status line |
+
+## Limitations
+
+- Android 7.0+, per Discord's platform requirements. GameNative's `minSdk` is already 26.
+- The Discord Android app must be installed and signed in. The RPC path talks to it locally, and
+  there is no fallback that would work without it.
+- No per-game detail. GameNative reports the game name, its cover art and the start time. A game's
+  own state ("Story Mode", a level name) would have to come from inside the game; `DiscordRichPresence`
+  has a `details` field ready for it.
+- Custom games get no cover art. Their art is scanned from local files, which Discord's servers
+  cannot fetch; they fall back to the `gamenative` asset.

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -45,3 +45,9 @@
 # Samsung Performance SDK (bundled stub jar, referenced by powercontrol Samsung driver)
 -keep class com.samsung.sdk.sperf.** { *; }
 -dontwarn com.samsung.sdk.sperf.**
+
+# Discord Rich Presence (JNI_OnLoad looks up DiscordNative.onNativeResult by name, and
+# DiscordSocialSdkCompat reaches the SDK's init class reflectively)
+-keep class app.gamenative.discord.DiscordNative { *; }
+-keep class com.discord.socialsdk.** { *; }
+-dontwarn com.discord.socialsdk.**

--- a/app/src/main/cpp/discordrpc/CMakeLists.txt
+++ b/app/src/main/cpp/discordrpc/CMakeLists.txt
@@ -1,0 +1,21 @@
+# JNI bridge between app/src/main/java/app/gamenative/discord and the Discord Social SDK's C++
+# API. Only wired into the Gradle build when app/libs/discord_partner_sdk.aar exists, see the
+# discordSdkBundled guard in app/build.gradle.kts.
+cmake_minimum_required(VERSION 3.22.1)
+project(discordbridge)
+
+add_library(discordbridge SHARED
+    discord_bridge.cpp
+)
+
+# Provided by discord_partner_sdk.aar via prefab (android.buildFeatures.prefab is already on).
+find_package(discord_partner_sdk REQUIRED CONFIG)
+
+target_link_libraries(discordbridge
+    discord_partner_sdk::discord_partner_sdk
+    android
+    log
+)
+
+target_compile_features(discordbridge PRIVATE cxx_std_17)
+target_compile_options(discordbridge PRIVATE -Wall -Wextra -Werror=return-type -Wno-unused-parameter)

--- a/app/src/main/cpp/discordrpc/discord_bridge.cpp
+++ b/app/src/main/cpp/discordrpc/discord_bridge.cpp
@@ -1,0 +1,276 @@
+// JNI bridge to the Discord Social SDK (discordpp), used by
+// app/src/main/java/app/gamenative/discord/DiscordNative.kt.
+//
+// Only the SDK's unauthenticated RPC path is used: set an application ID and call
+// UpdateRichPresence / ClearRichPresence, never Client::Connect. On Android that publishes through
+// the installed Discord app while it is signed in. If Discord is missing or signed out the SDK
+// reports a failed result, which reaches Kotlin as "unavailable".
+
+#include <jni.h>
+#include <android/log.h>
+
+#include <atomic>
+#include <chrono>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+
+#define DISCORDPP_IMPLEMENTATION
+#if __has_include(<discord_partner_sdk/discordpp.h>)
+#include <discord_partner_sdk/discordpp.h>
+#else
+#include <discordpp.h>
+#endif
+
+namespace {
+
+#define LOG_TAG "discordbridge"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+
+constexpr const char *kNativeClassName = "app/gamenative/discord/DiscordNative";
+
+// Keep in sync with DiscordNative.OP_UPDATE_PRESENCE.
+constexpr jint kOpUpdatePresence = 1;
+
+// Presence changes a few times an hour at most, so the pump can tick slowly.
+constexpr int kPumpIntervalMs = 250;
+
+// Callback ticks spent flushing the final ClearRichPresence before the client is destroyed.
+constexpr int kShutdownDrainTicks = 5;
+
+JavaVM *gVm = nullptr;
+jclass gNativeClass = nullptr;
+jmethodID gOnNativeResult = nullptr;
+
+// Guards gClient and the pump thread. Every entry point holds it for the whole call, so the pump
+// thread can never observe a half-torn-down client.
+std::mutex gMutex;
+std::shared_ptr<discordpp::Client> gClient;
+std::thread gPumpThread;
+std::atomic<bool> gPumpRunning{false};
+
+struct ScopedEnv {
+    JNIEnv *env = nullptr;
+    bool attached = false;
+
+    ScopedEnv() {
+        if (gVm == nullptr) return;
+        if (gVm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) == JNI_OK) return;
+        if (gVm->AttachCurrentThread(&env, nullptr) == JNI_OK) {
+            attached = true;
+        } else {
+            env = nullptr;
+        }
+    }
+
+    ~ScopedEnv() {
+        if (attached && gVm != nullptr) gVm->DetachCurrentThread();
+    }
+
+    ScopedEnv(const ScopedEnv &) = delete;
+    ScopedEnv &operator=(const ScopedEnv &) = delete;
+};
+
+// Must not be called while holding gMutex: it runs Kotlin code, and gMutex is not recursive.
+void PostResult(jint op, bool success, const std::string &message) {
+    ScopedEnv scoped;
+    if (scoped.env == nullptr || gNativeClass == nullptr || gOnNativeResult == nullptr) return;
+
+    jstring jMessage = scoped.env->NewStringUTF(message.c_str());
+    scoped.env->CallStaticVoidMethod(gNativeClass, gOnNativeResult, op,
+                                     success ? JNI_TRUE : JNI_FALSE, jMessage);
+    if (scoped.env->ExceptionCheck()) {
+        scoped.env->ExceptionDescribe();
+        scoped.env->ExceptionClear();
+    }
+    if (jMessage != nullptr) scoped.env->DeleteLocalRef(jMessage);
+}
+
+std::string ToStdString(JNIEnv *env, jstring value) {
+    if (value == nullptr) return {};
+    const char *chars = env->GetStringUTFChars(value, nullptr);
+    if (chars == nullptr) return {};
+    std::string result(chars);
+    env->ReleaseStringUTFChars(value, chars);
+    return result;
+}
+
+// nullopt for null/empty, so blank Rich Presence fields are never published.
+std::optional<std::string> ToOptionalString(JNIEnv *env, jstring value) {
+    std::string result = ToStdString(env, value);
+    if (result.empty()) return std::nullopt;
+    return result;
+}
+
+// discordpp delivers callbacks from RunCallbacks(), which a game would normally drive from its
+// render loop. GameNative has no such loop, so the bridge owns a slow tick of its own.
+void PumpLoop() {
+    while (gPumpRunning.load(std::memory_order_acquire)) {
+        discordpp::RunCallbacks();
+        std::this_thread::sleep_for(std::chrono::milliseconds(kPumpIntervalMs));
+    }
+}
+
+// Stops the pump and waits for it, leaving this thread the only caller of RunCallbacks().
+// PumpLoop never takes gMutex, so this is safe to call with the lock held.
+void StopPumpLocked() {
+    gPumpRunning.store(false, std::memory_order_release);
+    if (gPumpThread.joinable()) gPumpThread.join();
+}
+
+}  // namespace
+
+extern "C" {
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
+    gVm = vm;
+
+    JNIEnv *env = nullptr;
+    if (vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK) {
+        return JNI_ERR;
+    }
+
+    jclass localClass = env->FindClass(kNativeClassName);
+    if (localClass == nullptr) {
+        LOGE("JNI_OnLoad: could not find %s", kNativeClassName);
+        return JNI_ERR;
+    }
+    gNativeClass = static_cast<jclass>(env->NewGlobalRef(localClass));
+    env->DeleteLocalRef(localClass);
+
+    gOnNativeResult =
+            env->GetStaticMethodID(gNativeClass, "onNativeResult", "(IZLjava/lang/String;)V");
+    if (gOnNativeResult == nullptr) {
+        LOGE("JNI_OnLoad: could not find onNativeResult(IZLjava/lang/String;)V");
+        return JNI_ERR;
+    }
+    return JNI_VERSION_1_6;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_app_gamenative_discord_DiscordNative_nativeInitialize(JNIEnv *, jobject, jlong applicationId) {
+    if (applicationId <= 0) {
+        LOGE("nativeInitialize: refusing to start without a Discord application ID");
+        return JNI_FALSE;
+    }
+
+    std::lock_guard<std::mutex> lock(gMutex);
+    if (gClient != nullptr) return JNI_TRUE;
+
+    try {
+        gClient = std::make_shared<discordpp::Client>();
+        gClient->SetApplicationId(static_cast<uint64_t>(applicationId));
+        gPumpRunning.store(true, std::memory_order_release);
+        gPumpThread = std::thread(PumpLoop);
+    } catch (const std::exception &e) {
+        LOGE("nativeInitialize: %s", e.what());
+        gPumpRunning.store(false, std::memory_order_release);
+        gClient.reset();
+        return JNI_FALSE;
+    }
+
+    LOGI("nativeInitialize: discordpp client ready (RPC-only, no account linking)");
+    return JNI_TRUE;
+}
+
+JNIEXPORT void JNICALL
+Java_app_gamenative_discord_DiscordNative_nativeUpdatePresence(JNIEnv *env, jobject, jstring name,
+                                                               jstring details, jstring state,
+                                                               jlong startTimestampMs,
+                                                               jstring largeImage,
+                                                               jstring largeText,
+                                                               jstring smallImage,
+                                                               jstring smallText) {
+    // Marshal on the calling thread; this JNIEnv is not valid on the SDK's callback thread.
+    const std::string activityName = ToStdString(env, name);
+    const std::optional<std::string> activityDetails = ToOptionalString(env, details);
+    const std::optional<std::string> activityState = ToOptionalString(env, state);
+    const std::optional<std::string> assetLargeImage = ToOptionalString(env, largeImage);
+    const std::optional<std::string> assetLargeText = ToOptionalString(env, largeText);
+    const std::optional<std::string> assetSmallImage = ToOptionalString(env, smallImage);
+    const std::optional<std::string> assetSmallText = ToOptionalString(env, smallText);
+
+    bool dispatched = false;
+    {
+        std::lock_guard<std::mutex> lock(gMutex);
+        if (gClient != nullptr) {
+            dispatched = true;
+
+            discordpp::Activity activity;
+            activity.SetType(discordpp::ActivityTypes::Playing);
+            activity.SetName(activityName);
+            activity.SetDetails(activityDetails);
+            activity.SetState(activityState);
+
+            if (startTimestampMs > 0) {
+                discordpp::ActivityTimestamps timestamps;
+                timestamps.SetStart(static_cast<uint64_t>(startTimestampMs));
+                activity.SetTimestamps(timestamps);
+            }
+
+            // Image fields take either an art-asset key uploaded in the Developer Portal or an
+            // external image URL, so callers can pass cover art straight from a store CDN.
+            if (assetLargeImage.has_value() || assetLargeText.has_value() ||
+                assetSmallImage.has_value() || assetSmallText.has_value()) {
+                discordpp::ActivityAssets assets;
+                if (assetLargeImage.has_value()) assets.SetLargeImage(assetLargeImage);
+                if (assetLargeText.has_value()) assets.SetLargeText(assetLargeText);
+                if (assetSmallImage.has_value()) assets.SetSmallImage(assetSmallImage);
+                if (assetSmallText.has_value()) assets.SetSmallText(assetSmallText);
+                activity.SetAssets(assets);
+            }
+
+            try {
+                gClient->UpdateRichPresence(activity, [](discordpp::ClientResult result) {
+                    PostResult(kOpUpdatePresence, result.Successful(), result.ToString());
+                });
+            } catch (const std::exception &e) {
+                LOGE("nativeUpdatePresence: %s", e.what());
+                dispatched = false;
+            }
+        }
+    }
+
+    if (!dispatched) PostResult(kOpUpdatePresence, false, "presence update not dispatched");
+}
+
+JNIEXPORT void JNICALL
+Java_app_gamenative_discord_DiscordNative_nativeClearPresence(JNIEnv *, jobject) {
+    std::lock_guard<std::mutex> lock(gMutex);
+    if (gClient == nullptr) return;
+    try {
+        gClient->ClearRichPresence();
+    } catch (const std::exception &e) {
+        LOGE("nativeClearPresence: %s", e.what());
+    }
+}
+
+JNIEXPORT void JNICALL
+Java_app_gamenative_discord_DiscordNative_nativeShutdown(JNIEnv *, jobject) {
+    std::lock_guard<std::mutex> lock(gMutex);
+    if (gClient == nullptr) return;
+
+    // Stop the pump first: destroying the client while PumpLoop sits inside RunCallbacks()
+    // would tear down state that call is still walking.
+    StopPumpLocked();
+
+    try {
+        // Now the only caller of RunCallbacks(), so the clear can be flushed before teardown.
+        gClient->ClearRichPresence();
+        for (int i = 0; i < kShutdownDrainTicks; ++i) {
+            discordpp::RunCallbacks();
+            std::this_thread::sleep_for(std::chrono::milliseconds(kPumpIntervalMs / 5));
+        }
+    } catch (const std::exception &e) {
+        LOGE("nativeShutdown: %s", e.what());
+    }
+
+    gClient.reset();
+    LOGI("nativeShutdown: discordpp client torn down");
+}
+
+}  // extern "C"

--- a/app/src/main/java/app/gamenative/MainActivity.kt
+++ b/app/src/main/java/app/gamenative/MainActivity.kt
@@ -192,6 +192,9 @@ class MainActivity : ComponentActivity() {
 
         app.gamenative.launch.installLaunchReadiness(applicationContext, lifecycleScope)
 
+        // Registration only, the SDK is not touched until the user enables Rich Presence
+        app.gamenative.discord.DiscordSocialSdkCompat.registerActivity(this)
+
         if (isHeadset(this)) {
             requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
             android.view.InputDevice.getDeviceIds().forEach { id ->

--- a/app/src/main/java/app/gamenative/MainActivity.kt
+++ b/app/src/main/java/app/gamenative/MainActivity.kt
@@ -35,6 +35,7 @@ import coil.intercept.Interceptor
 import coil.request.CachePolicy
 import app.gamenative.BuildConfig
 import app.gamenative.PrefManager
+import app.gamenative.discord.DiscordRichPresence
 import app.gamenative.events.AndroidEvent
 import app.gamenative.mods.NexusDownloadLinkInbox
 import app.gamenative.mods.NexusIntegrationStatus
@@ -461,6 +462,7 @@ class MainActivity : ComponentActivity() {
                 }
                 else -> {
                     PluviaApp.xEnvironment?.onResume()
+                    DiscordRichPresence.onGameResumed()
                     Timber.d("Game resumed")
                 }
             }
@@ -494,6 +496,9 @@ class MainActivity : ComponentActivity() {
                 }
                 else -> {
                     PluviaApp.xEnvironment?.onPause()
+                    // Reached only when the game really was suspended — the never-suspend policy
+                    // returns above, and there the game plays on and keeps its presence.
+                    DiscordRichPresence.onGameSuspended()
                     if (PluviaApp.isManualSuspendMode()) {
                         PluviaApp.isOverlayPaused = true
                         Timber.d("Game paused due to app backgrounded (manual resume required)")

--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -1505,4 +1505,9 @@ object PrefManager {
     var powerControlDefaultEnabled: Boolean
         get() = getPref(POWER_CONTROL_DEFAULT_ENABLED, DeviceGate.isDeviceSupported())
         set(value) { setPref(POWER_CONTROL_DEFAULT_ENABLED, value) }
+
+    private val DISCORD_RICH_PRESENCE_ENABLED = booleanPreferencesKey("discord_rich_presence_enabled")
+    var discordRichPresenceEnabled: Boolean
+        get() = getPref(DISCORD_RICH_PRESENCE_ENABLED, false)
+        set(value) { setPref(DISCORD_RICH_PRESENCE_ENABLED, value) }
 }

--- a/app/src/main/java/app/gamenative/discord/DiscordConfig.kt
+++ b/app/src/main/java/app/gamenative/discord/DiscordConfig.kt
@@ -1,0 +1,25 @@
+package app.gamenative.discord
+
+import app.gamenative.BuildConfig
+
+/**
+ * Build-time configuration for Discord Rich Presence.
+ *
+ * The application ID is public (it is broadcast with every presence update) but is injected at
+ * build time so forks can point at their own Discord application.
+ * See app/libs/README-discord-social-sdk.md.
+ */
+internal object DiscordConfig {
+
+    /** Discord application ID, or 0 when this build wasn't configured with one. */
+    val applicationId: Long = BuildConfig.DISCORD_APPLICATION_ID.trim().toLongOrNull() ?: 0L
+
+    /** True when the Discord Social SDK AAR was bundled at build time. */
+    val sdkBundled: Boolean = BuildConfig.DISCORD_SDK_BUNDLED
+
+    // Art asset uploaded under the Discord application, used only for games with no cover art of
+    // their own. Presence still publishes if it was never uploaded; the slot renders empty.
+    const val FALLBACK_IMAGE_ASSET_KEY = "gamenative"
+
+    const val FALLBACK_IMAGE_TEXT = "Played on GameNative"
+}

--- a/app/src/main/java/app/gamenative/discord/DiscordNative.kt
+++ b/app/src/main/java/app/gamenative/discord/DiscordNative.kt
@@ -1,0 +1,66 @@
+package app.gamenative.discord
+
+import androidx.annotation.Keep
+import timber.log.Timber
+
+/**
+ * JNI wrapper around the Discord Social SDK bridge in app/src/main/cpp/discordrpc.
+ *
+ * The bridge is only built when the Discord Social SDK AAR is present in app/libs, so without it
+ * there is no libdiscordbridge.so to load and [isAvailable] stays false.
+ *
+ * Use [DiscordRichPresence] rather than talking to this directly.
+ */
+@Keep
+internal object DiscordNative {
+
+    private const val TAG = "DiscordRPC"
+
+    /** Matches kOpUpdatePresence in discord_bridge.cpp. */
+    private const val OP_UPDATE_PRESENCE = 1
+
+    val isAvailable: Boolean
+
+    @Volatile
+    var presenceResultListener: ((Boolean, String) -> Unit)? = null
+
+    init {
+        var loaded = false
+        try {
+            System.loadLibrary("discordbridge")
+            loaded = true
+        } catch (t: Throwable) {
+            Timber.tag(TAG).i("Discord bridge not present in this build (%s)", t.javaClass.simpleName)
+        }
+        isAvailable = loaded
+    }
+
+    external fun nativeInitialize(applicationId: Long): Boolean
+
+    external fun nativeUpdatePresence(
+        name: String,
+        details: String?,
+        state: String?,
+        startTimestampMs: Long,
+        largeImage: String?,
+        largeText: String?,
+        smallImage: String?,
+        smallText: String?,
+    )
+
+    external fun nativeClearPresence()
+
+    external fun nativeShutdown()
+
+    /** Invoked from the SDK's callback thread. Looked up by name in JNI_OnLoad. */
+    @Keep
+    @JvmStatic
+    fun onNativeResult(op: Int, success: Boolean, message: String?) {
+        if (op != OP_UPDATE_PRESENCE) return
+        try {
+            presenceResultListener?.invoke(success, message.orEmpty())
+        } catch (t: Throwable) {
+            Timber.tag(TAG).e(t, "presence result listener threw")
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/discord/DiscordRichPresence.kt
+++ b/app/src/main/java/app/gamenative/discord/DiscordRichPresence.kt
@@ -48,6 +48,7 @@ object DiscordRichPresence {
 
     private const val TAG = "DiscordRPC"
     private const val UPDATE_RETRY_DELAY_MS = 5_000L
+    private const val TASK_REMOVED_TIMEOUT_MS = 2_000L
     private const val FALLBACK_GAME_NAME = "a Windows game"
 
     private val dispatcher = Executors.newSingleThreadExecutor { runnable ->
@@ -71,6 +72,13 @@ object DiscordRichPresence {
     private var pendingLaunch: PendingLaunch? = null
     private var initialized = false
 
+    /**
+     * True while presence is withheld because the running game was suspended along with the app.
+     * [currentSession] is deliberately kept, so [onGameResumed] republishes the same session
+     * instead of starting a new one.
+     */
+    private var suspendedForBackground = false
+
     private data class PendingLaunch(val containerId: String, val startedAtMs: Long)
 
     private data class GameSession(
@@ -88,6 +96,7 @@ object DiscordRichPresence {
         scope.launch {
             // Held even when we can't publish, so flipping the setting on mid-game works.
             pendingLaunch = PendingLaunch(containerId, startedAtMs)
+            suspendedForBackground = false
             if (!ensureInitialized()) return@launch
             publishPendingLaunch()
         }
@@ -99,6 +108,74 @@ object DiscordRichPresence {
             pendingLaunch = null
             clearPresence()
         }
+    }
+
+    /**
+     * Withdraws presence because the running game was suspended along with the app: GameNative was
+     * backgrounded, or the screen locked. The session is kept, so [onGameResumed] can put it back
+     * with its original start time and let the elapsed timer carry on rather than restart.
+     *
+     * Only call this when the game really did stop. Under the "never suspend" container policy it
+     * keeps running in its container while GameNative is in the background, and clearing presence
+     * there would hide a game that is genuinely still being played.
+     */
+    fun onGameSuspended() {
+        scope.launch {
+            if (suspendedForBackground) return@launch
+            val session = currentSession ?: return@launch
+            suspendedForBackground = true
+            if (!initialized) return@launch
+
+            runCatching { DiscordNative.nativeClearPresence() }
+                .onSuccess { Timber.tag(TAG).i("Suspended presence for '%s'", session.name) }
+                .onFailure { Timber.tag(TAG).w(it, "Failed to suspend presence") }
+        }
+    }
+
+    /**
+     * Republishes a session withdrawn by [onGameSuspended]. A no-op otherwise, so every path that
+     * resumes a game can call it without first working out how the game came to be suspended.
+     */
+    fun onGameResumed() {
+        scope.launch {
+            if (!suspendedForBackground) return@launch
+            suspendedForBackground = false
+            val session = currentSession ?: return@launch
+            if (!ensureInitialized()) return@launch
+
+            // Republished with the original startedAtMs, so Discord's elapsed timer picks up where
+            // it left off instead of resetting to zero on every alt-tab.
+            Timber.tag(TAG).i("Republishing presence for '%s'", session.name)
+            publish(session, isRetry = false)
+        }
+    }
+
+    /**
+     * Clears presence when the user swipes GameNative off the recents screen, called from
+     * [android.app.Service.onTaskRemoved]. Activity.onDestroy is not reliably delivered on a
+     * swipe, so without this the process is killed with a game still published and the user is
+     * shown as playing until Discord notices the socket is gone, which it is slow to do.
+     *
+     * Unlike every other entry point this blocks the caller: the process is usually killed moments
+     * later, and work merely posted to the RPC thread would lose that race. It goes through
+     * [teardown] rather than [clearPresence] because [DiscordNative.nativeClearPresence] only
+     * queues the change for the native callback pump — which will not tick again — while teardown
+     * stops that pump and flushes the clear itself.
+     *
+     * Bounded by [TASK_REMOVED_TIMEOUT_MS] so an unresponsive SDK cannot wedge the main thread.
+     */
+    fun onAppTaskRemoved() {
+        runCatching {
+            runBlocking {
+                withTimeout(TASK_REMOVED_TIMEOUT_MS) {
+                    scope.launch {
+                        pendingLaunch = null
+                        clearPresence()
+                        teardown()
+                    }.join()
+                }
+            }
+        }.onFailure { Timber.tag(TAG).w(it, "Presence not cleared before task removal") }
     }
 
     /** Turning the setting off clears presence; turning it on republishes a running game. */
@@ -184,6 +261,7 @@ object DiscordRichPresence {
     }
 
     private fun clearPresence() {
+        suspendedForBackground = false
         val session = currentSession ?: return
         currentSession = null
         if (!initialized) return

--- a/app/src/main/java/app/gamenative/discord/DiscordRichPresence.kt
+++ b/app/src/main/java/app/gamenative/discord/DiscordRichPresence.kt
@@ -1,0 +1,289 @@
+package app.gamenative.discord
+
+import androidx.annotation.VisibleForTesting
+import app.gamenative.PrefManager
+import app.gamenative.data.GameSource
+import app.gamenative.service.SteamService
+import app.gamenative.service.amazon.AmazonService
+import app.gamenative.service.epic.EpicService
+import app.gamenative.service.gog.GOGService
+import app.gamenative.utils.ContainerUtils
+import java.util.concurrent.Executors
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import timber.log.Timber
+
+/** Why Discord Rich Presence is or is not currently publishing. */
+enum class DiscordAvailability {
+    DISABLED,
+    SDK_NOT_BUNDLED,
+    NOT_CONFIGURED,
+    READY,
+
+    /** The SDK rejected an update, usually because Discord isn't installed or is signed out. */
+    UNAVAILABLE,
+}
+
+/**
+ * Publishes the running game as the user's Discord activity ("Playing <game>" with an elapsed
+ * timer), and clears it when the game exits.
+ *
+ * Uses the Discord Social SDK's unauthenticated RPC path via [DiscordNative], which on Android
+ * publishes through the installed Discord app while it is signed in. No login, no account linking
+ * and nothing is read back from the user's account.
+ *
+ * Every path is best-effort: a missing SDK, a missing app ID or Discord being unreachable lands in
+ * [availability] and GameNative carries on as if the integration weren't there.
+ *
+ * All work is posted to a single background thread, so no internal locking is needed and callers
+ * never block.
+ */
+object DiscordRichPresence {
+
+    private const val TAG = "DiscordRPC"
+    private const val UPDATE_RETRY_DELAY_MS = 5_000L
+    private const val FALLBACK_GAME_NAME = "a Windows game"
+
+    private val dispatcher = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "discord-rpc").apply { isDaemon = true }
+    }.asCoroutineDispatcher()
+
+    // Backstop only: every native and service call below is already guarded individually. An
+    // optional feature must never take the app down from a background coroutine.
+    private val handler = CoroutineExceptionHandler { _, t ->
+        Timber.tag(TAG).e(t, "Unhandled failure on the Discord thread")
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher + handler)
+
+    @Volatile
+    var availability = DiscordAvailability.SDK_NOT_BUNDLED
+        private set
+
+    // Only ever touched from the dispatcher's single thread.
+    private var currentSession: GameSession? = null
+    private var pendingLaunch: PendingLaunch? = null
+    private var initialized = false
+
+    private data class PendingLaunch(val containerId: String, val startedAtMs: Long)
+
+    private data class GameSession(
+        val containerId: String,
+        val name: String,
+        val startedAtMs: Long,
+        val artUrl: String?,
+    )
+
+    /**
+     * Publishes [containerId]'s game, counting up from [startedAtMs] (epoch millis). Safe to call
+     * for every launch, it is a no-op unless the feature is enabled and Discord is reachable.
+     */
+    fun onGameStarted(containerId: String, startedAtMs: Long) {
+        scope.launch {
+            // Held even when we can't publish, so flipping the setting on mid-game works.
+            pendingLaunch = PendingLaunch(containerId, startedAtMs)
+            if (!ensureInitialized()) return@launch
+            publishPendingLaunch()
+        }
+    }
+
+    /** Clears the published activity. Safe to call when nothing is published. */
+    fun onGameStopped() {
+        scope.launch {
+            pendingLaunch = null
+            clearPresence()
+        }
+    }
+
+    /** Turning the setting off clears presence; turning it on republishes a running game. */
+    fun onEnabledChanged(enabled: Boolean) {
+        scope.launch {
+            if (!enabled) {
+                clearPresence()
+                teardown()
+                availability = DiscordAvailability.DISABLED
+                return@launch
+            }
+            if (ensureInitialized()) publishPendingLaunch()
+        }
+    }
+
+    private fun publishPendingLaunch() {
+        val launch = pendingLaunch ?: return
+        // Resolving name and art hits the store services, so it is deferred to here rather than
+        // done on every game launch regardless of whether Discord is enabled.
+        val session = GameSession(
+            containerId = launch.containerId,
+            name = resolveGameName(launch.containerId),
+            startedAtMs = launch.startedAtMs.takeIf { it > 0L } ?: System.currentTimeMillis(),
+            artUrl = resolveArtUrl(launch.containerId),
+        )
+        currentSession = session
+        Timber.tag(TAG).i("Publishing presence for '%s'", session.name)
+        publish(session, isRetry = false)
+    }
+
+    private fun ensureInitialized(): Boolean {
+        // Re-checked every call so the setting takes effect without a restart, and guarded because
+        // an optional feature must not be what brings the app down.
+        val enabled = runCatching { PrefManager.discordRichPresenceEnabled }.getOrDefault(false)
+        if (!enabled) {
+            availability = DiscordAvailability.DISABLED
+            return false
+        }
+        if (!DiscordNative.isAvailable) {
+            availability = DiscordAvailability.SDK_NOT_BUNDLED
+            if (DiscordConfig.sdkBundled) {
+                // Packaging problem, not the ordinary "this build ships without Discord" case.
+                Timber.tag(TAG).w("Discord SDK bundled but the JNI bridge failed to load")
+            }
+            return false
+        }
+        if (DiscordConfig.applicationId <= 0L) {
+            availability = DiscordAvailability.NOT_CONFIGURED
+            Timber.tag(TAG).w("Discord SDK bundled but no DISCORD_APPLICATION_ID was set at build time")
+            return false
+        }
+        if (initialized) return true
+
+        // Handing the Activity over starts the SDK's own networking, which aborts the process if
+        // it fails, so a user who never enables the feature must not be exposed to it.
+        if (!DiscordSocialSdkCompat.attachEngineActivity()) {
+            availability = DiscordAvailability.UNAVAILABLE
+            return false
+        }
+
+        val started = runCatching { DiscordNative.nativeInitialize(DiscordConfig.applicationId) }
+            .onFailure { Timber.tag(TAG).e(it, "Discord client failed to initialize") }
+            .getOrDefault(false)
+        if (!started) {
+            availability = DiscordAvailability.UNAVAILABLE
+            return false
+        }
+
+        DiscordNative.presenceResultListener = ::onPresenceResult
+        initialized = true
+        availability = DiscordAvailability.READY
+        Timber.tag(TAG).i("Discord Rich Presence initialized")
+        return true
+    }
+
+    /** Stops the native client and its callback pump. */
+    private fun teardown() {
+        if (!initialized) return
+        initialized = false
+        DiscordNative.presenceResultListener = null
+        runCatching { DiscordNative.nativeShutdown() }
+            .onFailure { Timber.tag(TAG).w(it, "Failed to shut down Discord client") }
+    }
+
+    private fun clearPresence() {
+        val session = currentSession ?: return
+        currentSession = null
+        if (!initialized) return
+
+        runCatching { DiscordNative.nativeClearPresence() }
+            .onSuccess { Timber.tag(TAG).i("Cleared presence for '%s'", session.name) }
+            .onFailure { Timber.tag(TAG).w(it, "Failed to clear presence") }
+    }
+
+    private fun publish(session: GameSession, isRetry: Boolean) {
+        val hasGameArt = session.artUrl != null
+        val posted = runCatching {
+            DiscordNative.nativeUpdatePresence(
+                name = session.name,
+                details = null,
+                state = null,
+                startTimestampMs = session.startedAtMs,
+                largeImage = session.artUrl ?: DiscordConfig.FALLBACK_IMAGE_ASSET_KEY,
+                largeText = if (hasGameArt) session.name else DiscordConfig.FALLBACK_IMAGE_TEXT,
+                smallImage = null,
+                smallText = null,
+            )
+        }.onFailure {
+            Timber.tag(TAG).e(it, "Failed to publish presence")
+            availability = DiscordAvailability.UNAVAILABLE
+        }.isSuccess
+
+        if (posted && !isRetry) scheduleRetryIfStillFailing(session)
+    }
+
+    /**
+     * A rejected update surfaces in [onPresenceResult] rather than at the call site, so retry once
+     * a few seconds later: Discord's RPC endpoint is often not up yet when a game launch wakes the
+     * device. One retry only, so a user without Discord doesn't cost a polling loop.
+     */
+    private fun scheduleRetryIfStillFailing(session: GameSession) {
+        scope.launch {
+            delay(UPDATE_RETRY_DELAY_MS)
+            if (currentSession != session) return@launch
+            if (availability != DiscordAvailability.UNAVAILABLE) return@launch
+            Timber.tag(TAG).i("Retrying presence for '%s'", session.name)
+            publish(session, isRetry = true)
+        }
+    }
+
+    private fun onPresenceResult(success: Boolean, message: String) {
+        if (success) {
+            availability = DiscordAvailability.READY
+            Timber.tag(TAG).d("Presence update accepted")
+        } else {
+            availability = DiscordAvailability.UNAVAILABLE
+            Timber.tag(TAG).w("Presence update rejected: %s", message)
+        }
+    }
+
+    /** Test-only: the dispatcher is single-threaded and FIFO, so a finished no-op means idle. */
+    @VisibleForTesting
+    internal fun awaitIdle(timeoutMs: Long = 5_000L) {
+        runBlocking { withTimeout(timeoutMs) { scope.launch { }.join() } }
+    }
+
+    private fun resolveGameName(containerId: String): String =
+        runCatching { ContainerUtils.resolveGameName(containerId) }
+            .getOrElse {
+                Timber.tag(TAG).w(it, "Could not resolve game name")
+                ""
+            }
+            .ifBlank { FALLBACK_GAME_NAME }
+
+    /**
+     * The game's own cover art as an https URL. Discord's image fields take an uploaded asset key
+     * or an external URL, and an application is capped at 300 uploaded assets, so per-game art
+     * comes from the store CDNs instead. Squarer art is preferred, since Discord renders it square.
+     *
+     * Null for custom games: their art is local files Discord's servers can't reach.
+     */
+    private fun resolveArtUrl(containerId: String): String? = runCatching {
+        val gameId = ContainerUtils.extractGameIdFromContainerId(containerId)
+        val candidates = when (ContainerUtils.extractGameSourceFromContainerId(containerId)) {
+            GameSource.STEAM -> SteamService.getAppInfoOf(gameId)?.let {
+                listOf(it.getCapsuleUrl(), it.headerUrl, it.iconUrl)
+            }
+            GameSource.GOG -> GOGService.getGOGGameOf(gameId.toString())?.let {
+                listOf(it.iconUrl, it.imageUrl)
+            }
+            GameSource.EPIC -> EpicService.getEpicGameOf(gameId)?.let {
+                listOf(it.iconUrl, it.primaryImageUrl)
+            }
+            GameSource.AMAZON -> AmazonService.getAmazonGameByAppId(gameId)?.let {
+                listOf(it.artUrl, it.heroUrl)
+            }
+            GameSource.CUSTOM_GAME -> null
+        }
+        candidates.orEmpty().firstOrNull(::isPublishableImageUrl)
+    }.getOrElse {
+        Timber.tag(TAG).w(it, "Could not resolve game art")
+        null
+    }
+
+    /** Discord caps image fields at 300 characters and can only fetch http(s) URLs. */
+    private fun isPublishableImageUrl(url: String): Boolean =
+        url.length in 1..300 && (url.startsWith("https://") || url.startsWith("http://"))
+}

--- a/app/src/main/java/app/gamenative/discord/DiscordSocialSdkCompat.kt
+++ b/app/src/main/java/app/gamenative/discord/DiscordSocialSdkCompat.kt
@@ -1,0 +1,52 @@
+package app.gamenative.discord
+
+import android.app.Activity
+import java.lang.ref.WeakReference
+import timber.log.Timber
+
+/**
+ * Reflective shim for `com.discord.socialsdk.DiscordSocialSdkInit.setEngineActivity(Activity)`,
+ * the one Java entry point the Discord Social SDK AAR exposes. Reached by reflection so that
+ * app/src/main/java compiles identically whether or not the AAR is present.
+ *
+ * The Activity is registered at startup but not handed to the SDK there: setEngineActivity starts
+ * the SDK's own networking, which aborts the process if it fails, so [DiscordRichPresence] calls
+ * it once the user has actually enabled the feature.
+ */
+internal object DiscordSocialSdkCompat {
+
+    private const val TAG = "DiscordRPC"
+    private const val INIT_CLASS = "com.discord.socialsdk.DiscordSocialSdkInit"
+
+    @Volatile
+    private var activityRef: WeakReference<Activity>? = null
+
+    @Volatile
+    private var attached = false
+
+    /** Called from Activity.onCreate. Does not touch the SDK. */
+    fun registerActivity(activity: Activity) {
+        activityRef = WeakReference(activity)
+    }
+
+    /** Hands the registered Activity to the SDK. Returns false when unavailable. */
+    fun attachEngineActivity(): Boolean {
+        if (attached) return true
+        if (!DiscordNative.isAvailable) return false
+        val activity = activityRef?.get() ?: run {
+            Timber.tag(TAG).w("No activity registered for the Discord Social SDK")
+            return false
+        }
+        return try {
+            Class.forName(INIT_CLASS)
+                .getMethod("setEngineActivity", Activity::class.java)
+                .invoke(null, activity)
+            attached = true
+            Timber.tag(TAG).i("Attached engine activity to Discord Social SDK")
+            true
+        } catch (t: Throwable) {
+            Timber.tag(TAG).w("Could not attach engine activity: %s", t.javaClass.simpleName)
+            false
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -10,6 +10,7 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.IBinder
 import android.util.Base64
+import app.gamenative.discord.DiscordRichPresence
 import app.gamenative.ui.util.GameInviteNotificationManager
 import app.gamenative.ui.util.SnackbarManager
 import app.gamenative.service.callback.GameInviteCallback
@@ -3671,6 +3672,9 @@ class SteamService : Service(), IChallengeUrlChanged {
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
+        // Swipe-away does not reliably deliver Activity.onDestroy, and the process is about
+        // to go; clear synchronously so no game is left published. No-op when idle.
+        DiscordRichPresence.onAppTaskRemoved()
         if (!hasActiveOperations() && !(BuildConfig.XR_BUILD && keepAlive)) {
             Timber.i("Task removed and no active work — stopping service")
             stopSelf()

--- a/app/src/main/java/app/gamenative/service/amazon/AmazonService.kt
+++ b/app/src/main/java/app/gamenative/service/amazon/AmazonService.kt
@@ -12,6 +12,7 @@ import app.gamenative.data.AmazonGame
 import app.gamenative.data.DownloadInfo
 import app.gamenative.data.GameSource
 import app.gamenative.db.dao.AmazonGameDao
+import app.gamenative.discord.DiscordRichPresence
 import app.gamenative.enums.Marker
 import app.gamenative.events.AndroidEvent
 import app.gamenative.service.NotificationHelper
@@ -863,6 +864,9 @@ class AmazonService : Service() {
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
+        // Swipe-away does not reliably deliver Activity.onDestroy, and the process is about
+        // to go; clear synchronously so no game is left published. No-op when idle.
+        DiscordRichPresence.onAppTaskRemoved()
         if (!hasActiveOperations()) {
             Timber.i("[Amazon] Task removed and no active work — stopping service")
             stopSelf()

--- a/app/src/main/java/app/gamenative/service/epic/EpicService.kt
+++ b/app/src/main/java/app/gamenative/service/epic/EpicService.kt
@@ -11,6 +11,7 @@ import app.gamenative.data.EpicGame
 import app.gamenative.data.LaunchInfo
 import app.gamenative.data.LibraryItem
 import app.gamenative.data.EpicGameToken
+import app.gamenative.discord.DiscordRichPresence
 import app.gamenative.utils.MarkerUtils
 import app.gamenative.enums.Marker
 import app.gamenative.events.AndroidEvent
@@ -747,6 +748,9 @@ class EpicService : Service() {
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
+        // Swipe-away does not reliably deliver Activity.onDestroy, and the process is about
+        // to go; clear synchronously so no game is left published. No-op when idle.
+        DiscordRichPresence.onAppTaskRemoved()
         if (!hasActiveOperations()) {
             Timber.tag("Epic").i("Task removed and no active work — stopping service")
             stopSelf()

--- a/app/src/main/java/app/gamenative/service/gog/GOGService.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGService.kt
@@ -10,6 +10,7 @@ import app.gamenative.data.GOGCredentials
 import app.gamenative.data.GOGGame
 import app.gamenative.data.LaunchInfo
 import app.gamenative.data.LibraryItem
+import app.gamenative.discord.DiscordRichPresence
 import app.gamenative.events.AndroidEvent
 import app.gamenative.PluviaApp
 import app.gamenative.ui.util.SnackbarManager
@@ -833,6 +834,9 @@ class GOGService : Service() {
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
+        // Swipe-away does not reliably deliver Activity.onDestroy, and the process is about
+        // to go; clear synchronously so no game is left published. No-op when idle.
+        DiscordRichPresence.onAppTaskRemoved()
         if (!hasActiveOperations()) {
             Timber.tag("GOG").i("Task removed and no active work — stopping service")
             stopSelf()

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -12,6 +12,7 @@ import app.gamenative.data.GameProcessInfo
 import app.gamenative.data.GameSource
 import app.gamenative.data.LibraryPlayHistory
 import app.gamenative.db.dao.LibraryPlayHistoryDao
+import app.gamenative.discord.DiscordRichPresence
 import app.gamenative.di.IAppTheme
 import app.gamenative.enums.AppTheme
 import app.gamenative.enums.LoginResult
@@ -501,6 +502,7 @@ class MainViewModel @Inject constructor(
 
     fun launchApp(context: Context, appId: String) {
         gameSessionStartTime = System.currentTimeMillis()
+        DiscordRichPresence.onGameStarted(appId, gameSessionStartTime)
         gamePlayedThisSession = true
         PrefManager.hasAttemptedGameLaunch = true
         // Show booting splash before launching the app
@@ -606,6 +608,7 @@ class MainViewModel @Inject constructor(
                 val gameId = ContainerUtils.extractGameIdFromContainerId(appId)
                 Timber.tag("Exit").i("Got game id: $gameId")
                 ActiveGameRegistry.clearIfMatches(gameId)
+                DiscordRichPresence.onGameStopped()
                 SteamService.notifyRunningProcesses()
                 handleExitCloudSync(context, appId, gameId)
 
@@ -815,6 +818,10 @@ class MainViewModel @Inject constructor(
             PluviaApp.events.emit(AndroidEvent.ClearBootingSplash)
 
             // You could also show an error dialog here if needed
+
+            // The launch never produced a running game, so drop the presence published above
+            DiscordRichPresence.onGameStopped()
+
             Timber.tag("MainViewModel").e("Game launch error: $error")
         }
     }

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupDiscord.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsGroupDiscord.kt
@@ -1,0 +1,47 @@
+package app.gamenative.ui.screen.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.stringResource
+import app.gamenative.PrefManager
+import app.gamenative.R
+import app.gamenative.discord.DiscordRichPresence
+import app.gamenative.ui.theme.settingsTileColorsAlt
+import com.alorma.compose.settings.ui.SettingsGroup
+import com.alorma.compose.settings.ui.SettingsSwitch
+
+@Composable
+fun SettingsGroupDiscord() {
+    val context = LocalContext.current
+    val isPreview = LocalInspectionMode.current
+    if (!isPreview) {
+        PrefManager.init(context)
+    }
+
+    var richPresenceEnabled by rememberSaveable {
+        mutableStateOf(if (isPreview) false else PrefManager.discordRichPresenceEnabled)
+    }
+
+    SettingsGroup(modifier = Modifier.background(Color.Transparent)) {
+        SettingsSwitch(
+            colors = settingsTileColorsAlt(),
+            title = { Text(text = stringResource(R.string.settings_discord_rich_presence_title)) },
+            subtitle = { Text(text = stringResource(R.string.settings_discord_rich_presence_subtitle)) },
+            state = richPresenceEnabled,
+            onCheckedChange = {
+                richPresenceEnabled = it
+                PrefManager.discordRichPresenceEnabled = it
+                DiscordRichPresence.onEnabledChanged(it)
+            },
+        )
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/settings/SettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Gamepad
@@ -57,6 +58,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.gamenative.PrefManager
 import app.gamenative.R
+import app.gamenative.discord.DiscordConfig
 import app.gamenative.enums.AppTheme
 import app.gamenative.ui.theme.PluviaTheme
 import com.materialkolor.PaletteStyle
@@ -152,6 +154,17 @@ private fun SettingsScreenContent(
                         onAppTheme = onAppTheme,
                         onPaletteStyle = onPaletteStyle,
                     )
+                }
+
+                // Discord section, only in builds that bundled the Social SDK
+                if (DiscordConfig.sdkBundled) {
+                    SettingsSection(
+                        title = stringResource(R.string.settings_discord_title),
+                        icon = Icons.AutoMirrored.Filled.Chat,
+                        iconTint = PluviaTheme.colors.accentPurple,
+                    ) {
+                        SettingsGroupDiscord()
+                    }
                 }
 
                 // Info section

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -98,6 +98,7 @@ import app.gamenative.data.LaunchInfo
 import app.gamenative.data.LibraryItem
 import app.gamenative.data.ShooterModeConfig
 import app.gamenative.data.SteamApp
+import app.gamenative.discord.DiscordRichPresence
 import app.gamenative.events.AndroidEvent
 import app.gamenative.events.SteamEvent
 import app.gamenative.ui.enums.Orientation
@@ -852,12 +853,14 @@ fun XServerScreen(
             return
         }
         PluviaApp.xEnvironment?.onResume()
+        DiscordRichPresence.onGameResumed()
         clearOverlayPauseState()
     }
 
     fun forceResumeIfSuspended() {
         if (PluviaApp.isOverlayPaused && !neverSuspend) {
             PluviaApp.xEnvironment?.onResume()
+            DiscordRichPresence.onGameResumed()
         }
         clearOverlayPauseState()
     }
@@ -866,6 +869,9 @@ fun XServerScreen(
         if (!PluviaApp.isOverlayPaused) return
         if (!neverSuspend) {
             PluviaApp.xEnvironment?.onResume()
+            // Under the manual policy this button, not MainActivity.onResume, is what actually
+            // restarts the game after a backgrounding — so it is what restores presence.
+            DiscordRichPresence.onGameResumed()
         }
         keepPausedForEditor = false
         clearOverlayPauseState()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1093,6 +1093,11 @@
     <string name="settings_debug_clear_cache_title">Clear Image Cache</string>
     <string name="settings_debug_clear_cache_subtitle">Remove all images that were loaded.</string>
 
+    <!-- Settings: Discord Group -->
+    <string name="settings_discord_title">Discord</string>
+    <string name="settings_discord_rich_presence_title">Show game on Discord</string>
+    <string name="settings_discord_rich_presence_subtitle">Publish the game you are playing as your Discord activity. Needs the Discord app installed and signed in.</string>
+
     <!-- Settings: Info Group -->
     <string name="settings_info_title">Info</string>
     <string name="settings_info_send_tip_title">Become a member</string>

--- a/app/src/test/java/app/gamenative/discord/DiscordRichPresenceTest.kt
+++ b/app/src/test/java/app/gamenative/discord/DiscordRichPresenceTest.kt
@@ -1,8 +1,10 @@
 package app.gamenative.discord
 
+import kotlin.system.measureTimeMillis
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -35,5 +37,39 @@ class DiscordRichPresenceTest {
         DiscordRichPresence.awaitIdle()
 
         assertEquals(DiscordAvailability.DISABLED, DiscordRichPresence.availability)
+    }
+
+    @Test
+    fun suspendAndResume_areNoOpsWhenDiscordIsUnavailable() {
+        DiscordRichPresence.onGameStarted("STEAM_271590", System.currentTimeMillis())
+        DiscordRichPresence.onGameSuspended()
+        DiscordRichPresence.onGameResumed()
+        DiscordRichPresence.onGameStopped()
+        DiscordRichPresence.awaitIdle()
+
+        assertNotEquals(DiscordAvailability.READY, DiscordRichPresence.availability)
+    }
+
+    /** Resuming without a preceding suspend must not republish or throw. */
+    @Test
+    fun resume_withoutSuspend_isANoOp() {
+        DiscordRichPresence.onGameResumed()
+        DiscordRichPresence.awaitIdle()
+
+        assertNotEquals(DiscordAvailability.READY, DiscordRichPresence.availability)
+    }
+
+    /**
+     * onAppTaskRemoved blocks its caller (the main thread, from Service.onTaskRemoved), so the
+     * thing worth guarding is that it returns promptly and does not throw with no SDK present.
+     */
+    @Test
+    fun taskRemoved_returnsPromptlyWithoutDiscord() {
+        DiscordRichPresence.onGameStarted("STEAM_271590", System.currentTimeMillis())
+
+        val elapsed = measureTimeMillis { DiscordRichPresence.onAppTaskRemoved() }
+
+        assertTrue("onAppTaskRemoved must not block the main thread: took ${elapsed}ms", elapsed < 2_000)
+        assertNotEquals(DiscordAvailability.READY, DiscordRichPresence.availability)
     }
 }

--- a/app/src/test/java/app/gamenative/discord/DiscordRichPresenceTest.kt
+++ b/app/src/test/java/app/gamenative/discord/DiscordRichPresenceTest.kt
@@ -1,0 +1,39 @@
+package app.gamenative.discord
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Guards the contract that makes the integration safe to ship disabled: with no Discord Social SDK
+ * present, no entry point may throw and none may claim to be publishing.
+ */
+class DiscordRichPresenceTest {
+
+    @Test
+    fun nativeBridge_isAbsentWithoutTheDiscordSdk() {
+        assertFalse(
+            "libdiscordbridge.so must not be loadable in a plain JVM test",
+            DiscordNative.isAvailable,
+        )
+    }
+
+    @Test
+    fun lifecycleCalls_areNoOpsWhenDiscordIsUnavailable() {
+        DiscordRichPresence.onGameStarted("STEAM_271590", System.currentTimeMillis())
+        DiscordRichPresence.onGameStopped()
+        DiscordRichPresence.awaitIdle()
+
+        assertNotEquals(DiscordAvailability.READY, DiscordRichPresence.availability)
+    }
+
+    @Test
+    fun settingToggle_isSafeWithoutDiscord() {
+        DiscordRichPresence.onEnabledChanged(true)
+        DiscordRichPresence.onEnabledChanged(false)
+        DiscordRichPresence.awaitIdle()
+
+        assertEquals(DiscordAvailability.DISABLED, DiscordRichPresence.availability)
+    }
+}


### PR DESCRIPTION
## Description
<!-- What changed and why? -->

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [ ] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional Discord Rich Presence on Android via the official Discord Social SDK. Previously we did not publish activity; now, when enabled, we publish the current game through the installed Discord app and clear it when play stops.

- Publishes game name, start time, and cover art URL; no login, tokens, or account linking. Off by default.
- Ships a gated integration: when `app/libs/discord_partner_sdk.aar` is absent, builds and runtime behave unchanged (settings section hidden; no SDK load).
- Adds a small JNI bridge (`libdiscordbridge.so`) and CMake target, enabled only when the AAR exists.
- Handles lifecycle: suspend/resume mirrors container policy; clears presence on game stop and on task removal to avoid stale status.
- Adds settings toggle (Settings > Discord) and `proguard-rules.pro` keep rules for `app.gamenative.discord.DiscordNative` and `com.discord.socialsdk.**`.

**Rollout**
- To enable: place `app/libs/discord_partner_sdk.aar` and build with `DISCORD_APPLICATION_ID` (e.g., `-PDISCORD_APPLICATION_ID=000...`); ensure the Android NDK is installed.
- Optional: upload a `gamenative` Rich Presence art asset in the Discord Developer Portal for custom games.
- Users must opt in per device (toggle is off by default). Presence requires the Discord app installed and signed in.

<sup>Written for commit cac85ff48bc06ad2a57e1ca9ac921ce0b300f6fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Discord Rich Presence support for displaying the currently playing game.
  * Added a Discord Rich Presence toggle under Settings; it is disabled by default.
  * Presence updates automatically when games start, stop, suspend, resume, or when the app closes.
  * Builds without the optional Discord SDK continue to work normally.

* **Documentation**
  * Added setup, configuration, licensing, and platform guidance for Discord Rich Presence.

* **Tests**
  * Added coverage confirming safe behavior when Discord support is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->