### PR TITLE
Exempt pipelined clients from SHM frame pacing

### DIFF
--- a/app/src/main/java/com/winlator/xconnector/Client.java
+++ b/app/src/main/java/com/winlator/xconnector/Client.java
@@ -17,6 +17,8 @@ public class Client {
     protected boolean connected;
     protected java.util.concurrent.ScheduledFuture<?> pauseTask;
     protected long pauseDeadlineNs;
+    protected int pacedSupersedes;
+    protected boolean pacingExempt;
 
     public Client(XConnectorEpoll connector, ClientSocket clientSocket) {
         this.connector = connector;

--- a/app/src/main/java/com/winlator/xconnector/XConnectorEpoll.java
+++ b/app/src/main/java/com/winlator/xconnector/XConnectorEpoll.java
@@ -199,7 +199,7 @@ public class XConnectorEpoll implements Runnable {
     }
 
     public void pauseClientReads(Client client, long delayNs) {
-        if (this.multithreadedClients || !client.connected || !this.running) return;
+        if (this.multithreadedClients || !client.connected || !this.running || client.pacingExempt) return;
         long deadlineNs = System.nanoTime() + delayNs;
         final java.util.concurrent.ScheduledExecutorService sched = PauseScheduler.INSTANCE;
         synchronized (client) {
@@ -207,6 +207,16 @@ public class XConnectorEpoll implements Runnable {
             // earlier task firing first would resume reads before the newest
             // frame's slot.
             if (client.pauseTask != null && !client.pauseTask.isDone()) {
+                // Repeated supersedes within one pause window mean the client
+                // pipelines frames without a per-frame sync; read-suspension
+                // cannot pace such a client smoothly (its loop only feels the
+                // brake in whole batches), so it runs uncapped instead.
+                if (client.pacedSupersedes++ >= 8) {
+                    client.pacingExempt = true;
+                    Log.i(TAG, logPrefix() + " client fd " + client.clientSocket.fd
+                            + " pipelines frames without a per-frame sync; SHM pacing exempted");
+                    return;
+                }
                 if (client.pauseDeadlineNs >= deadlineNs) return;
                 client.pauseTask.cancel(false);
             }
@@ -215,6 +225,7 @@ public class XConnectorEpoll implements Runnable {
             client.pauseTask = sched.schedule(() -> {
                 synchronized (client) {
                     client.pauseTask = null;
+                    client.pacedSupersedes = 0;
                     if (client.connected && this.running) {
                         addFdToEpoll(this.epollFd, client.clientSocket.fd);
                     }


### PR DESCRIPTION
## Description
Fixes severe stutter (freeze then fast-forward) in Mewgenics cutscenes with the FPS limiter enabled.

The SHM frame limiter paces a game by suspending its socket reads until the next frame slot. That works for clients that block on a per-frame sync (Balatro, Stardew, Brotato: one frame per read batch, one small delay each). Mewgenics' cutscenes stream full-frame SHM blits with no per-frame sync, so the server reads a whole batch of ~15 buffered frames at once and the per-frame delays collapse into one giant suspension. The game's own loop then only feels the brake in whole batches, which chops its clock into freeze and catch-up bursts. This is a protocol-shape limitation: no granularity of read-suspension back-pressure can pace such a client smoothly (verified on device with per-second ingress counters on every frame path - even with delivery corrected to an exact 60/s into the X server, the game-side burst cycle remains).

The fix detects the pattern and stops pacing that client: repeated pause supersedes within a single pause window (a new paced frame arriving while a pause is already pending) only occur when a client pipelines - per-frame-syncing clients never generate them. After the 9th supersede the client is marked exempt, logged once, and runs uncapped for the session. Syncing games keep their cap byte-for-byte unchanged.

Diff is 14 lines across Client.java and XConnectorEpoll.java; nothing on the connector stop/shutdown path.

Reviewer notes:
- Detection trips inside Mewgenics' first cutscene batch (~150 ms), so at most one brief mini-batch is visible before it runs free.
- Exemption is per X client connection and lasts until the game restarts, so a game that streams only in cutscenes also runs uncapped in gameplay afterwards. Accepted trade-off: uncapped-but-smooth is what affected users get today by turning the limiter off manually.
- The proper long-term fix for smooth-and-capped streamers is pacing via ShmCompletionEvent (the server currently never sends it); that needs guest-side wine work and is out of scope here.

## Recording
<!-- to be attached -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [ ] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes severe stutter (freeze then fast-forward) in Mewgenics cutscenes by exempting pipelined clients from SHM frame pacing. The old pacing suspended socket reads per frame slot, which worked for clients that sync per-frame, but pipelined clients stream full-frame blits without sync and only feel the brake in whole batches, causing freeze-and-catch-up bursts.

- Detects the pattern via repeated pause supersedes within one pause window; per-frame-syncing clients never generate them.
- After the 9th supersede the client is marked exempt and runs uncapped for the session; syncing games keep their cap unchanged.
- Detection trips within ~150 ms (first cutscene batch), so at most one brief mini-batch appears before the client runs free.
- Exemption lasts until the game restarts, so a game that only streams in cutscenes also runs uncapped in gameplay afterward - accepted trade-off, since disabling the limiter manually is today's workaround.

<sup>Written for commit 13aceb2c510003d9bfa05d491c71022ec0082a56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved handling of clients that rapidly submit multiple frames.
  * Reduced unnecessary synchronization for sustained pipelined activity, allowing eligible clients to run without per-frame pacing.
  * Pacing automatically resets when the pause window ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->