### PR TITLE
Added GOG installer for v1 (fixes registry keys, needing CD drive for older games)

### DIFF
--- a/app/src/main/java/app/gamenative/enums/Marker.kt
+++ b/app/src/main/java/app/gamenative/enums/Marker.kt
@@ -8,6 +8,7 @@ enum class Marker(val fileName: String ) {
     STEAM_COLDCLIENT_USED(".steam_coldclient_used"),
     VCREDIST_INSTALLED(".vcredist_installed"),
     GOG_SCRIPT_INSTALLED(".gog_script_installed"),
+    GOG_SUPPORT_INSTALLED(".gog_support_installed"),
     PHYSX_INSTALLED(".physx_installed"),
     OPENAL_INSTALLED(".openal_installed"),
     XNA_INSTALLED(".xna_installed"),

--- a/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGDownloadManager.kt
@@ -549,11 +549,23 @@ class GOGDownloadManager @Inject constructor(
                     },
                 )
             }
+            val supportCommandsArray = JSONArray()
+            gameManifest.supportCommands.forEach { c ->
+                supportCommandsArray.put(
+                    JSONObject().apply {
+                        put("executable", c.executable)
+                        put("gameID", c.gameId)
+                        put("argument", c.argument)
+                        put("languages", JSONArray(c.languages))
+                    },
+                )
+            }
             val root = JSONObject().apply {
                 put("version", 2)
                 put("baseProductId", gameManifest.baseProductId)
                 put("scriptInterpreter", gameManifest.scriptInterpreter)
                 put("products", productsArray)
+                put("supportCommands", supportCommandsArray)
                 put("buildId", buildId)
                 put("versionName", versionName)
                 put("language", language)

--- a/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
@@ -906,15 +906,19 @@ class GOGManager @Inject constructor(
      * Galaxy and Heroic perform after installing a Gen 1 game. Idempotent, so run each launch
      * like the scriptinterpreter path; the registry also self-heals if the prefix is recreated.
      */
-    fun getSupportCommandPartsForLaunch(appId: String): List<String> {
-        val gameId = ContainerUtils.extractGameIdFromContainerId(appId) ?: return emptyList()
-        val game = runBlocking { getGameFromDbById(gameId.toString()) } ?: return emptyList()
-        val computedPath = getGameInstallPath(gameId.toString(), game.title)
-        val gameInstallPath = when {
-            game.installPath.isNotEmpty() && File(game.installPath).exists() -> game.installPath
-            else -> computedPath
+    fun getSupportCommandPartsForLaunch(appId: String, knownInstallDir: File? = null): List<String> {
+        val gameInstallDir = if (knownInstallDir != null && knownInstallDir.isDirectory) {
+            knownInstallDir
+        } else {
+            val gameId = ContainerUtils.extractGameIdFromContainerId(appId) ?: return emptyList()
+            val game = runBlocking { getGameFromDbById(gameId.toString()) } ?: return emptyList()
+            val computedPath = getGameInstallPath(gameId.toString(), game.title)
+            val gameInstallPath = when {
+                game.installPath.isNotEmpty() && File(game.installPath).exists() -> game.installPath
+                else -> computedPath
+            }
+            File(gameInstallPath)
         }
-        val gameInstallDir = File(gameInstallPath)
         val root = GOGManifestUtils.readLocalManifest(gameInstallDir) ?: return emptyList()
         val commandsArray = root.optJSONArray("supportCommands") ?: return emptyList()
         if (commandsArray.length() == 0) return emptyList()
@@ -935,9 +939,10 @@ class GOGManager @Inject constructor(
             val langsArr = cmd.optJSONArray("languages")
             var languageMatches = langsArr == null || langsArr.length() == 0
             if (langsArr != null) {
+                val aliases = languageAliases(language)
                 for (j in 0 until langsArr.length()) {
                     val l = langsArr.getString(j)
-                    if (l.equals("Neutral", ignoreCase = true) || l.equals(language, ignoreCase = true)) {
+                    if (l.equals("Neutral", ignoreCase = true) || l.lowercase() in aliases) {
                         languageMatches = true
                         break
                     }
@@ -974,6 +979,19 @@ class GOGManager @Inject constructor(
         }
 
         return parts
+    }
+
+    /**
+     * All spellings that refer to the same language as [language] (container name plus GOG
+     * codes, lowercased), so support_commands language names ("English") match whichever
+     * form the download saved ("english", "en-US", "en", ...).
+     */
+    private fun languageAliases(language: String): Set<String> {
+        val lower = language.lowercase()
+        val entry = GOGConstants.CONTAINER_LANGUAGE_TO_GOG_CODES.entries.firstOrNull { (name, codes) ->
+            name == lower || codes.any { it.equals(lower, ignoreCase = true) }
+        } ?: return setOf(lower)
+        return (entry.value.map { it.lowercase() } + entry.key).toSet()
     }
 
     // ==========================================================================

--- a/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
@@ -816,19 +816,23 @@ class GOGManager @Inject constructor(
         val commonRedistDir = File(gameInstallDir, "_CommonRedist")
         val isiDir = File(commonRedistDir, "ISI")
         if (isiDir.isDirectory) {
-            val rootDirLink = File(isiDir, "rootdir")
-            if (!rootDirLink.exists() || !WinlatorFileUtils.isSymlink(rootDirLink)) {
-                try {
+            ensureRootDirSymlink(gameInstallDir, isiDir)
+        }
+    }
+
+    private fun ensureRootDirSymlink(gameInstallDir: File, parentDir: File) {
+        val rootDirLink = File(parentDir, "rootdir")
+        if (!rootDirLink.exists() || !WinlatorFileUtils.isSymlink(rootDirLink)) {
+            try {
                 WinlatorFileUtils.symlink(gameInstallDir, rootDirLink)
-                    Timber.tag("GOG").d(
-                        "Created scriptinterpreter rootdir symlink: ${rootDirLink.absolutePath} -> ${gameInstallDir.absolutePath}",
-                    )
-                } catch (e: Exception) {
-                    Timber.tag("GOG").e(
-                        e,
-                        "Failed to create scriptinterpreter rootdir symlink: ${rootDirLink.absolutePath} -> ${gameInstallDir.absolutePath}",
-                    )
-                }
+                Timber.tag("GOG").d(
+                    "Created rootdir symlink: ${rootDirLink.absolutePath} -> ${gameInstallDir.absolutePath}",
+                )
+            } catch (e: Exception) {
+                Timber.tag("GOG").e(
+                    e,
+                    "Failed to create rootdir symlink: ${rootDirLink.absolutePath} -> ${gameInstallDir.absolutePath}",
+                )
             }
         }
     }
@@ -890,6 +894,83 @@ class GOGManager @Inject constructor(
             ).joinToString(" ")
 
             parts.add("$exePathWin $args")
+        }
+
+        return parts
+    }
+
+    /**
+     * Returns command parts to run Gen 1 (legacy) support_commands setup executables for launch.
+     * These are per-game installers GOG ships in the support depot (downloaded to
+     * _CommonRedist/<gameID>/) that create registry keys, shortcuts, etc. — the same step
+     * Galaxy and Heroic perform after installing a Gen 1 game. Idempotent, so run each launch
+     * like the scriptinterpreter path; the registry also self-heals if the prefix is recreated.
+     */
+    fun getSupportCommandPartsForLaunch(appId: String): List<String> {
+        val gameId = ContainerUtils.extractGameIdFromContainerId(appId) ?: return emptyList()
+        val game = runBlocking { getGameFromDbById(gameId.toString()) } ?: return emptyList()
+        val computedPath = getGameInstallPath(gameId.toString(), game.title)
+        val gameInstallPath = when {
+            game.installPath.isNotEmpty() && File(game.installPath).exists() -> game.installPath
+            else -> computedPath
+        }
+        val gameInstallDir = File(gameInstallPath)
+        val root = GOGManifestUtils.readLocalManifest(gameInstallDir) ?: return emptyList()
+        val commandsArray = root.optJSONArray("supportCommands") ?: return emptyList()
+        if (commandsArray.length() == 0) return emptyList()
+
+        val language = root.optString("language", "english")
+        val buildId = root.optString("buildId", "")
+        val versionName = root.optString("versionName", "")
+        val gameDriveLetter = "A"
+
+        val parts = mutableListOf<String>()
+        for (i in 0 until commandsArray.length()) {
+            val cmd = commandsArray.getJSONObject(i)
+            val executable = cmd.optString("executable", "").trimStart('/')
+            if (executable.isEmpty()) continue
+            val cmdGameId = cmd.optString("gameID", "")
+            if (cmdGameId.isEmpty()) continue
+
+            val langsArr = cmd.optJSONArray("languages")
+            var languageMatches = langsArr == null || langsArr.length() == 0
+            if (langsArr != null) {
+                for (j in 0 until langsArr.length()) {
+                    val l = langsArr.getString(j)
+                    if (l.equals("Neutral", ignoreCase = true) || l.equals(language, ignoreCase = true)) {
+                        languageMatches = true
+                        break
+                    }
+                }
+            }
+            if (!languageMatches) continue
+
+            val supportSubDir = File(gameInstallDir, "_CommonRedist/$cmdGameId")
+            val exeFile = File(supportSubDir, executable)
+            if (!exeFile.exists()) {
+                Timber.tag("GOG").w("Support command executable missing, skipping: ${exeFile.absolutePath}")
+                continue
+            }
+
+            ensureRootDirSymlink(gameInstallDir, supportSubDir)
+
+            val exePathWin = "$gameDriveLetter:\\_CommonRedist\\$cmdGameId\\${executable.replace('/', '\\')}"
+            val dirArg = "$gameDriveLetter:\\_CommonRedist\\$cmdGameId\\rootdir"
+            val args = listOf(
+                "/VERYSILENT",
+                "/DIR=$dirArg",
+                "/Language=$language",
+                "/LANG=$language",
+                "/ProductId=$cmdGameId",
+                "/galaxyclient",
+                "/buildId=$buildId",
+                "/versionName=$versionName",
+                "/nodesktopshorctut",
+                "/nodesktopshortcut",
+            ).joinToString(" ")
+
+            val extraArg = cmd.optString("argument", "")
+            parts.add(if (extraArg.isNotEmpty()) "$exePathWin $extraArg $args" else "$exePathWin $args")
         }
 
         return parts

--- a/app/src/main/java/app/gamenative/service/gog/api/GOGDataModels.kt
+++ b/app/src/main/java/app/gamenative/service/gog/api/GOGDataModels.kt
@@ -168,6 +168,7 @@ data class GOGManifestMeta(
     val products: List<Product>,
     val productTimestamp: String? = null,
     val scriptInterpreter: Boolean = false,
+    val supportCommands: List<SupportCommand> = emptyList(),
 ) {
     companion object {
         fun fromJson(json: JSONObject): GOGManifestMeta {
@@ -288,6 +289,18 @@ data class Depot(
  * Product metadata (base game or DLC)
  * @param temp_executable Optional post-install exe (e.g. game-specific installer) when scriptInterpreter is false
  */
+/**
+ * Gen 1 (legacy) post-install setup command: an installer executable shipped in the game's
+ * support depot that creates registry keys, shortcuts, etc. (Galaxy/Heroic run these after
+ * install; see Heroic's gog/setup.ts.)
+ */
+data class SupportCommand(
+    val executable: String,
+    val gameId: String,
+    val argument: String = "",
+    val languages: List<String> = emptyList(),
+)
+
 data class Product(
     val productId: String,
     val name: String,

--- a/app/src/main/java/app/gamenative/service/gog/api/GOGManifestParser.kt
+++ b/app/src/main/java/app/gamenative/service/gog/api/GOGManifestParser.kt
@@ -419,14 +419,40 @@ class GOGManifestParser @Inject constructor() {
             }
         }
 
-        Timber.tag(TAG).d("Parsed Gen 1 manifest: installDirectory=$installDirectory, depots=${depots.size}, timestamp=$timestamp")
+        val supportCommands = mutableListOf<SupportCommand>()
+        val supportArray = product.optJSONArray("support_commands")
+        if (supportArray != null) {
+            for (i in 0 until supportArray.length()) {
+                val c = supportArray.getJSONObject(i)
+                val executable = c.optString("executable", "")
+                if (executable.isEmpty()) continue
+                val cmdLangs = mutableListOf<String>()
+                val cmdLangArr = c.optJSONArray("languages")
+                if (cmdLangArr != null) {
+                    for (j in 0 until cmdLangArr.length()) cmdLangs.add(cmdLangArr.getString(j))
+                }
+                supportCommands.add(
+                    SupportCommand(
+                        executable = executable,
+                        gameId = c.optString("gameID", ""),
+                        argument = c.optString("argument", ""),
+                        languages = cmdLangs,
+                    ),
+                )
+            }
+        }
+
+        Timber.tag(TAG).d(
+            "Parsed Gen 1 manifest: installDirectory=$installDirectory, depots=${depots.size}, timestamp=$timestamp, supportCommands=${supportCommands.size}",
+        )
         return GOGManifestMeta(
             baseProductId = baseProductId,
             installDirectory = installDirectory,
             depots = depots,
             dependencies = dependencies,
             products = products,
-            productTimestamp = timestamp
+            productTimestamp = timestamp,
+            supportCommands = supportCommands
         )
     }
 

--- a/app/src/main/java/app/gamenative/service/gog/api/GOGManifestParser.kt
+++ b/app/src/main/java/app/gamenative/service/gog/api/GOGManifestParser.kt
@@ -426,6 +426,17 @@ class GOGManifestParser @Inject constructor() {
                 val c = supportArray.getJSONObject(i)
                 val executable = c.optString("executable", "")
                 if (executable.isEmpty()) continue
+                val systemsArr = c.optJSONArray("systems")
+                if (systemsArr != null && systemsArr.length() > 0) {
+                    var forWindows = false
+                    for (j in 0 until systemsArr.length()) {
+                        if (systemsArr.getString(j).equals("Windows", ignoreCase = true)) {
+                            forWindows = true
+                            break
+                        }
+                    }
+                    if (!forWindows) continue
+                }
                 val cmdLangs = mutableListOf<String>()
                 val cmdLangArr = c.optJSONArray("languages")
                 if (cmdLangArr != null) {

--- a/app/src/main/java/app/gamenative/utils/MarkerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/MarkerUtils.kt
@@ -10,6 +10,7 @@ object MarkerUtils {
     private val VERIFY_PREREQUISITE_MARKERS = listOf(
         Marker.VCREDIST_INSTALLED,
         Marker.GOG_SCRIPT_INSTALLED,
+        Marker.GOG_SUPPORT_INSTALLED,
         Marker.PHYSX_INSTALLED,
         Marker.OPENAL_INSTALLED,
         Marker.XNA_INSTALLED,

--- a/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
@@ -29,6 +29,7 @@ object PreInstallSteps {
         OpenALStep,
         XnaFrameworkStep,
         GogScriptInterpreterStep,
+        GogSupportCommandsStep,
         UbisoftConnectStep,
     )
 

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/GogSupportCommandsStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/GogSupportCommandsStep.kt
@@ -1,0 +1,37 @@
+package app.gamenative.utils
+
+import app.gamenative.data.GameSource
+import app.gamenative.enums.Marker
+import app.gamenative.service.gog.GOGService
+import com.winlator.container.Container
+import java.io.File
+
+/**
+ * Runs Gen 1 (legacy) GOG support_commands: per-game setup executables shipped in the
+ * support depot that create registry keys, shortcuts, etc. Galaxy and Heroic run these
+ * after install; without them many old titles fail (e.g. CD checks from missing keys).
+ */
+object GogSupportCommandsStep : PreInstallStep {
+    override val marker: Marker = Marker.GOG_SUPPORT_INSTALLED
+
+    override fun appliesTo(
+        container: Container,
+        gameSource: GameSource,
+        gameDirPath: String,
+    ): Boolean {
+        return gameSource == GameSource.GOG &&
+            !MarkerUtils.hasMarker(gameDirPath, Marker.GOG_SUPPORT_INSTALLED)
+    }
+
+    override fun buildCommand(
+        container: Container,
+        appId: String,
+        gameSource: GameSource,
+        gameDir: File,
+        gameDirPath: String,
+    ): String? {
+        val parts = GOGService.getInstance()?.gogManager
+            ?.getSupportCommandPartsForLaunch(appId) ?: return null
+        return if (parts.isEmpty()) null else parts.joinToString(" & ")
+    }
+}

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/GogSupportCommandsStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/GogSupportCommandsStep.kt
@@ -2,6 +2,7 @@ package app.gamenative.utils
 
 import app.gamenative.data.GameSource
 import app.gamenative.enums.Marker
+import app.gamenative.service.gog.GOGManifestUtils
 import app.gamenative.service.gog.GOGService
 import com.winlator.container.Container
 import java.io.File
@@ -10,9 +11,17 @@ import java.io.File
  * Runs Gen 1 (legacy) GOG support_commands: per-game setup executables shipped in the
  * support depot that create registry keys, shortcuts, etc. Galaxy and Heroic run these
  * after install; without them many old titles fail (e.g. CD checks from missing keys).
+ *
+ * Completion is tracked twice: the game-dir marker (framework convention, cleared by
+ * verify) and a stamp inside the container's Wine prefix. The prefix stamp makes the
+ * installers rerun when the same install is launched in a newly created prefix, whose
+ * registry no longer has the keys the first run created.
  */
 object GogSupportCommandsStep : PreInstallStep {
     override val marker: Marker = Marker.GOG_SUPPORT_INSTALLED
+
+    private fun prefixStamp(container: Container): File =
+        File(container.rootDir, ".wine/${Marker.GOG_SUPPORT_INSTALLED.fileName}")
 
     override fun appliesTo(
         container: Container,
@@ -20,7 +29,10 @@ object GogSupportCommandsStep : PreInstallStep {
         gameDirPath: String,
     ): Boolean {
         return gameSource == GameSource.GOG &&
-            !MarkerUtils.hasMarker(gameDirPath, Marker.GOG_SUPPORT_INSTALLED)
+            (
+                !MarkerUtils.hasMarker(gameDirPath, Marker.GOG_SUPPORT_INSTALLED) ||
+                    !prefixStamp(container).exists()
+                )
     }
 
     override fun buildCommand(
@@ -30,8 +42,34 @@ object GogSupportCommandsStep : PreInstallStep {
         gameDir: File,
         gameDirPath: String,
     ): String? {
+        val manifest = GOGManifestUtils.readLocalManifest(gameDir) ?: return null
+        val commands = manifest.optJSONArray("supportCommands")
+        if (commands == null || commands.length() == 0) {
+            markDone(container, gameDirPath)
+            return null
+        }
+
         val parts = GOGService.getInstance()?.gogManager
-            ?.getSupportCommandPartsForLaunch(appId) ?: return null
-        return if (parts.isEmpty()) null else parts.joinToString(" & ")
+            ?.getSupportCommandPartsForLaunch(appId, gameDir) ?: return null
+        if (parts.isEmpty()) {
+            markDone(container, gameDirPath)
+            return null
+        }
+
+        // The session marker is written by the framework on termination; stamp the
+        // prefix here with the same optimistic semantics.
+        try {
+            prefixStamp(container).createNewFile()
+        } catch (_: Exception) {
+        }
+        return parts.joinToString(" & ")
+    }
+
+    private fun markDone(container: Container, gameDirPath: String) {
+        MarkerUtils.addMarker(gameDirPath, Marker.GOG_SUPPORT_INSTALLED)
+        try {
+            prefixStamp(container).createNewFile()
+        } catch (_: Exception) {
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,9 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx8192m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Description
Old games like interstate 76 errored out with asking for a cd. Needed GOG installer to write registry keys to fix this

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes legacy GOG (Gen 1) titles like Interstate 76 that failed with CD prompts by running GOG's `support_commands` setup executables. These installers create registry keys the games need; Galaxy and Heroic already run them after install.

- Parses `support_commands` from GOG manifests, keeps only Windows entries matching the game's language, and persists them in the local manifest.
- Adds a new pre-install step that runs each applicable support command with the required silent flags.
- Uses a `.gog_support_installed` marker plus a prefix-side stamp so commands run once per game and re-run when the prefix is recreated.
- Enables Gradle parallel execution and caching in `gradle.properties` (unrelated but included).

<sup>Written for commit 1f946c78ffdd677f425dd693a5a2fe21210b9b57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for legacy GOG setup commands during game installation.
  * Setup commands are filtered by language and platform, then run automatically when applicable.
  * Manifest data now preserves supported setup command details.

* **Bug Fixes**
  * Verification flows now correctly reset setup state so required GOG steps can run again.
  * Setup completion is tracked consistently across installations.

* **Performance**
  * Improved build performance through parallel execution and caching enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->