### PR TITLE
Let a controller claim the empty Player 1 slot on first input

### DIFF
--- a/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControllerManager.java
@@ -505,7 +505,15 @@ public class ControllerManager {
         int slot = getSlotForDevice(deviceId);
         if (slot == 0) return false;
         InputDevice occupant = getAssignedDeviceForSlot(0);
-        if (occupant == null) return false;
+        if (occupant == null) {
+            String deviceIdentifier = getDeviceIdentifierForDeviceId(deviceId);
+            if (deviceIdentifier == null) return false;
+            assignDeviceIdentifierToSlot(0, deviceIdentifier);
+            saveAssignments();
+            notifySlotsChanged();
+            Log.i(TAG, "deviceId=" + deviceId + " claimed empty Player 1");
+            return true;
+        }
         String occupantIdentifier = getDeviceIdentifier(occupant);
         if (occupantIdentifier == null || sessionActiveIdentifiers.contains(occupantIdentifier)) return false;
         String deviceIdentifier = getDeviceIdentifierForDeviceId(deviceId);


### PR DESCRIPTION
When slot 0 was assigned to a controller that is no longer connected, noteGamepadButton bailed out because there was no occupant to displace, so a built-in controller stuck on P2 could never regain P1. Treat an empty or disconnected P1 slot as claimable: the first device that sends real gamepad input takes slot 0. Connected active occupants are still never displaced.

## Description
See above

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Player 1 slot claim so a controller can take an empty or disconnected slot on first input.

- Connected active occupants are still never displaced.

<sup>Written for commit 40a04b6bcef9a10d25feec840ca0dd4a6a4faf06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gamepad input can now automatically claim the empty Player 1 slot when a button is pressed.
  * The assignment is saved and reflected immediately in the controller configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->