### PR TITLE
Fix ad-hoc signed build dying during APK extraction

### DIFF
--- a/.github/workflows/adhoc-signed-build.yml
+++ b/.github/workflows/adhoc-signed-build.yml
@@ -15,6 +15,11 @@ jobs:
     if: github.actor == 'utkarshdalal'
 
     steps:
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /usr/local/share/boost /usr/share/swift
+        df -h /
+
     - uses: actions/checkout@v4
     - name: Check out PR head (fork-aware)
       if: ${{ inputs.pr != '' }}
@@ -91,18 +96,28 @@ jobs:
 
     - name: Stage bundles
       run: |
-        cp app/build/outputs/bundle/legacyRelease/app-legacy-release.aab app-release.aab
-        cp app/build/outputs/bundle/modernRelease/app-modern-release.aab app-modern-release.aab
-        cp app/build/outputs/bundle/legacyXrRelease/app-legacyXr-release.aab app-legacy-xr-release.aab
+        mv app/build/outputs/bundle/legacyRelease/app-legacy-release.aab app-release.aab
+        mv app/build/outputs/bundle/modernRelease/app-modern-release.aab app-modern-release.aab
+        mv app/build/outputs/bundle/legacyXrRelease/app-legacyXr-release.aab app-legacy-xr-release.aab
+
+    - name: Stop Gradle daemons
+      run: |
+        ./gradlew --stop
+        df -h /
+        free -m
 
     - name: Extract APKs from Bundles
       run: |
-        java -jar tools/bundletool-all-1.17.2.jar build-apks --bundle=app-release.aab --output=app-release.apks --mode=universal
+        java -Xmx3g -jar tools/bundletool-all-1.17.2.jar build-apks --bundle=app-release.aab --output=app-release.apks --mode=universal
         unzip -o app-release.apks universal.apk
-        java -jar tools/bundletool-all-1.17.2.jar build-apks --bundle=app-modern-release.aab --output=app-modern-release.apks --mode=universal
+        rm app-release.apks app-release.aab
+        java -Xmx3g -jar tools/bundletool-all-1.17.2.jar build-apks --bundle=app-modern-release.aab --output=app-modern-release.apks --mode=universal
         unzip -p app-modern-release.apks universal.apk > universal-modern.apk
-        java -jar tools/bundletool-all-1.17.2.jar build-apks --bundle=app-legacy-xr-release.aab --output=app-legacy-xr-release.apks --mode=universal
+        rm app-modern-release.apks app-modern-release.aab
+        java -Xmx3g -jar tools/bundletool-all-1.17.2.jar build-apks --bundle=app-legacy-xr-release.aab --output=app-legacy-xr-release.apks --mode=universal
         unzip -p app-legacy-xr-release.apks universal.apk > universal-legacy-xr.apk
+        rm app-legacy-xr-release.apks app-legacy-xr-release.aab
+        df -h /
 
     - name: Copy lineage file
       run: |


### PR DESCRIPTION
Every ad-hoc build since late July has failed with "The runner has received a shutdown signal" a few seconds into the first bundletool build-apks call - the hosted runner VM is running out of disk/memory right when bundletool starts, since the three release bundles plus gradle intermediates and resident daemons are all still around at that point.

Changes:
- Delete unused preinstalled toolchains (dotnet, ghc, CodeQL, boost, swift) at job start to free disk
- Stage bundles with mv instead of cp so we don't hold two copies of each ~600MB aab
- Stop gradle daemons before extraction to free RAM
- Bound bundletool's heap at 3g and delete each .apks/.aab as soon as its universal apk is extracted
- df/free diagnostics around the extract step so the next failure (if any) shows which resource ran out

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ad-hoc signed builds dying with "The runner has received a shutdown signal" during the first bundletool call by freeing up disk and memory on the hosted runner before and during extraction.

**Bug Fixes**
- Removes unused preinstalled toolchains (`dotnet`, `ghc`, CodeQL, `boost`, `swift`) and stops Gradle daemons before extraction.
- Stages bundles with `mv` instead of `cp` so only one copy of each ~600MB AAB exists.
- Caps bundletool's heap at 3g and deletes each `.apks`/`.aab` once its universal APK is extracted.
- Adds `df`/`free` diagnostics around extraction so the next failure shows which resource ran out.

<sup>Written for commit 067ba7a3af100a21eab57db4dff396ef20969c0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release build reliability by managing disk space and cleanup more efficiently.
  * Optimized packaging steps to reduce unnecessary file duplication and remove temporary artifacts.
  * Increased available memory for bundle processing to support smoother builds.
  * Added resource usage reporting to help monitor build performance.

* **Refactor**
  * Streamlined the release workflow without changing the application’s user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->