### PR TITLE
Fix Sally Face download failing when the Season Pass is selected

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -2000,7 +2000,11 @@ class SteamService : Service(), IChallengeUrlChanged {
                         }
 
                         calculatedDlcAppIds.forEach { dlcAppId ->
-                            val dlcDepots = selectedDepots.filter { it.value.dlcAppId == dlcAppId }
+                            val dlcAppDepotIds = getAppInfoOf(dlcAppId)?.depots?.keys.orEmpty()
+                            val dlcDepots = selectedDepots.filter { (depotId, depot) ->
+                                depot.dlcAppId == dlcAppId &&
+                                    (depotId !in mainAppDepots || depotId in dlcAppDepotIds)
+                            }
                             val dlcDepotIds = dlcDepots.keys.sorted()
 
                             val dlcAppItem = AppItem(
@@ -2176,7 +2180,11 @@ class SteamService : Service(), IChallengeUrlChanged {
 
                         // Complete dlc app download
                         calculatedDlcAppIds.forEach { dlcAppId ->
-                            val dlcDepots = selectedDepots.filter { it.value.dlcAppId == dlcAppId }
+                            val dlcAppDepotIds = getAppInfoOf(dlcAppId)?.depots?.keys.orEmpty()
+                            val dlcDepots = selectedDepots.filter { (depotId, depot) ->
+                                depot.dlcAppId == dlcAppId &&
+                                    (depotId !in mainAppDepots || depotId in dlcAppDepotIds)
+                            }
                             val dlcDepotIds = dlcDepots.keys.sorted()
                             completeAppDownload(
                                 downloadInfo = di,


### PR DESCRIPTION
## Description

Sally Face's download failed the moment it started whenever the Season Pass was ticked.

The developer confirmed the Steam layout is unusual, and SteamDB matches it: the Season Pass content (1.87 GiB) is depot 567990 inside the base app 541570, tagged `dlcappid 567990`. The Season Pass DLC app 567990 only lists its own 6 MiB depot 567993 and does not list depot 567990.

In `downloadApp`, the DLC `AppItem` was built from every selected depot whose `dlcAppId` matched, so it asked app 567990 for depot 567990 on top of the main-app item already requesting it under 541570. DepotDownloader checks each requested depot against that app's depot section and throws `Depot 567990 not listed for app 567990`, which fails the whole download before any chunk is fetched.

The DLC item now skips a depot that is already in the main-app item unless the DLC app's own depot section lists it. Same filter in the completion bookkeeping loop so the installed-app rows stay consistent.

This only changes request lists for downloads that already fail: the only depots removed are the exact ones DepotDownloader rejects. Any download that completes today keeps an identical request list. Both Sally Face depots contain the executable; DepotDownloader already de-duplicates by path in last-depot-wins order and our main item sorts depots ascending, so the Season Pass build lands on disk, same as Steam.

To verify on device: download Sally Face with the Season Pass ticked and check logcat for

```
App contains 2 depot(s): [541571, 567990]
DLC contains 1 depot(s): [567993]
```

Depot data: https://steamdb.info/app/541570/depots/ and https://steamdb.info/app/567990/depots/

## Recording

Not attached. Server-side depot selection; the log lines above are the observable change.

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Sally Face downloads failing immediately when the Season Pass is selected, because the DLC item asked app 567990 for depot 567990, which actually belongs to the base app 541570 and isn't listed in the DLC app's depot section.

- The DLC item now skips depots already covered by the main-app item unless the DLC app's own depot section lists them.
- Applies the same filter to the completion bookkeeping loop.
- Downloads that already succeeded keep identical request lists; only the requests DepotDownloader would reject are removed.

<sup>Written for commit 70b1d35e530ce8ab779d699506994581ee2f0b7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DLC download handling by preventing duplicate depot assignments when those depots are already associated with the main app.
  * Ensured DLC completion records consistently reflect only valid DLC-specific depots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->