### PR TITLE
Make Steam cloud save sync case-insensitive and guard against overwriting never-synced cloud saves

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -1067,14 +1067,39 @@ object SteamAutoCloud {
                 microsecAcExit = measureTime {
                     // var fileChanges: FileChanges? = null
 
-                    val hasLocalChanges = cachedFileList
-                        ?.let {
-                            val result = getFilesDiff(allLocalUserFiles, it.userFileInfo)
-                            // fileChanges = result.second
-                            result.first
-                        } == true
+                    val localDiff = cachedFileList?.let { getFilesDiff(allLocalUserFiles, it.userFileInfo) }
+                    val hasLocalChanges = localDiff?.first == true
 
-                    if (hasLocalChanges) {
+                    // A local file the cache never saw, but which already exists in the cloud with
+                    // different content, is a save this device never synced (e.g. downloaded under a
+                    // different casing). Uploading it would silently replace the cloud save.
+                    val remoteByPath = appFileListChange.files.associate {
+                        getFullFilePath(it, appFileListChange).toString().lowercase() to it.shaFile
+                    }
+                    val overwritesUnsyncedCloudFile = localDiff?.second?.filesCreated?.any { local ->
+                        remoteByPath[local.getAbsPath(prefixToPath).toString().lowercase()]
+                            ?.let { !it.contentEquals(local.sha) } == true
+                    } == true
+
+                    if (hasLocalChanges && overwritesUnsyncedCloudFile) {
+                        Timber.i("Found local changes that would overwrite never-synced cloud user files, conflict resolution...")
+
+                        when (preferredSave) {
+                            SaveLocation.Local -> uploadUserFiles(parentScope).await()
+
+                            SaveLocation.Remote -> {
+                                downloadUserFiles(parentScope).await()?.let {
+                                    return@async it
+                                }
+                            }
+
+                            SaveLocation.None -> {
+                                syncResult = SyncResult.Conflict
+                                remoteTimestamp = appFileListChange.files.map { it.timestamp.time }.maxOrNull() ?: 0L
+                                localTimestamp = allLocalUserFiles.map { it.timestamp }.maxOrNull() ?: 0L
+                            }
+                        }
+                    } else if (hasLocalChanges) {
                         Timber.i("Found local changes and no new cloud user files")
 
                         uploadUserFiles(parentScope).await()

--- a/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
+++ b/app/src/main/java/app/gamenative/service/SteamAutoCloud.kt
@@ -27,6 +27,7 @@ import `in`.dragonbra.javasteam.steam.handlers.steamcloud.AppFileInfo
 import `in`.dragonbra.javasteam.steam.handlers.steamcloud.SteamCloud
 import `in`.dragonbra.javasteam.types.KeyValue
 import java.io.BufferedInputStream
+import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
 import java.io.RandomAccessFile
@@ -297,20 +298,20 @@ object SteamAutoCloud {
 
         val getFilesDiff: (List<UserFileInfo>, List<UserFileInfo>) -> Pair<Boolean, FileChanges> = { currentFiles, oldFiles ->
             val overlappingFiles = currentFiles.filter { currentFile ->
-                oldFiles.any { currentFile.prefixPath == it.prefixPath }
+                oldFiles.any { currentFile.prefixPath.equals(it.prefixPath, ignoreCase = true) }
             }
 
             val newFiles = currentFiles.filter { currentFile ->
-                !oldFiles.any { currentFile.prefixPath == it.prefixPath }
+                !oldFiles.any { currentFile.prefixPath.equals(it.prefixPath, ignoreCase = true) }
             }
 
             val deletedFiles = oldFiles.filter { oldFile ->
-                !currentFiles.any { oldFile.prefixPath == it.prefixPath }
+                !currentFiles.any { oldFile.prefixPath.equals(it.prefixPath, ignoreCase = true) }
             }
 
             val modifiedFiles = overlappingFiles.filter { file ->
                 oldFiles.first {
-                    it.prefixPath == file.prefixPath
+                    it.prefixPath.equals(file.prefixPath, ignoreCase = true)
                 }.let {
                     Timber.i("Comparing SHA of ${it.prefixPath} and ${file.prefixPath}")
                     Timber.i("[${it.sha.joinToString(", ")}]\n[${file.sha.joinToString(", ")}]")
@@ -329,11 +330,12 @@ object SteamAutoCloud {
                 fileList.files.any { file ->
                     Timber.i("Checking for " + "${getFilePrefix(file, fileList)} in ${localUserFiles.keys}")
 
-                    localUserFiles[getFilePrefix(file, fileList)]?.let { localUserFile ->
+                    val cloudPrefix = getFilePrefix(file, fileList)
+                    localUserFiles.entries.firstOrNull { it.key.equals(cloudPrefix, ignoreCase = true) }?.value?.let { localUserFile ->
                         localUserFile.firstOrNull {
                             Timber.i("Comparing ${file.filename} and ${it.filename}")
 
-                            it.filename == file.filename
+                            it.filename.equals(file.filename, ignoreCase = true)
                         }?.let {
                             Timber.i("Comparing SHA of ${getFilePrefixPath(file, fileList)} and ${it.prefixPath}")
                             Timber.i("[${file.shaFile.joinToString(", ")}]\n[${it.sha.joinToString(", ")}]")
@@ -356,7 +358,10 @@ object SteamAutoCloud {
                         return@forEach
                     }
 
-                    val basePath = Paths.get(prefixToPath(userFile.root.toString()), userFile.substitutedPath)
+                    val basePath = FileUtils.resolveCaseInsensitive(
+                        File("/"),
+                        Paths.get(prefixToPath(userFile.root.toString()), userFile.substitutedPath).toString().trimStart('/'),
+                    ).toPath()
 
                     Timber.i("Looking for saves in $basePath with pattern ${userFile.pattern} (prefix ${userFile.prefix})")
 
@@ -1170,7 +1175,10 @@ object SteamAutoCloud {
         onProgress: ((message: String, progress: Float) -> Unit)?, // invoked from IO thread
     ): UserFilesDownloadResult? {
         val prefixedPath = getFilePrefixPath(file, fileList)
-        val actualFilePath = getFullFilePath(file, fileList)
+        val actualFilePath = FileUtils.resolveCaseInsensitive(
+            File("/"),
+            getFullFilePath(file, fileList).toString().trimStart('/'),
+        ).toPath()
 
         Timber.i("$prefixedPath -> $actualFilePath")
 


### PR DESCRIPTION
## Description
Steam Cloud keeps the original casing of a file key, while the game and Wine treat paths without case. Portal 2 is the reproducer: old saves live under `portal2/save/...` in the cloud, the game writes `portal2/SAVE/...`, and Steam matches the two on upload. Our Steam sync did not:

- The local/remote diff compared `prefixPath` with exact equality, so `save/autosave01.sav` and `SAVE/autosave01.sav` were two different files. On a download pass the local copy was deleted and the cloud copy was written into a lowercase folder the game never reads.
- The download writer created directories with the cloud casing verbatim. Android storage is case-sensitive, so this produced a second folder next to the game's own.
- The local scan walked the config path case-sensitively, so files in a folder created with the other casing were never picked up for upload.

Epic and GOG already resolve save paths against on-disk casing via `FileUtils.resolveCaseInsensitive`. This brings Steam in line: the diff and conflict check compare without case, and both the download target and the scan base path go through the resolver.

Second commit adds a conflict guard. At equal change numbers, a local file missing from the sync cache was uploaded without question. When the cloud already holds that file with different content, this device never synced it (for example because it was downloaded under the other casing and the game started fresh), and the upload replaces the cloud save. That case now goes through the same Keep local / Keep remote dialog as the behind-cloud branch.

No behavior change for users whose cloud and disk casing already agree: equal strings compare equal either way, and the resolver returns the input path when every segment exists as written.

Not built or device-tested yet. Test plan: Portal 2 on an account with mixed-case cloud keys; confirm saves show in the load menu after a fresh install, confirm a fresh local save on top of an existing cloud save prompts instead of uploading, confirm a game with plain keys syncs as before.

## Recording
None yet.

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Steam cloud save sync to treat paths case-insensitively, matching the game's behavior, guards against overwriting never-synced cloud saves, and always fetches the full cloud file list so those reconcile checks actually fire.

**Changes**
- Path comparisons in the sync diff and conflict check are now case-insensitive, so `save/` and `SAVE/` are treated as the same file.
- Download and scan paths are resolved against on-disk casing via `FileUtils.resolveCaseInsensitive`, matching Epic and GOG behavior.
- A local file missing from the sync cache but already present in the cloud with different content now triggers the conflict dialog instead of silently uploading.
- The cloud file list is always requested from change number zero; the previous stored change number could return an empty delta and leave the delete diff and overwrite guard blind.

<sup>Written for commit 34ca1d9afc644a51ace8dad8946de034eea37d89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

