### PR TITLE
Add relative mouse input option for Shooter Mode

### DIFF
--- a/app/src/main/java/app/gamenative/data/ShooterModeConfig.kt
+++ b/app/src/main/java/app/gamenative/data/ShooterModeConfig.kt
@@ -19,6 +19,7 @@ data class ShooterModeConfig(
     val mouseAccelerationEnabled: Boolean = false,
     val mouseAccelerationStrength: Float = 1.0f,
     val mouseAccelerationMaxMultiplier: Float = 3.0f,
+    val win32RelativeMouseInput: Boolean = false,
     val movementJoystickSize: Float = 1.0f,
     val lookJoystickSize: Float = 1.0f,
     val movementJoystickDeadzone: Float = DEFAULT_ANALOG_STICK_DEADZONE,
@@ -49,6 +50,7 @@ data class ShooterModeConfig(
             put(KEY_MOUSE_ACCELERATION_ENABLED, mouseAccelerationEnabled)
             put(KEY_MOUSE_ACCELERATION_STRENGTH, mouseAccelerationStrength.toDouble())
             put(KEY_MOUSE_ACCELERATION_MAX_MULTIPLIER, mouseAccelerationMaxMultiplier.toDouble())
+            put(KEY_WIN32_RELATIVE_MOUSE_INPUT, win32RelativeMouseInput)
             put(KEY_MOVEMENT_JOYSTICK_SIZE, movementJoystickSize.toDouble())
             put(KEY_LOOK_JOYSTICK_SIZE, lookJoystickSize.toDouble())
             put(KEY_MOVEMENT_JOYSTICK_DEADZONE, movementJoystickDeadzone.toDouble())
@@ -135,6 +137,7 @@ data class ShooterModeConfig(
         private const val KEY_MOUSE_ACCELERATION_ENABLED = "mouseAccelerationEnabled"
         private const val KEY_MOUSE_ACCELERATION_STRENGTH = "mouseAccelerationStrength"
         private const val KEY_MOUSE_ACCELERATION_MAX_MULTIPLIER = "mouseAccelerationMaxMultiplier"
+        private const val KEY_WIN32_RELATIVE_MOUSE_INPUT = "win32RelativeMouseInput"
         private const val KEY_MOVEMENT_ZONE_SPLIT = "movementZoneSplit"
         private const val KEY_BUTTON_LOOK_THROUGH_ENABLED = "buttonLookThroughEnabled"
         private const val KEY_BUTTON_LOOK_THROUGH_DRAG_THRESHOLD = "buttonLookThroughDragThreshold"
@@ -196,6 +199,7 @@ data class ShooterModeConfig(
                         1.0f,
                         8.0f,
                     ),
+                    win32RelativeMouseInput = obj.optBoolean(KEY_WIN32_RELATIVE_MOUSE_INPUT, false),
                     movementJoystickSize = clampFloat(
                         obj.optDouble(KEY_MOVEMENT_JOYSTICK_SIZE, legacyJoystickSize.toDouble()).toFloat(),
                         0.5f,

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ShooterModeSettingsDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ShooterModeSettingsDialog.kt
@@ -162,6 +162,16 @@ fun ShooterModeSettingsDialog(
                         if (showMouseLookOptions) {
                             SettingsDialogSectionHeader(stringResource(R.string.shooter_section_mouse_look))
 
+                            GestureBlock {
+                                SettingsSwitch(
+                                    colors = settingsTileColorsAlt(),
+                                    title = { Text(stringResource(R.string.win32_relative_mouse_input)) },
+                                    subtitle = { Text(stringResource(R.string.win32_relative_mouse_input_subtitle)) },
+                                    state = config.win32RelativeMouseInput,
+                                    onCheckedChange = { config = config.copy(win32RelativeMouseInput = it) },
+                                )
+                            }
+
                             SliderSettingBlock(
                                 title = stringResource(R.string.look_sensitivity_x),
                                 subtitle = stringResource(R.string.look_sensitivity_x_subtitle),

--- a/app/src/main/java/com/winlator/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/widget/InputControlsView.java
@@ -615,6 +615,7 @@ public class InputControlsView extends View {
         }
         this.shooterModeActive = active;
         if (!active) commitGamepadState();
+        applyShooterMouseInputMode();
         invalidate();
     }
 
@@ -628,6 +629,7 @@ public class InputControlsView extends View {
             releaseAllShooterInputs();
             commitGamepadState();
         }
+        applyShooterMouseInputMode();
         invalidate();
     }
 
@@ -648,7 +650,8 @@ public class InputControlsView extends View {
     private void applyShooterMouseInputMode() {
         if (xServer == null || shooterModeConfig == null) return;
         boolean useWin32RelativeInput =
-                ShooterModeConfig.LOOK_MOUSE.equals(shooterModeConfig.getLookType())
+                (shooterModeActive || containerShooterModeRuntime)
+                        && ShooterModeConfig.LOOK_MOUSE.equals(shooterModeConfig.getLookType())
                         && shooterModeConfig.getWin32RelativeMouseInput();
         xServer.setRelativeMouseMovement(useWin32RelativeInput);
     }
@@ -911,8 +914,9 @@ public class InputControlsView extends View {
     }
 
     private void commitGamepadState() {
-        WinHandler winHandler = xServer != null ? xServer.getWinHandler() : null;
-        if (winHandler != null && profile != null) {
+        if (xServer == null || profile == null) return;
+        WinHandler winHandler = xServer.getWinHandler();
+        if (winHandler != null) {
             GamepadState state = profile.getGamepadState();
             winHandler.sendGamepadState();
             winHandler.sendVirtualGamepadState(state);
@@ -1236,6 +1240,7 @@ public class InputControlsView extends View {
                     releaseAllShooterInputs();
                     commitGamepadState();
                 }
+                applyShooterMouseInputMode();
                 performHapticFeedback(android.view.HapticFeedbackConstants.VIRTUAL_KEY);
                 invalidate();
                 return true;

--- a/app/src/main/java/com/winlator/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/widget/InputControlsView.java
@@ -543,6 +543,7 @@ public class InputControlsView extends View {
 
     public void setXServer(XServer xServer) {
         this.xServer = xServer;
+        applyShooterMouseInputMode();
         createMouseMoveTimer();
     }
 
@@ -634,6 +635,7 @@ public class InputControlsView extends View {
         releaseAllShooterInputs();
         commitGamepadState();
         this.shooterModeConfig = config != null ? config : ShooterModeConfig.fromJson("");
+        applyShooterMouseInputMode();
         lookAccumX = 0;
         lookAccumY = 0;
         lookDeadzoneAccumX = 0;
@@ -641,6 +643,14 @@ public class InputControlsView extends View {
         lookSmoothX = 0;
         lookSmoothY = 0;
         invalidate();
+    }
+
+    private void applyShooterMouseInputMode() {
+        if (xServer == null || shooterModeConfig == null) return;
+        boolean useWin32RelativeInput =
+                ShooterModeConfig.LOOK_MOUSE.equals(shooterModeConfig.getLookType())
+                        && shooterModeConfig.getWin32RelativeMouseInput();
+        xServer.setRelativeMouseMovement(useWin32RelativeInput);
     }
 
     public void setShooterModeConfigJson(String json) {

--- a/app/src/main/java/com/winlator/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/widget/InputControlsView.java
@@ -651,7 +651,7 @@ public class InputControlsView extends View {
         if (xServer == null || shooterModeConfig == null) return;
         boolean useWin32RelativeInput =
                 (shooterModeActive || containerShooterModeRuntime)
-                        && ShooterModeConfig.LOOK_MOUSE.equals(shooterModeConfig.getLookType())
+                        && ShooterModeConfig.LOOK_MOUSE.equals(getResolvedShooterLookType())
                         && shooterModeConfig.getWin32RelativeMouseInput();
         xServer.setRelativeMouseMovement(useWin32RelativeInput);
     }

--- a/app/src/main/java/com/winlator/xserver/XServer.java
+++ b/app/src/main/java/com/winlator/xserver/XServer.java
@@ -6,6 +6,7 @@ import android.util.SparseArray;
 
 import com.winlator.math.Mathf;
 import com.winlator.renderer.XServerRenderer;
+import com.winlator.winhandler.MouseEventFlags;
 import com.winlator.winhandler.WinHandler;
 import com.winlator.xserver.extensions.BigReqExtension;
 import com.winlator.xserver.extensions.DRI3Extension;
@@ -44,7 +45,7 @@ public class XServer {
     private XServerRenderer renderer;
     private WinHandler winHandler;
     private final EnumMap<Lockable, ReentrantLock> locks = new EnumMap<>(Lockable.class);
-    private boolean relativeMouseMovement = false;
+    private volatile boolean relativeMouseMovement = false;
     private final boolean mouseDragCompatibilityEnabled;
     private boolean simulateTouchScreen = false;
     private final boolean runningFromGlibc;
@@ -187,6 +188,14 @@ public class XServer {
     }
 
     public void injectPointerMoveDelta(int dx, int dy) {
+        if (dx == 0 && dy == 0) return;
+
+        WinHandler handler = winHandler;
+        if (relativeMouseMovement && handler != null) {
+            handler.mouseEvent(MouseEventFlags.MOVE, dx, dy, 0);
+            return;
+        }
+
         try (XLock lock = lock(Lockable.WINDOW_MANAGER, Lockable.INPUT_DEVICE)) {
             int minX = 0, minY = 0;
             int maxX = screenInfo.width - 1, maxY = screenInfo.height - 1;

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -2013,6 +2013,8 @@
     <string name="mouse_acceleration_strength_subtitle">Hvor hurtigt hurtigere træk giver ekstra musehastighed</string>
     <string name="mouse_acceleration_max">Maks. acceleration</string>
     <string name="mouse_acceleration_max_subtitle">Øvre multiplikator ved hurtige musekig-træk</string>
+    <string name="win32_relative_mouse_input">Relativt museinput</string>
+    <string name="win32_relative_mouse_input_subtitle">Send bevægelse direkte til Wine som relativt museinput. Prøv dette, når musen ikke virker i spillet.</string>
     <string name="joystick_opacity">Joystick-gennemsigtighed</string>
     <string name="joystick_opacity_subtitle">Gennemsigtighed for dynamiske joystick-ringe og knapper</string>
     <string name="show_shooter_runtime_toggle">Vis knap i spillet</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2083,6 +2083,8 @@
     <string name="mouse_acceleration_strength_subtitle">Wie schnell schnellere Ziehbewegungen zusätzliche Mausgeschwindigkeit hinzufügen</string>
     <string name="mouse_acceleration_max">Max. Beschleunigung</string>
     <string name="mouse_acceleration_max_subtitle">Oberer Multiplikator bei schnellen Mausblick-Ziehbewegungen</string>
+    <string name="win32_relative_mouse_input">Relative Mauseingabe</string>
+    <string name="win32_relative_mouse_input_subtitle">Sendet Bewegungen direkt als relative Mauseingabe an Wine. Probiere dies aus, wenn die Maus im Spiel nicht funktioniert.</string>
     <string name="joystick_opacity">Joystick-Deckkraft</string>
     <string name="joystick_opacity_subtitle">Deckkraft für dynamische Joystick-Ringe und Daumenpunkte</string>
     <string name="show_shooter_runtime_toggle">Schalter im Spiel anzeigen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2141,6 +2141,8 @@
     <string name="mouse_acceleration_strength_subtitle">Qué tan rápido los arrastres más rápidos añaden velocidad extra al ratón</string>
     <string name="mouse_acceleration_max">Aceleración máxima</string>
     <string name="mouse_acceleration_max_subtitle">Multiplicador máximo aplicado durante arrastres rápidos de vista con ratón</string>
+    <string name="win32_relative_mouse_input">Entrada relativa del ratón</string>
+    <string name="win32_relative_mouse_input_subtitle">Envía el movimiento directamente a Wine como entrada relativa del ratón. Prueba esta opción cuando el ratón no funcione dentro del juego.</string>
     <string name="joystick_opacity">Opacidad del joystick</string>
     <string name="joystick_opacity_subtitle">Opacidad de los anillos y controles de los joysticks dinámicos</string>
     <string name="show_shooter_runtime_toggle">Mostrar botón en juego</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2161,6 +2161,8 @@
     <string name="mouse_acceleration_strength_subtitle">Vitesse à laquelle les glissements rapides ajoutent de la vitesse souris</string>
     <string name="mouse_acceleration_max">Accélération maximale</string>
     <string name="mouse_acceleration_max_subtitle">Multiplicateur maximal appliqué pendant les glissements rapides du regard souris</string>
+    <string name="win32_relative_mouse_input">Entrée relative de la souris</string>
+    <string name="win32_relative_mouse_input_subtitle">Envoie les mouvements directement à Wine sous forme d’entrée relative de la souris. Essayez cette option lorsque la souris ne fonctionne pas en jeu.</string>
     <string name="joystick_opacity">Opacité du joystick</string>
     <string name="joystick_opacity_subtitle">Opacité des anneaux et boutons des joysticks dynamiques</string>
     <string name="show_shooter_runtime_toggle">Afficher le bouton en jeu</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -2134,6 +2134,8 @@
     <string name="mouse_acceleration_strength_subtitle">Quanto rapidamente i trascinamenti veloci aggiungono velocità al mouse</string>
     <string name="mouse_acceleration_max">Accelerazione massima</string>
     <string name="mouse_acceleration_max_subtitle">Moltiplicatore massimo applicato durante trascinamenti rapidi della visuale mouse</string>
+    <string name="win32_relative_mouse_input">Input relativo del mouse</string>
+    <string name="win32_relative_mouse_input_subtitle">Invia il movimento direttamente a Wine come input relativo del mouse. Prova questa opzione quando il mouse non funziona nel gioco.</string>
     <string name="joystick_opacity">Opacità joystick</string>
     <string name="joystick_opacity_subtitle">Opacità di anelli e cursori dei joystick dinamici</string>
     <string name="show_shooter_runtime_toggle">Mostra pulsante in gioco</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2099,6 +2099,8 @@
     <string name="mouse_acceleration_strength_subtitle">速いドラッグで追加されるマウス速度の強さ</string>
     <string name="mouse_acceleration_max">最大加速</string>
     <string name="mouse_acceleration_max_subtitle">高速なマウス視点ドラッグ中に適用される上限倍率</string>
+    <string name="win32_relative_mouse_input">相対マウス入力</string>
+    <string name="win32_relative_mouse_input_subtitle">マウスの移動を相対入力として Wine に直接送信します。ゲーム内でマウスが動作しない場合にお試しください。</string>
     <string name="joystick_opacity">ジョイスティックの不透明度</string>
     <string name="joystick_opacity_subtitle">動的ジョイスティックのリングとつまみの不透明度</string>
     <string name="show_shooter_runtime_toggle">ゲーム中ボタンを表示</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2140,6 +2140,8 @@
     <string name="mouse_acceleration_strength_subtitle">빠른 드래그가 추가 마우스 속도를 더하는 정도</string>
     <string name="mouse_acceleration_max">최대 가속</string>
     <string name="mouse_acceleration_max_subtitle">빠른 마우스 시선 드래그 중 적용되는 최대 배율</string>
+    <string name="win32_relative_mouse_input">상대 마우스 입력</string>
+    <string name="win32_relative_mouse_input_subtitle">움직임을 상대 마우스 입력으로 Wine에 직접 전송합니다. 게임 내에서 마우스가 작동하지 않을 때 사용해 보세요.</string>
     <string name="joystick_opacity">조이스틱 불투명도</string>
     <string name="joystick_opacity_subtitle">동적 조이스틱 링과 손잡이의 불투명도</string>
     <string name="show_shooter_runtime_toggle">게임 중 버튼 표시</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -2143,6 +2143,8 @@
     <string name="mouse_acceleration_strength_subtitle">Jak szybko szybsze przeciągnięcia dodają prędkość myszy</string>
     <string name="mouse_acceleration_max">Maks. przyspieszenie</string>
     <string name="mouse_acceleration_max_subtitle">Górny mnożnik podczas szybkich przeciągnięć rozglądania myszą</string>
+    <string name="win32_relative_mouse_input">Względne sterowanie myszą</string>
+    <string name="win32_relative_mouse_input_subtitle">Przesyła ruch bezpośrednio do Wine jako względne sterowanie myszą. Wypróbuj, gdy mysz nie działa w grze.</string>
     <string name="joystick_opacity">Nieprzezroczystość joysticka</string>
     <string name="joystick_opacity_subtitle">Nieprzezroczystość pierścieni i gałek joysticków dynamicznych</string>
     <string name="show_shooter_runtime_toggle">Pokaż przycisk w grze</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -2013,6 +2013,8 @@
     <string name="mouse_acceleration_strength_subtitle">Quão rápido arrastos mais rápidos adicionam velocidade extra ao mouse</string>
     <string name="mouse_acceleration_max">Aceleração máxima</string>
     <string name="mouse_acceleration_max_subtitle">Multiplicador máximo aplicado durante arrastos rápidos do olhar com mouse</string>
+    <string name="win32_relative_mouse_input">Entrada relativa do mouse</string>
+    <string name="win32_relative_mouse_input_subtitle">Envia o movimento diretamente ao Wine como entrada relativa do mouse. Tente usar esta opção quando o mouse não funcionar dentro do jogo.</string>
     <string name="joystick_opacity">Opacidade do joystick</string>
     <string name="joystick_opacity_subtitle">Opacidade dos anéis e botões dos joysticks dinâmicos</string>
     <string name="show_shooter_runtime_toggle">Mostrar botão em jogo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -2145,6 +2145,8 @@
     <string name="mouse_acceleration_strength_subtitle">Cât de rapid adaugă glisările rapide viteză suplimentară mouse-ului</string>
     <string name="mouse_acceleration_max">Accelerație maximă</string>
     <string name="mouse_acceleration_max_subtitle">Multiplicatorul maxim aplicat în timpul glisărilor rapide pentru privirea cu mouse</string>
+    <string name="win32_relative_mouse_input">Intrare relativă a mouse-ului</string>
+    <string name="win32_relative_mouse_input_subtitle">Trimite mișcarea direct către Wine ca intrare relativă a mouse-ului. Încearcă această opțiune când mouse-ul nu funcționează în joc.</string>
     <string name="joystick_opacity">Opacitate joystick</string>
     <string name="joystick_opacity_subtitle">Opacitatea inelelor și butoanelor joystick-urilor dinamice</string>
     <string name="show_shooter_runtime_toggle">Afișează butonul în joc</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2071,6 +2071,8 @@ https://gamenative.app
     <string name="mouse_acceleration_strength_subtitle">Как быстро быстрые перетаскивания добавляют скорость мыши</string>
     <string name="mouse_acceleration_max">Максимальное ускорение</string>
     <string name="mouse_acceleration_max_subtitle">Верхний множитель при быстрых перетаскиваниях обзора мышью</string>
+    <string name="win32_relative_mouse_input">Относительный ввод мыши</string>
+    <string name="win32_relative_mouse_input_subtitle">Передаёт движение напрямую в Wine как относительный ввод мыши. Попробуйте эту настройку, если мышь не работает в игре.</string>
     <string name="joystick_opacity">Непрозрачность джойстика</string>
     <string name="joystick_opacity_subtitle">Непрозрачность колец и ручек динамических джойстиков</string>
     <string name="show_shooter_runtime_toggle">Показывать кнопку в игре</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -2139,6 +2139,8 @@
     <string name="mouse_acceleration_strength_subtitle">Як швидко швидші перетягування додають швидкість миші</string>
     <string name="mouse_acceleration_max">Максимальне прискорення</string>
     <string name="mouse_acceleration_max_subtitle">Верхній множник під час швидких перетягувань огляду мишею</string>
+    <string name="win32_relative_mouse_input">Відносне введення миші</string>
+    <string name="win32_relative_mouse_input_subtitle">Передає рух безпосередньо до Wine як відносне введення миші. Спробуйте, якщо миша не працює у грі.</string>
     <string name="joystick_opacity">Непрозорість джойстика</string>
     <string name="joystick_opacity_subtitle">Непрозорість кілець і ручок динамічних джойстиків</string>
     <string name="show_shooter_runtime_toggle">Показувати кнопку в грі</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2160,6 +2160,8 @@
     <string name="mouse_acceleration_strength_subtitle">更快拖动增加额外鼠标速度的速度</string>
     <string name="mouse_acceleration_max">最大加速</string>
     <string name="mouse_acceleration_max_subtitle">快速鼠标视角拖动时应用的最高倍率</string>
+    <string name="win32_relative_mouse_input">相对鼠标输入</string>
+    <string name="win32_relative_mouse_input_subtitle">将移动作为相对鼠标输入直接发送到 Wine。游戏内鼠标无法正常工作时可尝试启用此选项。</string>
     <string name="joystick_opacity">摇杆不透明度</string>
     <string name="joystick_opacity_subtitle">动态摇杆圆环和拇指点的不透明度</string>
     <string name="show_shooter_runtime_toggle">显示游戏内按钮</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2151,6 +2151,8 @@
     <string name="mouse_acceleration_strength_subtitle">較快拖曳增加額外滑鼠速度的速度</string>
     <string name="mouse_acceleration_max">最大加速</string>
     <string name="mouse_acceleration_max_subtitle">快速滑鼠視角拖曳時套用的最高倍率</string>
+    <string name="win32_relative_mouse_input">相對滑鼠輸入</string>
+    <string name="win32_relative_mouse_input_subtitle">將移動以相對滑鼠輸入直接傳送至 Wine。若滑鼠在遊戲中無法運作，請嘗試啟用此選項。</string>
     <string name="joystick_opacity">搖桿不透明度</string>
     <string name="joystick_opacity_subtitle">動態搖桿圓環和拇指點的不透明度</string>
     <string name="show_shooter_runtime_toggle">顯示遊戲內按鈕</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -531,6 +531,8 @@
     <string name="mouse_acceleration_strength_subtitle">How quickly faster drags add extra mouse speed</string>
     <string name="mouse_acceleration_max">Max Acceleration</string>
     <string name="mouse_acceleration_max_subtitle">Upper multiplier applied during fast mouse-look drags</string>
+    <string name="win32_relative_mouse_input">Win32 Relative Mouse Input</string>
+    <string name="win32_relative_mouse_input_subtitle">Send movement directly to Wine as relative mouse input. Try this when the mouse works in menus but cannot move the in-game camera.</string>
     <string name="joystick_size">Joystick Size</string>
     <string name="joystick_size_subtitle">Dynamic joystick size multiplier</string>
     <string name="joystick_opacity">Joystick Opacity</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -531,8 +531,8 @@
     <string name="mouse_acceleration_strength_subtitle">How quickly faster drags add extra mouse speed</string>
     <string name="mouse_acceleration_max">Max Acceleration</string>
     <string name="mouse_acceleration_max_subtitle">Upper multiplier applied during fast mouse-look drags</string>
-    <string name="win32_relative_mouse_input">Win32 Relative Mouse Input</string>
-    <string name="win32_relative_mouse_input_subtitle">Send movement directly to Wine as relative mouse input. Try this when the mouse works in menus but cannot move the in-game camera.</string>
+    <string name="win32_relative_mouse_input">Relative Mouse Input</string>
+    <string name="win32_relative_mouse_input_subtitle">Send movement directly to Wine as relative mouse input. Try this when the mouse isn\'t working in-game.</string>
     <string name="joystick_size">Joystick Size</string>
     <string name="joystick_size_subtitle">Dynamic joystick size multiplier</string>
     <string name="joystick_opacity">Joystick Opacity</string>

--- a/app/src/test/java/app/gamenative/data/ShooterModeConfigTest.kt
+++ b/app/src/test/java/app/gamenative/data/ShooterModeConfigTest.kt
@@ -2,12 +2,23 @@ package app.gamenative.data
 
 import com.winlator.inputcontrols.Binding
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ShooterModeConfigTest {
     @Test
     fun `invalid json falls back to default config`() {
         assertEquals(ShooterModeConfig(), ShooterModeConfig.fromJson("{not-json"))
+    }
+
+    @Test
+    fun `Win32 relative mouse input is opt in and survives serialization`() {
+        assertFalse(ShooterModeConfig.fromJson("").win32RelativeMouseInput)
+
+        val serialized = ShooterModeConfig(win32RelativeMouseInput = true).toJson()
+
+        assertTrue(ShooterModeConfig.fromJson(serialized).win32RelativeMouseInput)
     }
 
     @Test

--- a/app/src/test/java/com/winlator/widget/InputControlsViewRelativeMouseTest.kt
+++ b/app/src/test/java/com/winlator/widget/InputControlsViewRelativeMouseTest.kt
@@ -1,0 +1,44 @@
+package com.winlator.widget
+
+import androidx.test.core.app.ApplicationProvider
+import app.gamenative.data.ShooterModeConfig
+import com.winlator.xserver.XServer
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class InputControlsViewRelativeMouseTest {
+    @Test
+    fun `mouse look can enable Win32 relative input`() {
+        val xServer = mockk<XServer>(relaxed = true)
+        val view = InputControlsView(ApplicationProvider.getApplicationContext())
+        view.setShooterModeConfig(
+            ShooterModeConfig(
+                lookType = ShooterModeConfig.LOOK_MOUSE,
+                win32RelativeMouseInput = true,
+            ),
+        )
+        view.setXServer(xServer)
+
+        verify { xServer.setRelativeMouseMovement(true) }
+    }
+
+    @Test
+    fun `right stick look keeps Win32 relative input disabled`() {
+        val xServer = mockk<XServer>(relaxed = true)
+        val view = InputControlsView(ApplicationProvider.getApplicationContext())
+        view.setShooterModeConfig(
+            ShooterModeConfig(
+                lookType = ShooterModeConfig.LOOK_GAMEPAD_RIGHT_STICK,
+                win32RelativeMouseInput = true,
+            ),
+        )
+        view.setXServer(xServer)
+
+        verify(atLeast = 1) { xServer.setRelativeMouseMovement(false) }
+        verify(exactly = 0) { xServer.setRelativeMouseMovement(true) }
+    }
+}

--- a/app/src/test/java/com/winlator/widget/InputControlsViewRelativeMouseTest.kt
+++ b/app/src/test/java/com/winlator/widget/InputControlsViewRelativeMouseTest.kt
@@ -2,6 +2,8 @@ package com.winlator.widget
 
 import androidx.test.core.app.ApplicationProvider
 import app.gamenative.data.ShooterModeConfig
+import com.winlator.inputcontrols.ControlElement
+import com.winlator.inputcontrols.ControlsProfile
 import com.winlator.xserver.XServer
 import io.mockk.mockk
 import io.mockk.verify
@@ -76,6 +78,32 @@ class InputControlsViewRelativeMouseTest {
                 win32RelativeMouseInput = true,
             ),
         )
+        view.setXServer(xServer)
+
+        verify(atLeast = 1) { xServer.setRelativeMouseMovement(false) }
+        verify(exactly = 0) { xServer.setRelativeMouseMovement(true) }
+    }
+
+    @Test
+    fun `shooter mode control uses its resolved look type for relative input`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val xServer = mockk<XServer>(relaxed = true)
+        val view = InputControlsView(context)
+        val profile = ControlsProfile(context, 1)
+        profile.addElement(
+            ControlElement(view).apply {
+                setType(ControlElement.Type.SHOOTER_MODE)
+                shooterLookType = ShooterModeConfig.LOOK_GAMEPAD_RIGHT_STICK
+            },
+        )
+        view.setProfile(profile)
+        view.setShooterModeConfig(
+            ShooterModeConfig(
+                lookType = ShooterModeConfig.LOOK_MOUSE,
+                win32RelativeMouseInput = true,
+            ),
+        )
+        view.setShooterModeActive(true)
         view.setXServer(xServer)
 
         verify(atLeast = 1) { xServer.setRelativeMouseMovement(false) }

--- a/app/src/test/java/com/winlator/widget/InputControlsViewRelativeMouseTest.kt
+++ b/app/src/test/java/com/winlator/widget/InputControlsViewRelativeMouseTest.kt
@@ -12,9 +12,10 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class InputControlsViewRelativeMouseTest {
     @Test
-    fun `mouse look can enable Win32 relative input`() {
+    fun `mouse look enables Win32 relative input while container shooter mode is active`() {
         val xServer = mockk<XServer>(relaxed = true)
         val view = InputControlsView(ApplicationProvider.getApplicationContext())
+        view.setContainerShooterMode(true)
         view.setShooterModeConfig(
             ShooterModeConfig(
                 lookType = ShooterModeConfig.LOOK_MOUSE,
@@ -27,9 +28,48 @@ class InputControlsViewRelativeMouseTest {
     }
 
     @Test
+    fun `disabling container shooter mode restores normal pointer input`() {
+        val xServer = mockk<XServer>(relaxed = true)
+        val view = InputControlsView(ApplicationProvider.getApplicationContext())
+        view.setContainerShooterMode(true)
+        view.setShooterModeConfig(
+            ShooterModeConfig(
+                lookType = ShooterModeConfig.LOOK_MOUSE,
+                win32RelativeMouseInput = true,
+            ),
+        )
+        view.setXServer(xServer)
+
+        view.setContainerShooterMode(false)
+
+        verify { xServer.setRelativeMouseMovement(true) }
+        verify { xServer.setRelativeMouseMovement(false) }
+    }
+
+    @Test
+    fun `disabling shooter mode control restores normal pointer input`() {
+        val xServer = mockk<XServer>(relaxed = true)
+        val view = InputControlsView(ApplicationProvider.getApplicationContext())
+        view.setShooterModeActive(true)
+        view.setShooterModeConfig(
+            ShooterModeConfig(
+                lookType = ShooterModeConfig.LOOK_MOUSE,
+                win32RelativeMouseInput = true,
+            ),
+        )
+        view.setXServer(xServer)
+
+        view.setShooterModeActive(false)
+
+        verify { xServer.setRelativeMouseMovement(true) }
+        verify { xServer.setRelativeMouseMovement(false) }
+    }
+
+    @Test
     fun `right stick look keeps Win32 relative input disabled`() {
         val xServer = mockk<XServer>(relaxed = true)
         val view = InputControlsView(ApplicationProvider.getApplicationContext())
+        view.setContainerShooterMode(true)
         view.setShooterModeConfig(
             ShooterModeConfig(
                 lookType = ShooterModeConfig.LOOK_GAMEPAD_RIGHT_STICK,


### PR DESCRIPTION
## Description

Adds a per-game Relative Mouse Input toggle to Shooter Mode’s Mouse Look settings. Routes pointer movement through Wine’s Win32 relative mouse path when enabled.

## Recording

https://github.com/user-attachments/assets/b89e8567-b28c-44d3-a965-7e97b250c8f0

## Type of Change

- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist

- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in Relative Mouse Input toggle to Shooter Mode's Mouse Look settings. When enabled, pointer movement goes directly to Wine's Win32 relative mouse path, fixing in-game mouse issues for games where standard pointer movement doesn't register correctly.

- The setting is stored per game and defaults to off.
- It only takes effect when the Shooter Mode control's resolved Look Type is Mouse; other look types keep relative input disabled.
- Enabling or disabling Shooter Mode re-syncs the relative input state so exiting Shooter Mode restores normal pointer movement.

<sup>Written for commit 784fae0de54c76052074d614723be6c596cb0543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Relative Mouse Input option to Shooter Mode settings.
  - Sends mouse movement directly to Wine when enabled, which may help when in-game mouse controls do not work.
  - The setting applies only while Shooter Mode is active.
  - Added localized labels and descriptions across supported languages.

- **Bug Fixes**
  - Improved input handling when Shooter Mode, container settings, or runtime configuration changes.
  - Ensured controls use the active mode’s configured look behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->