### PR TITLE
Fix Steam Input config generation for games with an "In Game Actions" manifest

### DIFF
--- a/app/src/main/java/app/gamenative/service/SteamService.kt
+++ b/app/src/main/java/app/gamenative/service/SteamService.kt
@@ -1727,21 +1727,17 @@ class SteamService : Service(), IChallengeUrlChanged {
                 } else {
                     kv["Action Manifest"]
                 }
-                if (actionManifest === KeyValue.INVALID) return null
+                if (actionManifest === KeyValue.INVALID) {
+                    return findSiblingControllerConfig(manifestDirPath)
+                }
 
                 val configs = actionManifest["configurations"]
                 if (configs === KeyValue.INVALID || configs.children.isEmpty()) {
-                    throw IllegalStateException("No configurations found in Action Manifest")
+                    return findSiblingControllerConfig(manifestDirPath)
+                        ?: throw IllegalStateException("No configurations found in Action Manifest")
                 }
 
-                val preferredControllers = listOf(
-                    "controller_xboxone",
-                    "controller_steamcontroller_gordon",
-                    "controller_generic",
-                    "controller_xbox360",
-                )
-
-                for (controllerType in preferredControllers) {
+                for (controllerType in PREFERRED_CONTROLLER_TYPES) {
                     val controllerBlock = configs[controllerType]
                     if (controllerBlock === KeyValue.INVALID) continue
 
@@ -1756,11 +1752,28 @@ class SteamService : Service(), IChallengeUrlChanged {
                     }
                 }
 
-                throw IllegalStateException("No valid controller configuration found in Action Manifest")
+                findSiblingControllerConfig(manifestDirPath)
+                    ?: throw IllegalStateException("No valid controller configuration found in Action Manifest")
             } catch (e: Exception) {
                 Timber.e(e, "Failed to parse Steam Input manifest config")
                 null
             }
+        }
+
+        private val PREFERRED_CONTROLLER_TYPES = listOf(
+            "controller_xboxone",
+            "controller_steamcontroller_gordon",
+            "controller_generic",
+            "controller_xbox360",
+        )
+
+        private fun findSiblingControllerConfig(manifestDirPath: String): String? {
+            for (controllerType in PREFERRED_CONTROLLER_TYPES) {
+                val configFile = FileUtils.findFileCaseInsensitive(File(manifestDirPath), "$controllerType.vdf")
+                    ?: continue
+                return configFile.readText(Charsets.UTF_8)
+            }
+            return null
         }
 
         private fun readBuiltInSteamInputTemplate(fileName: String): String? {


### PR DESCRIPTION
Allumeria (3516590) has Steam Input turned on but never gets a `steam_settings/controller/` dir. Its `steaminputmanifestpath` points at `res/configs/input/game_actions_3516590.vdf`, which is the older `"In Game Actions"` format: it only has an `actions` block, and the actual config (`controller_xbox360.vdf`) just sits next to it. Our parser only understood the `"Action Manifest"` format with a `configurations` block, returned null, and `loadConfigFromManifest` then fell back to passing the manifest text itself to `generateControllerConfig`, which found no `controller_mappings` and returned without writing anything or logging.

Change: when the manifest has no usable `configurations` block, look in the manifest's directory for `controller_xboxone.vdf`, `controller_steamcontroller_gordon.vdf`, `controller_generic.vdf`, `controller_xbox360.vdf` (same preference order the `configurations` path already uses) and convert that.

This only runs on the paths that previously produced null, so games whose manifest already worked (e.g. No Man's Sky) take exactly the same route as before.

Tested by running the same conversion logic against the Allumeria manifest layout and against the No Man's Sky `Action Manifest` layout; NMS still resolves through the `configurations` block.
