### PR TITLE
Stop the master build runner from being OOM-killed

### DIFF
--- a/.github/workflows/app-release-signed.yml
+++ b/.github/workflows/app-release-signed.yml
@@ -23,6 +23,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Add swap
+      run: |
+        sudo fallocate -l 8G /mnt/swapfile.ci
+        sudo chmod 600 /mnt/swapfile.ci
+        sudo mkswap /mnt/swapfile.ci
+        sudo swapon /mnt/swapfile.ci
+        free -m
     - name: set up Java 17
       uses: actions/setup-java@v4
       with:
@@ -81,7 +88,11 @@ jobs:
         yes | "$SDKMANAGER" --install "build-tools;34.0.0"
 
     - name: Build with Gradle
-      run: ./gradlew :app:bundleLegacyRelease :app:bundleModernRelease :app:bundleLegacyXrRelease
+      run: |
+        ./gradlew -Pkotlin.daemon.jvmargs=-Xmx3g :app:bundleLegacyRelease
+        ./gradlew -Pkotlin.daemon.jvmargs=-Xmx3g :app:bundleModernRelease
+        ./gradlew -Pkotlin.daemon.jvmargs=-Xmx3g :app:bundleLegacyXrRelease
+        free -m
 
     - name: Stage bundles
       run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -229,6 +229,7 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
+            all { it.maxHeapSize = "4g" }
         }
     }
 


### PR DESCRIPTION
Every recent failure of the master build (Android CI) has the same signature: the `Build with Gradle` step dies with `The runner has received a shutdown signal` about 17–20 minutes in, always while one flavour's `minify*WithR8` is running at the same time as another flavour's `packageBundle` / `signBundle` / `shrinkBundleResources`. Examples: runs 33975875939, 33959687427, 33885501902, 33838788113. That message is what you get when the 16 GB runner VM is killed for memory. `org.gradle.jvmargs` is `-Xmx8g`, and the Kotlin daemon inherits the same `-Xmx8g` because `kotlin.daemon.jvmargs` is not set, so two JVMs can each grow to 8 GB before R8 and bundletool workers are even counted. Successful runs go through the same overlap and just happen to stay under the line.

Changes to `app-release-signed.yml`:

- Build the three bundles in three separate `./gradlew` invocations (same daemon, so no warm-up cost) so packaging of one flavour can never overlap R8 of the next. R8 itself was already serialised by Gradle.
- Pass `-Pkotlin.daemon.jvmargs=-Xmx3g` on CI only, so the Kotlin daemon stops reserving 8 GB it never needs. Local builds are untouched.
- Add an 8 GB swapfile on `/mnt` at the start of the job as a safety net, and print `free -m` after the build so future failures are easier to read.

Also raises the unit-test JVM heap to 4g in `app/build.gradle.kts`. The PR check has been failing intermittently with `OutOfMemoryError` in `testModernDebugUnitTest` (e.g. run 33959541344); the Gradle test worker default is 512m and the Robolectric suite is over 1200 tests now.

This does not change what gets built or signed, only how much memory the job uses.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the Android master build runner from being OOM-killed during CI and raises the unit-test JVM heap to fix intermittent OOM failures.

**Bug Fixes**
- Build each bundle in a separate Gradle invocation so packaging of one flavour never overlaps R8 of the next.
- Cap the Kotlin daemon at 3g on CI via `-Pkotlin.daemon.jvmargs=-Xmx3g`; local builds are unchanged.
- Add an 8 GB swapfile on `/mnt` and print `free -m` after the build to ease future diagnosis.
- Raise the unit-test JVM heap to 4g in `app/build.gradle.kts` since the Robolectric suite now exceeds 1200 tests.

<sup>Written for commit b9615c8e63372abb7e39ddcf2df714bbcb7d1f1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Android release builds to better support memory-intensive compilation and packaging.
  - Improved release workflow resource management with additional swap capacity and separate build steps.
  - Increased the available memory for Android unit tests to improve build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->