### PR TITLE
fix: power control profile selection problem

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/quickMenus/PowerControlQuickMenuTab.kt
+++ b/app/src/main/java/app/gamenative/ui/component/quickMenus/PowerControlQuickMenuTab.kt
@@ -112,18 +112,21 @@ fun PowerControlQuickMenuTab(
         },
         onProfileSelected = { profile ->
             coroutineScope.launch(Dispatchers.IO) {
-                Timber.d("Applying profile: $profile")
-
                 // Update PowerManager's current profile reference immediately
                 // Preserve current enableFanControl and enableGamePinning settings
-                val currentProfile = PowerManager.currentProfile
+                val currentProfile = PowerManager.currentProfile.copy()
+                Timber.d("Current profile: $currentProfile")
+
                 val updatedProfile = profile.copy(
+                    enablePowerControl = currentProfile.enablePowerControl,
                     adaptiveFpsCapEnabled = currentProfile.adaptiveFpsCapEnabled,
                     enableAutoTuning = false,
                     enablePerClusterTuning = false,
                     enableFanControl = currentProfile.enableFanControl,
                     enableGamePinning = currentProfile.enableGamePinning,
                 )
+
+                Timber.d("Applying profile: $updatedProfile")
                 PowerManager.setPowerProfile(updatedProfile)
 
                 val success = PowerManager.update {


### PR DESCRIPTION
## Description
fix: power control profile selection problem

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes power control profile selection so switching profiles no longer resets the current power control setting.

- Preserves the current `enablePowerControl` value when applying a new profile.
- Adds logging for the current and updated profiles.

<sup>Written for commit a7e49d837f1c4c655fb84987d7e105d040bc1d7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Selecting a power-control profile now preserves the current power-control setting.
  * Profile application logs now reflect the complete profile being applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->