### PR TITLE
Add per-profile mouse speed settings

### DIFF
--- a/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
+++ b/app/src/main/java/app/gamenative/ui/component/QuickMenu.kt
@@ -102,6 +102,7 @@ import app.gamenative.R
 import app.gamenative.data.GyroSettings
 import app.gamenative.powercontrol.PowerManager
 import app.gamenative.ui.component.dialog.GyroSettingsDialog
+import app.gamenative.ui.component.dialog.OnScreenControllerSettingsDialog
 import app.gamenative.ui.component.quickMenus.PowerControlQuickMenuTab
 import app.gamenative.ui.data.PerformanceHudConfig
 import app.gamenative.ui.data.PerformanceHudSize
@@ -109,6 +110,7 @@ import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.ui.util.adaptivePanelWidth
 import app.gamenative.utils.MathUtils.normalizedProgress
 import com.winlator.container.Container
+import com.winlator.inputcontrols.ControlsProfile
 import com.winlator.renderer.GLRenderer
 import com.winlator.renderer.VulkanRenderer
 import com.winlator.winhandler.ProcessInfo
@@ -522,6 +524,9 @@ fun QuickMenu(
     // broken D8 codegen path).
     val inviteMenu = remember(container?.id) { SteamInviteState.createIfAvailable(container) }
     var showGyroSettingsDialog by rememberSaveable(container?.id) { mutableStateOf(false) }
+    var onScreenControllerSettingsProfile by remember(container?.id) {
+        mutableStateOf<ControlsProfile?>(null)
+    }
     // Owned here, not plumbed through XServerScreen (register limit; see inviteMenu).
     var lsfgPresentMode by remember(container?.id) {
         mutableStateOf(container?.let { app.gamenative.utils.LsfgQuickMenuHelper.presentMode(it) } ?: "mailbox")
@@ -1082,21 +1087,27 @@ fun QuickMenu(
                                                         }
                                                     },
                                                     focusRequester = if (index == 0) controllerItemFocusRequester else null,
-                                                    secondaryIcon = if (item.id == QuickMenuAction.TOUCHSCREEN_MODE && isTouchscreenModeActive)
+                                                    secondaryIcon = if (item.id == QuickMenuAction.INPUT_CONTROLS && item.id in activeToggleIds)
+                                                        Icons.Default.Settings
+                                                    else if (item.id == QuickMenuAction.TOUCHSCREEN_MODE && isTouchscreenModeActive)
                                                         Icons.Default.Settings
                                                     else if (item.id == QuickMenuAction.SHOOTER_MODE && isShooterModeActive)
                                                         Icons.Default.Settings
                                                     else if (item.id == QuickMenuAction.GYRO && gyroEnabled)
                                                         Icons.Default.Settings
                                                     else null,
-                                                    secondaryContentDescriptionResId = if (item.id == QuickMenuAction.TOUCHSCREEN_MODE && isTouchscreenModeActive)
+                                                    secondaryContentDescriptionResId = if (item.id == QuickMenuAction.INPUT_CONTROLS && item.id in activeToggleIds)
+                                                        R.string.on_screen_controller_settings
+                                                    else if (item.id == QuickMenuAction.TOUCHSCREEN_MODE && isTouchscreenModeActive)
                                                         R.string.gesture_settings_title
                                                     else if (item.id == QuickMenuAction.SHOOTER_MODE && isShooterModeActive)
                                                         R.string.shooter_mode_settings_title
                                                     else if (item.id == QuickMenuAction.GYRO && gyroEnabled)
                                                         R.string.gyro_settings_title
                                                     else null,
-                                                    onSecondaryClick = if (item.id == QuickMenuAction.TOUCHSCREEN_MODE && isTouchscreenModeActive)
+                                                    onSecondaryClick = if (item.id == QuickMenuAction.INPUT_CONTROLS && item.id in activeToggleIds)
+                                                        ({ onScreenControllerSettingsProfile = PluviaApp.inputControlsView?.profile })
+                                                    else if (item.id == QuickMenuAction.TOUCHSCREEN_MODE && isTouchscreenModeActive)
                                                         onTouchGestureSettingsClick
                                                     else if (item.id == QuickMenuAction.SHOOTER_MODE && isShooterModeActive)
                                                         onShooterModeSettingsClick
@@ -1133,6 +1144,19 @@ fun QuickMenu(
                 gyroMenu.persistSettings(settings)
                 showGyroSettingsDialog = false
                 if (onItemSelected(QuickMenuAction.EDIT_CONTROLS)) onDismiss()
+            },
+        )
+    }
+
+    onScreenControllerSettingsProfile?.let { profile ->
+        OnScreenControllerSettingsDialog(
+            initialCursorSpeed = profile.cursorSpeed,
+            onDismiss = { onScreenControllerSettingsProfile = null },
+            onSave = { speed ->
+                profile.cursorSpeed = speed
+                profile.save()
+                PluviaApp.touchpadView?.setSensitivity(profile.cursorSpeed)
+                onScreenControllerSettingsProfile = null
             },
         )
     }

--- a/app/src/main/java/app/gamenative/ui/component/dialog/OnScreenControllerSettingsDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/OnScreenControllerSettingsDialog.kt
@@ -124,7 +124,10 @@ fun OnScreenControllerSettingsDialog(
                     subtitle = stringResource(R.string.mouse_speed_subtitle),
                     value = cursorSpeed,
                     valueRange = MIN_MOUSE_SPEED..MAX_MOUSE_SPEED,
-                    valueText = multiplierText(cursorSpeed, locale),
+                    valueText = multiplierText(
+                        mouseSpeedForSave(initialCursorSpeed, cursorSpeed, cursorSpeedWasEdited),
+                        locale,
+                    ),
                     onValueChange = {
                         cursorSpeed = it
                         cursorSpeedWasEdited = true

--- a/app/src/main/java/app/gamenative/ui/component/dialog/OnScreenControllerSettingsDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/OnScreenControllerSettingsDialog.kt
@@ -1,0 +1,118 @@
+package app.gamenative.ui.component.dialog
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import app.gamenative.R
+import app.gamenative.ui.theme.PluviaBackground
+import com.winlator.inputcontrols.ControlsProfile
+import java.util.Locale
+
+internal val DEFAULT_MOUSE_SPEED = ControlsProfile.DEFAULT_CURSOR_SPEED
+internal const val MIN_MOUSE_SPEED = 0.1f
+internal const val MAX_MOUSE_SPEED = 3.0f
+
+internal fun mouseSpeedOrDefault(value: Float): Float {
+    return value.takeIf { it.isFinite() && it > 0f } ?: DEFAULT_MOUSE_SPEED
+}
+
+internal fun mouseSpeedForSlider(value: Float): Float {
+    return mouseSpeedOrDefault(value).coerceIn(MIN_MOUSE_SPEED, MAX_MOUSE_SPEED)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OnScreenControllerSettingsDialog(
+    initialCursorSpeed: Float,
+    onDismiss: () -> Unit,
+    onSave: (Float) -> Unit,
+) {
+    var cursorSpeed by remember(initialCursorSpeed) {
+        mutableFloatStateOf(mouseSpeedForSlider(initialCursorSpeed))
+    }
+    val locale = Locale.getDefault()
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false,
+        ),
+    ) {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            containerColor = PluviaBackground,
+            topBar = {
+                CenterAlignedTopAppBar(
+                    title = {
+                        Text(
+                            text = stringResource(R.string.on_screen_controller_settings),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = onDismiss) {
+                            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.close))
+                        }
+                    },
+                    actions = {
+                        IconButton(onClick = { cursorSpeed = DEFAULT_MOUSE_SPEED }) {
+                            Icon(
+                                Icons.Default.Refresh,
+                                contentDescription = stringResource(R.string.reset_mouse_speed),
+                            )
+                        }
+                        IconButton(onClick = { onSave(cursorSpeed) }) {
+                            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.save))
+                        }
+                    },
+                )
+            },
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize()
+                    .padding(bottom = 16.dp)
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                SettingsDialogSectionHeader(stringResource(R.string.mouse))
+
+                SettingsSliderBlock(
+                    title = stringResource(R.string.mouse_speed),
+                    subtitle = stringResource(R.string.mouse_speed_subtitle),
+                    value = cursorSpeed,
+                    valueRange = MIN_MOUSE_SPEED..MAX_MOUSE_SPEED,
+                    valueText = String.format(locale, "%.1fx", cursorSpeed),
+                    onValueChange = { cursorSpeed = it },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/component/dialog/OnScreenControllerSettingsDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/OnScreenControllerSettingsDialog.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -44,6 +45,10 @@ internal fun mouseSpeedForSlider(value: Float): Float {
     return mouseSpeedOrDefault(value).coerceIn(MIN_MOUSE_SPEED, MAX_MOUSE_SPEED)
 }
 
+internal fun mouseSpeedForSave(initialValue: Float, editedValue: Float, wasEdited: Boolean): Float {
+    return if (wasEdited) mouseSpeedForSlider(editedValue) else mouseSpeedOrDefault(initialValue)
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OnScreenControllerSettingsDialog(
@@ -54,6 +59,7 @@ fun OnScreenControllerSettingsDialog(
     var cursorSpeed by remember(initialCursorSpeed) {
         mutableFloatStateOf(mouseSpeedForSlider(initialCursorSpeed))
     }
+    var cursorSpeedWasEdited by remember(initialCursorSpeed) { mutableStateOf(false) }
     val locale = Locale.getDefault()
 
     Dialog(
@@ -82,13 +88,22 @@ fun OnScreenControllerSettingsDialog(
                         }
                     },
                     actions = {
-                        IconButton(onClick = { cursorSpeed = DEFAULT_MOUSE_SPEED }) {
+                        IconButton(
+                            onClick = {
+                                cursorSpeed = DEFAULT_MOUSE_SPEED
+                                cursorSpeedWasEdited = true
+                            },
+                        ) {
                             Icon(
                                 Icons.Default.Refresh,
                                 contentDescription = stringResource(R.string.reset_mouse_speed),
                             )
                         }
-                        IconButton(onClick = { onSave(cursorSpeed) }) {
+                        IconButton(
+                            onClick = {
+                                onSave(mouseSpeedForSave(initialCursorSpeed, cursorSpeed, cursorSpeedWasEdited))
+                            },
+                        ) {
                             Icon(Icons.Default.Check, contentDescription = stringResource(R.string.save))
                         }
                     },
@@ -109,8 +124,11 @@ fun OnScreenControllerSettingsDialog(
                     subtitle = stringResource(R.string.mouse_speed_subtitle),
                     value = cursorSpeed,
                     valueRange = MIN_MOUSE_SPEED..MAX_MOUSE_SPEED,
-                    valueText = String.format(locale, "%.1fx", cursorSpeed),
-                    onValueChange = { cursorSpeed = it },
+                    valueText = multiplierText(cursorSpeed, locale),
+                    onValueChange = {
+                        cursorSpeed = it
+                        cursorSpeedWasEdited = true
+                    },
                 )
             }
         }

--- a/app/src/main/java/app/gamenative/ui/component/dialog/SettingsDialogBlocks.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/SettingsDialogBlocks.kt
@@ -57,6 +57,7 @@ import app.gamenative.ui.theme.settingsTileColors
 import app.gamenative.ui.theme.settingsTileColorsAlt
 import com.alorma.compose.settings.ui.SettingsSwitch
 import com.winlator.inputcontrols.Binding
+import java.util.Locale
 import kotlin.math.ceil
 import kotlin.math.floor
 
@@ -250,6 +251,10 @@ fun SettingsSliderBlock(
     }
 
     if (compact) content() else GestureBlock { content() }
+}
+
+internal fun multiplierText(value: Float, locale: Locale): String {
+    return String.format(locale, "%.1fx", value)
 }
 
 @Composable

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ShooterModeSettingsDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ShooterModeSettingsDialog.kt
@@ -412,10 +412,6 @@ private fun joystickBehaviorLabels(): List<String> = listOf(
     stringResource(R.string.joystick_behavior_floating),
 )
 
-private fun multiplierText(value: Float, locale: Locale): String {
-    return String.format(locale, "%.1fx", value)
-}
-
 private fun pixelText(value: Float, locale: Locale): String {
     return String.format(locale, "%.1f px", value)
 }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/PhysicalControllerHandler.kt
@@ -354,7 +354,7 @@ class PhysicalControllerHandler(
                     if (magnitude < 0.08) return
 
                     // Look up cursor speed dynamically so it updates when profile changes
-                    val cursorSpeed = profile?.cursorSpeed ?: 1f
+                    val cursorSpeed = profile?.cursorSpeed ?: ControlsProfile.DEFAULT_CURSOR_SPEED
                     val deltaX = (mouseMoveOffset.x * 10 * cursorSpeed).toInt()
                     val deltaY = (mouseMoveOffset.y * 10 * cursorSpeed).toInt()
                     xServer?.injectPointerMoveDelta(deltaX, deltaY)

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -3331,7 +3331,7 @@ private fun showInputControls(profile: ControlsProfile, winHandler: WinHandler, 
         }
     }
 
-    PluviaApp.touchpadView?.setSensitivity(profile.getCursorSpeed() * 1.0f)
+    PluviaApp.touchpadView?.setSensitivity(profile.cursorSpeed)
 
     // If the selected profile is a virtual gamepad, we must enable the P1 slot.
     if (container.containerVariant.equals(Container.BIONIC) && profile.isVirtualGamepad()) {
@@ -3354,7 +3354,7 @@ private fun hideInputControls() {
     PluviaApp.inputControlsView?.hideProfileForOverlay()
     PluviaApp.xServerView?.getxServer()?.winHandler?.refreshControllerMappingsForHotplug()
 
-    PluviaApp.touchpadView?.setSensitivity(1.0f)
+    PluviaApp.touchpadView?.setSensitivity(ControlsProfile.DEFAULT_CURSOR_SPEED)
     PluviaApp.touchpadView?.setPointerButtonLeftEnabled(true)
     PluviaApp.touchpadView?.setPointerButtonRightEnabled(true)
     PluviaApp.touchpadView?.isEnabled()?.let {

--- a/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
@@ -123,12 +123,7 @@ public class ControlElement {
 
         int scale(float value, float multiplier) {
             if (value == 0.0f) return 0;
-            if (multiplier >= 1.0f) {
-                remainder = 0.0f;
-                return Mathf.roundPoint(value * multiplier);
-            }
-
-            float scaledValue = Mathf.roundPoint(value) * multiplier + remainder;
+            float scaledValue = value * multiplier + remainder;
             int wholePixels = (int)scaledValue;
             remainder = scaledValue - wholePixels;
             return wholePixels;

--- a/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
@@ -1377,6 +1377,10 @@ public class ControlElement {
             else if (type == Type.TRACKPAD) {
                 final boolean[] states = {deltaY <= -TRACKPAD_MIN_SPEED, deltaX >= TRACKPAD_MIN_SPEED, deltaY >= TRACKPAD_MIN_SPEED, deltaX <= -TRACKPAD_MIN_SPEED};
                 if (handleRadialMenuDirectionalMove(pointerId, states, x, y)) return true;
+                ControlsProfile activeProfile = inputControlsView.getProfile();
+                float cursorSpeed = activeProfile != null
+                        ? activeProfile.getCursorSpeed()
+                        : ControlsProfile.DEFAULT_CURSOR_SPEED;
                 int cursorDx = 0;
                 int cursorDy = 0;
 
@@ -1390,10 +1394,10 @@ public class ControlElement {
                             value *= TouchpadView.CURSOR_ACCELERATION;
                         }
                         if (mouseMoveBinding == Binding.MOUSE_MOVE_LEFT || mouseMoveBinding == Binding.MOUSE_MOVE_RIGHT) {
-                            cursorDx = Mathf.roundPoint(value);
+                            cursorDx = Mathf.roundPoint(value * cursorSpeed);
                         }
                         else {
-                            cursorDy = Mathf.roundPoint(value);
+                            cursorDy = Mathf.roundPoint(value * cursorSpeed);
                         }
                         boolean nextState = states[i];
                         if (!bindingCombo.isSingleBinding() && this.states[i] != nextState) {

--- a/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControlElement.java
@@ -97,6 +97,8 @@ public class ControlElement {
     private PointF currentPosition;
     private RangeScroller scroller;
     private CubicBezierInterpolator interpolator;
+    private final MouseDeltaAccumulator trackpadCursorX = new MouseDeltaAccumulator();
+    private final MouseDeltaAccumulator trackpadCursorY = new MouseDeltaAccumulator();
     private Object touchTime;
     private String shooterMovementType = "wasd";
     private String shooterLookType = "mouse";
@@ -114,6 +116,32 @@ public class ControlElement {
 
     public ControlElement(InputControlsView inputControlsView) {
         this.inputControlsView = inputControlsView;
+    }
+
+    static final class MouseDeltaAccumulator {
+        private float remainder;
+
+        int scale(float value, float multiplier) {
+            if (value == 0.0f) return 0;
+            if (multiplier >= 1.0f) {
+                remainder = 0.0f;
+                return Mathf.roundPoint(value * multiplier);
+            }
+
+            float scaledValue = Mathf.roundPoint(value) * multiplier + remainder;
+            int wholePixels = (int)scaledValue;
+            remainder = scaledValue - wholePixels;
+            return wholePixels;
+        }
+
+        void reset() {
+            remainder = 0.0f;
+        }
+    }
+
+    private void resetTrackpadCursorRemainders() {
+        trackpadCursorX.reset();
+        trackpadCursorY.reset();
     }
 
     private static Object[] createBindingSources(int count) {
@@ -1288,6 +1316,7 @@ public class ControlElement {
             }
             else {
                 if (type == Type.TRACKPAD) {
+                    resetTrackpadCursorRemainders();
                     if (currentPosition == null) currentPosition = new PointF();
                     currentPosition.set(x, y);
                 }
@@ -1381,8 +1410,8 @@ public class ControlElement {
                 float cursorSpeed = activeProfile != null
                         ? activeProfile.getCursorSpeed()
                         : ControlsProfile.DEFAULT_CURSOR_SPEED;
-                int cursorDx = 0;
-                int cursorDy = 0;
+                float cursorDeltaX = 0;
+                float cursorDeltaY = 0;
 
                 for (byte i = 0; i < 4; i++) {
                     float value = (i == 1 || i == 3 ? deltaX : deltaY);
@@ -1394,10 +1423,10 @@ public class ControlElement {
                             value *= TouchpadView.CURSOR_ACCELERATION;
                         }
                         if (mouseMoveBinding == Binding.MOUSE_MOVE_LEFT || mouseMoveBinding == Binding.MOUSE_MOVE_RIGHT) {
-                            cursorDx = Mathf.roundPoint(value * cursorSpeed);
+                            cursorDeltaX = value;
                         }
                         else {
-                            cursorDy = Mathf.roundPoint(value * cursorSpeed);
+                            cursorDeltaY = value;
                         }
                         boolean nextState = states[i];
                         if (!bindingCombo.isSingleBinding() && this.states[i] != nextState) {
@@ -1436,6 +1465,8 @@ public class ControlElement {
                     }
                 }
 
+                int cursorDx = trackpadCursorX.scale(cursorDeltaX, cursorSpeed);
+                int cursorDy = trackpadCursorY.scale(cursorDeltaY, cursorSpeed);
                 if (cursorDx != 0 || cursorDy != 0) inputControlsView.getXServer().injectPointerMoveDelta(cursorDx, cursorDy);
             }
             else {
@@ -1515,6 +1546,8 @@ public class ControlElement {
             else if (type == Type.RANGE_BUTTON || type == Type.D_PAD || type == Type.STICK || type == Type.TRACKPAD) {
                 releaseActiveDirectionalStates();
 
+                if (type == Type.TRACKPAD) resetTrackpadCursorRemainders();
+
                 if (type == Type.RANGE_BUTTON) {
                     scroller.handleTouchUp();
                 }
@@ -1555,6 +1588,7 @@ public class ControlElement {
         }
         else if (type == Type.RANGE_BUTTON || type == Type.D_PAD || type == Type.STICK || type == Type.TRACKPAD) {
             releaseActiveDirectionalStates();
+            if (type == Type.TRACKPAD) resetTrackpadCursorRemainders();
             if (type == Type.RANGE_BUTTON) scroller.cancelTouch();
             currentPosition = null;
         }

--- a/app/src/main/java/com/winlator/inputcontrols/ControlsProfile.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ControlsProfile.java
@@ -19,9 +19,11 @@ import java.util.List;
 import java.util.Locale;
 
 public class ControlsProfile implements Comparable<ControlsProfile> {
+    public static final float DEFAULT_CURSOR_SPEED = 1.0f;
+
     public final int id;
     private String name;
-    private float cursorSpeed = 1.0f;
+    private volatile float cursorSpeed = DEFAULT_CURSOR_SPEED;
     private final ArrayList<ControlElement> elements = new ArrayList<>();
     private final ArrayList<ExternalController> controllers = new ArrayList<>();
     private final ArrayList<RadialMenu> radialMenus = new ArrayList<>();
@@ -51,7 +53,9 @@ public class ControlsProfile implements Comparable<ControlsProfile> {
     }
 
     public void setCursorSpeed(float cursorSpeed) {
-        this.cursorSpeed = cursorSpeed;
+        this.cursorSpeed = Float.isFinite(cursorSpeed) && cursorSpeed > 0.0f
+                ? cursorSpeed
+                : DEFAULT_CURSOR_SPEED;
     }
 
     public boolean isVirtualGamepad() {

--- a/app/src/main/java/com/winlator/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/widget/InputControlsView.java
@@ -421,6 +421,8 @@ public class InputControlsView extends View {
             }
         }
 
+        if (profile == null) stopMouseMoveTimer();
+
         onControlsProfileContentChanged(profileChanged);
         gyroController.setHasProfile(profile != null);
     }
@@ -431,6 +433,7 @@ public class InputControlsView extends View {
         synchronized (this) {
             this.profile = null;
         }
+        stopMouseMoveTimer();
     }
 
     /** Re-evaluates latched gyro activation after the active profile is edited in place. */
@@ -554,8 +557,7 @@ public class InputControlsView extends View {
     protected void onDetachedFromWindow() {
         cancelTouchRouting();
         gyroController.onDetachedFromWindow();
-        if (mouseMoveTimer != null)
-            mouseMoveTimer.cancel();
+        stopMouseMoveTimer();
         super.onDetachedFromWindow();
     }
 
@@ -569,17 +571,32 @@ public class InputControlsView extends View {
         return (int)Mathf.roundTo(getHeight(), snappingSize);
     }
 
-    private void createMouseMoveTimer() {
+    private synchronized void createMouseMoveTimer() {
         if (profile != null && mouseMoveTimer == null) {
-            final float cursorSpeed = profile.getCursorSpeed();
             mouseMoveTimer = new Timer();
             mouseMoveTimer.schedule(new TimerTask() {
                 @Override
                 public void run() {
-                    xServer.injectPointerMoveDelta((int)(mouseMoveOffset.x * 10 * cursorSpeed), (int)(mouseMoveOffset.y * 10 * cursorSpeed));
+                    ControlsProfile currentProfile = getProfile();
+                    if (currentProfile == null) return;
+
+                    float cursorSpeed = currentProfile.getCursorSpeed();
+                    int deltaX = (int)(mouseMoveOffset.x * 10 * cursorSpeed);
+                    int deltaY = (int)(mouseMoveOffset.y * 10 * cursorSpeed);
+                    if (deltaX != 0 || deltaY != 0) {
+                        xServer.injectPointerMoveDelta(deltaX, deltaY);
+                    }
                 }
             }, 0, 1000 / 60);
         }
+    }
+
+    private synchronized void stopMouseMoveTimer() {
+        if (mouseMoveTimer != null) {
+            mouseMoveTimer.cancel();
+            mouseMoveTimer = null;
+        }
+        mouseMoveOffset.set(0, 0);
     }
 
     private void processJoystickInput(ExternalController controller) {

--- a/app/src/main/java/com/winlator/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/widget/InputControlsView.java
@@ -73,7 +73,7 @@ public class InputControlsView extends View {
     private float offsetX;
     private float offsetY;
     private ControlElement selectedElement;
-    private ControlsProfile profile;
+    private volatile ControlsProfile profile;
     // Retained while the overlay controls are hidden so gyro can keep targeting the active gamepad.
     private ControlsProfile gyroProfile;
     private float overlayOpacity = DEFAULT_OVERLAY_OPACITY;
@@ -82,6 +82,7 @@ public class InputControlsView extends View {
     private final Bitmap[] icons = new Bitmap[40];
     private Timer mouseMoveTimer;
     private final PointF mouseMoveOffset = new PointF();
+    private final Object mouseMoveStateLock = new Object();
     private boolean showTouchscreenControls = true;
 
     // Shooter mode state
@@ -577,14 +578,16 @@ public class InputControlsView extends View {
             mouseMoveTimer.schedule(new TimerTask() {
                 @Override
                 public void run() {
-                    ControlsProfile currentProfile = getProfile();
-                    if (currentProfile == null) return;
+                    synchronized (mouseMoveStateLock) {
+                        ControlsProfile currentProfile = profile;
+                        if (currentProfile == null) return;
 
-                    float cursorSpeed = currentProfile.getCursorSpeed();
-                    int deltaX = (int)(mouseMoveOffset.x * 10 * cursorSpeed);
-                    int deltaY = (int)(mouseMoveOffset.y * 10 * cursorSpeed);
-                    if (deltaX != 0 || deltaY != 0) {
-                        xServer.injectPointerMoveDelta(deltaX, deltaY);
+                        float cursorSpeed = currentProfile.getCursorSpeed();
+                        int deltaX = (int)(mouseMoveOffset.x * 10 * cursorSpeed);
+                        int deltaY = (int)(mouseMoveOffset.y * 10 * cursorSpeed);
+                        if (deltaX != 0 || deltaY != 0) {
+                            xServer.injectPointerMoveDelta(deltaX, deltaY);
+                        }
                     }
                 }
             }, 0, 1000 / 60);
@@ -596,7 +599,9 @@ public class InputControlsView extends View {
             mouseMoveTimer.cancel();
             mouseMoveTimer = null;
         }
-        mouseMoveOffset.set(0, 0);
+        synchronized (mouseMoveStateLock) {
+            mouseMoveOffset.set(0, 0);
+        }
     }
 
     private void processJoystickInput(ExternalController controller) {
@@ -1764,11 +1769,15 @@ public class InputControlsView extends View {
                 return;
             }
             else if (binding == Binding.MOUSE_MOVE_LEFT || binding == Binding.MOUSE_MOVE_RIGHT) {
-                mouseMoveOffset.x = isActionDown ? (offset != 0 ? offset : (binding == Binding.MOUSE_MOVE_LEFT ? -1 : 1)) : 0;
+                synchronized (mouseMoveStateLock) {
+                    mouseMoveOffset.x = isActionDown ? (offset != 0 ? offset : (binding == Binding.MOUSE_MOVE_LEFT ? -1 : 1)) : 0;
+                }
                 if (isActionDown) createMouseMoveTimer();
             }
             else if (binding == Binding.MOUSE_MOVE_DOWN || binding == Binding.MOUSE_MOVE_UP) {
-                mouseMoveOffset.y = isActionDown ? (offset != 0 ? offset : (binding == Binding.MOUSE_MOVE_UP ? -1 : 1)) : 0;
+                synchronized (mouseMoveStateLock) {
+                    mouseMoveOffset.y = isActionDown ? (offset != 0 ? offset : (binding == Binding.MOUSE_MOVE_UP ? -1 : 1)) : 0;
+                }
                 if (isActionDown) createMouseMoveTimer();
             }
             else {

--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -15,6 +15,7 @@ import timber.log.Timber;
 
 import com.winlator.core.AppUtils;
 import com.winlator.inputcontrols.Binding;
+import com.winlator.inputcontrols.ControlsProfile;
 import com.winlator.math.Mathf;
 import com.winlator.math.XForm;
 import com.winlator.renderer.ViewTransformation;
@@ -243,7 +244,7 @@ public class TouchpadView extends View implements View.OnCapturedPointerListener
         this.capturePointerOnExternalMouse = capturePointerOnExternalMouse;
         this.fingers = new Finger[4];
         this.numFingers = (byte) 0;
-        this.sensitivity = 1.0f;
+        this.sensitivity = ControlsProfile.DEFAULT_CURSOR_SPEED;
         this.pointerButtonLeftEnabled = true;
         this.pointerButtonRightEnabled = true;
         this.moveCursorToTouchpoint = false;

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -210,6 +210,10 @@
     <string name="dpad_right">D-Pad højre</string>
     <string name="input_controls">On-screen-controller</string>
     <string name="edit_controls">Redigér on-screen-controller</string>
+    <string name="on_screen_controller_settings">Indstillinger for on-screen-controller</string>
+    <string name="mouse_speed">Musehastighed</string>
+    <string name="mouse_speed_subtitle">Juster markørhastigheden for berøringsbevægelser og betjeningselementer, der er tildelt til at flytte musen. Shooter-tilstand bruger sin egen kigfølsomhed.</string>
+    <string name="reset_mouse_speed">Nulstil musehastighed</string>
     <string name="edit_physical_controller">Redigér fysisk controller</string>
     <string name="controller_disconnected">Afbrudt</string>
     <string name="reset_onscreen_controls">Nulstil on-screen-kontroller</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -274,6 +274,10 @@
     <string name="dpad_right">D-Pad rechts</string>
     <string name="input_controls">On-Screen-Controller</string>
     <string name="edit_controls">On-Screen-Controller bearbeiten</string>
+    <string name="on_screen_controller_settings">Einstellungen für den On-Screen-Controller</string>
+    <string name="mouse_speed">Mausgeschwindigkeit</string>
+    <string name="mouse_speed_subtitle">Passe die Zeigergeschwindigkeit für Touch-Bewegungen und Steuerelemente an, die zum Bewegen der Maus zugewiesen sind. Der Shooter-Modus verwendet eine eigene Blickempfindlichkeit.</string>
+    <string name="reset_mouse_speed">Mausgeschwindigkeit zurücksetzen</string>
     <string name="edit_physical_controller">Physische Controller bearbeiten</string>
     <string name="controller_disconnected">Verbindung getrennt</string>
     <string name="reset_onscreen_controls">On-Screen-Steuerung zurücksetzen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -292,6 +292,10 @@
     <string name="dpad_right">Cruceta derecha</string>
     <string name="input_controls">Controles en pantalla</string>
     <string name="edit_controls">Editar controles en pantalla</string>
+    <string name="on_screen_controller_settings">Ajustes de controles en pantalla</string>
+    <string name="mouse_speed">Velocidad del ratón</string>
+    <string name="mouse_speed_subtitle">Ajusta la velocidad del puntero para el movimiento táctil y los controles asignados a mover el ratón. El modo shooter usa su propia sensibilidad de vista.</string>
+    <string name="reset_mouse_speed">Restablecer velocidad del ratón</string>
     <string name="edit_physical_controller">Editar mando físico</string>
     <string name="controller_disconnected">Desconectado</string>
     <string name="reset_onscreen_controls">Restablecer controles en pantalla</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -282,6 +282,10 @@
     <string name="dpad_right">D-Pad Droite</string>
     <string name="input_controls">Contrôleur à l\'écran</string>
     <string name="edit_controls">Modifier le contrôleur à l\'écran</string>
+    <string name="on_screen_controller_settings">Paramètres du contrôleur à l\'écran</string>
+    <string name="mouse_speed">Vitesse de la souris</string>
+    <string name="mouse_speed_subtitle">Règle la vitesse du pointeur pour les mouvements tactiles et les commandes assignées au déplacement de la souris. Le mode tireur utilise sa propre sensibilité du regard.</string>
+    <string name="reset_mouse_speed">Réinitialiser la vitesse de la souris</string>
     <string name="edit_physical_controller">Modifier le contrôleur physique</string>
     <string name="controller_disconnected">Déconnecté</string>
     <string name="reset_onscreen_controls">Réinitialiser les contrôles à l\'écran</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -281,6 +281,10 @@
     <string name="dpad_right">D-Pad Destra</string>
     <string name="input_controls">Controller a schermo</string>
     <string name="edit_controls">Modifica Controller a schermo</string>
+    <string name="on_screen_controller_settings">Impostazioni controller a schermo</string>
+    <string name="mouse_speed">Velocità del mouse</string>
+    <string name="mouse_speed_subtitle">Regola la velocità del puntatore per i movimenti touch e i controlli assegnati al movimento del mouse. La modalità sparatutto usa una sensibilità di visuale separata.</string>
+    <string name="reset_mouse_speed">Reimposta velocità del mouse</string>
     <string name="edit_physical_controller">Modifica Controller Fisico</string>
     <string name="controller_disconnected">Disconnesso</string>
     <string name="reset_onscreen_controls">Reimposta Controlli a Schermo</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -235,6 +235,10 @@
     <string name="dpad_right">十字キー右</string>
     <string name="input_controls">オンスクリーンコントローラー</string>
     <string name="edit_controls">オンスクリーンコントローラーの編集</string>
+    <string name="on_screen_controller_settings">オンスクリーンコントローラー設定</string>
+    <string name="mouse_speed">マウス速度</string>
+    <string name="mouse_speed_subtitle">タッチ操作およびマウス移動に割り当てられたコントロールのポインター速度を調整します。シューターモードでは独自の視点感度が使用されます。</string>
+    <string name="reset_mouse_speed">マウス速度をリセット</string>
     <string name="edit_physical_controller">物理コントローラーの編集</string>
     <string name="controller_disconnected">切断されました</string>
     <string name="reset_onscreen_controls">オンスクリーンコントロールをリセットする</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -289,6 +289,10 @@
     <string name="dpad_right">십자 버튼 오른쪽</string>
     <string name="input_controls">화면 컨트롤러</string>
     <string name="edit_controls">화면 컨트롤러 편집</string>
+    <string name="on_screen_controller_settings">화면 컨트롤러 설정</string>
+    <string name="mouse_speed">마우스 속도</string>
+    <string name="mouse_speed_subtitle">터치 이동 및 마우스 이동에 할당된 컨트롤의 포인터 속도를 조절합니다. 슈터 모드는 별도의 시점 감도를 사용합니다.</string>
+    <string name="reset_mouse_speed">마우스 속도 재설정</string>
     <string name="edit_physical_controller">물리 컨트롤러 편집</string>
     <string name="controller_disconnected">연결 끊김</string>
     <string name="reset_onscreen_controls">화면 컨트롤 초기화</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -289,6 +289,10 @@
     <string name="dpad_right">D-Pad Prawo</string>
     <string name="input_controls">Kontroler ekranowy</string>
     <string name="edit_controls">Edytuj kontroler ekranowy</string>
+    <string name="on_screen_controller_settings">Ustawienia kontrolera ekranowego</string>
+    <string name="mouse_speed">Prędkość myszy</string>
+    <string name="mouse_speed_subtitle">Dostosuj prędkość wskaźnika dla ruchu dotykowego i elementów sterujących przypisanych do poruszania myszą. Tryb strzelanki używa własnej czułości rozglądania.</string>
+    <string name="reset_mouse_speed">Resetuj prędkość myszy</string>
     <string name="edit_physical_controller">Edytuj kontroler fizyczny</string>
     <string name="controller_disconnected">Rozłączono</string>
     <string name="reset_onscreen_controls">Zresetuj kontroler ekranowy</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -210,6 +210,10 @@
     <string name="dpad_right">D-Pad Direita</string>
     <string name="input_controls">Controle On-screen</string>
     <string name="edit_controls">Editar Controle On-screen</string>
+    <string name="on_screen_controller_settings">Configurações do controle na tela</string>
+    <string name="mouse_speed">Velocidade do mouse</string>
+    <string name="mouse_speed_subtitle">Ajuste a velocidade do ponteiro para movimentos por toque e controles atribuídos ao movimento do mouse. O modo tiro usa sua própria sensibilidade de visão.</string>
+    <string name="reset_mouse_speed">Redefinir velocidade do mouse</string>
     <string name="edit_physical_controller">Editar Controle Físico</string>
     <string name="controller_disconnected">Desconectado</string>
     <string name="reset_onscreen_controls">Redefinir Controles On-screen</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -279,6 +279,10 @@
     <string name="dpad_right">D‑Pad Dreapta</string>
     <string name="input_controls">Controller pe ecran</string>
     <string name="edit_controls">Editează controllerul pe ecran</string>
+    <string name="on_screen_controller_settings">Setări controller pe ecran</string>
+    <string name="mouse_speed">Viteza mouse-ului</string>
+    <string name="mouse_speed_subtitle">Reglează viteza indicatorului pentru mișcarea tactilă și comenzile atribuite deplasării mouse-ului. Modul shooter folosește propria sensibilitate a privirii.</string>
+    <string name="reset_mouse_speed">Resetează viteza mouse-ului</string>
     <string name="edit_physical_controller">Editează controllerul fizic</string>
     <string name="controller_disconnected">Deconectat</string>
     <string name="reset_onscreen_controls">Resetează controalele pe ecran</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -623,6 +623,10 @@
     <string name="in_progress">В процессе</string>
     <string name="indeterminate">Частично отмечено</string>
     <string name="input_controls">Экранный контроллер</string>
+    <string name="on_screen_controller_settings">Настройки экранного контроллера</string>
+    <string name="mouse_speed">Скорость мыши</string>
+    <string name="mouse_speed_subtitle">Настройте скорость указателя для сенсорного перемещения и элементов управления, назначенных на движение мыши. Режим шутера использует отдельную чувствительность обзора.</string>
+    <string name="reset_mouse_speed">Сбросить скорость мыши</string>
     <string name="install">Установить</string>
     <string name="install_anyway">Установить в любом случае</string>
     <string name="install_app">Установить</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -276,6 +276,10 @@
     <string name="dpad_right">D-Pad вправо</string>
     <string name="input_controls">Елементи керування введенням</string>
     <string name="edit_controls">Редагувати екранний контролер</string>
+    <string name="on_screen_controller_settings">Налаштування екранного контролера</string>
+    <string name="mouse_speed">Швидкість миші</string>
+    <string name="mouse_speed_subtitle">Налаштуйте швидкість вказівника для сенсорного переміщення й елементів керування, призначених для руху миші. Режим шутера використовує окрему чутливість огляду.</string>
+    <string name="reset_mouse_speed">Скинути швидкість миші</string>
     <string name="edit_physical_controller">Редагувати фізичний контролер</string>
     <string name="controller_disconnected">Від\'єднано</string>
     <string name="reset_onscreen_controls">Скинути екранні елементи керування</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -278,7 +278,7 @@
     <string name="edit_controls">Редагувати екранний контролер</string>
     <string name="on_screen_controller_settings">Налаштування екранного контролера</string>
     <string name="mouse_speed">Швидкість миші</string>
-    <string name="mouse_speed_subtitle">Налаштуйте швидкість вказівника для сенсорного переміщення й елементів керування, призначених для руху миші. Режим шутера використовує окрему чутливість огляду.</string>
+    <string name="mouse_speed_subtitle">Налаштуйте швидкість вказівника для руху дотиком і елементів керування, призначених для руху миші. Режим шутера використовує окрему чутливість огляду.</string>
     <string name="reset_mouse_speed">Скинути швидкість миші</string>
     <string name="edit_physical_controller">Редагувати фізичний контролер</string>
     <string name="controller_disconnected">Від\'єднано</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -274,6 +274,10 @@
     <string name="dpad_right">方向键 右</string>
     <string name="input_controls">屏幕控制器</string>
     <string name="edit_controls">编辑屏幕控制器</string>
+    <string name="on_screen_controller_settings">屏幕控制器设置</string>
+    <string name="mouse_speed">鼠标速度</string>
+    <string name="mouse_speed_subtitle">调整触摸移动和分配为移动鼠标的控件的指针速度。射击模式使用独立的视角灵敏度。</string>
+    <string name="reset_mouse_speed">重置鼠标速度</string>
     <string name="edit_physical_controller">编辑实体控制器</string>
     <string name="controller_disconnected">已断开</string>
     <string name="reset_onscreen_controls">重置屏幕控制器</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -274,6 +274,10 @@
     <string name="dpad_right">方向鍵 右</string>
     <string name="input_controls">螢幕控制器</string>
     <string name="edit_controls">編輯螢幕控制器</string>
+    <string name="on_screen_controller_settings">螢幕控制器設定</string>
+    <string name="mouse_speed">滑鼠速度</string>
+    <string name="mouse_speed_subtitle">調整觸控移動及指派為移動滑鼠之控制項的指標速度。射擊模式使用獨立的視角靈敏度。</string>
+    <string name="reset_mouse_speed">重設滑鼠速度</string>
     <string name="edit_physical_controller">編輯實體控制器</string>
     <string name="controller_disconnected">已斷線</string>
     <string name="reset_onscreen_controls">重置螢幕控制器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,6 +269,10 @@
     <string name="dpad_right">D-Pad Right</string>
     <string name="input_controls">On-screen Controller</string>
     <string name="edit_controls">Edit On-screen Controller</string>
+    <string name="on_screen_controller_settings">On-screen Controller Settings</string>
+    <string name="mouse_speed">Mouse Speed</string>
+    <string name="mouse_speed_subtitle">Adjust pointer speed for touch movement and controls assigned to move the mouse. Shooter Mode uses its own look sensitivity.</string>
+    <string name="reset_mouse_speed">Reset mouse speed</string>
     <string name="edit_physical_controller">Edit Physical Controller</string>
     <string name="controller_disconnected">Disconnected</string>
     <string name="reset_onscreen_controls">Reset On-Screen Controls</string>

--- a/app/src/test/java/app/gamenative/ui/component/dialog/OnScreenControllerSettingsDialogTest.kt
+++ b/app/src/test/java/app/gamenative/ui/component/dialog/OnScreenControllerSettingsDialogTest.kt
@@ -1,0 +1,24 @@
+package app.gamenative.ui.component.dialog
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OnScreenControllerSettingsDialogTest {
+    @Test
+    fun `invalid stored speeds fall back to default`() {
+        assertEquals(DEFAULT_MOUSE_SPEED, mouseSpeedOrDefault(Float.NaN), 0f)
+        assertEquals(DEFAULT_MOUSE_SPEED, mouseSpeedOrDefault(-1f), 0f)
+        assertEquals(DEFAULT_MOUSE_SPEED, mouseSpeedOrDefault(0f), 0f)
+    }
+
+    @Test
+    fun `valid stored speeds remain unchanged before slider clamping`() {
+        assertEquals(4f, mouseSpeedOrDefault(4f), 0f)
+    }
+
+    @Test
+    fun `slider speed is constrained to the supported range`() {
+        assertEquals(MIN_MOUSE_SPEED, mouseSpeedForSlider(0.01f), 0f)
+        assertEquals(MAX_MOUSE_SPEED, mouseSpeedForSlider(4f), 0f)
+    }
+}

--- a/app/src/test/java/app/gamenative/ui/component/dialog/OnScreenControllerSettingsDialogTest.kt
+++ b/app/src/test/java/app/gamenative/ui/component/dialog/OnScreenControllerSettingsDialogTest.kt
@@ -21,4 +21,14 @@ class OnScreenControllerSettingsDialogTest {
         assertEquals(MIN_MOUSE_SPEED, mouseSpeedForSlider(0.01f), 0f)
         assertEquals(MAX_MOUSE_SPEED, mouseSpeedForSlider(4f), 0f)
     }
+
+    @Test
+    fun `saving without editing preserves a valid value outside the slider range`() {
+        assertEquals(4f, mouseSpeedForSave(4f, MAX_MOUSE_SPEED, false), 0f)
+    }
+
+    @Test
+    fun `saving an edited value uses the slider range`() {
+        assertEquals(MAX_MOUSE_SPEED, mouseSpeedForSave(4f, 4f, true), 0f)
+    }
 }

--- a/app/src/test/java/com/winlator/inputcontrols/ControlElementMouseSpeedTest.kt
+++ b/app/src/test/java/com/winlator/inputcontrols/ControlElementMouseSpeedTest.kt
@@ -1,0 +1,33 @@
+package com.winlator.inputcontrols
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ControlElementMouseSpeedTest {
+    @Test
+    fun `default trackpad speed preserves existing rounding`() {
+        val accumulator = ControlElement.MouseDeltaAccumulator()
+
+        assertEquals(1, accumulator.scale(0.2f, 1f))
+        assertEquals(-1, accumulator.scale(-0.2f, 1f))
+    }
+
+    @Test
+    fun `sub one trackpad speed accumulates fractional pixels`() {
+        val accumulator = ControlElement.MouseDeltaAccumulator()
+
+        assertEquals(
+            listOf(0, 1, 0, 1),
+            List(4) { accumulator.scale(0.2f, 0.5f) },
+        )
+    }
+
+    @Test
+    fun `reset discards a partial trackpad pixel`() {
+        val accumulator = ControlElement.MouseDeltaAccumulator()
+
+        assertEquals(0, accumulator.scale(0.2f, 0.5f))
+        accumulator.reset()
+        assertEquals(0, accumulator.scale(0.2f, 0.5f))
+    }
+}

--- a/app/src/test/java/com/winlator/inputcontrols/ControlElementMouseSpeedTest.kt
+++ b/app/src/test/java/com/winlator/inputcontrols/ControlElementMouseSpeedTest.kt
@@ -5,29 +5,51 @@ import org.junit.Test
 
 class ControlElementMouseSpeedTest {
     @Test
-    fun `default trackpad speed preserves existing rounding`() {
-        val accumulator = ControlElement.MouseDeltaAccumulator()
+    fun `default trackpad speed accumulates transformed subpixels`() {
+        val positive = ControlElement.MouseDeltaAccumulator()
+        val negative = ControlElement.MouseDeltaAccumulator()
 
-        assertEquals(1, accumulator.scale(0.2f, 1f))
-        assertEquals(-1, accumulator.scale(-0.2f, 1f))
+        assertEquals(listOf(0, 0, 0, 0, 1), List(5) { positive.scale(0.2f, 1f) })
+        assertEquals(listOf(0, 0, 0, 0, -1), List(5) { negative.scale(-0.2f, 1f) })
     }
 
     @Test
-    fun `sub one trackpad speed accumulates fractional pixels`() {
+    fun `sub one trackpad speed remains proportional`() {
         val accumulator = ControlElement.MouseDeltaAccumulator()
 
         assertEquals(
-            listOf(0, 1, 0, 1),
-            List(4) { accumulator.scale(0.2f, 0.5f) },
+            listOf(0, 0, 0, 0, 0, 0, 0, 1),
+            List(8) { accumulator.scale(0.25f, 0.5f) },
         )
     }
 
     @Test
-    fun `reset discards a partial trackpad pixel`() {
+    fun `above one trackpad speed remains proportional`() {
         val accumulator = ControlElement.MouseDeltaAccumulator()
 
-        assertEquals(0, accumulator.scale(0.2f, 0.5f))
+        assertEquals(
+            listOf(0, 1, 1, 1),
+            List(4) { accumulator.scale(0.25f, 3f) },
+        )
+    }
+
+    @Test
+    fun `direction reversal cancels the pending subpixel`() {
+        val accumulator = ControlElement.MouseDeltaAccumulator()
+
+        assertEquals(0, accumulator.scale(0.75f, 1f))
+        assertEquals(0, accumulator.scale(-0.75f, 1f))
+        assertEquals(0, accumulator.scale(-0.5f, 1f))
+        assertEquals(-1, accumulator.scale(-0.5f, 1f))
+    }
+
+    @Test
+    fun `reset discards a pending subpixel`() {
+        val accumulator = ControlElement.MouseDeltaAccumulator()
+
+        assertEquals(0, accumulator.scale(0.75f, 1f))
         accumulator.reset()
-        assertEquals(0, accumulator.scale(0.2f, 0.5f))
+        assertEquals(0, accumulator.scale(0.5f, 1f))
+        assertEquals(1, accumulator.scale(0.5f, 1f))
     }
 }

--- a/app/src/test/java/com/winlator/inputcontrols/ControlsProfileCursorSpeedTest.kt
+++ b/app/src/test/java/com/winlator/inputcontrols/ControlsProfileCursorSpeedTest.kt
@@ -1,0 +1,45 @@
+package com.winlator.inputcontrols
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+@RunWith(RobolectricTestRunner::class)
+class ControlsProfileCursorSpeedTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val profile = ControlsProfile(context, 1)
+
+    @Test
+    fun `cursor speed accepts positive finite values`() {
+        profile.cursorSpeed = 2.5f
+
+        assertEquals(2.5f, profile.cursorSpeed, 0f)
+    }
+
+    @Test
+    fun `cursor speed rejects values that would stop or corrupt movement`() {
+        listOf(Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, 0f, -1f).forEach { value ->
+            profile.cursorSpeed = value
+
+            assertEquals(ControlsProfile.DEFAULT_CURSOR_SPEED, profile.cursorSpeed, 0f)
+        }
+    }
+
+    @Test
+    fun `legacy profile without cursor speed loads the default`() {
+        val json = """{"id":7,"name":"Legacy"}"""
+        val loadedProfile = InputControlsManager.loadProfile(
+            context,
+            ByteArrayInputStream(json.toByteArray(StandardCharsets.UTF_8)),
+        )
+
+        assertNotNull(loadedProfile)
+        assertEquals(ControlsProfile.DEFAULT_CURSOR_SPEED, loadedProfile!!.cursorSpeed, 0f)
+    }
+}


### PR DESCRIPTION
## Description

Adds a per-profile Mouse Speed setting for non-Shooter Mode pointer input.

The setting is available from the settings icon on the active On-screen Controller row in the Quick Menu.

This setting affects on-screen controls assigned to Mouse Move, including trackpad controls & physical controller inputs assigned to Mouse Move.

Shooter Mode retains its independent look-sensitivity settings.

## Recording

https://github.com/user-attachments/assets/b88226eb-4e1d-49c3-8c7d-a01c1939c2fa

## Type of Change

- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist

- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [x] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-profile Mouse Speed setting for non-Shooter Mode pointer input, opened from the settings icon on the On-screen Controller row in the Quick Menu. The speed scales trackpad movement and any input assigned to Mouse Move, while Shooter Mode keeps its independent look sensitivity.

- Mouse Move reads the profile's current speed each tick, stops when the active profile is hidden or removed, and resets the touchpad when input controls close.
- Trackpad movement accumulates fractional pixels so slow speeds stay smooth instead of being rounded away.
- Invalid stored speeds and legacy profiles without a speed fall back to the default; the slider is limited to 0.1x–3.0x with a reset action, and saving without editing preserves valid stored speeds outside that range.
- Adds tests for speed validation, defaults, slider limits, and fractional accumulation.

<sup>Written for commit f17a77507fd10eaeeaaf836950a14de8289b5848. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added adjustable mouse speed settings for on-screen controls.
  - Users can open settings from Input Controls, adjust or reset speed, and save changes.
  - Mouse speed now applies consistently to touchpad movement and mouse-move controls.
  - Added localized labels and descriptions, including clarification that Shooter Mode uses separate sensitivity.

- **Bug Fixes**
  - Invalid or missing speed values safely revert to the default.
  - Touchpad sensitivity resets appropriately when input controls are closed.
  - Improved accuracy for slower cursor speeds and fractional movement.

- **Tests**
  - Added coverage for speed validation, defaults, slider limits, and fractional cursor movement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->