### PR TITLE
Persist libredirect and faster external loading in default config

### DIFF
--- a/app/src/main/java/app/gamenative/PrefManager.kt
+++ b/app/src/main/java/app/gamenative/PrefManager.kt
@@ -584,6 +584,20 @@ object PrefManager {
             setPref(UNPACK_FILES, value)
         }
 
+    private val FASTER_EXTERNAL_LOADING = booleanPreferencesKey("faster_external_loading")
+    var fasterExternalLoading: Boolean
+        get() = getPref(FASTER_EXTERNAL_LOADING, false)
+        set(value) {
+            setPref(FASTER_EXTERNAL_LOADING, value)
+        }
+
+    private val DISABLE_LIBREDIRECT = booleanPreferencesKey("disable_libredirect")
+    var disableLibredirect: Boolean
+        get() = getPref(DISABLE_LIBREDIRECT, false)
+        set(value) {
+            setPref(DISABLE_LIBREDIRECT, value)
+        }
+
     private val SUSPEND_POLICY = stringPreferencesKey("suspend_policy")
     var suspendPolicy: String
         get() = Container.normalizeSuspendPolicy(getPref(SUSPEND_POLICY, Container.SUSPEND_POLICY_MANUAL))

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -148,6 +148,8 @@ object ContainerUtils {
             useLegacyDRM = PrefManager.useLegacyDRM,
             unpackFiles = PrefManager.unpackFiles,
             suspendPolicy = PrefManager.suspendPolicy,
+            fasterExternalLoading = PrefManager.fasterExternalLoading,
+            disableLibredirect = PrefManager.disableLibredirect,
             wineVersion = PrefManager.wineVersion,
             emulator = PrefManager.emulator,
             fexcoreVersion = PrefManager.fexcoreVersion,
@@ -237,6 +239,8 @@ object ContainerUtils {
         PrefManager.useLegacyDRM = containerData.useLegacyDRM
         PrefManager.unpackFiles = containerData.unpackFiles
         PrefManager.suspendPolicy = containerData.suspendPolicy
+        PrefManager.fasterExternalLoading = containerData.fasterExternalLoading
+        PrefManager.disableLibredirect = containerData.disableLibredirect
         PrefManager.portraitMode = containerData.portraitMode
         PrefManager.sharpnessEffect = containerData.sharpnessEffect
         PrefManager.sharpnessLevel = containerData.sharpnessLevel
@@ -936,6 +940,8 @@ object ContainerUtils {
                 useLegacyDRM = PrefManager.useLegacyDRM,
                 unpackFiles = PrefManager.unpackFiles,
                 suspendPolicy = PrefManager.suspendPolicy,
+                fasterExternalLoading = PrefManager.fasterExternalLoading,
+                disableLibredirect = PrefManager.disableLibredirect,
                 portraitMode = PrefManager.portraitMode,
                 externalDisplayMode = PrefManager.externalDisplayInputMode,
                 externalDisplaySwap = PrefManager.externalDisplaySwap,


### PR DESCRIPTION
The "Disable libredirect" and "Faster external loading" toggles don't do anything in the default container config. They work fine on a per-game container, where the value lands in the container's JSON, but the default config dialog drops it.

Three places lose it:

- `setDefaultContainerData` never wrote either field, so hitting save did nothing.
- `getDefaultContainerData` never read them, so the dialog reopened with both off. Reset-to-defaults also cleared them on an existing container.
- `createNewContainer` builds its own ContainerData from PrefManager and didn't include them, so new containers always started with both off.

Root cause is that there were no PrefManager keys at all. #1865 added the Container field, the JSON round-trip, the ContainerData field and the UI switch, but not the backing preference.

This adds the two keys and wires them through all three spots, following the existing `unpackFiles` pattern. Both default to false, so behaviour is unchanged until someone flips the toggle. The mutual exclusion between the two switches stays in GeneralTab as before.

Not compile-tested yet. Worth a quick check on device: set the toggle in Settings, save, reopen the dialog to confirm it stuck, then create a fresh container and confirm it inherited the value.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Disable libredirect" and "Faster external loading" toggles so they persist in the default container config instead of only working per-game. Previously, saving did nothing, the dialog reopened with both off, and new containers always started with both off.

- Adds `fasterExternalLoading` and `disableLibredirect` PrefManager keys, both defaulting to false.
- Wires both keys through `getDefaultContainerData`, `setDefaultContainerData`, and `createNewContainer` following the existing `unpackFiles` pattern.
- Behavior is unchanged until a toggle is flipped; no migration needed.
- Not compile-tested; verify on device by setting a toggle, saving, reopening, and creating a fresh container.

<sup>Written for commit a023b7a3c7e0d4a349724ded5df789e074105ee6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added preferences for faster external loading and disabling LibRedirect.
  - These settings are saved and applied to default and newly created containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->