### PR TITLE
Rework AI debug offer triggers and track the dialog

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -283,6 +283,19 @@ private fun trackMembershipPrompt(event: String, trigger: String) {
     }
 }
 
+private fun trackAiDebugOffer(event: String, appId: String, trigger: String) {
+    if (PrefManager.usageAnalyticsEnabled) {
+        PostHog.capture(
+            event = event,
+            properties = mapOf(
+                "game_name" to ContainerUtils.resolveGameName(appId),
+                "game_store" to ContainerUtils.extractGameSourceFromContainerId(appId).name,
+                "trigger" to trigger,
+            ),
+        )
+    }
+}
+
 private fun trackGameLaunched(appId: String) {
     val gameSource = ContainerUtils.extractGameSourceFromContainerId(appId)
     val gameName = ContainerUtils.resolveGameName(appId)
@@ -325,6 +338,7 @@ fun PluviaMain(
     }
     var debugPaywallReason by rememberSaveable { mutableStateOf<String?>(null) }
     var aiDebugOfferAppId by rememberSaveable { mutableStateOf("") }
+    var aiDebugOfferTrigger by rememberSaveable { mutableStateOf("") }
     var debugPreRunVisible by rememberSaveable { mutableStateOf(false) }
     var debugPreRunAppId by rememberSaveable { mutableStateOf("") }
     var debugPreRunOffline by rememberSaveable { mutableStateOf(false) }
@@ -709,7 +723,9 @@ fun PluviaMain(
 
                 is MainViewModel.MainUiEvent.ShowAiDebugOffer -> {
                     aiDebugOfferAppId = event.appId
+                    aiDebugOfferTrigger = event.trigger
                     PrefManager.lastWarmPitchTime = System.currentTimeMillis()
+                    trackAiDebugOffer("ai_debug_offer_shown", event.appId, event.trigger)
                     msgDialogState = MessageDialogState(
                         visible = true,
                         type = DialogType.AI_DEBUG_OFFER,
@@ -1202,6 +1218,7 @@ fun PluviaMain(
             onConfirmClick = {
                 setMessageDialogState(MessageDialogState(false))
                 if (aiDebugOfferAppId.isNotEmpty()) {
+                    trackAiDebugOffer("ai_debug_offer_accepted", aiDebugOfferAppId, aiDebugOfferTrigger)
                     debugPreRunAppId = aiDebugOfferAppId
                     debugPreRunOffline = viewModel.isOffline.value
                     debugPreRunVisible = true
@@ -1209,9 +1226,15 @@ fun PluviaMain(
             }
             onDismissClick = {
                 setMessageDialogState(MessageDialogState(false))
+                if (aiDebugOfferAppId.isNotEmpty()) {
+                    trackAiDebugOffer("ai_debug_offer_dismissed", aiDebugOfferAppId, aiDebugOfferTrigger)
+                }
             }
             onDismissRequest = {
                 setMessageDialogState(MessageDialogState(false))
+                if (aiDebugOfferAppId.isNotEmpty()) {
+                    trackAiDebugOffer("ai_debug_offer_dismissed", aiDebugOfferAppId, aiDebugOfferTrigger)
+                }
             }
         }
 
@@ -1368,12 +1391,12 @@ fun PluviaMain(
                         // Close the dialog regardless of success
                         Timber.d("GameFeedback: Closing dialog")
                         gameFeedbackState = GameFeedbackDialogState(visible = false)
-                        viewModel.onGameFeedbackResolved(feedbackState.rating)
+                        viewModel.onGameFeedbackResolved(context, feedbackState.rating, feedbackState.selectedTags)
                     }
                 },
                 onDismiss = {
                     gameFeedbackState = GameFeedbackDialogState(visible = false)
-                    viewModel.onGameFeedbackResolved(null)
+                    viewModel.onGameFeedbackResolved(context, null)
                 },
                 onDiscordSupport = {
                     uriHandler.openUri("https://discord.gg/2hKv4VfZfE")

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -73,6 +73,10 @@ class MainViewModel @Inject constructor(
         private const val KEY_CURRENT_SCREEN_ROUTE = "current_screen_route"
         private const val MIN_WARM_PITCH_SESSION_MS = 7 * 60 * 1000L
         private const val WARM_PITCH_COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000L
+        private const val SHORT_SESSION_MS = 90 * 1000L
+        private const val AI_DEBUG_OFFER_INTERVAL_MS = 3 * 24 * 60 * 60 * 1000L
+        private const val LOW_RATING_MAX = 3
+        private val FAILURE_TAGS = setOf("does_not_open", "no_graphics", "directx_error")
         private const val BOOT_AD_REUSE_WINDOW_MS = 2 * 60 * 1000L
 
         var gamePlayedThisSession = false
@@ -84,6 +88,7 @@ class MainViewModel @Inject constructor(
     private var bootAdHiddenAtMs = 0L
     private var bootAdDwellReported = false
     private var bootAwaitingGameWindow = false
+    private var gameWindowSeen = false
     private var pendingWarmPitch: Pair<String, Boolean>? = null
 
     private fun warmPitchAllowed(): Boolean {
@@ -91,9 +96,13 @@ class MainViewModel @Inject constructor(
         return System.currentTimeMillis() - PrefManager.lastWarmPitchTime >= WARM_PITCH_COOLDOWN_MS
     }
 
-    fun onGameFeedbackResolved(rating: Int?) {
+    fun onGameFeedbackResolved(context: Context, rating: Int?, tags: Set<String> = emptySet()) {
         val (appId, sessionLongEnough) = pendingWarmPitch ?: return
         pendingWarmPitch = null
+        if (rating != null && (rating <= LOW_RATING_MAX || tags.any { it in FAILURE_TAGS })) {
+            viewModelScope.launch { offerAiDebugRun(context, appId, "low_rating") }
+            return
+        }
         val trigger = when {
             rating == 5 -> "five_star"
             rating == null && sessionLongEnough -> "long_session"
@@ -116,7 +125,7 @@ class MainViewModel @Inject constructor(
         data class ShowGameFeedbackDialog(val appId: String) : MainUiEvent()
         data class ShowMembershipPitch(val appId: String, val trigger: String) : MainUiEvent()
         data class ShowDebugReportDialog(val appId: String, val reportDir: String) : MainUiEvent()
-        data class ShowAiDebugOffer(val appId: String) : MainUiEvent()
+        data class ShowAiDebugOffer(val appId: String, val trigger: String) : MainUiEvent()
         data object ServiceReady : MainUiEvent()
     }
 
@@ -564,6 +573,7 @@ class MainViewModel @Inject constructor(
 
     fun launchApp(context: Context, appId: String) {
         gameSessionStartTime = System.currentTimeMillis()
+        gameWindowSeen = false
         gamePlayedThisSession = true
         PrefManager.hasAttemptedGameLaunch = true
         // Show booting splash before launching the app
@@ -575,15 +585,6 @@ class MainViewModel @Inject constructor(
                         lastPlayed = System.currentTimeMillis(),
                     ),
                 )
-                try {
-                    val container = ContainerUtils.getContainer(context, appId)
-                    if (container.getSessionMetadata("guest_self_exited", "false") == "true") {
-                        container.putSessionMetadata("guest_self_exited", "false")
-                        container.saveData()
-                    }
-                } catch (e: Exception) {
-                    Timber.w(e, "Failed to clear guest_self_exited for $appId")
-                }
             }
 
             bootAwaitingGameWindow = true
@@ -761,27 +762,25 @@ class MainViewModel @Inject constructor(
     }
 
     private suspend fun maybeOfferAiDebugRun(context: Context, appId: String, sessionLengthMs: Long): Boolean {
+        val trigger = when {
+            !gameWindowSeen -> "no_window"
+            sessionLengthMs in 1 until SHORT_SESSION_MS -> "short_session"
+            else -> return false
+        }
+        return offerAiDebugRun(context, appId, trigger)
+    }
+
+    private suspend fun offerAiDebugRun(context: Context, appId: String, trigger: String): Boolean {
         return try {
             val container = ContainerUtils.getContainer(context, appId)
-            val guestSelfExited = container.getSessionMetadata("guest_self_exited", "false") == "true"
-            if (guestSelfExited) {
-                container.putSessionMetadata("guest_self_exited", "false")
-                container.saveData()
-            }
-            val firstLaunch = container.getExtra("discord_support_prompt_shown", "false") != "true"
-            val avgFps = container.getSessionMetadata("avg_fps", "").toFloatOrNull()
-            val crashSignal = guestSelfExited ||
-                (firstLaunch && sessionLengthMs in 1 until 180_000L) ||
-                (avgFps != null && avgFps < 0.01f)
-            if (!crashSignal) return false
+            val now = System.currentTimeMillis()
+            val lastShownForGame = container.getExtra("ai_debug_offer_last_shown", "0").toLongOrNull() ?: 0L
+            if (now - lastShownForGame < AI_DEBUG_OFFER_INTERVAL_MS) return false
+            if (now - PrefManager.lastWarmPitchTime < WARM_PITCH_COOLDOWN_MS) return false
 
-            val offeredBefore = container.getExtra("ai_debug_offer_shown", "false") == "true"
-            val cooldownElapsed = System.currentTimeMillis() - PrefManager.lastWarmPitchTime >= WARM_PITCH_COOLDOWN_MS
-            if (!(PrefManager.tipped || (cooldownElapsed && !offeredBefore))) return false
-
-            container.putExtra("ai_debug_offer_shown", "true")
+            container.putExtra("ai_debug_offer_last_shown", now.toString())
             container.saveData()
-            _uiEvent.send(MainUiEvent.ShowAiDebugOffer(appId))
+            _uiEvent.send(MainUiEvent.ShowAiDebugOffer(appId, trigger))
             true
         } catch (e: Exception) {
             Timber.w(e, "Failed to evaluate AI debug offer for $appId")
@@ -867,6 +866,9 @@ class MainViewModel @Inject constructor(
             // Hide the booting splash when a window is mapped. During boot, Wine's own shell
             // windows (explorer.exe etc.) map long before the game renders, so they must not
             // end it; outside boot (exit/teardown re-shows) any window map hides it as before.
+            if (window.isApplicationWindow() && !WineProcessSnapshotHelper.isSystemProcessName(window.className)) {
+                gameWindowSeen = true
+            }
             if (bootAwaitingGameWindow && WineProcessSnapshotHelper.isSystemProcessName(window.className)) {
                 Timber.tag("BootAdTrace").i("ignoring system window map: %s", window.className)
             } else {

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -4091,10 +4091,6 @@ private fun setupXEnvironment(
     guestProgramLauncherComponent.envVars = envVars
 
     val gameTerminationCallback = Callback<Int> { status ->
-        if (!isExiting.get() && status != 0) {
-            container.putSessionMetadata("guest_self_exited", "true")
-            container.saveData()
-        }
         if (status != 0) {
             Timber.e("Guest program terminated with status: $status")
             onGameLaunchError?.invoke("Game terminated with error status: $status")


### PR DESCRIPTION
## Description

Users who had turned off membership offers were getting the AI debug offer after almost every launch. That setting (`PrefManager.tipped`) bypassed both the once-per-container flag and the cooldown, so any crash signal showed the dialog. Two of the three crash signals were also unreliable: the zero-FPS check fires on working games whose frames the counter never sees (Slay the Spire 2, Project Zomboid, Binding of Isaac all show up with 0 FPS after 5+ minute sessions in PostHog), and the first-launch flag was never set because the offer returned before the feedback block ran.

New triggers, evaluated at game exit in this order:

1. **no_window** – no top-level game window mapped during the session. Uses the same `onWindowMapped` classification that clears the boot splash (Wine shell / Steam / winedbg windows don't count). Covers the black-screen case regardless of how the user exited.
2. **short_session** – a game window mapped but the session was under 90s of wall time from launch.
3. **low_rating** – feedback dialog submitted with ≤3 stars or a `does_not_open` / `no_graphics` / `directx_error` tag.

Limits, same for everyone: one offer per game per 3 days (timestamp in container extras, replaces the one-shot flag) plus the existing 3-day global cooldown shared with the membership pitch. The tipped bypass is gone.

Removed: the zero-FPS and first-launch signals, the `guest_self_exited` container write in the termination callback, and its launch-time clear. The window flag lives in the view model, so nothing is written to the container at exit any more.

Tracking: `ai_debug_offer_shown` / `ai_debug_offer_accepted` / `ai_debug_offer_dismissed` with `game_name`, `game_store` and `trigger`, gated on usage analytics like the membership pitch events. Accept rate split by trigger is the number to watch for tuning the 90s threshold and the cooldowns.

Not compiled locally.

## Recording

N/A – dialog is unchanged, only the trigger logic.

## Type of Change
- [x] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the AI debug offer so it no longer fires after nearly every launch for users who disabled membership offers, and replaces unreliable crash signals with three checks evaluated at game exit: no game window mapped, session under 90 seconds, or a low feedback rating. The per-game one-shot flag is now a 3-day timestamp, and the tipped bypass is removed.

**Tracking**
- Adds `ai_debug_offer_shown`, `ai_debug_offer_accepted`, and `ai_debug_offer_dismissed` events with `game_name`, `game_store`, and `trigger` properties, gated on usage analytics.
- No container writes happen at game exit anymore; the window flag lives in the view model.

<sup>Written for commit 68d4cb68fcbb9d93594a821c9de89a6d3bea7929. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI debugging offers now appear based on additional signals, including short sessions, low feedback ratings, and reported failure types.
  - Offers are rate-limited per game to avoid repeated interruptions.
  - Feedback submissions now include selected issue categories to improve troubleshooting.

- **Analytics**
  - AI debugging offer displays, acceptances, and dismissals are tracked when usage analytics are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->