### PR TITLE
Allow a custom executable path outside the A: drive

### DIFF
--- a/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
+++ b/app/src/main/java/app/gamenative/service/gog/GOGManager.kt
@@ -824,6 +824,10 @@ class GOGManager @Inject constructor(
             return "\"explorer.exe\""
         }
 
+        if (ContainerUtils.isAbsoluteWindowsPath(executablePath)) {
+            return "\"$executablePath\""
+        }
+
         // Find the drive letter that's mapped to this game's install path
         var gogDriveLetter: String? = null
         for (drive in com.winlator.container.Container.drivesIterator(container.drives)) {

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ContainerConfigDialog.kt
@@ -1401,6 +1401,8 @@ internal fun ExecutablePathDropdown(
     var expanded by remember { mutableStateOf(false) }
     var executables by remember { mutableStateOf<List<String>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
+    var showCustomPathDialog by remember { mutableStateOf(false) }
+    var customPathText by remember { mutableStateOf("") }
     val context = LocalContext.current
 
     // Load executables from A: drive when component is first created
@@ -1449,7 +1451,7 @@ internal fun ExecutablePathDropdown(
             singleLine = true
         )
 
-        if (!isLoading && executables.isNotEmpty()) {
+        if (!isLoading) {
             ExposedDropdownMenu(
                 expanded = expanded,
                 onDismissRequest = { expanded = false }
@@ -1477,7 +1479,40 @@ internal fun ExecutablePathDropdown(
                         }
                     )
                 }
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.container_config_executable_path_custom)) },
+                    onClick = {
+                        customPathText = value
+                        showCustomPathDialog = true
+                        expanded = false
+                    }
+                )
             }
         }
+    }
+
+    if (showCustomPathDialog) {
+        AlertDialog(
+            onDismissRequest = { showCustomPathDialog = false },
+            title = { Text(stringResource(R.string.container_config_executable_path_custom)) },
+            text = {
+                NoExtractOutlinedTextField(
+                    value = customPathText,
+                    onValueChange = { customPathText = it },
+                    placeholder = { Text(stringResource(R.string.container_config_executable_path_custom_placeholder)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    onValueChange(customPathText.trim())
+                    showCustomPathDialog = false
+                }) { Text(stringResource(R.string.ok)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCustomPathDialog = false }) { Text(stringResource(R.string.cancel)) }
+            }
+        )
     }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -4508,16 +4508,19 @@ private fun getWineStartCommand(
             Timber.tag("XServerScreen").i("Using cached Amazon executablePath: $resolvedRelativePath")
         }
 
+        val isAbsoluteExe = ContainerUtils.isAbsoluteWindowsPath(resolvedRelativePath)
         val winPath = resolvedRelativePath.replace("/", "\\")
-        val amazonCommand = "A:\\$winPath"
+        val amazonCommand = if (isAbsoluteExe) resolvedRelativePath else "A:\\$winPath"
 
-        val workDir = if (fuelCommand != null && fuelWorkingDir != null && resolvedRelativePath.replace("\\", "/") == fuelCommand.replace("\\", "/")) {
-            installPath + "/" + fuelWorkingDir.replace("\\", "/")
-        } else {
-            val exeDir = resolvedRelativePath.substringBeforeLast("/", "")
-            if (exeDir.isNotEmpty()) installPath + "/" + exeDir else installPath
+        if (!isAbsoluteExe) {
+            val workDir = if (fuelCommand != null && fuelWorkingDir != null && resolvedRelativePath.replace("\\", "/") == fuelCommand.replace("\\", "/")) {
+                installPath + "/" + fuelWorkingDir.replace("\\", "/")
+            } else {
+                val exeDir = resolvedRelativePath.substringBeforeLast("/", "")
+                if (exeDir.isNotEmpty()) installPath + "/" + exeDir else installPath
+            }
+            guestProgramLauncherComponent.workingDir = File(workDir)
         }
-        guestProgramLauncherComponent.workingDir = File(workDir)
 
         // ── Set FuelPump environment variables (P3-2) ────────────────
         // Nile reference: nile/utils/launch.py — sets these for Amazon Games SDK / FuelPump DRM.

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -4381,7 +4381,8 @@ private fun getWineStartCommand(
 
         // Use A: drive (or the mapped drive letter) instead of Z:
         // The container setup in ContainerUtils maps the game install path to A: drive
-        val epicCommand = if (ContainerUtils.isAbsoluteWindowsPath(exePath)) exePath else "A:\\$relativePath".replace("/", "\\")
+        val isAbsoluteExe = ContainerUtils.isAbsoluteWindowsPath(exePath)
+        val epicCommand = if (isAbsoluteExe) exePath else "A:\\$relativePath".replace("/", "\\")
 
         // Get Epic launch parameters
         Timber.tag("XServerScreen").d("Building Epic launch parameters for ${game.appName}...")
@@ -4395,8 +4396,10 @@ private fun getWineStartCommand(
             params
         }
         // Set working directory to the folder containing the executable
-        val executableDir = game.installPath + "/" + relativePath.substringBeforeLast("/", "")
-        guestProgramLauncherComponent.workingDir = File(executableDir)
+        if (!isAbsoluteExe) {
+            val executableDir = game.installPath + "/" + relativePath.substringBeforeLast("/", "")
+            guestProgramLauncherComponent.workingDir = File(executableDir)
+        }
 
         Timber.tag("XServerScreen").i("Epic launch command: \"$epicCommand\"")
 
@@ -4628,13 +4631,13 @@ private fun getWineStartCommand(
             }
         }
 
+        if (ContainerUtils.isAbsoluteWindowsPath(executablePath)) {
+            return "winhandler.exe \"$executablePath\""
+        }
+
         if (gameFolderPath == null) {
             Timber.tag("XServerScreen").e("Could not find A: drive for Custom Game: $appId")
             return "winhandler.exe \"wfm.exe\""
-        }
-
-        if (ContainerUtils.isAbsoluteWindowsPath(executablePath)) {
-            return "winhandler.exe \"$executablePath\""
         }
 
         // Set working directory to the game folder

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -4306,7 +4306,7 @@ private fun getWineStartCommand(
             container.executablePath = SteamService.getInstalledExe(gameId)
             container.saveData()
         }
-        if (!container.isUseLegacyDRM){
+        if (!container.isUseLegacyDRM && !ContainerUtils.isAbsoluteWindowsPath(container.executablePath)){
             // Create ColdClientLoader.ini file
             SteamUtils.writeColdClientIni(gameId, container, appLaunchInfo)
         }
@@ -4381,7 +4381,7 @@ private fun getWineStartCommand(
 
         // Use A: drive (or the mapped drive letter) instead of Z:
         // The container setup in ContainerUtils maps the game install path to A: drive
-        val epicCommand = "A:\\$relativePath".replace("/", "\\")
+        val epicCommand = if (ContainerUtils.isAbsoluteWindowsPath(exePath)) exePath else "A:\\$relativePath".replace("/", "\\")
 
         // Get Epic launch parameters
         Timber.tag("XServerScreen").d("Building Epic launch parameters for ${game.appName}...")
@@ -4630,6 +4630,10 @@ private fun getWineStartCommand(
             return "winhandler.exe \"wfm.exe\""
         }
 
+        if (ContainerUtils.isAbsoluteWindowsPath(executablePath)) {
+            return "winhandler.exe \"$executablePath\""
+        }
+
         // Set working directory to the game folder
         val executableDir = gameFolderPath + "/" + executablePath.substringBeforeLast("/", "")
         guestProgramLauncherComponent.workingDir = File(executableDir)
@@ -4643,7 +4647,9 @@ private fun getWineStartCommand(
         Timber.tag("XServerScreen").w("appLaunchInfo is null for Steam game: $appId")
         "\"wfm.exe\""
     } else {
-        if (container.isLaunchBionicSteam) {
+        if (ContainerUtils.isAbsoluteWindowsPath(container.executablePath)) {
+            "\"${container.executablePath}\""
+        } else if (container.isLaunchBionicSteam) {
             // Bionic-Steam mode: launch the game executable directly.
             // The native libsteamclient.so is already running in the Android process
             // and will monitor the game via nativeWaitAppExit.

--- a/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/ContainerUtils.kt
@@ -1280,6 +1280,9 @@ object ContainerUtils {
         return null
     }
 
+    fun isAbsoluteWindowsPath(path: String): Boolean =
+        Regex("^[A-Za-z]:[\\\\/]").containsMatchIn(path)
+
     /**
      * Scans the container's A: drive for all .exe and .bat files
      */

--- a/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
+++ b/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
@@ -412,6 +412,7 @@ object CustomGameScanner {
     fun getLaunchExecutable(container: Container): String {
         val gameFolderPath = ContainerUtils.getADrivePath(container.drives) ?: return ""
         val exe = container.executablePath
+        if (ContainerUtils.isAbsoluteWindowsPath(exe)) return exe
         if (exe.isNotEmpty()) {
             val fullPath = File(gameFolderPath, exe.replace('\\', File.separatorChar))
             if (fullPath.exists() && fullPath.isFile) return exe

--- a/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
+++ b/app/src/main/java/app/gamenative/utils/CustomGameScanner.kt
@@ -410,9 +410,9 @@ object CustomGameScanner {
      * When container has a configured path, verifies the file exists to avoid launching stale/missing paths.
      */
     fun getLaunchExecutable(container: Container): String {
-        val gameFolderPath = ContainerUtils.getADrivePath(container.drives) ?: return ""
         val exe = container.executablePath
         if (ContainerUtils.isAbsoluteWindowsPath(exe)) return exe
+        val gameFolderPath = ContainerUtils.getADrivePath(container.drives) ?: return ""
         if (exe.isNotEmpty()) {
             val fullPath = File(gameFolderPath, exe.replace('\\', File.separatorChar))
             if (fullPath.exists() && fullPath.isFile) return exe

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -996,6 +996,8 @@
     <string name="container_config_vkd3d_version">VKD3D-version</string>
     <string name="container_config_executable_path">Sti til eksekverbar fil</string>
     <string name="container_config_executable_path_placeholder">f.eks. sti\\til\\exe</string>
+    <string name="container_config_executable_path_custom">Brugerdefineret sti…</string>
+    <string name="container_config_executable_path_custom_placeholder">f.eks. C:\\Spil\\spil.exe</string>
 
     <!-- TODO: Manual review - Libraries Dialog -->
     <string name="libraries_title">Anvendte biblioteker</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1126,6 +1126,8 @@
     <string name="container_config_vkd3d_version">VKD3D-Version</string>
     <string name="container_config_executable_path">Pfad zur Ausführbaren Datei</string>
     <string name="container_config_executable_path_placeholder">z.B. pfad\\zu\\exe</string>
+    <string name="container_config_executable_path_custom">Benutzerdefinierter Pfad…</string>
+    <string name="container_config_executable_path_custom_placeholder">z.B. C:\\Spiele\\spiel.exe</string>
     <!-- Libraries Dialog -->
     <string name="libraries_title">Verwendete Bibliotheken</string>
     <string name="libraries_message">Pluvia - github.com/oxters168/Pluvia\nJavaSteam - github.com/Longi94/JavaSteam\nWinlator &amp; Vortek - github.com/brunodev85/winlator\nWinlator Cmod - github.com/coffincolors/winlator\nWrapper - https://github.com/leegao/bionic-vulkan-wrapper &amp; https://github.com/pipetto-crypto/\nUbuntu RootFs - releases.ubuntu.com/focal</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1186,6 +1186,8 @@
     <string name="container_config_vkd3d_version">Versión de VKD3D</string>
     <string name="container_config_executable_path">Ruta del ejecutable</string>
     <string name="container_config_executable_path_placeholder">p. ej., ruta\\al\\exe</string>
+    <string name="container_config_executable_path_custom">Ruta personalizada…</string>
+    <string name="container_config_executable_path_custom_placeholder">p. ej., C:\\Juegos\\juego.exe</string>
 
     <!-- Libraries Dialog -->
     <string name="libraries_title">Librerías utilizadas</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1196,6 +1196,8 @@
     <string name="container_config_vkd3d_version">Version VKD3D</string>
     <string name="container_config_executable_path">Chemin de l\'exécutable</string>
     <string name="container_config_executable_path_placeholder">ex. : chemin\\vers\\exe</string>
+    <string name="container_config_executable_path_custom">Chemin personnalisé…</string>
+    <string name="container_config_executable_path_custom_placeholder">ex. : C:\\Jeux\\jeu.exe</string>
 
     <!-- Libraries Dialog -->
     <string name="libraries_title">Bibliothèques utilisées</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1169,6 +1169,8 @@
     <string name="container_config_vkd3d_version">Versione VKD3D</string>
     <string name="container_config_executable_path">Percorso Eseguibile</string>
     <string name="container_config_executable_path_placeholder">es. percorso\\a\\exe</string>
+    <string name="container_config_executable_path_custom">Percorso personalizzato…</string>
+    <string name="container_config_executable_path_custom_placeholder">es. C:\\Giochi\\gioco.exe</string>
 
     <!-- Libraries Dialog -->
     <string name="libraries_title">Librerie Usate</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1210,6 +1210,8 @@
     <string name="container_config_vkd3d_version">VKD3Dバージョン</string>
     <string name="container_config_executable_path">実行可能パス</string>
     <string name="container_config_executable_path_placeholder">例: path\\to\\exe</string>
+    <string name="container_config_executable_path_custom">カスタムパス…</string>
+    <string name="container_config_executable_path_custom_placeholder">例: C:\\Games\\game.exe</string>
 
     <!-- Libraries Dialog -->
     <string name="libraries_title">使用するライブラリ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1173,6 +1173,8 @@
     <string name="container_config_vkd3d_version">VKD3D 버전</string>
     <string name="container_config_executable_path">실행 파일 경로</string>
     <string name="container_config_executable_path_placeholder">예: path\\to\\exe</string>
+    <string name="container_config_executable_path_custom">사용자 지정 경로…</string>
+    <string name="container_config_executable_path_custom_placeholder">예: C:\\Games\\game.exe</string>
 
     <!-- Libraries Dialog -->
     <string name="libraries_title">사용된 라이브러리</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1186,6 +1186,8 @@
     <string name="container_config_vkd3d_version">Wersja VKD3D</string>
     <string name="container_config_executable_path">Ścieżka pliku wykonywalnego</string>
     <string name="container_config_executable_path_placeholder">np. ścieżka\\do\\exe</string>
+    <string name="container_config_executable_path_custom">Własna ścieżka…</string>
+    <string name="container_config_executable_path_custom_placeholder">np. C:\\Gry\\gra.exe</string>
 
     <!-- Libraries Dialog -->
     <string name="libraries_title">Użyte biblioteki</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -996,6 +996,8 @@
     <string name="container_config_vkd3d_version">Versão do VKD3D</string>
     <string name="container_config_executable_path">Caminho do executável</string>
     <string name="container_config_executable_path_placeholder">ex.: caminho\\para\\exe</string>
+    <string name="container_config_executable_path_custom">Caminho personalizado…</string>
+    <string name="container_config_executable_path_custom_placeholder">ex.: C:\\Jogos\\jogo.exe</string>
 
     <!-- TODO: Revisão manual - Diálogo de bibliotecas -->
     <string name="libraries_title">Bibliotecas utilizadas</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1178,6 +1178,8 @@
 	<string name="container_config_vkd3d_version">Versiune VKD3D</string>
 	<string name="container_config_executable_path">Cale executabil</string>
 	<string name="container_config_executable_path_placeholder">ex.: path\\to\\exe</string>
+	<string name="container_config_executable_path_custom">Cale personalizată…</string>
+	<string name="container_config_executable_path_custom_placeholder">ex.: C:\\Jocuri\\joc.exe</string>
 
 	<!-- Libraries Dialog -->
 	<string name="libraries_title">Biblioteci utilizate</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -293,6 +293,8 @@
     <string name="container_config_drive_letter_missing">Буква диска отсутствует</string>
     <string name="container_config_executable_path">Путь исполняемого файла</string>
     <string name="container_config_executable_path_placeholder">например, path\\to\\exe</string>
+    <string name="container_config_executable_path_custom">Свой путь…</string>
+    <string name="container_config_executable_path_custom_placeholder">например, C:\\Games\\game.exe</string>
     <string name="container_config_invalid_drive_path">Неверный путь диска</string>
     <string name="container_config_tab_advanced">Дополнительно</string>
     <string name="container_config_tab_controller">Контроллер</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1172,6 +1172,8 @@
     <string name="container_config_vkd3d_version">Версія VKD3D</string>
     <string name="container_config_executable_path">Шлях до виконуваного файлу</string>
     <string name="container_config_executable_path_placeholder">напр., path\\to\\exe</string>
+    <string name="container_config_executable_path_custom">Власний шлях…</string>
+    <string name="container_config_executable_path_custom_placeholder">напр., C:\\Games\\game.exe</string>
 
     <!-- Libraries Dialog -->
     <string name="libraries_title">Використані бібліотеки</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1156,6 +1156,8 @@
     <string name="container_config_vkd3d_version">VKD3D 版本</string>
     <string name="container_config_executable_path">可执行文件路径</string>
     <string name="container_config_executable_path_placeholder">例如：path\\to\\exe</string>
+    <string name="container_config_executable_path_custom">自定义路径…</string>
+    <string name="container_config_executable_path_custom_placeholder">例如：C:\\Games\\game.exe</string>
 
     <!-- 使用的库对话框 -->
     <string name="libraries_title">使用的库</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1158,6 +1158,8 @@
     <string name="container_config_vkd3d_version">VKD3D 版本</string>
     <string name="container_config_executable_path">可執行檔路徑</string>
     <string name="container_config_executable_path_placeholder">e.g., path\\to\\exe</string>
+    <string name="container_config_executable_path_custom">自訂路徑…</string>
+    <string name="container_config_executable_path_custom_placeholder">e.g., C:\\Games\\game.exe</string>
 
     <!-- Libraries Dialog -->
     <string name="libraries_title">使用的函式庫</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1382,6 +1382,8 @@
     <string name="container_config_vkd3d_version">VKD3D Version</string>
     <string name="container_config_executable_path">Executable Path</string>
     <string name="container_config_executable_path_placeholder">e.g., path\\to\\exe</string>
+    <string name="container_config_executable_path_custom">Custom path…</string>
+    <string name="container_config_executable_path_custom_placeholder">e.g., C:\\Games\\game.exe</string>
 
     <!-- Libraries Dialog -->
     <string name="libraries_title">Libraries Used</string>


### PR DESCRIPTION
## Description
The executable path dropdown in Edit Container → General only lists `.exe`/`.bat` files found under the A: drive. Some users need to launch an executable that lives elsewhere in the prefix (e.g. `C:\Games\game.exe`).

This adds a **Custom path…** item at the end of that dropdown. Picking it opens a small dialog with a text field, seeded with the current value. OK trims and saves the text as the executable path. Nothing else in the dropdown flow changes.

At launch, a value that starts with a drive letter and colon (`^[A-Za-z]:[\\/]`, `ContainerUtils.isAbsoluteWindowsPath`) is treated as an absolute Windows path and passed through as-is:

- **Steam**: skips the ColdClient loader and does not write `ColdClientLoader.ini`. Checked ahead of the bionic / Real Steam / legacy-DRM arms.
- **Custom games**: skips the `A:\` prefix and the A:-relative working directory.
- **Epic**: skips the install-dir strip.
- **GOG**: skips the drive-letter lookup and install-dir relativize in `GOGManager.getGogWineStartCommand`.
- **Amazon**: skips the `A:\` prefix and the fuel.json working directory. FuelPump env vars and SDK deploy still run.

Every value the app produces today is relative to the game folder (the A: scanner relativizes, Steam/GOG/Amazon `getInstalledExe` and fuel.json paths are relative, Epic auto-detect is a host path starting with `/`), so the predicate is false for all existing containers and they run the exact code they run now. A `.bat` picked from the list still goes through the loader as before.

Strings added to `values/` and all 14 locale files.

Note: an absolute path is launched without Goldberg, so a Steam game that needs the Steam API will not find it from a custom path. That is the accepted tradeoff for this edge case.

## Recording
N/A

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [x] Compatibility improvements
- [ ] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [x] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Custom path** option for entering executable locations directly, including when no detected executables are available.
  - Added support for launching games from absolute Windows executable paths across supported game sources.
  - Added localized labels and placeholder text for custom executable paths in multiple languages.
- **Bug Fixes**
  - Improved launch handling for absolute Windows paths to avoid incorrect path conversion and working-directory setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->