### PR TITLE
Fix custom game frontend sync to use per-source dao/scanner lookups

### DIFF
--- a/app/src/main/java/app/gamenative/sync/FrontendSyncManager.kt
+++ b/app/src/main/java/app/gamenative/sync/FrontendSyncManager.kt
@@ -168,13 +168,19 @@ object FrontendSyncManager {
         val dir = PrefManager.getFrontendSyncDir(source)
         if (dir.isEmpty()) return
 
+        val ext = extensionFor(source)
         val gameName = lookupGameName(appId, source) ?: run {
-            Timber.w("FrontendSyncManager: no game name for appId=%d source=%s", appId, source)
+            Timber.w(
+                "FrontendSyncManager: no game name for appId=%d source=%s, removing stale export if present",
+                appId,
+                source,
+            )
+            deleteExportFileForAppId(dir, ext, appId)
             return
         }
 
         val isInstalled = isGameInstalled(appId, source)
-        val file = File(dir, "${sanitizeFileName(gameName)}${extensionFor(source)}")
+        val file = File(dir, "${sanitizeFileName(gameName)}$ext")
 
         try {
             if (isInstalled) {
@@ -250,6 +256,29 @@ object FrontendSyncManager {
 
     private fun sanitizeFileName(name: String): String =
         name.replace(invalidFileChars, "_").trim().ifEmpty { "unknown" }
+
+    /**
+     * Finds and deletes the export file for [appId] inside [dir] by matching each candidate
+     * file's stored appId content, since the game's current name may no longer be resolvable
+     * (e.g. a custom game whose folder was deleted).
+     */
+    private fun deleteExportFileForAppId(dir: String, extension: String, appId: Int) {
+        try {
+            val directory = File(dir)
+            if (!directory.isDirectory) return
+            val target = appId.toString()
+            directory.walkTopDown().maxDepth(1)
+                .filter { it.isFile && it.name.endsWith(extension) }
+                .firstOrNull { it.readText(Charsets.UTF_8).trim() == target }
+                ?.let { file ->
+                    if (!file.delete()) {
+                        Timber.w("FrontendSyncManager: could not delete stale export %s", file.absolutePath)
+                    }
+                }
+        } catch (e: Exception) {
+            Timber.e(e, "FrontendSyncManager: failed to remove stale export for appId=%d in %s", appId, dir)
+        }
+    }
 
     /** Deletes all files with [extension] directly inside [dir] (non-recursive, depth = 1). */
     internal fun deleteAllFilesWithExtension(dir: String, extension: String) {

--- a/app/src/main/java/app/gamenative/sync/FrontendSyncManager.kt
+++ b/app/src/main/java/app/gamenative/sync/FrontendSyncManager.kt
@@ -12,6 +12,7 @@ import app.gamenative.db.dao.SteamAppDao
 import app.gamenative.events.AndroidEvent
 import app.gamenative.service.SteamService
 import app.gamenative.ui.util.SnackbarManager
+import app.gamenative.utils.CustomGameScanner
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.EntryPoint
@@ -190,8 +191,13 @@ object FrontendSyncManager {
     private suspend fun syncAllInstalledGames(source: GameSource, dir: String) {
         try {
             val games: List<Pair<Int, String>> = when (source) {
-                GameSource.STEAM, GameSource.CUSTOM_GAME -> {
+                GameSource.STEAM -> {
                     steamAppDao.getInstalledGames().map { it.id to it.name }
+                }
+                GameSource.CUSTOM_GAME -> {
+                    CustomGameScanner.scanAsLibraryItems()
+                        .filter { it.gameSource == GameSource.CUSTOM_GAME }
+                        .map { it.gameId to it.name }
                 }
                 GameSource.EPIC -> {
                     epicGameDao.getInstalledGames().map { it.id to it.title }
@@ -225,14 +231,16 @@ object FrontendSyncManager {
     }
 
     private suspend fun lookupGameName(appId: Int, source: GameSource): String? = when (source) {
-        GameSource.STEAM, GameSource.CUSTOM_GAME -> steamAppDao.findApp(appId)?.name
+        GameSource.STEAM -> steamAppDao.findApp(appId)?.name
+        GameSource.CUSTOM_GAME -> CustomGameScanner.findCustomGameById(appId)?.let { File(it).name }
         GameSource.EPIC -> epicGameDao.getById(appId)?.title
         GameSource.GOG -> gogGameDao.getById(appId.toString())?.title
         GameSource.AMAZON -> amazonGameDao.getByAppId(appId)?.title
     }
 
     private suspend fun isGameInstalled(appId: Int, source: GameSource): Boolean = when (source) {
-        GameSource.STEAM, GameSource.CUSTOM_GAME -> SteamService.isAppInstalled(appId)
+        GameSource.STEAM -> SteamService.isAppInstalled(appId)
+        GameSource.CUSTOM_GAME -> CustomGameScanner.isGameInstalled(appId)
         GameSource.EPIC -> epicGameDao.getById(appId)?.isInstalled ?: false
         GameSource.GOG -> gogGameDao.getById(appId.toString())?.isInstalled ?: false
         GameSource.AMAZON -> amazonGameDao.getByAppId(appId)?.isInstalled ?: false


### PR DESCRIPTION
## Summary
- `FrontendSyncManager` previously routed `GameSource.CUSTOM_GAME` through the same `steamAppDao` lookups used for `GameSource.STEAM` in `syncAllInstalledGames()`, `lookupGameName()`, and `isGameInstalled()`. Custom games aren't in the Steam app DAO, so this caused frontend sync to miss, misname, or leak Steam data across custom games.
- Splits the `CUSTOM_GAME` branch out to use `CustomGameScanner` (`scanAsLibraryItems()`, `findCustomGameById()`, `isGameInstalled()`) instead, matching how custom games are actually resolved elsewhere in the app.

## Test plan
- [x] Built the `legacy` debug flavor (Frontend Sync is only shown when `!BuildConfig.MODERN_ANDROID`) and installed on a physical Odin 3.
- [x] Confirmed frontend sync correctly resolves and syncs a custom game.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes frontend sync for custom games so the installed-game scan, name lookup, and install check use `CustomGameScanner` instead of Steam DAO lookups. Custom games aren't in the Steam DAO, so the old shared lookups could miss, misname, or leak Steam data across custom games; scan results are also filtered to `GameSource.CUSTOM_GAME` entries so games imported as Steam games don't leak into `.pcgame` exports.

Also deletes stale `.pcgame` exports for removed custom games by matching the stored appId, which previously left the file behind when the name lookup failed.

<sup>Written for commit 85d4147495ee3def35867889a7eee680351dcdb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed stale export files when a game name can no longer be resolved during synchronization.
  - Improved synchronization cleanup for games whose metadata is missing, helping prevent outdated exports from remaining in the library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->