### PR TITLE
More info handed to AI debugging for more accurate results

### DIFF
--- a/.github/workflows/pluvia-pr-check.yml
+++ b/.github/workflows/pluvia-pr-check.yml
@@ -40,5 +40,9 @@ jobs:
         uses: gradle/actions/wrapper-validation@v4
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Run unit tests
-        run: ./gradlew :app:testLegacyDebugUnitTest :app:testModernDebugUnitTest
+      - name: Run unit tests (legacy)
+        timeout-minutes: 30
+        run: ./gradlew :app:testLegacyDebugUnitTest
+      - name: Run unit tests (modern)
+        timeout-minutes: 30
+        run: ./gradlew :app:testModernDebugUnitTest

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -229,7 +229,10 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
-            all { it.maxHeapSize = "4g" }
+            all {
+                it.maxHeapSize = "4g"
+                it.testLogging { events("started", "failed") }
+            }
         }
     }
 

--- a/app/src/main/java/app/gamenative/api/DebugReportApi.kt
+++ b/app/src/main/java/app/gamenative/api/DebugReportApi.kt
@@ -30,6 +30,7 @@ object DebugReportApi {
         logFile: File,
         relayToken: String,
         perfFile: File? = null,
+        logcatFile: File? = null,
     ): SubmitResult = withContext(Dispatchers.IO) {
         try {
             val headerString = header.toString()
@@ -50,6 +51,13 @@ object DebugReportApi {
                     "perf",
                     "perf.json",
                     perfFile.asRequestBody("application/json".toMediaType()),
+                )
+            }
+            if (logcatFile != null && logcatFile.exists()) {
+                bodyBuilder.addFormDataPart(
+                    "logcat",
+                    "logcat.gz",
+                    logcatFile.asRequestBody("application/gzip".toMediaType()),
                 )
             }
             val body = bodyBuilder.build()

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -1226,14 +1226,12 @@ fun PluviaMain(
             }
             onDismissClick = {
                 setMessageDialogState(MessageDialogState(false))
-                PrefManager.lastWarmPitchTime = System.currentTimeMillis()
                 if (aiDebugOfferAppId.isNotEmpty()) {
                     trackAiDebugOffer("ai_debug_offer_dismissed", aiDebugOfferAppId, aiDebugOfferTrigger)
                 }
             }
             onDismissRequest = {
                 setMessageDialogState(MessageDialogState(false))
-                PrefManager.lastWarmPitchTime = System.currentTimeMillis()
                 if (aiDebugOfferAppId.isNotEmpty()) {
                     trackAiDebugOffer("ai_debug_offer_dismissed", aiDebugOfferAppId, aiDebugOfferTrigger)
                 }

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -724,16 +724,16 @@ fun PluviaMain(
                 is MainViewModel.MainUiEvent.ShowAiDebugOffer -> {
                     aiDebugOfferAppId = event.appId
                     aiDebugOfferTrigger = event.trigger
-                    PrefManager.lastWarmPitchTime = System.currentTimeMillis()
                     trackAiDebugOffer("ai_debug_offer_shown", event.appId, event.trigger)
+                    val offerMessage = context.getString(
+                        R.string.debug_offer_message,
+                        ContainerUtils.resolveGameName(event.appId),
+                    )
                     msgDialogState = MessageDialogState(
                         visible = true,
                         type = DialogType.AI_DEBUG_OFFER,
                         title = context.getString(R.string.debug_offer_title),
-                        message = context.getString(
-                            R.string.debug_offer_message,
-                            ContainerUtils.resolveGameName(event.appId),
-                        ),
+                        message = offerMessage + " " + context.getString(R.string.debug_trial_note),
                         confirmBtnText = context.getString(R.string.debug_offer_confirm),
                         dismissBtnText = context.getString(R.string.close),
                     )
@@ -1226,12 +1226,14 @@ fun PluviaMain(
             }
             onDismissClick = {
                 setMessageDialogState(MessageDialogState(false))
+                PrefManager.lastWarmPitchTime = System.currentTimeMillis()
                 if (aiDebugOfferAppId.isNotEmpty()) {
                     trackAiDebugOffer("ai_debug_offer_dismissed", aiDebugOfferAppId, aiDebugOfferTrigger)
                 }
             }
             onDismissRequest = {
                 setMessageDialogState(MessageDialogState(false))
+                PrefManager.lastWarmPitchTime = System.currentTimeMillis()
                 if (aiDebugOfferAppId.isNotEmpty()) {
                     trackAiDebugOffer("ai_debug_offer_dismissed", aiDebugOfferAppId, aiDebugOfferTrigger)
                 }
@@ -1415,7 +1417,7 @@ fun PluviaMain(
 
             val shareDebugLog: () -> Unit = {
                 val reportDir = File(debugReportState.reportDir)
-                val files = listOf(DebugReportUtils.logFile(reportDir), DebugReportUtils.perfFile(reportDir))
+                val files = listOf(DebugReportUtils.logFile(reportDir), DebugReportUtils.perfFile(reportDir), DebugReportUtils.logcatFile(reportDir))
                     .filter { it.exists() }
                 if (files.isNotEmpty()) {
                     val uris = files.map { FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", it) }
@@ -1456,7 +1458,8 @@ fun PluviaMain(
                         return@launch
                     }
                     val perfFile = DebugReportUtils.perfFile(dir)
-                    when (val result = DebugReportApi.submit(header, logFile, PrefManager.discordRelayToken, perfFile)) {
+                    val logcatFile = DebugReportUtils.logcatFile(dir)
+                    when (val result = DebugReportApi.submit(header, logFile, PrefManager.discordRelayToken, perfFile, logcatFile)) {
                         is DebugReportApi.SubmitResult.Success -> {
                             withContext(Dispatchers.IO) { DebugReportUtils.deleteReport(dir) }
                             debugReportState = debugReportState.copy(

--- a/app/src/main/java/app/gamenative/ui/component/dialog/DebugPreRunDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/DebugPreRunDialog.kt
@@ -63,7 +63,7 @@ fun DebugPreRunDialog(
                             .padding(bottom = 8.dp),
                     )
                     Text(
-                        text = stringResource(R.string.debug_prerun_message_2),
+                        text = stringResource(R.string.debug_prerun_message_2) + " " + stringResource(R.string.debug_trial_note),
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Bold,
                         modifier = Modifier

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -75,6 +75,7 @@ class MainViewModel @Inject constructor(
         private const val WARM_PITCH_COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000L
         private const val SHORT_SESSION_MS = 90 * 1000L
         private const val AI_DEBUG_OFFER_INTERVAL_MS = 3 * 24 * 60 * 60 * 1000L
+        private const val BOOT_GAME_SEEN_GRACE_MS = 15_000L
         private const val LOW_RATING_MAX = 3
         private val FAILURE_TAGS = setOf("does_not_open", "no_graphics", "directx_error")
         private const val BOOT_AD_REUSE_WINDOW_MS = 2 * 60 * 1000L
@@ -274,6 +275,7 @@ class MainViewModel @Inject constructor(
     private val onClearBootingSplash: (AndroidEvent.ClearBootingSplash) -> Unit = {
         bootingSplashTimeoutJob?.cancel()
         bootingSplashTimeoutJob = null
+        bootAwaitingGameWindow = false
         setShowBootingSplash(false)
     }
 
@@ -591,6 +593,7 @@ class MainViewModel @Inject constructor(
             bootAdHiddenAtMs = 0L
             setShowBootingSplash(true)
             bootAwaitingGameWindow = _state.value.bootAd != null
+            if (bootAwaitingGameWindow) startBootGameExitWatch(context, appId)
             PluviaApp.events.emit(AndroidEvent.SetAllowedOrientation(PrefManager.allowedOrientation))
 
             val heroUrl = withContext(Dispatchers.IO) {
@@ -857,6 +860,22 @@ class MainViewModel @Inject constructor(
                 throw e
             } catch (t: Throwable) {
                 Timber.tag("Steam").e(t, "[Cloud Saves] Exception during close app sync for $gameId")
+            }
+        }
+    }
+
+    private fun startBootGameExitWatch(context: Context, appId: String) = viewModelScope.launch(Dispatchers.IO) {
+        val exe = ContainerUtils.getContainer(context, appId).executablePath
+            .substringAfterLast('/').substringAfterLast('\\').lowercase()
+        if (!exe.endsWith(".exe")) return@launch
+        var seenAt = 0L
+        while (bootAwaitingGameWindow) {
+            delay(200)
+            val running = WineProcessSnapshotHelper.readFromProc().any { it.name.lowercase().endsWith(exe) }
+            if (running && seenAt == 0L) seenAt = System.currentTimeMillis()
+            if (seenAt != 0L && (!running || System.currentTimeMillis() - seenAt >= BOOT_GAME_SEEN_GRACE_MS)) {
+                PluviaApp.events.emit(AndroidEvent.ClearBootingSplash)
+                return@launch
             }
         }
     }

--- a/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/MainViewModel.kt
@@ -779,7 +779,6 @@ class MainViewModel @Inject constructor(
             val now = System.currentTimeMillis()
             val lastShownForGame = container.getExtra("ai_debug_offer_last_shown", "0").toLongOrNull() ?: 0L
             if (now - lastShownForGame < AI_DEBUG_OFFER_INTERVAL_MS) return false
-            if (now - PrefManager.lastWarmPitchTime < WARM_PITCH_COOLDOWN_MS) return false
 
             container.putExtra("ai_debug_offer_last_shown", now.toString())
             container.saveData()

--- a/app/src/main/java/app/gamenative/ui/screen/DebugPaywallScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/DebugPaywallScreen.kt
@@ -181,7 +181,7 @@ fun DebugPaywallScreen(
                 )
 
                 Text(
-                    text = stringResource(R.string.debug_paywall_cancel_anytime),
+                    text = stringResource(R.string.debug_paywall_cancel_anytime) + " " + stringResource(R.string.debug_trial_note),
                     style = MaterialTheme.typography.bodySmall,
                     color = PluviaTheme.colors.textMuted,
                 )

--- a/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/xserver/XServerScreen.kt
@@ -128,6 +128,7 @@ import app.gamenative.utils.AssetUtils
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.downloader.CoreDriverDownloader
 import app.gamenative.utils.CustomGameScanner
+import app.gamenative.utils.DebugReportUtils
 import app.gamenative.utils.ExecutableSelectionUtils
 import app.gamenative.utils.LsfgQuickMenuHelper
 import app.gamenative.utils.LsfgVkManager
@@ -3876,7 +3877,10 @@ private fun setupXEnvironment(
     val wineDebugChannels = PrefManager.wineDebugChannels
     // explicitly enable or disable Wine debug channels
     if (debugRun) {
-        envVars.put("WINEDEBUG", "warn+seh,+loaddll,+timestamp,+pid,+tid")
+        envVars.put("WINEDEBUG", "warn+seh,+loaddll,+process,+timestamp,+pid,+tid")
+        envVars.put("DXVK_LOG_LEVEL", "info")
+        envVars.put("DXVK_LOG_PATH", "none")
+        envVars.put("VKD3D_DEBUG", "warn")
     } else if (diagnostics) {
         envVars.put("WRAPPER_DIAG", "1")
         envVars.put("WRAPPER_DIAG_APPID", appId)
@@ -3901,6 +3905,7 @@ private fun setupXEnvironment(
         wineLogDir.mkdirs()
         logFile = File(wineLogDir, if (debugRun) "debug_run_$appId.log" else "wine_debug.log")
         if (logFile.exists()) logFile.delete()
+        if (debugRun) DebugReportUtils.startLogcatCapture(context, appId)
     }
 
     ProcessHelper.addDebugCallback { line ->

--- a/app/src/main/java/app/gamenative/utils/DebugReportUtils.kt
+++ b/app/src/main/java/app/gamenative/utils/DebugReportUtils.kt
@@ -18,6 +18,10 @@ object DebugReportUtils {
     private const val HEADER_FILE = "header.json"
     private const val LOG_FILE = "log.gz"
     private const val PERF_FILE = "perf.json"
+    private const val LOGCAT_FILE = "logcat.gz"
+
+    @Volatile
+    private var logcatProcess: Process? = null
     private const val LOG_HEAD_BYTES = 1L * 1024 * 1024
     private const val LOG_TAIL_BYTES = 7L * 1024 * 1024
     private const val LOG_MAX_BYTES = LOG_HEAD_BYTES + LOG_TAIL_BYTES
@@ -33,6 +37,38 @@ object DebugReportUtils {
     fun logFile(reportDir: File): File = File(reportDir, LOG_FILE)
 
     fun perfFile(reportDir: File): File = File(reportDir, PERF_FILE)
+
+    fun logcatFile(reportDir: File): File = File(reportDir, LOGCAT_FILE)
+
+    private fun rawLogcatFile(context: Context, appId: String): File =
+        File(context.getExternalFilesDir(null), "wine_logs/debug_run_$appId.logcat")
+
+    fun startLogcatCapture(context: Context, appId: String) {
+        stopLogcatCapture()
+        try {
+            val out = rawLogcatFile(context, appId)
+            out.parentFile?.mkdirs()
+            if (out.exists()) out.delete()
+            Runtime.getRuntime().exec(arrayOf("logcat", "-c")).waitFor()
+            logcatProcess = ProcessBuilder("logcat", "-v", "threadtime")
+                .redirectOutput(out)
+                .redirectErrorStream(true)
+                .start()
+        } catch (e: Exception) {
+            Timber.e(e, "DebugReportUtils: Failed to start logcat capture")
+            logcatProcess = null
+        }
+    }
+
+    fun stopLogcatCapture() {
+        logcatProcess?.let {
+            try {
+                it.destroy()
+            } catch (_: Exception) {
+            }
+        }
+        logcatProcess = null
+    }
 
     fun readHeader(reportDir: File): JSONObject? = try {
         val file = headerFile(reportDir)
@@ -61,6 +97,7 @@ object DebugReportUtils {
     suspend fun createPendingReport(context: Context, appId: String): File? = withContext(Dispatchers.IO) {
         var reportDir: File? = null
         val perf = PerfSampler.stop()
+        stopLogcatCapture()
         try {
             val wineLog = wineLogFile(context, appId)
             if (!wineLog.exists() || wineLog.length() == 0L) {
@@ -89,6 +126,11 @@ object DebugReportUtils {
                 perfFile(dir).writeText(perf.perf.toString())
                 header.put("perf", perf.verdict)
             }
+            val rawLogcat = rawLogcatFile(context, appId)
+            if (rawLogcat.exists() && rawLogcat.length() > 0L) {
+                compressLog(rawLogcat, logcatFile(dir))
+            }
+            rawLogcat.delete()
             headerFile(dir).writeText(header.toString())
             claimedLog.delete()
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1697,6 +1697,7 @@
     <string name="debug_prerun_title">Få AI-hjælp</string>
     <string name="debug_prerun_message_1">Kører spillet med debug-logning og deler loggen med vores AI på Discord, når du afslutter. Spil, indtil du oplever problemet.</string>
     <string name="debug_prerun_message_2">AI-svar er kun for abonnenter.</string>
+    <string name="debug_trial_note">Gratis prøveperiode tilgængelig.</string>
     <string name="debug_prerun_message_3">Alle kan dele rapporten for at få menneskelig hjælp.</string>
     <string name="debug_paywall_title">Få AI-fejlfindingshjælp</string>
     <string name="debug_paywall_pitch">Vores AI læser din nøjagtige log og konfiguration og fortæller dig, hvad du skal ændre, som regel på under 5 minutter.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1767,6 +1767,7 @@
     <string name="debug_prerun_title">AI-Hilfe erhalten</string>
     <string name="debug_prerun_message_1">Startet das Spiel mit Debug-Logging und teilt das Log nach dem Beenden mit unserer AI auf Discord. Das Spiel so lange ausführen, bis das Problem auftritt.</string>
     <string name="debug_prerun_message_2">AI-Antworten sind nur für Abonnenten.</string>
+    <string name="debug_trial_note">Kostenlose Testphase verfügbar.</string>
     <string name="debug_prerun_message_3">Jeder kann den Bericht teilen, um menschliche Hilfe zu erhalten.</string>
     <string name="debug_paywall_title">AI-Debug-Support erhalten</string>
     <string name="debug_paywall_pitch">Unsere AI liest dein genaues Log und deine Konfiguration und sagt dir, was du ändern musst, meist in unter 5 Minuten.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1825,6 +1825,7 @@
     <string name="debug_prerun_title">Obtén ayuda de la AI</string>
     <string name="debug_prerun_message_1">Ejecuta el juego con registro de depuración y comparte el registro con nuestra AI en Discord al salir. Juega hasta que aparezca el problema.</string>
     <string name="debug_prerun_message_2">Las respuestas de la AI son solo para suscriptores.</string>
+    <string name="debug_trial_note">Prueba gratuita disponible.</string>
     <string name="debug_prerun_message_3">Cualquiera puede compartir el informe para recibir ayuda humana.</string>
     <string name="debug_paywall_title">Consigue soporte de depuración con AI</string>
     <string name="debug_paywall_pitch">Nuestra AI lee tu registro y tu configuración exactos y te dice qué cambiar, normalmente en menos de 5 minutos.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1845,6 +1845,7 @@
     <string name="debug_prerun_title">Obtenez l\'aide de l\'AI</string>
     <string name="debug_prerun_message_1">Lance le jeu avec les journaux de débogage et les partage avec notre AI sur Discord quand vous quittez. Jouez jusqu\'à ce que le problème se produise.</string>
     <string name="debug_prerun_message_2">Les réponses de l\'AI sont réservées aux abonnés.</string>
+    <string name="debug_trial_note">Essai gratuit disponible.</string>
     <string name="debug_prerun_message_3">Tout le monde peut partager le rapport pour obtenir de l\'aide humaine.</string>
     <string name="debug_paywall_title">Obtenez une assistance de débogage AI</string>
     <string name="debug_paywall_pitch">Notre AI lit votre journal et votre configuration exacts et vous dit quoi changer, généralement en moins de 5 minutes.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1818,6 +1818,7 @@
     <string name="debug_prerun_title">Ottieni aiuto dall\'AI</string>
     <string name="debug_prerun_message_1">Avvia il gioco con i log di debug e li condivide con la nostra AI su Discord alla chiusura. Gioca finché il problema non si presenta.</string>
     <string name="debug_prerun_message_2">Le risposte dell\'AI sono solo per gli abbonati.</string>
+    <string name="debug_trial_note">Prova gratuita disponibile.</string>
     <string name="debug_prerun_message_3">Chiunque può condividere il report per ricevere aiuto umano.</string>
     <string name="debug_paywall_title">Ottieni supporto di debug AI</string>
     <string name="debug_paywall_pitch">La nostra AI legge il tuo log e la tua configurazione esatti e ti dice cosa cambiare, di solito in meno di 5 minuti.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1783,6 +1783,7 @@
     <string name="debug_prerun_title">AI のサポートを受ける</string>
     <string name="debug_prerun_message_1">デバッグログ付きでゲームを起動し、終了時にログを Discord の AI に共有します。問題が発生するまでゲームをプレイしてください。</string>
     <string name="debug_prerun_message_2">AI の返信はサブスク会員限定です。</string>
+    <string name="debug_trial_note">無料トライアルあり。</string>
     <string name="debug_prerun_message_3">レポートは誰でも共有でき、人間のサポートを受けられます。</string>
     <string name="debug_paywall_title">AI デバッグサポートを利用</string>
     <string name="debug_paywall_pitch">AI があなたのログと設定をそのまま読み取り、変更すべき点を教えます。通常 5 分以内です。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1824,6 +1824,7 @@
     <string name="debug_prerun_title">AI 도움 받기</string>
     <string name="debug_prerun_message_1">디버그 로깅으로 게임을 실행하고, 종료 시 로그를 Discord의 AI에 공유합니다. 문제가 발생할 때까지 게임을 플레이하세요.</string>
     <string name="debug_prerun_message_2">AI 답변은 구독자 전용입니다.</string>
+    <string name="debug_trial_note">무료 체험 이용 가능.</string>
     <string name="debug_prerun_message_3">리포트는 누구나 공유해 사람의 도움을 받을 수 있습니다.</string>
     <string name="debug_paywall_title">AI 디버그 지원 받기</string>
     <string name="debug_paywall_pitch">AI가 로그와 설정을 그대로 읽고 무엇을 바꿔야 할지 알려드립니다. 보통 5분 이내입니다.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1827,6 +1827,7 @@
     <string name="debug_prerun_title">Uzyskaj pomoc AI</string>
     <string name="debug_prerun_message_1">Uruchamia grę z logowaniem debugowania i po wyjściu udostępnia log naszemu AI na Discordzie. Graj, aż wystąpi problem.</string>
     <string name="debug_prerun_message_2">Odpowiedzi AI są tylko dla subskrybentów.</string>
+    <string name="debug_trial_note">Dostępny bezpłatny okres próbny.</string>
     <string name="debug_prerun_message_3">Każdy może udostępnić raport, aby uzyskać pomoc od ludzi.</string>
     <string name="debug_paywall_title">Uzyskaj pomoc AI w debugowaniu</string>
     <string name="debug_paywall_pitch">Nasza AI czyta dokładnie Twój log i konfigurację i mówi, co zmienić, zwykle w niecałe 5 minut.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1697,6 +1697,7 @@
     <string name="debug_prerun_title">Receba ajuda da AI</string>
     <string name="debug_prerun_message_1">Executa o jogo com registro de depuração e compartilha o log com nossa AI no Discord ao sair. Jogue até que o problema aconteça.</string>
     <string name="debug_prerun_message_2">As respostas da AI são apenas para assinantes.</string>
+    <string name="debug_trial_note">Teste gratuito disponível.</string>
     <string name="debug_prerun_message_3">Qualquer pessoa pode compartilhar o relatório para receber ajuda humana.</string>
     <string name="debug_paywall_title">Obtenha suporte de depuração com AI</string>
     <string name="debug_paywall_pitch">Nossa AI lê exatamente o seu log e a sua configuração e diz o que mudar, geralmente em menos de 5 minutos.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1829,6 +1829,7 @@
     <string name="debug_prerun_title">Primește ajutor de la AI</string>
     <string name="debug_prerun_message_1">Rulează jocul cu jurnal de depanare și partajează jurnalul cu AI-ul nostru pe Discord la ieșire. Joacă până când apare problema.</string>
     <string name="debug_prerun_message_2">Răspunsurile AI sunt doar pentru abonați.</string>
+    <string name="debug_trial_note">Perioadă de probă gratuită disponibilă.</string>
     <string name="debug_prerun_message_3">Oricine poate partaja raportul pentru ajutor uman.</string>
     <string name="debug_paywall_title">Obține suport de depanare AI</string>
     <string name="debug_paywall_pitch">AI-ul nostru îți citește exact jurnalul și configurația și îți spune ce să schimbi, de obicei în mai puțin de 5 minute.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1755,6 +1755,7 @@ https://gamenative.app
     <string name="debug_prerun_title">Получить помощь AI</string>
     <string name="debug_prerun_message_1">Запускает игру с отладочным журналом и после выхода отправляет журнал нашему AI в Discord. Играйте, пока не возникнет проблема.</string>
     <string name="debug_prerun_message_2">Ответы AI доступны только подписчикам.</string>
+    <string name="debug_trial_note">Доступен бесплатный пробный период.</string>
     <string name="debug_prerun_message_3">Любой может поделиться отчётом, чтобы получить помощь людей.</string>
     <string name="debug_paywall_title">Получите AI-поддержку по отладке</string>
     <string name="debug_paywall_pitch">Наш AI читает именно ваш лог и конфигурацию и говорит, что изменить, обычно меньше чем за 5 минут.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1823,6 +1823,7 @@
     <string name="debug_prerun_title">Отримати допомогу AI</string>
     <string name="debug_prerun_message_1">Запускає гру з журналом налагодження і після виходу надсилає журнал нашому AI в Discord. Грайте, доки не виникне проблема.</string>
     <string name="debug_prerun_message_2">Відповіді AI доступні лише підписникам.</string>
+    <string name="debug_trial_note">Доступний безкоштовний пробний період.</string>
     <string name="debug_prerun_message_3">Будь-хто може поділитися звітом, щоб отримати допомогу людей.</string>
     <string name="debug_paywall_title">Отримайте AI-підтримку з налагодження</string>
     <string name="debug_paywall_pitch">Наш AI читає саме ваш лог і конфігурацію та каже, що змінити, зазвичай менше ніж за 5 хвилин.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1844,6 +1844,7 @@
     <string name="debug_prerun_title">获取 AI 帮助</string>
     <string name="debug_prerun_message_1">以调试日志运行游戏，退出后将日志分享给我们在 Discord 上的 AI。请一直运行游戏，直到出现问题。</string>
     <string name="debug_prerun_message_2">AI 回复仅限订阅者。</string>
+    <string name="debug_trial_note">提供免费试用。</string>
     <string name="debug_prerun_message_3">任何人都可以分享报告以获得人工帮助。</string>
     <string name="debug_paywall_title">获取 AI 调试支持</string>
     <string name="debug_paywall_pitch">我们的 AI 会阅读你的完整日志和配置，并告诉你需要更改什么，通常不到 5 分钟。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1835,6 +1835,7 @@
     <string name="debug_prerun_title">取得 AI 協助</string>
     <string name="debug_prerun_message_1">以除錯日誌執行遊戲，退出後將日誌分享給我們在 Discord 上的 AI。請持續執行遊戲，直到問題出現。</string>
     <string name="debug_prerun_message_2">AI 回覆僅限訂閱者。</string>
+    <string name="debug_trial_note">提供免費試用。</string>
     <string name="debug_prerun_message_3">任何人都可以分享報告以獲得人工協助。</string>
     <string name="debug_paywall_title">取得 AI 除錯支援</string>
     <string name="debug_paywall_pitch">我們的 AI 會閱讀你的完整記錄與設定，並告訴你需要更改什麼，通常不到 5 分鐘。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1823,6 +1823,7 @@
     <string name="debug_prerun_title">Get AI help</string>
     <string name="debug_prerun_message_1">Runs the game with debug logging and shares the log with our AI on Discord when you quit. Run the game until you experience the issue.</string>
     <string name="debug_prerun_message_2">AI replies are for subscribers only.</string>
+    <string name="debug_trial_note">Free trial available.</string>
     <string name="debug_prerun_message_3">Anyone can share the report for human help.</string>
     <string name="diagnostics_share_title">Share diagnostics log</string>
     <string name="diagnostics_share_none">No diagnostics log yet. Use \"Diagnostic Run\" first.</string>


### PR DESCRIPTION
## Description
AI debugging was missing some data, added dxvk, vkd3d logs

## Recording
<!-- Attach a short recording/GIF showing the change -->

## Type of Change
- [ ] Bug fix
- [ ] Performance / stability improvement
- [ ] Compatibility improvements
- [x] Other (requires prior approval)

## Checklist
- [x] If I have access to `#code-changes`, I have discussed this change there and it has been green-lighted. If I do not have access, I have still provided clear context in this PR. If I skip both, I accept that this change may face delays in review, may not be reviewed at all, or may be closed.
- [ ] This change aligns with the current project scope (core functionality, stability, or performance). If not, it has been explicitly approved beforehand.
- [ ] I have attached a recording of the change.
- [x] I have read and agree to the contribution guidelines in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Debug reports now include logcat and DXVK/VKD3D logs so the AI debugging service has more context, and the AI debug offer is no longer gated by the global cooldown. CI unit tests now run sequentially with a 30-minute timeout and log each test as it starts, preventing intermittent runner OOM failures and making hung tests easier to spot.

**Debug report enrichment**
- Captures logcat during debug runs and attaches it as `logcat.gz` to report submissions and manual share sheets.
- Enables DXVK and VKD3D debug logging during debug runs.

**Offer and splash behavior**
- Removed the global warm-pitch cooldown; the per-game cooldown still applies.
- The AI debug offer, pre-run dialog, and paywall message now mention the free trial.
- The booting splash now clears when the game process exits, or 15 seconds after the game process is detected.

<sup>Written for commit 0973e621eccb1fad6eebf4167ab29896cdede130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debug reports now include compressed device log data when available.
  * Debug runs provide expanded diagnostic logging and device log capture.
  * Added localized “Free trial available” messaging.
* **Bug Fixes**
  * The booting splash screen now clears when the launched game exits or fails to start.
  * Debug assistance offers are no longer blocked by the general warm-pitch cooldown.
* **User Experience**
  * Debug assistance dialogs and paywall messaging now clearly display trial availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->