### PR TITLE
Add Spore registry pre-install step

### DIFF
--- a/app/src/main/java/app/gamenative/enums/Marker.kt
+++ b/app/src/main/java/app/gamenative/enums/Marker.kt
@@ -9,6 +9,7 @@ enum class Marker(val fileName: String ) {
     VCREDIST_INSTALLED(".vcredist_installed"),
     GOG_SCRIPT_INSTALLED(".gog_script_installed"),
     GOG_SUPPORT_INSTALLED(".gog_support_installed"),
+    SPORE_REGISTRY_INSTALLED(".spore_registry_installed"),
     PHYSX_INSTALLED(".physx_installed"),
     OPENAL_INSTALLED(".openal_installed"),
     XNA_INSTALLED(".xna_installed"),

--- a/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
+++ b/app/src/main/java/app/gamenative/utils/PreInstallSteps.kt
@@ -30,6 +30,7 @@ object PreInstallSteps {
         XnaFrameworkStep,
         GogScriptInterpreterStep,
         GogSupportCommandsStep,
+        SporeRegistryStep,
         UbisoftConnectStep,
     )
 

--- a/app/src/main/java/app/gamenative/utils/preInstallSteps/SporeRegistryStep.kt
+++ b/app/src/main/java/app/gamenative/utils/preInstallSteps/SporeRegistryStep.kt
@@ -1,0 +1,55 @@
+package app.gamenative.utils
+
+import app.gamenative.data.GameSource
+import app.gamenative.enums.Marker
+import com.winlator.container.Container
+import java.io.File
+
+/**
+ * Creates the registry entries normally supplied by Spore's Steam install script.
+ * Without the SPORE key, Spore stops at startup with "Configuration script failed".
+ */
+object SporeRegistryStep : PreInstallStep {
+    private const val SPORE_APP_ID = "17390"
+    private const val REGISTRY_KEY = "HKLM\\Software\\Wow6432Node\\Electronic Arts\\SPORE"
+
+    override val marker: Marker = Marker.SPORE_REGISTRY_INSTALLED
+
+    private fun prefixStamp(container: Container): File =
+        File(container.rootDir, ".wine/${Marker.SPORE_REGISTRY_INSTALLED.fileName}")
+
+    override fun appliesTo(
+        container: Container,
+        gameSource: GameSource,
+        gameDirPath: String,
+    ): Boolean = gameSource == GameSource.STEAM
+
+    override fun buildCommand(
+        container: Container,
+        appId: String,
+        gameSource: GameSource,
+        gameDir: File,
+        gameDirPath: String,
+    ): String? {
+        if (appId != SPORE_APP_ID ||
+            (MarkerUtils.hasMarker(gameDirPath, marker) && prefixStamp(container).exists())
+        ) {
+            return null
+        }
+
+        val values = linkedMapOf(
+            "InstallLoc" to "A:\\",
+            "DataDir" to "A:\\Data",
+            "AppDir" to "A:\\SporeBin",
+        )
+        val commands = values.map { (name, value) ->
+            "reg add \"$REGISTRY_KEY\" /v $name /t REG_SZ /d \"$value\" /f"
+        }
+
+        try {
+            prefixStamp(container).createNewFile()
+        } catch (_: Exception) {
+        }
+        return commands.joinToString(" & ")
+    }
+}


### PR DESCRIPTION
Root cause: Steam app 17390 launches without the registry entries normally created by its Steam install script. The member's +reg log shows SporeApp.exe repeatedly failing to open HKLM\Software\Wow6432Node\Electronic Arts\SPORE immediately before the Configuration script failed dialog. This adds a targeted Steam pre-install step that writes InstallLoc=A:\, DataDir=A:\Data, and AppDir=A:\SporeBin, with both game-directory and Wine-prefix completion tracking so a new container restores the keys. Implementation: app/src/main/java/app/gamenative/utils/preInstallSteps/SporeRegistryStep.kt:12; pipeline registration: app/src/main/java/app/gamenative/utils/PreInstallSteps.kt:33; marker: app/src/main/java/app/gamenative/enums/Marker.kt:12.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Spore on Steam failing startup with "Configuration script failed" by creating registry entries that its Steam install script normally provides.

- Adds a pre-install step that writes `InstallLoc`, `DataDir`, and `AppDir` under `HKLM\Software\Wow6432Node\Electronic Arts\SPORE` for Steam app 17390.
- Tracks completion with both a game-directory marker and a Wine-prefix marker, so a new container re-runs the step and restores the keys.
- Only runs for Spore's Steam app ID, so other Steam games are unaffected.

<sup>Written for commit 83ffefcc3d47b88d1b8a4bdacec34d78bc83aa02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/utkarshdalal/GameNative/pull/1924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation support for the Steam version of Spore by automatically applying the required registry settings before installation.
  * Prevents repeated application of the same setup once it has already been completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->